### PR TITLE
fix(rag): quality review — error semantics, allocations, docs, page ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/oxidize-pdf-core/examples/rag_pipeline.rs
+++ b/oxidize-pdf-core/examples/rag_pipeline.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  Elements: {}", chunk.element_types.join(", "));
         println!("  Tokens:   ~{}", chunk.token_estimate);
         if chunk.is_oversized {
-            println!("  ⚠ oversized chunk");
+            println!("  [!] oversized chunk");
         }
         let preview: String = chunk.text.chars().take(80).collect();
         println!("  Preview:  {}", preview);

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1362,7 +1362,27 @@ impl<R: Read + Seek> PdfDocument<R> {
         self.rag_chunks_with(crate::pipeline::HybridChunkConfig::default())
     }
 
-    /// Extract and chunk the document with a custom [`HybridChunkConfig`](crate::pipeline::HybridChunkConfig).
+    /// Extract and chunk the document with a custom chunking configuration.
+    ///
+    /// Use this when the default 512-token limit is too large or too small for your
+    /// vector store or embedding model. All other metadata (pages, bounding boxes,
+    /// element types, heading context) is identical to [`rag_chunks()`](Self::rag_chunks).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    /// use oxidize_pdf::pipeline::HybridChunkConfig;
+    ///
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// let config = HybridChunkConfig {
+    ///     max_tokens: 256,
+    ///     ..HybridChunkConfig::default()
+    /// };
+    /// let chunks = doc.rag_chunks_with(config)?;
+    /// println!("Got {} chunks at 256-token limit", chunks.len());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn rag_chunks_with(
         &self,
         config: crate::pipeline::HybridChunkConfig,
@@ -1385,10 +1405,7 @@ impl<R: Read + Seek> PdfDocument<R> {
     #[cfg(feature = "semantic")]
     pub fn rag_chunks_json(&self) -> ParseResult<String> {
         let chunks = self.rag_chunks()?;
-        serde_json::to_string(&chunks).map_err(|e| ParseError::SyntaxError {
-            position: 0,
-            message: e.to_string(),
-        })
+        serde_json::to_string(&chunks).map_err(|e| ParseError::SerializationError(e.to_string()))
     }
 
     /// Split the document text into chunks of approximately `target_tokens` size.

--- a/oxidize-pdf-core/src/parser/mod.rs
+++ b/oxidize-pdf-core/src/parser/mod.rs
@@ -477,6 +477,10 @@ pub enum ParseError {
     /// Unexpected character in PDF content
     #[error("Unexpected character: {character}")]
     UnexpectedCharacter { character: String },
+
+    /// Serialization error (e.g. JSON serialization of RAG chunks)
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
 }
 
 impl From<ParseError> for OxidizePdfError {

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -23,7 +23,7 @@ pub struct RagChunk {
     pub text: String,
     /// Text with heading context prepended — use this for embedding generation.
     pub full_text: String,
-    /// Page numbers where this chunk's elements appear (deduplicated, ordered).
+    /// Page numbers where this chunk's elements appear (deduplicated, sorted numerically).
     pub page_numbers: Vec<u32>,
     /// Bounding boxes of each element in the chunk.
     pub bounding_boxes: Vec<ElementBBox>,
@@ -32,6 +32,12 @@ pub struct RagChunk {
     /// Heading context inherited from the nearest parent heading.
     pub heading_context: Option<String>,
     /// Approximate token count (word-count proxy).
+    ///
+    /// Computed as the number of whitespace-separated words. LLM subword
+    /// tokenizers (BPE/WordPiece) typically produce 1.3–1.7x more tokens
+    /// than the raw word count. Size your chunk budget accordingly: a
+    /// `max_tokens: 512` setting corresponds to roughly 300–390 actual
+    /// subword tokens for typical English prose.
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,
@@ -43,7 +49,10 @@ impl RagChunk {
         let elements = chunk.elements();
         let page_numbers = collect_pages(elements);
         let bounding_boxes = elements.iter().map(|e| *e.bbox()).collect();
-        let element_types = elements.iter().map(element_type_name).collect();
+        let element_types: Vec<String> = elements
+            .iter()
+            .map(|e| element_type_name(e).to_string())
+            .collect();
 
         Self {
             chunk_index,
@@ -65,7 +74,7 @@ impl RagChunk {
     }
 }
 
-/// Collect unique page numbers from elements, preserving first-occurrence order.
+/// Collect unique page numbers from elements, deduplicated and sorted numerically.
 fn collect_pages(elements: &[Element]) -> Vec<u32> {
     let mut seen = HashSet::new();
     let mut pages = Vec::new();
@@ -75,11 +84,12 @@ fn collect_pages(elements: &[Element]) -> Vec<u32> {
             pages.push(p);
         }
     }
+    pages.sort_unstable();
     pages
 }
 
 /// Map an `Element` variant to its snake_case type name.
-fn element_type_name(element: &Element) -> String {
+fn element_type_name(element: &Element) -> &'static str {
     match element {
         Element::Title(_) => "title",
         Element::Paragraph(_) => "paragraph",
@@ -91,5 +101,4 @@ fn element_type_name(element: &Element) -> String {
         Element::CodeBlock(_) => "code_block",
         Element::KeyValue(_) => "key_value",
     }
-    .to_string()
 }

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -285,3 +285,125 @@ fn test_rag_chunks_json_serializes_vec_as_array() {
     assert!(json.ends_with(']'));
     assert!(json.contains("\"chunk_index\""));
 }
+
+// ── page_numbers sorted numerically ──
+
+#[test]
+fn test_rag_chunk_page_numbers_are_sorted() {
+    let elements = vec![
+        make_para("Third page.", 3, 50.0, 700.0),
+        make_para("First page.", 1, 50.0, 700.0),
+        make_para("Second page.", 2, 50.0, 700.0),
+    ];
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+        propagate_headings: false,
+    });
+    let hybrid_chunks = chunker.chunk(&elements);
+    let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
+
+    assert_eq!(
+        rag.page_numbers,
+        vec![1u32, 2u32, 3u32],
+        "page_numbers must be deduplicated and sorted numerically"
+    );
+}
+
+// ── element_type_name covers all variants ──
+
+#[test]
+fn test_element_type_names_for_all_variants() {
+    use oxidize_pdf::pipeline::{ImageElementData, KeyValueElementData, TableElementData};
+
+    fn single_chunk(element: Element) -> RagChunk {
+        let chunker = HybridChunker::new(HybridChunkConfig {
+            max_tokens: 512,
+            overlap_tokens: 0,
+            merge_adjacent: false,
+            propagate_headings: false,
+            merge_policy: MergePolicy::AnyInlineContent,
+        });
+        let chunks = chunker.chunk(&[element]);
+        RagChunk::from_hybrid_chunk(0, &chunks[0])
+    }
+
+    let md = ElementMetadata::default();
+
+    let cases: Vec<(&str, Element)> = vec![
+        (
+            "title",
+            Element::Title(ElementData {
+                text: "T".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "paragraph",
+            Element::Paragraph(ElementData {
+                text: "P".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "header",
+            Element::Header(ElementData {
+                text: "H".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "footer",
+            Element::Footer(ElementData {
+                text: "F".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "list_item",
+            Element::ListItem(ElementData {
+                text: "L".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "code_block",
+            Element::CodeBlock(ElementData {
+                text: "C".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "image",
+            Element::Image(ImageElementData {
+                alt_text: Some("img".into()),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "key_value",
+            Element::KeyValue(KeyValueElementData {
+                key: "k".into(),
+                value: "v".into(),
+                metadata: md.clone(),
+            }),
+        ),
+        (
+            "table",
+            Element::Table(TableElementData {
+                rows: vec![vec!["a".into()]],
+                metadata: md.clone(),
+            }),
+        ),
+    ];
+
+    for (expected_name, element) in cases {
+        let chunk = single_chunk(element);
+        assert_eq!(
+            chunk.element_types[0], expected_name,
+            "element_type for variant {expected_name}"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/rag_pipeline_test.rs
+++ b/oxidize-pdf-core/tests/rag_pipeline_test.rs
@@ -13,6 +13,7 @@ fn fixture_path(name: &str) -> std::path::PathBuf {
 fn test_rag_chunks_returns_vec() {
     let path = fixture_path("simple.pdf");
     if !path.exists() {
+        eprintln!("[WARN] fixture missing, skipping test: {}", path.display());
         return;
     }
     let reader = PdfReader::open(&path).expect("must open PDF");
@@ -38,6 +39,7 @@ fn test_rag_chunks_returns_vec() {
 fn test_rag_chunks_with_custom_config() {
     let path = fixture_path("simple.pdf");
     if !path.exists() {
+        eprintln!("[WARN] fixture missing, skipping test: {}", path.display());
         return;
     }
     let reader = PdfReader::open(&path).expect("must open PDF");
@@ -62,6 +64,7 @@ fn test_rag_chunks_with_custom_config() {
 fn test_rag_chunks_json_returns_valid_json() {
     let path = fixture_path("simple.pdf");
     if !path.exists() {
+        eprintln!("[WARN] fixture missing, skipping test: {}", path.display());
         return;
     }
     let reader = PdfReader::open(&path).expect("must open PDF");
@@ -78,6 +81,7 @@ fn test_rag_chunks_json_returns_valid_json() {
 fn test_deprecated_chunk_methods_still_work() {
     let path = fixture_path("simple.pdf");
     if !path.exists() {
+        eprintln!("[WARN] fixture missing, skipping test: {}", path.display());
         return;
     }
     let reader = PdfReader::open(&path).expect("must open");


### PR DESCRIPTION
## Summary
Addresses all 7 findings from quality review of the RAG Pipeline API:

- **Critical**: `rag_chunks_json` used `ParseError::SyntaxError` for JSON errors. Added `ParseError::SerializationError` variant with correct semantics.
- **Recommended**: `element_type_name` now returns `&'static str` (avoids heap alloc per element)
- **Recommended**: `collect_pages` sorts numerically after dedup (predictable `[1,2,3]` not `[3,1,2]`)
- **Recommended**: `rag_chunks_with()` has full doc comment with example
- **Recommended**: Integration test skip guards emit `eprintln!` warning
- **Optional**: `token_estimate` doc explains subword tokenizer 1.3-1.7x multiplier
- **Optional**: Removed emoji from `rag_pipeline.rs` example

## Test plan
- [x] 7,993 workspace tests passing (+3 new)
- [x] Clippy clean, fmt clean
- [x] `test_rag_chunk_page_numbers_are_sorted` — out-of-order pages → sorted
- [x] `test_element_type_names_for_all_variants` — all 9 element types covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)