### PR TITLE
Release: fix(text) sanitize control characters (#116)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,29 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Session** | 2026-01-17 - Fix Issue #115 Font Subsetting |
+| **Last Session** | 2026-01-28 - Fix Issue #116 Text Sanitization |
 | **Branch** | develop_santi |
-| **Version** | v1.6.8 (released to crates.io) |
-| **Tests** | 5005 unit + 185 doc tests passing |
+| **Version** | v1.6.9 (released to crates.io) |
+| **Tests** | 5022 unit + 186 doc tests passing |
 | **Coverage** | 70.00% |
 | **Quality Grade** | A (95/100) |
 | **PDF Success Rate** | 99.3% (275/277 failure corpus) |
 | **ISO Requirements** | 310 curated, 100% linked to code (66.8% high verification) |
+
+### Session Summary (2026-01-28) - Fix Issue #116 Text Sanitization
+- **Issue #116 Fixed**: Extracted text no longer contains NUL bytes and control characters
+  - **Bug**: Text extraction returned `\0\u{3}` (NUL+ETX) instead of spaces between words
+  - **Root Cause**: `encoding.rs` converted control bytes (0x00-0x1F) directly to chars without filtering
+  - **Fix**: Added `sanitize_extracted_text()` function in `extraction.rs`
+    - Replaces `\0\u{3}` sequences with space (common word separator pattern)
+    - Replaces standalone `\0` with space
+    - Removes other ASCII control chars (except `\t`, `\n`, `\r`)
+    - Collapses multiple consecutive spaces
+  - **Integration**: Applied to both CMap decode and fallback encoding paths
+  - **TDD Approach**: 14 new tests covering all edge cases
+- **Tests**: 5022 unit + 186 doc tests (14 new sanitization tests)
+- **Files Modified**: `oxidize-pdf-core/src/text/extraction.rs`, `oxidize-pdf-core/src/text/mod.rs`
+- **New Test File**: `oxidize-pdf-core/tests/text_sanitization_test.rs`
 
 ### Session Summary (2026-01-17) - Fix Issue #115 Font Subsetting
 - **Issue #115 Fixed**: Large fonts with few characters now properly subset
@@ -22,7 +37,7 @@
     - Large fonts always subset, regardless of char count
   - **New Constants**: `SUBSETTING_SIZE_THRESHOLD` (100KB), `SUBSETTING_CHAR_THRESHOLD` (10)
   - **TDD Approach**: 9 new tests covering all edge cases
-- **Tests**: 5005 unit + 185 doc tests (9 new subsetting tests)
+- **Tests**: 5008 unit + 185 doc tests (9 new subsetting tests, +3 from pre-commit)
 - **Files Modified**: `oxidize-pdf-core/src/text/fonts/truetype_subsetter.rs`
 
 ### Session Summary (2026-01-10) - Release v1.6.8

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -25,7 +25,9 @@ mod cmap_tests;
 pub mod tesseract_provider;
 
 pub use encoding::TextEncoding;
-pub use extraction::{ExtractedText, ExtractionOptions, TextExtractor, TextFragment};
+pub use extraction::{
+    sanitize_extracted_text, ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
+};
 pub use flow::{TextAlign, TextFlowContext};
 pub use font::{Font, FontEncoding, FontFamily, FontWithEncoding};
 pub use font_manager::{CustomFont, FontDescriptor, FontFlags, FontManager, FontMetrics, FontType};

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -1,0 +1,124 @@
+//! Tests for text sanitization in text extraction
+//!
+//! Issue #116: Extracted text contains NUL bytes (`\0`) and ETX (`\u{3}`)
+//! where spaces should appear.
+//!
+//! These tests follow TDD methodology - written BEFORE implementation.
+
+use oxidize_pdf::text::extraction::sanitize_extracted_text;
+
+#[test]
+fn test_sanitize_nul_etx_sequence() {
+    // Issue #116: The pattern `\0\u{3}` appears between words
+    let input = "a\0\u{3}sergeant\0\u{3}and\0\u{3}two";
+    let expected = "a sergeant and two";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_sanitize_nul_etx_sequence_complex() {
+    // Full example from issue #116
+    let input = "a\0\u{3}sergeant\0\u{3}and\0\u{3}tw o\0\u{3}constables\0\u{3}ignored";
+    let expected = "a sergeant and tw o constables ignored";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_sanitize_single_nul() {
+    // NUL without ETX should also become space
+    let input = "word\0another";
+    let expected = "word another";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_sanitize_multiple_nul() {
+    // Multiple consecutive NULs should collapse to single space
+    let input = "word\0\0\0another";
+    let expected = "word another";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_collapse_multiple_spaces() {
+    // Multiple spaces should collapse to single space
+    let input = "a    b";
+    let expected = "a b";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_preserve_allowed_whitespace() {
+    // Tab, newline, carriage return should be preserved
+    let input = "line1\nline2\ttab\rcarriage";
+    let expected = "line1\nline2\ttab\rcarriage";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_remove_control_characters() {
+    // Control chars other than NUL (which becomes space) should be removed
+    // SOH (0x01), STX (0x02), EOT (0x04), etc.
+    let input = "text\u{1}\u{2}\u{4}more";
+    let expected = "textmore";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_etx_alone_removed() {
+    // ETX (0x03) alone (not preceded by NUL) should be removed
+    let input = "text\u{3}more";
+    let expected = "textmore";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_empty_string() {
+    let input = "";
+    let expected = "";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_only_control_chars() {
+    // String with only control chars should become empty or single space
+    let input = "\0\u{1}\u{2}\u{3}\u{4}";
+    let result = sanitize_extracted_text(input);
+    // After sanitization: NUL->space, others removed, collapse spaces
+    assert!(result.trim().is_empty() || result == " ");
+}
+
+#[test]
+fn test_unicode_preservation() {
+    // Unicode characters should be preserved
+    let input = "中国人\0\u{3}test\0\u{3}日本語";
+    let expected = "中国人 test 日本語";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_no_change_clean_text() {
+    // Clean text without control characters should pass through unchanged
+    let input = "This is normal text with spaces.";
+    let expected = "This is normal text with spaces.";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_mixed_whitespace_and_control() {
+    // Mix of normal spaces, NUL sequences, and control chars
+    let input = "word1 word2\0\u{3}word3\u{1}word4";
+    let expected = "word1 word2 word3word4";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_leading_trailing_control_chars() {
+    // Control chars at start/end
+    let input = "\0\u{3}text\0\u{3}";
+    let result = sanitize_extracted_text(input);
+    // Should have leading/trailing space or be trimmed - implementation decides
+    assert!(result.contains("text"));
+    assert!(!result.contains('\0'));
+    assert!(!result.contains('\u{3}'));
+}


### PR DESCRIPTION
## Summary

Merge develop to main for release preparation.

### Changes included

- **Fix Issue #116**: Text extraction now properly handles NUL bytes and control characters
  - Added `sanitize_extracted_text()` function
  - Replaces `\0\u{3}` (NUL+ETX) sequences with spaces
  - Removes other ASCII control characters (except tab, newline, CR)
  - Collapses multiple consecutive spaces
- Documentation updates

### Files changed

- `oxidize-pdf-core/src/text/extraction.rs`: New sanitization function
- `oxidize-pdf-core/src/text/mod.rs`: Export new function
- `oxidize-pdf-core/tests/text_sanitization_test.rs`: 14 new tests
- `CLAUDE.md`: Session summary

### Test results

- 5,022 unit tests passing
- 186 doc tests passing
- CI passed on Ubuntu, Windows, macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)