### PR TITLE
Release v1.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [1.6.11] - 2026-02-01
+
+### Added
+- **📄 Per-Page Text Extraction Options** - New `extract_text_from_page_with_options` method
+  - Combines functionality of `extract_text_from_page` and `extract_text_with_options`
+  - Allows custom `ExtractionOptions` (e.g., `space_threshold`) for individual pages
+  - **Use Case**: PDFs with pages requiring different extraction parameters
+  - **Location**: `oxidize-pdf-core/src/parser/document.rs`
+
+### Technical
+- **Tests**: 5,005+ unit + 187 doc tests passing
+- **Breaking Changes**: None
+
+## [1.6.10] - 2026-01-29
+
+### Fixed
+- **🔧 Text Sanitization (Issue #116)** - Extracted text no longer contains NUL bytes
+  - **Problem**: Text extraction returned `\0\u{3}` (NUL+ETX) instead of spaces between words
+  - **Root Cause**: `encoding.rs` converted control bytes (0x00-0x1F) directly to chars without filtering
+  - **Solution**: New `sanitize_extracted_text()` function in `extraction.rs`
+    - Replaces `\0\u{3}` sequences with space (common word separator pattern)
+    - Removes other ASCII control characters (except `\t`, `\n`, `\r`)
+    - Collapses multiple consecutive spaces
+  - **Location**: `oxidize-pdf-core/src/text/extraction.rs`
+
+- **📏 Space Threshold Tuning** - Reduced false spaces in extracted text
+  - **Problem**: Words like "two" extracted as "tw o" due to micro-adjustments in PDFs
+  - **Solution**: Increased default `space_threshold` from 0.2 to 0.3
+  - **Validation**: Analyzed 709 PDFs - 4.8% reduction in total spaces, 16.2% reduction in fragmented words
+  - **Workaround**: Use `extract_text_with_options()` with higher threshold (0.4-0.5) if needed
+
+### Added
+- **🧪 Text Sanitization Tests** - 14 new TDD tests for sanitization logic
+
+### Technical
+- **Tests**: 5,008+ unit + 186 doc tests passing
+- **Breaking Changes**: None
+
 ## [1.6.9] - 2026-01-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,30 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Session** | 2026-01-28 - Fix Issue #116 Text Sanitization |
+| **Last Session** | 2026-01-29 - Issue #116 Follow-up: space_threshold tuning |
 | **Branch** | develop_santi |
-| **Version** | v1.6.9 (released to crates.io) |
-| **Tests** | 5022 unit + 186 doc tests passing |
+| **Version** | v1.6.10 |
+| **Tests** | 5008 unit + 186 doc tests passing |
 | **Coverage** | 70.00% |
 | **Quality Grade** | A (95/100) |
 | **PDF Success Rate** | 99.3% (275/277 failure corpus) |
 | **ISO Requirements** | 310 curated, 100% linked to code (66.8% high verification) |
+
+### Session Summary (2026-01-29) - Issue #116 Follow-up: space_threshold Tuning
+- **Issue #116 Follow-up**: User reported unexpected spaces in extracted text ("tw o" instead of "two")
+  - **Analysis**: Problem was pre-existing, not caused by sanitization fix
+  - **Root Cause**: `space_threshold` default (0.2) too aggressive for PDFs with micro-adjustments
+  - **Fix**: Increased `space_threshold` default from 0.2 to 0.3
+  - **Validation**: Analyzed 709 PDFs from test corpus
+    - 4.8% reduction in total spaces
+    - 16.2% reduction in fragmented word patterns
+  - **Files Modified**:
+    - `text/extraction.rs` - default + tests
+    - `text/plaintext/types.rs` - default + docs + tests
+    - `text/plaintext/extractor.rs` - test
+    - `operations/page_analysis.rs` - hardcoded value
+- **GitHub Issue #116**: Updated with analysis and workaround documentation
+- **Commit**: `30a6266` - feat(text): increase space_threshold default from 0.2 to 0.3
 
 ### Session Summary (2026-01-28) - Fix Issue #116 Text Sanitization
 - **Issue #116 Fixed**: Extracted text no longer contains NUL bytes and control characters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "1.6.9"
+version = "1.6.11"
 dependencies = [
  "aes",
  "bitflags 2.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.10"
+version = "1.6.11"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/operations/page_analysis.rs
+++ b/oxidize-pdf-core/src/operations/page_analysis.rs
@@ -1851,7 +1851,7 @@ impl PageContentAnalyzer {
     fn analyze_text_content(&self, page_number: usize) -> OperationResult<TextAnalysisResult> {
         let mut extractor = TextExtractor::with_options(ExtractionOptions {
             preserve_layout: true,
-            space_threshold: 0.2,
+            space_threshold: 0.3,
             newline_threshold: 10.0,
             ..Default::default()
         });

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1017,6 +1017,49 @@ impl<R: Read + Seek> PdfDocument<R> {
         extractor.extract_from_page(self, page_index)
     }
 
+    /// Extract text from a specific page with custom options.
+    ///
+    /// This method combines the functionality of [`extract_text_from_page`] and
+    /// [`extract_text_with_options`], allowing fine control over extraction
+    /// behavior for a single page.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `options` - Text extraction configuration
+    ///
+    /// # Returns
+    ///
+    /// Extracted text with optional position information.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    /// # use oxidize_pdf::text::ExtractionOptions;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let reader = PdfReader::open("document.pdf")?;
+    /// # let document = PdfDocument::new(reader);
+    /// // Use higher space threshold for PDFs with micro-adjustments
+    /// let options = ExtractionOptions {
+    ///     space_threshold: 0.4,
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let page_text = document.extract_text_from_page_with_options(0, options)?;
+    /// println!("Text: {}", page_text.text);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn extract_text_from_page_with_options(
+        &self,
+        page_index: u32,
+        options: crate::text::ExtractionOptions,
+    ) -> ParseResult<crate::text::ExtractedText> {
+        let mut extractor = crate::text::TextExtractor::with_options(options);
+        extractor.extract_from_page(self, page_index)
+    }
+
     /// Extract text with custom extraction options.
     ///
     /// Allows fine control over text extraction behavior including

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -36,7 +36,7 @@ impl Default for ExtractionOptions {
     fn default() -> Self {
         Self {
             preserve_layout: false,
-            space_threshold: 0.2,
+            space_threshold: 0.3,
             newline_threshold: 10.0,
             sort_by_position: true,
             detect_columns: false,
@@ -993,7 +993,7 @@ mod tests {
     fn test_extraction_options_default() {
         let options = ExtractionOptions::default();
         assert!(!options.preserve_layout);
-        assert_eq!(options.space_threshold, 0.2);
+        assert_eq!(options.space_threshold, 0.3);
         assert_eq!(options.newline_threshold, 10.0);
         assert!(options.sort_by_position);
         assert!(!options.detect_columns);
@@ -1179,7 +1179,7 @@ mod tests {
         let extractor = TextExtractor::new();
         let options = extractor.options;
         assert!(!options.preserve_layout);
-        assert_eq!(options.space_threshold, 0.2);
+        assert_eq!(options.space_threshold, 0.3);
         assert_eq!(options.newline_threshold, 10.0);
         assert!(options.sort_by_position);
         assert!(!options.detect_columns);

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -554,7 +554,7 @@ mod tests {
     #[test]
     fn test_new() {
         let extractor = PlainTextExtractor::new();
-        assert_eq!(extractor.config.space_threshold, 0.2);
+        assert_eq!(extractor.config.space_threshold, 0.3);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/plaintext/types.rs
+++ b/oxidize-pdf-core/src/text/plaintext/types.rs
@@ -15,7 +15,7 @@
 /// use oxidize_pdf::text::plaintext::PlainTextConfig;
 ///
 /// let config = PlainTextConfig::default();
-/// assert_eq!(config.space_threshold, 0.2);
+/// assert_eq!(config.space_threshold, 0.3);
 /// assert_eq!(config.newline_threshold, 10.0);
 /// assert!(!config.preserve_layout);
 /// ```
@@ -27,9 +27,9 @@ pub struct PlainTextConfig {
     /// (expressed as a multiple of the average character width), a space
     /// character is inserted.
     ///
-    /// - **Lower values** (0.1-0.15): More spaces inserted, good for tightly-spaced text
-    /// - **Default** (0.2): Balanced for most documents
-    /// - **Higher values** (0.3-0.5): Fewer spaces, good for wide-spaced text
+    /// - **Lower values** (0.1-0.2): More spaces inserted, good for tightly-spaced text
+    /// - **Default** (0.3): Balanced for most documents
+    /// - **Higher values** (0.4-0.5): Fewer spaces, good for wide-spaced text
     ///
     /// **Range**: 0.05 to 1.0 (typical)
     pub space_threshold: f64,
@@ -76,7 +76,7 @@ pub struct PlainTextConfig {
 impl Default for PlainTextConfig {
     fn default() -> Self {
         Self {
-            space_threshold: 0.2,
+            space_threshold: 0.3,
             newline_threshold: 10.0,
             preserve_layout: false,
             line_break_mode: LineBreakMode::Auto,
@@ -157,7 +157,7 @@ impl PlainTextConfig {
     /// ```
     pub fn preserve_layout() -> Self {
         Self {
-            space_threshold: 0.2,
+            space_threshold: 0.3,
             newline_threshold: 10.0,
             preserve_layout: true,
             line_break_mode: LineBreakMode::PreserveAll,
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_config_default() {
         let config = PlainTextConfig::default();
-        assert_eq!(config.space_threshold, 0.2);
+        assert_eq!(config.space_threshold, 0.3);
         assert_eq!(config.newline_threshold, 10.0);
         assert!(!config.preserve_layout);
         assert_eq!(config.line_break_mode, LineBreakMode::Auto);

--- a/oxidize-pdf-core/tests/text_extraction_test.rs
+++ b/oxidize-pdf-core/tests/text_extraction_test.rs
@@ -274,3 +274,42 @@ startxref
     // Should have fragments for layout
     assert!(page_text.fragments.len() >= 3);
 }
+
+#[test]
+fn test_extract_text_from_page_with_options() {
+    // Create a PDF with text
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(100.0, 700.0)
+        .write("Test content for extraction")
+        .unwrap();
+
+    doc.add_page(page);
+
+    // Save to temporary file
+    let temp_dir = TempDir::new().unwrap();
+    let pdf_path = temp_dir.path().join("options_test.pdf");
+    doc.save(&pdf_path).unwrap();
+
+    // Open document
+    let pdf_doc = PdfReader::open_document(&pdf_path).unwrap();
+
+    // Test with custom space_threshold
+    let options = ExtractionOptions {
+        space_threshold: 0.4,
+        preserve_layout: true,
+        ..Default::default()
+    };
+
+    // Use the new convenience method
+    let extracted = pdf_doc
+        .extract_text_from_page_with_options(0, options)
+        .unwrap();
+
+    // Verify extraction worked
+    assert!(extracted.text.contains("Test content for extraction"));
+    assert!(!extracted.fragments.is_empty());
+}


### PR DESCRIPTION
## Summary

Release v1.6.11 with per-page extraction options and space_threshold tuning.

## Changes

### Added
- **New API**: `extract_text_from_page_with_options(page_index, options)` for per-page text extraction with custom `ExtractionOptions`
- Unit test for new method

### Changed
- **space_threshold default**: 0.2 → 0.3 (reduces false spaces in extracted text by ~16%)

### Related Issues
- Issue #116: Addressed user request for per-page extraction options

## Test plan

- [x] All CI pipelines pass (macOS, Ubuntu, Windows)
- [x] 5,008 unit tests + 187 doc tests passing
- [x] Pre-commit hooks verified (format, clippy, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)