### PR TITLE
feat(rag): RagChunk API — one-liner RAG pipeline with full metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/README.md
+++ b/README.md
@@ -111,47 +111,49 @@ fn main() -> Result<()> {
 }
 ```
 
-### AI/RAG Document Chunking (v1.3.0+)
+### RAG Pipeline (v2.2.0+)
+
+Structure-aware chunking with full metadata for vector store ingestion. Each `RagChunk`
+carries page numbers, bounding boxes, element types, heading context, and token estimates.
 
 ```rust
-use oxidize_pdf::ai::DocumentChunker;
-use oxidize_pdf::parser::{PdfReader, PdfDocument};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
 use oxidize_pdf::Result;
 
 fn main() -> Result<()> {
-    // Load and parse PDF
-    let reader = PdfReader::open("document.pdf")?;
-    let pdf_doc = PdfDocument::new(reader);
-    let text_pages = pdf_doc.extract_text()?;
+    let doc = PdfDocument::open("document.pdf")?;
 
-    // Prepare page texts with page numbers
-    let page_texts: Vec<(usize, String)> = text_pages
-        .iter()
-        .enumerate()
-        .map(|(idx, page)| (idx + 1, page.text.clone()))
-        .collect();
+    // One-liner: default config (512 tokens, structure-aware merging)
+    let chunks = doc.rag_chunks()?;
 
-    // Create chunker: 512 tokens per chunk, 50 tokens overlap
-    let chunker = DocumentChunker::new(512, 50);
-    let chunks = chunker.chunk_text_with_pages(&page_texts)?;
+    for chunk in &chunks {
+        println!("Chunk {}: pages {:?}, ~{} tokens",
+            chunk.chunk_index, chunk.page_numbers, chunk.token_estimate);
 
-    // Process chunks for RAG pipeline
-    for chunk in chunks {
-        println!("Chunk {}: {} tokens", chunk.id, chunk.tokens);
-        println!("  Pages: {:?}", chunk.page_numbers);
-        println!("  Position: chars {}-{}",
-            chunk.metadata.position.start_char,
-            chunk.metadata.position.end_char);
-        println!("  Sentence boundary: {}",
-            chunk.metadata.sentence_boundary_respected);
-
-        // Send to embedding API, store in vector DB, etc.
-        // let embedding = openai.embed(&chunk.content)?;
-        // vector_db.insert(chunk.id, embedding, chunk.content)?;
+        // chunk.full_text — heading context + content (use for embeddings)
+        // chunk.text      — content only (use for display)
+        // chunk.element_types — ["title", "paragraph", "table", ...]
+        // chunk.bounding_boxes — spatial position on page
     }
 
     Ok(())
 }
+```
+
+Custom configuration and JSON output:
+
+```rust
+use oxidize_pdf::pipeline::HybridChunkConfig;
+
+// Smaller chunks for more precise retrieval
+let config = HybridChunkConfig {
+    max_tokens: 256,
+    ..HybridChunkConfig::default()
+};
+let chunks = doc.rag_chunks_with(config)?;
+
+// JSON output ready for vector store ingestion (requires `semantic` feature)
+// let json = doc.rag_chunks_json()?;
 ```
 
 ### Invoice Data Extraction (v1.6.2+)

--- a/oxidize-pdf-core/examples/rag_pipeline.rs
+++ b/oxidize-pdf-core/examples/rag_pipeline.rs
@@ -1,0 +1,54 @@
+//! RAG Pipeline Example
+//!
+//! Demonstrates the one-liner RAG API:
+//!   open PDF → rag_chunks() → iterate chunks → print metadata
+//!
+//! Run with:
+//!   cargo run --example rag_pipeline -- path/to/document.pdf
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::HybridChunkConfig;
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let path = args.get(1).map(|s| s.as_str()).unwrap_or("document.pdf");
+
+    let reader = PdfReader::open(path)?;
+    let doc = PdfDocument::new(reader);
+
+    // One-liner: default config (512 tokens, AnyInlineContent merge)
+    let chunks = doc.rag_chunks()?;
+
+    println!("Produced {} RAG chunks\n", chunks.len());
+
+    for chunk in &chunks {
+        println!("--- Chunk {} ---", chunk.chunk_index);
+        if let Some(ref heading) = chunk.heading_context {
+            println!("  Heading:  {}", heading);
+        }
+        println!("  Pages:    {:?}", chunk.page_numbers);
+        println!("  Elements: {}", chunk.element_types.join(", "));
+        println!("  Tokens:   ~{}", chunk.token_estimate);
+        if chunk.is_oversized {
+            println!("  ⚠ oversized chunk");
+        }
+        let preview: String = chunk.text.chars().take(80).collect();
+        println!("  Preview:  {}", preview);
+        println!();
+    }
+
+    // Custom config: 256 tokens
+    println!("=== Custom config (256 tokens) ===");
+    let config = HybridChunkConfig {
+        max_tokens: 256,
+        ..HybridChunkConfig::default()
+    };
+    let small_chunks = doc.rag_chunks_with(config)?;
+    println!(
+        "Produced {} chunks with 256-token limit\n",
+        small_chunks.len()
+    );
+
+    Ok(())
+}

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1338,9 +1338,67 @@ impl<R: Read + Seek> PdfDocument<R> {
         crate::ai::export_to_json(self)
     }
 
+    /// Extract and chunk the document into RAG-ready chunks with full metadata.
+    ///
+    /// Uses default [`HybridChunkConfig`](crate::pipeline::HybridChunkConfig)
+    /// (512 tokens, `AnyInlineContent` merge policy). Returns serializable
+    /// [`RagChunk`](crate::pipeline::RagChunk)s with page numbers, bounding boxes,
+    /// element types, and heading context — everything a vector store needs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    ///
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// let chunks = doc.rag_chunks()?;
+    /// for chunk in &chunks {
+    ///     println!("Chunk {}: pages {:?}, ~{} tokens",
+    ///         chunk.chunk_index, chunk.page_numbers, chunk.token_estimate);
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn rag_chunks(&self) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        self.rag_chunks_with(crate::pipeline::HybridChunkConfig::default())
+    }
+
+    /// Extract and chunk the document with a custom [`HybridChunkConfig`](crate::pipeline::HybridChunkConfig).
+    pub fn rag_chunks_with(
+        &self,
+        config: crate::pipeline::HybridChunkConfig,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let elements = self.partition()?;
+        let chunker = crate::pipeline::HybridChunker::new(config);
+        let hybrid_chunks = chunker.chunk(&elements);
+        let rag_chunks = hybrid_chunks
+            .iter()
+            .enumerate()
+            .map(|(idx, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(idx, hc))
+            .collect();
+        Ok(rag_chunks)
+    }
+
+    /// Extract chunks as a JSON string ready for vector store ingestion.
+    ///
+    /// Requires the `semantic` feature. Serializes [`Vec<RagChunk>`](crate::pipeline::RagChunk)
+    /// as a JSON array.
+    #[cfg(feature = "semantic")]
+    pub fn rag_chunks_json(&self) -> ParseResult<String> {
+        let chunks = self.rag_chunks()?;
+        serde_json::to_string(&chunks).map_err(|e| ParseError::SyntaxError {
+            position: 0,
+            message: e.to_string(),
+        })
+    }
+
     /// Split the document text into chunks of approximately `target_tokens` size.
     ///
     /// Uses a default overlap of 10% of the target token count.
+    #[deprecated(
+        since = "2.2.0",
+        note = "Use rag_chunks() for structure-aware RAG chunking"
+    )]
+    #[allow(deprecated)]
     pub fn chunk(
         &self,
         target_tokens: usize,
@@ -1350,6 +1408,10 @@ impl<R: Read + Seek> PdfDocument<R> {
     }
 
     /// Split the document text into chunks with explicit size and overlap control.
+    #[deprecated(
+        since = "2.2.0",
+        note = "Use rag_chunks_with() for structure-aware RAG chunking"
+    )]
     pub fn chunk_with(
         &self,
         target_tokens: usize,

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -4,6 +4,7 @@ pub mod graph;
 pub mod hybrid_chunking;
 pub mod partition;
 pub mod profile;
+pub mod rag;
 pub mod reading_order;
 pub mod semantic_chunking;
 
@@ -16,5 +17,6 @@ pub use graph::ElementGraph;
 pub use hybrid_chunking::{HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy};
 pub use partition::{PartitionConfig, Partitioner, ReadingOrderStrategy};
 pub use profile::ExtractionProfile;
+pub use rag::RagChunk;
 pub use reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker};

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -1,0 +1,95 @@
+use std::collections::HashSet;
+
+use crate::pipeline::element::Element;
+use crate::pipeline::hybrid_chunking::HybridChunk;
+use crate::pipeline::ElementBBox;
+
+#[cfg(feature = "semantic")]
+use serde::{Deserialize, Serialize};
+
+/// A RAG-ready chunk with full metadata for vector store ingestion.
+///
+/// Each `RagChunk` carries everything a vector store needs: text for embedding,
+/// heading context for retrieval, and structural metadata (pages, bounding boxes,
+/// element types) for citation and filtering.
+///
+/// Construct via [`RagChunk::from_hybrid_chunk`] or [`PdfDocument::rag_chunks()`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct RagChunk {
+    /// Sequential index of this chunk in the document (0-based).
+    pub chunk_index: usize,
+    /// Chunk text content (elements joined by newlines).
+    pub text: String,
+    /// Text with heading context prepended — use this for embedding generation.
+    pub full_text: String,
+    /// Page numbers where this chunk's elements appear (deduplicated, ordered).
+    pub page_numbers: Vec<u32>,
+    /// Bounding boxes of each element in the chunk.
+    pub bounding_boxes: Vec<ElementBBox>,
+    /// Type names of each element (e.g. "title", "paragraph", "table").
+    pub element_types: Vec<String>,
+    /// Heading context inherited from the nearest parent heading.
+    pub heading_context: Option<String>,
+    /// Approximate token count (word-count proxy).
+    pub token_estimate: usize,
+    /// Whether the chunk exceeds the configured `max_tokens`.
+    pub is_oversized: bool,
+}
+
+impl RagChunk {
+    /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its elements.
+    pub fn from_hybrid_chunk(chunk_index: usize, chunk: &HybridChunk) -> Self {
+        let elements = chunk.elements();
+        let page_numbers = collect_pages(elements);
+        let bounding_boxes = elements.iter().map(|e| *e.bbox()).collect();
+        let element_types = elements.iter().map(element_type_name).collect();
+
+        Self {
+            chunk_index,
+            text: chunk.text(),
+            full_text: chunk.full_text(),
+            page_numbers,
+            bounding_boxes,
+            element_types,
+            heading_context: chunk.heading_context.clone(),
+            token_estimate: chunk.token_estimate(),
+            is_oversized: chunk.is_oversized(),
+        }
+    }
+
+    /// Serialize this chunk to a JSON string (requires `semantic` feature).
+    #[cfg(feature = "semantic")]
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+/// Collect unique page numbers from elements, preserving first-occurrence order.
+fn collect_pages(elements: &[Element]) -> Vec<u32> {
+    let mut seen = HashSet::new();
+    let mut pages = Vec::new();
+    for e in elements {
+        let p = e.page();
+        if seen.insert(p) {
+            pages.push(p);
+        }
+    }
+    pages
+}
+
+/// Map an `Element` variant to its snake_case type name.
+fn element_type_name(element: &Element) -> String {
+    match element {
+        Element::Title(_) => "title",
+        Element::Paragraph(_) => "paragraph",
+        Element::Table(_) => "table",
+        Element::Header(_) => "header",
+        Element::Footer(_) => "footer",
+        Element::ListItem(_) => "list_item",
+        Element::Image(_) => "image",
+        Element::CodeBlock(_) => "code_block",
+        Element::KeyValue(_) => "key_value",
+    }
+    .to_string()
+}

--- a/oxidize-pdf-core/tests/pipeline_integration_test.rs
+++ b/oxidize-pdf-core/tests/pipeline_integration_test.rs
@@ -109,6 +109,7 @@ fn test_vibecoding_three_lines() {
     // The "golden path" — minimal code to process a PDF
     let doc = PdfDocument::open(fixture("Cold_Email_Hacks.pdf")).unwrap();
     let markdown = doc.to_markdown().unwrap();
+    #[allow(deprecated)]
     let chunks = doc.chunk(512).unwrap();
 
     assert!(!markdown.is_empty());

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -1,0 +1,287 @@
+use oxidize_pdf::pipeline::{
+    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+    MergePolicy, RagChunk,
+};
+
+fn make_para(text: &str, page: u32, x: f64, y: f64) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(x, y, 400.0, 12.0),
+            ..Default::default()
+        },
+    })
+}
+
+#[test]
+fn test_rag_chunk_has_required_fields() {
+    let chunk = RagChunk {
+        chunk_index: 0,
+        text: "Hello world.".to_string(),
+        full_text: "Introduction\n\nHello world.".to_string(),
+        page_numbers: vec![0],
+        bounding_boxes: vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
+        element_types: vec!["paragraph".to_string()],
+        heading_context: Some("Introduction".to_string()),
+        token_estimate: 2,
+        is_oversized: false,
+    };
+
+    assert_eq!(chunk.chunk_index, 0);
+    assert_eq!(chunk.text, "Hello world.");
+    assert_eq!(chunk.full_text, "Introduction\n\nHello world.");
+    assert_eq!(chunk.page_numbers, vec![0u32]);
+    assert_eq!(chunk.bounding_boxes.len(), 1);
+    assert_eq!(chunk.element_types, vec!["paragraph"]);
+    assert_eq!(chunk.heading_context.as_deref(), Some("Introduction"));
+    assert_eq!(chunk.token_estimate, 2);
+    assert!(!chunk.is_oversized);
+}
+
+// ── Cycle 1.2: from_hybrid_chunk ──
+
+fn para_at(text: &str, page: u32, y: f64) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(50.0, y, 400.0, 12.0),
+            parent_heading: Some("Section".to_string()),
+            ..Default::default()
+        },
+    })
+}
+
+#[test]
+fn test_rag_chunk_from_hybrid_chunk() {
+    let elements = vec![
+        para_at("First sentence.", 2, 700.0),
+        para_at("Second sentence.", 2, 680.0),
+    ];
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let hybrid_chunks = chunker.chunk(&elements);
+    assert_eq!(hybrid_chunks.len(), 1);
+
+    let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
+
+    assert_eq!(rag.chunk_index, 0);
+    assert!(rag.text.contains("First sentence."));
+    assert!(rag.text.contains("Second sentence."));
+    assert_eq!(rag.page_numbers, vec![2u32]);
+    assert_eq!(rag.bounding_boxes.len(), 2);
+    assert!(rag.element_types.iter().all(|t| t == "paragraph"));
+    assert_eq!(rag.heading_context.as_deref(), Some("Section"));
+    assert!(rag.token_estimate > 0);
+    assert!(!rag.is_oversized);
+    assert!(rag.full_text.contains("Section"));
+    assert!(rag.full_text.contains("First sentence."));
+}
+
+// ── Cycle 1.3: multi-page deduplication ──
+
+#[test]
+fn test_rag_chunk_collects_pages_from_multi_page_elements() {
+    let elements = vec![
+        make_para("Page zero.", 0, 50.0, 700.0),
+        make_para("Page one first.", 1, 50.0, 700.0),
+        make_para("Page one second.", 1, 50.0, 680.0),
+    ];
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+        propagate_headings: false,
+    });
+    let hybrid_chunks = chunker.chunk(&elements);
+    let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
+
+    assert_eq!(rag.page_numbers, vec![0u32, 1u32]);
+    assert_eq!(rag.bounding_boxes.len(), 3);
+}
+
+// ── Cycle 2.2: JSON serialization (feature semantic) ──
+
+#[cfg(feature = "semantic")]
+#[test]
+fn test_rag_chunk_serializes_to_json() {
+    let chunk = RagChunk {
+        chunk_index: 3,
+        text: "Some text content.".to_string(),
+        full_text: "Heading\n\nSome text content.".to_string(),
+        page_numbers: vec![0, 1],
+        bounding_boxes: vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
+        element_types: vec!["paragraph".to_string()],
+        heading_context: Some("Heading".to_string()),
+        token_estimate: 3,
+        is_oversized: false,
+    };
+
+    let json = serde_json::to_string(&chunk).expect("serialization must succeed");
+
+    assert!(json.contains("\"chunk_index\":3"));
+    assert!(json.contains("\"text\":"));
+    assert!(json.contains("\"full_text\":"));
+    assert!(json.contains("\"page_numbers\":[0,1]"));
+    assert!(json.contains("\"heading_context\":\"Heading\""));
+    assert!(json.contains("\"token_estimate\":3"));
+    assert!(json.contains("\"is_oversized\":false"));
+}
+
+#[cfg(feature = "semantic")]
+#[test]
+fn test_rag_chunk_to_json_method() {
+    let chunk = RagChunk {
+        chunk_index: 0,
+        text: "Test.".to_string(),
+        full_text: "Test.".to_string(),
+        page_numbers: vec![0],
+        bounding_boxes: vec![],
+        element_types: vec!["paragraph".to_string()],
+        heading_context: None,
+        token_estimate: 1,
+        is_oversized: false,
+    };
+
+    let json = chunk.to_json().expect("to_json must succeed");
+    assert!(json.starts_with('{'));
+    assert!(json.contains("\"chunk_index\":0"));
+}
+
+// ── Cycle 3.2: chunk_index is sequential ──
+
+#[test]
+fn test_rag_chunks_indices_are_sequential() {
+    let elements: Vec<Element> = (0..5)
+        .map(|i| {
+            Element::Title(ElementData {
+                text: format!("Section {}", i),
+                metadata: ElementMetadata {
+                    page: i as u32,
+                    ..Default::default()
+                },
+            })
+        })
+        .collect();
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 5,
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let hybrid_chunks = chunker.chunk(&elements);
+    let rag_chunks: Vec<RagChunk> = hybrid_chunks
+        .iter()
+        .enumerate()
+        .map(|(idx, hc)| RagChunk::from_hybrid_chunk(idx, hc))
+        .collect();
+
+    for (expected_idx, chunk) in rag_chunks.iter().enumerate() {
+        assert_eq!(chunk.chunk_index, expected_idx);
+    }
+}
+
+// ── Cycle 3.3: custom config produces different chunk counts ──
+
+#[test]
+fn test_rag_chunks_with_custom_config_produces_more_chunks() {
+    let elements: Vec<Element> = (0..10)
+        .map(|i| {
+            Element::Paragraph(ElementData {
+                text: format!("word word word word word word word word word {}", i),
+                metadata: ElementMetadata {
+                    page: 0,
+                    ..Default::default()
+                },
+            })
+        })
+        .collect();
+
+    let small_config = HybridChunkConfig {
+        max_tokens: 15,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+    let large_config = HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+
+    let small_chunks: Vec<RagChunk> = HybridChunker::new(small_config)
+        .chunk(&elements)
+        .iter()
+        .enumerate()
+        .map(|(idx, hc)| RagChunk::from_hybrid_chunk(idx, hc))
+        .collect();
+
+    let large_chunks: Vec<RagChunk> = HybridChunker::new(large_config)
+        .chunk(&elements)
+        .iter()
+        .enumerate()
+        .map(|(idx, hc)| RagChunk::from_hybrid_chunk(idx, hc))
+        .collect();
+
+    assert!(
+        small_chunks.len() > large_chunks.len(),
+        "smaller max_tokens must produce more chunks: small={}, large={}",
+        small_chunks.len(),
+        large_chunks.len()
+    );
+}
+
+// ── Cycle 4.1: Vec<RagChunk> serializes as JSON array ──
+
+#[cfg(feature = "semantic")]
+#[test]
+fn test_rag_chunks_json_serializes_vec_as_array() {
+    let elements = vec![
+        Element::Paragraph(ElementData {
+            text: "First chunk.".to_string(),
+            metadata: ElementMetadata {
+                page: 0,
+                ..Default::default()
+            },
+        }),
+        Element::Title(ElementData {
+            text: "Section Two".to_string(),
+            metadata: ElementMetadata {
+                page: 1,
+                ..Default::default()
+            },
+        }),
+    ];
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 5,
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+
+    let rag_chunks: Vec<RagChunk> = chunker
+        .chunk(&elements)
+        .iter()
+        .enumerate()
+        .map(|(idx, hc)| RagChunk::from_hybrid_chunk(idx, hc))
+        .collect();
+
+    let json = serde_json::to_string(&rag_chunks).expect("must serialize");
+    assert!(json.starts_with('['));
+    assert!(json.ends_with(']'));
+    assert!(json.contains("\"chunk_index\""));
+}

--- a/oxidize-pdf-core/tests/rag_pipeline_test.rs
+++ b/oxidize-pdf-core/tests/rag_pipeline_test.rs
@@ -1,0 +1,87 @@
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::RagChunk;
+use std::path::Path;
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[test]
+fn test_rag_chunks_returns_vec() {
+    let path = fixture_path("simple.pdf");
+    if !path.exists() {
+        return;
+    }
+    let reader = PdfReader::open(&path).expect("must open PDF");
+    let doc = PdfDocument::new(reader);
+
+    let chunks: Vec<RagChunk> = doc.rag_chunks().expect("rag_chunks must succeed");
+
+    for chunk in &chunks {
+        assert!(
+            chunk.chunk_index < chunks.len(),
+            "chunk_index must be in range"
+        );
+        if !chunk.text.is_empty() {
+            assert!(
+                !chunk.page_numbers.is_empty(),
+                "non-empty chunk must have page numbers"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_rag_chunks_with_custom_config() {
+    let path = fixture_path("simple.pdf");
+    if !path.exists() {
+        return;
+    }
+    let reader = PdfReader::open(&path).expect("must open PDF");
+    let doc = PdfDocument::new(reader);
+
+    let config = oxidize_pdf::pipeline::HybridChunkConfig {
+        max_tokens: 32,
+        ..Default::default()
+    };
+    let chunks = doc.rag_chunks_with(config).expect("must succeed");
+
+    // With smaller token limit, should have at least as many chunks as default
+    let default_chunks = doc.rag_chunks().expect("must succeed");
+    assert!(
+        chunks.len() >= default_chunks.len(),
+        "smaller max_tokens must produce >= chunks"
+    );
+}
+
+#[cfg(feature = "semantic")]
+#[test]
+fn test_rag_chunks_json_returns_valid_json() {
+    let path = fixture_path("simple.pdf");
+    if !path.exists() {
+        return;
+    }
+    let reader = PdfReader::open(&path).expect("must open PDF");
+    let doc = PdfDocument::new(reader);
+
+    let json = doc.rag_chunks_json().expect("must produce JSON");
+    assert!(json.starts_with('['));
+    assert!(json.ends_with(']'));
+}
+
+// Test with deprecated methods — backward compatibility
+#[allow(deprecated)]
+#[test]
+fn test_deprecated_chunk_methods_still_work() {
+    let path = fixture_path("simple.pdf");
+    if !path.exists() {
+        return;
+    }
+    let reader = PdfReader::open(&path).expect("must open");
+    let doc = PdfDocument::new(reader);
+    let result = doc.chunk(512);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary
- `RagChunk` struct with serializable metadata: page numbers, bounding boxes, element types, heading context, token estimates
- `PdfDocument::rag_chunks()` — one-liner default RAG pipeline (512 tokens)
- `PdfDocument::rag_chunks_with(config)` — custom `HybridChunkConfig`
- `PdfDocument::rag_chunks_json()` — JSON array for vector store ingestion (`semantic` feature)
- `RagChunk::from_hybrid_chunk()` — canonical constructor from `HybridChunk`
- Deprecate `chunk()`/`chunk_with()` in favor of `rag_chunks()`
- Example `rag_pipeline.rs` + README updated with RAG section

## Test plan
- [x] 8 unit tests in `rag_chunk_test.rs` (struct, from_hybrid_chunk, pages, serialization)
- [x] 4 integration tests in `rag_pipeline_test.rs` (PdfDocument facade, JSON, deprecated compat)
- [x] 7,990 workspace tests passing, 0 failed
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)