### PR TITLE
chore: Bump version to 1.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oxidize-pdf"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "bitflags 2.9.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]


### PR DESCRIPTION
Bump version to 1.2.5 for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)