### PR TITLE
Fix EOL handling in XRefTable::find_xref_offset

### DIFF
--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -5,6 +5,7 @@
 use super::{ParseError, ParseResult};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use crate::parser::reader::PDFLines;
 
 /// Cross-reference entry
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -209,14 +210,13 @@ impl XRefTable {
 
         // Convert to string and find startxref
         let content = String::from_utf8_lossy(&buffer);
-        let lines: Vec<&str> = content.lines().collect();
+        let mut lines = content.pdf_lines();
 
         // Find startxref line - need to iterate forward after finding it
-        for (i, line) in lines.iter().enumerate() {
+        while let Some(line) = lines.next() {
             if line.trim() == "startxref" {
                 // The offset should be on the next line
-                if i + 1 < lines.len() {
-                    let offset_line = lines[i + 1];
+                if let Some(offset_line) = lines.next() {
                     let offset = offset_line
                         .trim()
                         .parse::<u64>()

--- a/test-suite/src/spec_compliance.rs
+++ b/test-suite/src/spec_compliance.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use oxidize_pdf::parser::reader::PDFLines;
 
 /// Result of a specification test
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,7 +159,7 @@ impl SpecificationTest for Pdf17ComplianceTester {
 
             // Basic xref table format validation
             let xref_section = &pdf_str[xref_pos..];
-            let lines: Vec<&str> = xref_section.lines().collect();
+            let lines: Vec<&str> = xref_section.pdf_lines().collect();
 
             if lines.len() < 2 {
                 return TestResult::fail(


### PR DESCRIPTION
Previously, the code was using `.lines()` which splits lines only on '\n', even though the docs say it's supposed to handle `\r\n` as well.

It was failing for my document:

<details>

```
00000000 25 50 44 46 2d 31 2e 37 0d 25 e2 e3 cf d3 0d 0a |%PDF-1.7.%......|
00000010 36 35 33 37 20 30 20 6f 62 6a 0d 3c 3c 2f 4c 69 |6537 0 obj.<</Li|
00000020 6e 65 61 72 69 7a 65 64 20 31 2f 4c 20 38 33 36 |nearized 1/L 836|
00000030 32 33 32 34 34 2f 4f 20 36 35 33 39 2f 45 20 31 |23244/O 6539/E 1|
00000040 37 37 34 30 36 2f 4e 20 33 32 32 2f 54 20 38 33 |77406/N 322/T 83|
00000050 36 31 36 33 32 38 2f 48 20 5b 20 31 31 31 39 20 |616328/H [ 1119 |
00000060 31 36 37 32 5d 3e 3e 0d 65 6e 64 6f 62 6a 0d 20 |1672]>>.endobj. |
00000070 20 20 0d 0a 36 35 34 36 20 30 20 6f 62 6a 0d 3c | ..6546 0 obj.<|
00000080 3c 2f 44 65 63 6f 64 65 50 61 72 6d 73 3c 3c 2f |</DecodeParms<</|
00000090 43 6f 6c 75 6d 6e 73 20 35 2f 50 72 65 64 69 63 |Columns 5/Predic|
000000a0 74 6f 72 20 31 32 3e 3e 2f 46 69 6c 74 65 72 2f |tor 12>>/Filter/|
000000b0 46 6c 61 74 65 44 65 63 6f 64 65 2f 49 44 5b 3c |FlateDecode/ID[<|
000000c0 44 37 42 35 34 37 32 30 33 46 34 43 44 39 34 35 |D7B547203F4CD945|
000000d0 39 36 32 45 42 46 42 38 33 42 34 35 32 36 33 43 |962EBFB83B45263C|
000000e0 3e 3c 30 36 38 36 30 39 34 46 34 43 32 32 32 38 |><0686094F4C2228|
000000f0 34 42 42 44 42 44 43 36 32 35 43 39 46 41 42 45 |4BBDBDC625C9FABE|
00000100 31 46 3e 5d 2f 49 6e 64 65 78 5b 36 35 33 37 20 |1F>]/Index[6537 |
00000110 32 34 39 5d 2f 49 6e 66 6f 20 36 35 33 36 20 30 |249]/Info 6536 0|
00000120 20 52 2f 4c 65 6e 67 74 68 20 38 36 2f 50 72 65 | R/Length 86/Pre|
00000130 76 20 38 33 36 31 36 33 32 39 2f 52 6f 6f 74 20 |v 83616329/Root |
00000140 36 35 33 38 20 30 20 52 2f 53 69 7a 65 20 36 37 |6538 0 R/Size 67|
00000150 38 36 2f 54 79 70 65 2f 58 52 65 66 2f 57 5b 31 |86/Type/XRef/W[1|
00000160 20 33 20 31 5d 3e 3e 73 74 72 65 61 6d 0d 0a 68 | 3 1]>>stream..h|
00000170 de 62 62 64 60 10 60 60 62 60 e0 ba 0e 22 19 d7 |.bbd` .``b `..."..|
00000180 80 c9 e3 20 92 21 19 cc 3e 01 24 99 a6 35 80 d8 |... .!..>.$..5..|
00000190  1c 29 20 92 6d 12 90 fc  e7 5f c9 c0 c4 c8 20 29  |.) .m...._.... )|
000001a0  09 56 c9 04 26 19 18 47  c9 51 92 9a 24 e3 dc d1  |.V..&..G.Q..$...|
000001b0 70 18 25 47 d3 15 09 e4 7f 86 d7 e7 ee 00 04 18 |p.%G............|
000001c0 00 78 87 0f 57 0d 0a 65 6e 64 73 74 72 65 61 6d |.x..W..endstream|
000001d0 0d 65 6e 64 6f 62 6a 0d 73 74 61 72 74 78 72 65 |.endobj.startxre|
000001e0 66 0d 0a 30 0d 0a 25 25 45 4f 46 0d 0a 20 20 20 |f..0..%%EOF.. |
```

</details>

In any case, `.lines()` doesn't support singular `\r` delimiter, and spec says:

> 3.23
> end-of-line marker
> EOL marker
>
> one or two character (3.10) sequence marking the end of a line of text,
> consisting of a CARRIAGE RETURN character (0Dh) or a LINE FEED character (0Ah)
> or a CARRIAGE RETURN followed immediately by a LINE FEED

So... they can be used interchangeably throughout the document in worst case.

I added an iterator that works like `.lines()` but for PDF and handled `\r` as well. This improves spec compliance.

This PR is related to #15.