### PR TITLE
Sets PDF encoding metadata to "WinAnsiEncoding".

### DIFF
--- a/oxidize-pdf-core/src/writer.rs
+++ b/oxidize-pdf-core/src/writer.rs
@@ -121,6 +121,7 @@ impl<W: Write> PdfWriter<W> {
             let mut font_entry = Dictionary::new();
             font_entry.set("Type", Object::Name("Font".to_string()));
             font_entry.set("Subtype", Object::Name("Type1".to_string()));
+            font_entry.set("Encoding", Object::Name("WinAnsiEncoding".to_string()));
             font_entry.set("BaseFont", Object::Name(font_name.to_string()));
             font_dict.set(*font_name, Object::Dictionary(font_entry));
         }


### PR DESCRIPTION
It seems that only the "WinAnsiEncoding" is being used, however no encoding metadata is being set resulting in invisible characters. This is probably just a temporary fix as it hard-codes the encoding metadata.