### PR TITLE
fix(rag): quality review round 2 — 10 findings resolved

### DIFF
--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1431,10 +1431,43 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(rag_chunks)
     }
 
+    /// Combine a pre-configured extraction profile with a custom chunking config.
+    ///
+    /// Use this when you need both profile-tuned partitioning (e.g. `Rag` with
+    /// XYCut reading order) and a non-default chunk size.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use oxidize_pdf::parser::PdfDocument;
+    /// use oxidize_pdf::pipeline::{ExtractionProfile, HybridChunkConfig};
+    ///
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// let config = HybridChunkConfig { max_tokens: 256, ..Default::default() };
+    /// let chunks = doc.rag_chunks_with_profile_config(ExtractionProfile::Rag, config)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn rag_chunks_with_profile_config(
+        &self,
+        profile: crate::pipeline::ExtractionProfile,
+        config: crate::pipeline::HybridChunkConfig,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let elements = self.partition_with_profile(profile)?;
+        let chunker = crate::pipeline::HybridChunker::new(config);
+        let hybrid_chunks = chunker.chunk(&elements);
+        Ok(hybrid_chunks
+            .iter()
+            .enumerate()
+            .map(|(idx, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(idx, hc))
+            .collect())
+    }
+
     /// Extract chunks as a JSON string ready for vector store ingestion.
     ///
-    /// Requires the `semantic` feature. Serializes [`Vec<RagChunk>`](crate::pipeline::RagChunk)
-    /// as a JSON array.
+    /// # Feature flags
+    ///
+    /// Requires the `semantic` feature: `oxidize-pdf = { features = ["semantic"] }`.
+    /// Without it this method is not compiled.
     #[cfg(feature = "semantic")]
     pub fn rag_chunks_json(&self) -> ParseResult<String> {
         let chunks = self.rag_chunks()?;

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -107,6 +107,25 @@ impl Element {
         }
     }
 
+    /// Returns the snake_case type name of this element variant.
+    ///
+    /// Useful for logging, serialization, and metadata tagging.
+    /// Returns one of: `"title"`, `"paragraph"`, `"table"`, `"header"`,
+    /// `"footer"`, `"list_item"`, `"image"`, `"code_block"`, `"key_value"`.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::Title(_) => "title",
+            Self::Paragraph(_) => "paragraph",
+            Self::Table(_) => "table",
+            Self::Header(_) => "header",
+            Self::Footer(_) => "footer",
+            Self::ListItem(_) => "list_item",
+            Self::Image(_) => "image",
+            Self::CodeBlock(_) => "code_block",
+            Self::KeyValue(_) => "key_value",
+        }
+    }
+
     /// Set the parent heading for this element.
     pub fn set_parent_heading(&mut self, heading: Option<String>) {
         self.metadata_mut().parent_heading = heading;

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -143,7 +143,7 @@ impl HybridChunk {
 ///
 /// for chunk in &chunks {
 ///     println!("~{} tokens: {}", chunk.token_estimate(),
-///         &chunk.full_text()[..50.min(chunk.full_text().len())]);
+///         chunk.full_text().chars().take(50).collect::<String>());
 /// }
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -340,13 +340,7 @@ impl HybridChunker {
         let flushed = std::mem::take(buffer);
         let heading = buffer_heading.take();
 
-        chunks.push(HybridChunk {
-            elements: flushed.clone(),
-            heading_context: heading,
-            oversized: false,
-        });
-
-        // Apply overlap: carry trailing elements from flushed chunk into the next
+        // Compute overlap BEFORE moving flushed into the chunk (avoids clone)
         if self.config.overlap_tokens > 0 {
             let mut overlap_tokens = 0usize;
             let mut overlap_elements = Vec::new();
@@ -363,13 +357,18 @@ impl HybridChunker {
             overlap_elements.reverse();
             *buffer = overlap_elements;
             *buffer_tokens = overlap_tokens;
-            // Preserve heading from overlap elements
             if let Some(first) = buffer.first() {
                 *buffer_heading = first.metadata().parent_heading.clone();
             }
         } else {
             *buffer_tokens = 0;
         }
+
+        chunks.push(HybridChunk {
+            elements: flushed,
+            heading_context: heading,
+            oversized: false,
+        });
     }
 }
 
@@ -457,19 +456,18 @@ fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
 fn split_into_sentences(text: &str) -> Vec<String> {
     let mut sentences = Vec::new();
     let mut current = String::new();
-    let chars: Vec<char> = text.chars().collect();
-    let len = chars.len();
-    let mut i = 0;
+    let mut iter = text.chars().peekable();
 
-    while i < len {
-        let ch = chars[i];
+    while let Some(ch) = iter.next() {
         current.push(ch);
 
-        if matches!(ch, '.' | '!' | '?') && i + 1 < len && chars[i + 1] == ' ' {
-            sentences.push(current.trim().to_string());
-            current = String::new();
-            i += 2; // skip the space after delimiter
-            continue;
+        if matches!(ch, '.' | '!' | '?') {
+            if iter.peek() == Some(&' ') {
+                iter.next(); // skip the space after delimiter
+                sentences.push(current.trim().to_string());
+                current = String::new();
+                continue;
+            }
         } else if ch == '\n' {
             let trimmed = current.trim().to_string();
             if !trimmed.is_empty() {
@@ -477,8 +475,6 @@ fn split_into_sentences(text: &str) -> Vec<String> {
             }
             current = String::new();
         }
-
-        i += 1;
     }
 
     let remaining = current.trim().to_string();

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -16,7 +16,7 @@ pub use export::{ElementMarkdownExporter, ExportConfig};
 pub use graph::ElementGraph;
 pub use hybrid_chunking::{HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy};
 pub use partition::{PartitionConfig, Partitioner, ReadingOrderStrategy};
-pub use profile::ExtractionProfile;
+pub use profile::{ExtractionProfile, ProfileConfig};
 pub use rag::RagChunk;
 pub use reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker};

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -76,10 +76,8 @@ impl RagChunk {
         let elements = chunk.elements();
         let page_numbers = collect_pages(elements);
         let bounding_boxes = elements.iter().map(|e| *e.bbox()).collect();
-        let element_types: Vec<String> = elements
-            .iter()
-            .map(|e| element_type_name(e).to_string())
-            .collect();
+        let element_types: Vec<String> =
+            elements.iter().map(|e| e.type_name().to_string()).collect();
 
         Self {
             chunk_index,
@@ -103,6 +101,15 @@ impl RagChunk {
 
 /// Collect unique page numbers from elements, deduplicated and sorted numerically.
 fn collect_pages(elements: &[Element]) -> Vec<u32> {
+    if elements.is_empty() {
+        return Vec::new();
+    }
+    // Fast path: all elements on the same page (most common case)
+    let first_page = elements[0].page();
+    if elements.iter().all(|e| e.page() == first_page) {
+        return vec![first_page];
+    }
+    // General path: deduplicate and sort
     let mut seen = HashSet::new();
     let mut pages = Vec::new();
     for e in elements {
@@ -113,19 +120,4 @@ fn collect_pages(elements: &[Element]) -> Vec<u32> {
     }
     pages.sort_unstable();
     pages
-}
-
-/// Map an `Element` variant to its snake_case type name.
-fn element_type_name(element: &Element) -> &'static str {
-    match element {
-        Element::Title(_) => "title",
-        Element::Paragraph(_) => "paragraph",
-        Element::Table(_) => "table",
-        Element::Header(_) => "header",
-        Element::Footer(_) => "footer",
-        Element::ListItem(_) => "list_item",
-        Element::Image(_) => "image",
-        Element::CodeBlock(_) => "code_block",
-        Element::KeyValue(_) => "key_value",
-    }
 }

--- a/oxidize-pdf-core/tests/extraction_profile_test.rs
+++ b/oxidize-pdf-core/tests/extraction_profile_test.rs
@@ -15,6 +15,7 @@ fn test_all_profiles_are_constructible() {
     let _ = ExtractionProfile::Government;
     let _ = ExtractionProfile::Dense;
     let _ = ExtractionProfile::Presentation;
+    let _ = ExtractionProfile::Rag;
 }
 
 // Cycle 4.2

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -312,7 +312,7 @@ fn test_rag_chunk_page_numbers_are_sorted() {
     );
 }
 
-// ── element_type_name covers all variants ──
+// ── Element::type_name() covers all variants ──
 
 #[test]
 fn test_element_type_names_for_all_variants() {

--- a/oxidize-pdf-core/tests/rag_pipeline_test.rs
+++ b/oxidize-pdf-core/tests/rag_pipeline_test.rs
@@ -57,6 +57,16 @@ fn test_rag_chunks_with_custom_config() {
         chunks.len() >= default_chunks.len(),
         "smaller max_tokens must produce >= chunks"
     );
+    // No chunk should wildly exceed the token limit (2x tolerance for oversized)
+    for chunk in &chunks {
+        if !chunk.is_oversized {
+            assert!(
+                chunk.token_estimate <= 64,
+                "non-oversized chunk must respect ~2x token limit, got {}",
+                chunk.token_estimate
+            );
+        }
+    }
 }
 
 #[cfg(feature = "semantic")]
@@ -146,5 +156,38 @@ fn test_rag_chunks_with_profile_accepts_all_variants() {
             doc.rag_chunks_with_profile(profile).is_ok(),
             "must not fail for any profile"
         );
+    }
+}
+
+// ── rag_chunks_with_profile_config ─────────────────────────────────────────
+
+#[test]
+fn test_rag_chunks_with_profile_config_combines_both() {
+    use oxidize_pdf::pipeline::{ExtractionProfile, HybridChunkConfig};
+    let path = fixture_path("Cold_Email_Hacks.pdf");
+    if !path.exists() {
+        eprintln!("[WARN] fixture missing, skipping: {}", path.display());
+        return;
+    }
+    let reader = PdfReader::open(&path).expect("must open PDF");
+    let doc = PdfDocument::new(reader);
+
+    let config = HybridChunkConfig {
+        max_tokens: 128,
+        ..Default::default()
+    };
+    let chunks = doc
+        .rag_chunks_with_profile_config(ExtractionProfile::Rag, config)
+        .expect("must succeed");
+
+    assert!(!chunks.is_empty());
+    for chunk in &chunks {
+        if !chunk.is_oversized {
+            assert!(
+                chunk.token_estimate <= 256,
+                "non-oversized chunk must respect ~2x token limit, got {}",
+                chunk.token_estimate
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Resolves all 10 findings from quality review round 2:

**Critical (3)**:
- Remove `.clone()` in `flush_buffer` hot path — compute overlap before moving elements
- Re-export `ProfileConfig` from `pipeline::mod`
- Add `ExtractionProfile::Rag` to constructibility test

**Recommended (4)**:
- New `rag_chunks_with_profile_config()` — combine extraction profile + custom chunk config
- `Element::type_name()` public method (replaces private fn in rag.rs)
- Fix UTF-8 unsafe byte slicing in HybridChunker doc example
- Feature flag documentation for `rag_chunks_json`

**Optional (3)**:
- `split_into_sentences` uses peekable iterator instead of `Vec<char>`
- `collect_pages` early return for single-page chunks (skips HashSet)
- Strengthened integration test assertion

## Test plan
- [x] 8,008 workspace tests passing
- [x] 202 doc tests passing
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)