### PR TITLE
Release v2.3.4

### DIFF
--- a/.private/ROADMAP_MASTER.md
+++ b/.private/ROADMAP_MASTER.md
@@ -1,5 +1,5 @@
 # ROADMAP MASTER - oxidize-pdf
-**Ultima actualizacion**: 2026-03-21 (v2.3.3 released — CJK CID→Unicode fix, SMask remap fix)
+**Ultima actualizacion**: 2026-03-23 (fix/issue-160 — CJK font encoding in Table writer)
 **Horizonte**: Sin deadline — roadmap es orientativo, no vinculante
 **Owner**: bzsanti
 **Repositorio**: https://github.com/bzsanti/oxidizePdf
@@ -10,8 +10,8 @@
 
 ### Posicion en Roadmap
 - **Version**: v2.3.3 released (crates.io 2026-03-21, GitHub release via Actions)
-- **Sprint Actual**: Bug fixes — CJK text extraction, SMask remap
-- **Tests**: 6,241 unit + 1,608 integration + 208 doc tests passing (8,057 total)
+- **Sprint Actual**: Bug fixes — CJK table font encoding (#160)
+- **Tests**: 8,070 passing (unit + integration + doc)
 - **Coverage**: 72.14%
 - **Quality Grade**: A (95/100)
 - **PDF Success Rate**: 99.3% (275/277 failure corpus)
@@ -20,7 +20,7 @@
 - **Downloads**: ~10K+ total (estimado)
 - **Stars**: 20+
 - **Test coverage**: 72.14% (objetivo: 80%)
-- **Tests**: 8,057 passing (6,241 unit + 1,608 integration + 208 doc)
+- **Tests**: 8,070 passing
 - **Licencia**: MIT (cambiada desde AGPL-3.0 — monetizacion ya no es objetivo)
 - **ISO compliance**: 310 requisitos curados, 100% linked to code (66.8% alta verificacion)
 
@@ -97,8 +97,9 @@
 ## ISSUES GITHUB
 
 ### Abiertos
-- No hay issues abiertos
+- **#160** - CJK font NOT displayed correctly in Table (fix en rama `fix/issue-160-cjk-table-font`, pendiente PR+merge)
 - Feature branches activas:
+  - `fix/issue-160-cjk-table-font` — fix encoding CJK en GraphicsContext::show_text
   - `feature/pdf-editor` — nueva feature de edicion (AnnotationInjector, PageManipulator)
 
 ### Cerrados (2026)

--- a/.private/ROADMAP_MASTER.md
+++ b/.private/ROADMAP_MASTER.md
@@ -1,0 +1,439 @@
+# ROADMAP MASTER - oxidize-pdf
+**Ultima actualizacion**: 2026-03-21 (v2.3.3 released — CJK CID→Unicode fix, SMask remap fix)
+**Horizonte**: Sin deadline — roadmap es orientativo, no vinculante
+**Owner**: bzsanti
+**Repositorio**: https://github.com/bzsanti/oxidizePdf
+
+---
+
+## ESTADO ACTUAL
+
+### Posicion en Roadmap
+- **Version**: v2.3.3 released (crates.io 2026-03-21, GitHub release via Actions)
+- **Sprint Actual**: Bug fixes — CJK text extraction, SMask remap
+- **Tests**: 6,241 unit + 1,608 integration + 208 doc tests passing (8,057 total)
+- **Coverage**: 72.14%
+- **Quality Grade**: A (95/100)
+- **PDF Success Rate**: 99.3% (275/277 failure corpus)
+
+### Metricas Actuales
+- **Downloads**: ~10K+ total (estimado)
+- **Stars**: 20+
+- **Test coverage**: 72.14% (objetivo: 80%)
+- **Tests**: 8,057 passing (6,241 unit + 1,608 integration + 208 doc)
+- **Licencia**: MIT (cambiada desde AGPL-3.0 — monetizacion ya no es objetivo)
+- **ISO compliance**: 310 requisitos curados, 100% linked to code (66.8% alta verificacion)
+
+---
+
+## RELEASES PUBLICADOS
+
+| Version | Fecha | Highlights |
+|---------|-------|------------|
+| v2.3.3 | 2026-03-21 | CJK CID→Unicode tables (79K entries, 4 collections), SMask remap fix (#156, #157) |
+| v2.3.2 | 2026-03-15 | Overlay/watermark (OPS-005), Image::from_file, reorder exports, XObject stream fix |
+| v2.3.0 | 2026-03-14 | RagChunk API — one-liner RAG pipeline with serializable metadata |
+| v2.2.0 | 2026-03-14 | Encryption-on-write (RC4+AES-128+AES-256), pipeline profiling, ElementGraph, HybridChunker v2 |
+| v2.1.0 | 2026-03-09 | Pipeline Architecture v2: ElementGraph, HybridChunker v2, table detection improvements |
+| v1.8.0 | 2026-03-01 | JBIG2 decoder completo, float sort fix (Rust 1.81+) |
+| v1.7.1 | 2026-02-18 | Fix CFF fonts CIDToGIDMap (Issue #127) |
+| v1.7.0 | 2026-02-16 | Digital Signatures, PDF/A Validation, BER-to-DER, Issue #128 fix |
+| v1.6.13 | 2026-02-12 | Dependency updates (rand 0.10, quick-xml 0.39, criterion 0.8) |
+| v1.6.12 | 2026-02-07 | Generic ImageExtractor (PR #121), +234 tests |
+| v1.6.11 | 2026-02-01 | Per-page extraction options (Issue #116) |
+| v1.6.10 | 2026-01-29 | space_threshold tuning (0.2→0.3) |
+| v1.6.9 | 2026-01-28 | Text sanitization NUL bytes fix (Issue #116) |
+| v1.6.8 | 2026-01-10 | Cargo.toml version desync fix, test fixtures |
+| v1.6.7 | 2026-01-02 | Type0 security hardening, encryption improvements |
+
+---
+
+## FEATURES COMPLETADAS
+
+### v1.8.x
+| Feature | Version | Estado |
+|---------|---------|--------|
+| JBIG2 Decoder (9 fases, pure Rust) | v1.8.0 | Shipped |
+| Float sort panic fix (Rust 1.81+) | v1.8.0 | Shipped |
+| 7-tier corpus test infrastructure | WIP | En rama feature |
+| Decompression bomb protection | WIP | En rama feature |
+
+### v1.7.x
+| Feature | Version | Estado |
+|---------|---------|--------|
+| Digital Signatures API (6 fases) | v1.7.0 | Shipped |
+| PDF/A Validation module | v1.7.0 | Shipped |
+| BER-to-DER security hardening | v1.7.0 | Shipped |
+| CFF fonts CIDToGIDMap fix | v1.7.1 | Shipped |
+| merge_pdfs blank PDF fix (Issue #128) | v1.7.0 | Shipped |
+| text_wrap implementation (Issue #131) | v1.7.0 | Shipped |
+
+### v1.6.x
+| Feature | Version | Estado |
+|---------|---------|--------|
+| AES-256 R5/R6 encryption (Algorithm 2.B) | v1.6.8+ | Shipped |
+| Owner password R5/R6 support | v1.6.8+ | Shipped |
+| Cross-validation pypdf | v1.6.8+ | Shipped |
+| CID/Type0 font embedding | v1.6.8+ | Shipped |
+| Font subsetting large fonts (Issue #115) | v1.6.9 | Shipped |
+| Text sanitization NUL bytes (Issue #116) | v1.6.9 | Shipped |
+| Per-page extraction options | v1.6.11 | Shipped |
+| Generic ImageExtractor | v1.6.12 | Shipped |
+| Dependency updates | v1.6.13 | Shipped |
+| BDC inline dict parsing fix | v1.6.6 | Shipped |
+| XRef stream double-decode fix | v1.6.6 | Shipped |
+| TextContext used_characters fix | v1.6.5 | Shipped |
+| UTF-8 Panic Fix | v1.6.4 | Shipped |
+| Table Detection | v1.6.4 | Shipped |
+| Structured Data Extraction | v1.6.3 | Shipped |
+| Plain Text Optimization | v1.6.3 | Shipped |
+| Invoice Data Extraction | v1.6.3 | Shipped |
+| Unwrap Elimination (51) | v1.6.2 | Shipped |
+| Kerning Normalization | v1.6.1 | Shipped |
+| LLM-Optimized Formats | v1.6.0 | Shipped |
+
+---
+
+## ISSUES GITHUB
+
+### Abiertos
+- No hay issues abiertos
+- Feature branches activas:
+  - `feature/pdf-editor` — nueva feature de edicion (AnnotationInjector, PageManipulator)
+
+### Cerrados (2026)
+- **#159** - Release v2.3.3 (PR merged)
+- **#157** - CID-keyed fonts with CMaps — CJK text extraction fix (v2.3.3)
+- **#156** - SMask references not remapped — overlay fix (v2.3.3)
+- **#136** - JBIG2 decoder (PR merged)
+- **#137** - Release v1.8.0 (PR merged)
+- **#135** - JBIG2 full implementation (auto-closed by PR #136)
+- **#131** - text_wrap truncation bug
+- **#128** - merge_pdfs blank PDF (3 fases)
+- **#127** - CFF font rendering artifacts Firefox
+- **#116** - Text extraction NUL bytes + space_threshold
+- **#115** - Font subsetting large CJK fonts
+
+### Cerrados (2025)
+- **#104** - XRef non-contiguous subsections (v1.6.6)
+- **#97** - TextContext used_characters (v1.6.5)
+- **#98** - Linearized PDF XRef confusion (v1.6.5)
+- **#93** - UTF-8 Panic Fix (v1.6.4)
+- **#90** - Table Detection (v1.6.4)
+- **#87** - Kerning Normalization (v1.6.1)
+- **#83** - Parser Fails on Digitally Signed PDFs
+- **#82** - Stack Overflow Circular References (P0)
+- **#54** - ISO 32000-1:2008 Compliance Tracking
+
+---
+
+## EN PROGRESO
+
+### Architecture Changes (COMPETITIVE_ANALYSIS steps) — COMPLETADO
+**Merged**: PR #142, #143 → develop → main → v2.2.0
+**Origen**: COMPETITIVE_ANALYSIS.md seccion 7.3
+
+- ✅ Step 1: Merge `feature/element-type-system` → v2.1.0
+- ✅ Step 2: ElementGraph — index-based parent/child/next/prev relationships
+- ✅ Step 3: HybridChunker v2 — agnostic merge, sentence splitting, `full_text()`
+- ✅ Step 4: Table detection — region segmentation, confidence threshold, anti-list
+- ✅ Encryption-on-write: RC4-40/128, AES-128 R4, AES-256 R5/R6 (28 tests)
+- ⏳ Step 5: WASM target (baja prioridad, sin rama)
+
+### Pipeline Profiling — COMPLETADO (merged v2.2.0)
+**Merged**: PR #144 → develop → main → v2.2.0
+
+- ✅ Criterion benchmarks + corpus profiler + `verbose-debug` feature gate
+- ✅ Font cache two-tier + quick wins (-2.3%)
+- **Decision**: Performance no es prioridad. No invertir mas tiempo.
+
+### Corpus 7K Test Infrastructure (feature branch)
+**Rama**: `feature/corpus-7k-test-infrastructure`
+
+**Completado**:
+- ✅ `corpus_support.rs` (1,312 lineas) — runner streaming, panic safety, timeout 30s/file
+- ✅ T0-T6 test suites (7 archivos)
+- ✅ CI workflow `.github/workflows/corpus-tests.yml` (commit/nightly/weekly)
+- ✅ Download scripts para T1, T2, T4, T5
+- ✅ Decompression bomb protection (256MB limite, ratio 1000:1) en todos los filtros
+- ✅ 10 tests de seguridad para decompression bombs
+
+**Pendiente**:
+- [ ] Descargar y ejecutar corpus T0 con fixtures existentes
+- [ ] Descargar y ejecutar corpus T1 (veraPDF + pdf.js)
+- [ ] Generar baselines T0 (baseline_times.json)
+
+### Tiers del Corpus
+
+| Tier | PDFs | Trigger | Source | Proposito | Estado |
+|------|------|---------|--------|-----------|--------|
+| T0 | 749 | Cada commit | Production fixtures | Regresion | Codigo listo, pendiente ejecucion |
+| T1 | ~2,000 | Cada commit | veraPDF + pdf.js | Spec conformance | Codigo listo, descargando corpus |
+| T2 | 2,000 | Nightly | GovDocs1 | Diversidad real | Codigo listo |
+| T3 | 750 | Nightly | SafeDocs (curado) | Error recovery | Codigo listo, corpus manual |
+| T4 | 500 | Weekly | PubMed Central OA | AI/RAG accuracy | Codigo listo |
+| T5 | ~900 | Weekly | OmniDocBench | Quality benchmarking | Codigo listo |
+| T6 | 200 | Weekly | Qiqqa + SafeDocs | Adversarial safety | Codigo listo, corpus manual |
+
+---
+
+## PROXIMOS PASOS INMEDIATOS
+
+### 1. Benchmark RAG vs competencia
+- Medir chunks/sec contra pypdf, unstructured, docling
+- Requiere setup Python
+
+### 2. Coverage 72% → 80% (cuando haya ganas)
+- Modulos target: pure logic, <200 lineas, 30-85% cobertura actual
+
+### 3. Fix: detect_columns overflow (bug pre-existente)
+- extraction.rs:618 panic con Cold_Email_Hacks.pdf cuando detect_columns: true
+- Afecta ExtractionProfile::Academic
+
+### 4. feature/pdf-editor
+- Rama activa con AnnotationInjector y PageManipulator (no mergeada)
+
+---
+
+## SPRINTS COMPLETADOS
+
+### Q4 2025
+| Sprint | Estado | Grade | Logro Principal |
+|--------|--------|-------|-----------------|
+| Sprint 1 | COMPLETO | A- (90) | Code hygiene: 171 prints migrados, backup files eliminados, tracing |
+| Sprint 2 | COMPLETO | A (93) | Performance: 91 clones eliminados, 10-20% ahorro memoria |
+| Sprint 3 | PARCIAL | C (67%) | CI: pre-commit hooks, docs; coverage fallida |
+| Sprint 4 | COMPLETO | A (95) | ISO Compliance: 7,775→310 requisitos curados |
+
+### Q1 2026
+| Sprint | Estado | Grade | Logro Principal |
+|--------|--------|-------|-----------------|
+| Encryption R5/R6 | COMPLETO | A | Algorithm 2.B, owner passwords, cross-validation pypdf |
+| CID/Type0 Fonts | COMPLETO | A | Full embedding, security hardening |
+| Coverage 54→72% | COMPLETO | A | +1,515 tests en multiple sprints |
+| PDF/A Validation | COMPLETO | A | 8 niveles, 70 tests, integration tests |
+| Digital Signatures | COMPLETO | A | 6 fases, detection→validation→API |
+| JBIG2 Decoder | COMPLETO | A+ | 9 fases, pure Rust, 376 tests, ITU-T T.88 compliant |
+| Dependency Updates | COMPLETO | A | rand 0.10, quick-xml 0.39, criterion 0.8 |
+| Corpus 7K Infra | EN PROGRESO | - | 7-tier framework, CI, decompression protection |
+| Pipeline Architecture v2 | COMPLETADO | A | ElementGraph, HybridChunker v2, table detection |
+| Encryption on Write | COMPLETADO | A | RC4+AES-128+AES-256, 28 tests, round-trip verified |
+| Pipeline Profiling | COMPLETADO | A | Criterion benchmarks, profiler tool, font cache |
+| oxidize-pdf-dotnet v0.3.1 | COMPLETADO | A | Bump to v2.1.0, MIT license, NuGet published |
+| **Release v2.2.0** | COMPLETADO | A | Encryption-on-write, profiling, all branches merged |
+| RAG Pipeline API | COMPLETADO | A | RagChunk, rag_chunks(), rag_chunks_json(), deprecate chunk() |
+| **Release v2.3.0** | COMPLETADO | A | One-liner RAG pipeline, README updated |
+| OPS-005 Overlay/Watermark | COMPLETADO | A | overlay_pdf(), OverlayOptions, Form XObjects, 31 tests |
+| **Release v2.3.2** | COMPLETADO | A | Overlay, Image::from_file, reorder exports, XObject fix |
+| Fix #156 SMask remap | COMPLETADO | A | SMask references resolved during overlay, 11 tests |
+| Fix #157 CID CJK text | COMPLETADO | A | CID→Unicode tables (79K entries), 8 tests, user-reported bug |
+| **Release v2.3.3** | COMPLETADO | A | CJK fix, SMask fix, CLAUDE.md removed from VCS, branch cleanup |
+
+---
+
+## CONTEXTO ESTRATEGICO
+
+### Pivot Estrategico (Post v1.2.x Issues)
+
+**Aprendizaje Critico**: Issues reales de usuarios revelaron foundation debil
+
+**Issues que nos ensenaron**:
+1. PDFs en chino → Encoding/CJK failure (RESUELTO)
+2. Transparencias PNG → Alpha channel missing (RESUELTO)
+3. PDFs corruptos → Pipeline crash (RESUELTO)
+4. Stack overflow circular refs → (RESUELTO v1.6.0)
+
+**Balance Actual**: 70% fundamentals + 30% AI polish
+
+### Modelo de Negocio — DESCARTADO (2026-03-03)
+
+**Licencia**: MIT (cambiada desde AGPL-3.0)
+**Monetizacion**: Ya no es objetivo. Proyecto open-source puro.
+**Motivacion**: Aprendizaje, calidad, contribuir a la comunidad Rust.
+
+### Ventaja Competitiva
+- Pure Rust, type-safe, zero external deps (goal)
+- Performance: 12K pages/sec (simple), 161x faster que target en chunking
+- AI-Ready: Native RAG support, chunking, semantic tagging
+- Production-Grade: 99.3% parsing success (275/277 PDFs)
+- JBIG2 decoder puro Rust (sin dependencias C)
+- Digital Signatures & PDF/A validation
+- Decompression bomb protection
+
+### Competencia Principal
+- **lopdf**: General purpose, no optimizado para IA, sin foco comercial
+- **pypdf**: Python, mas lento, dominante en data science
+- **iText**: Java, EUR1,500+/year, target enterprise legacy
+
+---
+
+## ARQUITECTURA DEL PROYECTO
+
+### Estructura de Repositorio
+```
+oxidize-pdf/
+├── .private/                          # NUNCA commit a git
+│   ├── ROADMAP_MASTER.md             # Este archivo
+│   └── ...                           # Analisis estrategicos
+│
+├── oxidize-pdf-core/                  # Core library (MIT)
+│   ├── src/
+│   │   ├── ai/                       # AI/ML features
+│   │   ├── semantic/                 # Semantic tagging
+│   │   ├── parser/                   # PDF parsing
+│   │   ├── text/                     # Text extraction
+│   │   ├── signatures/              # Digital signatures
+│   │   ├── pdfa/                    # PDF/A validation
+│   │   └── ...
+│   ├── examples/                     # TODOS los ejemplos aqui
+│   │   └── results/                  # PDFs generados
+│   └── tests/                        # Unit tests + corpus tiers
+│
+├── oxidize-pdf-api/                   # REST API server
+├── oxidize-pdf-cli/                   # Command-line interface
+├── test-corpus/                       # 7-tier PDF corpus (gitignored PDFs)
+│   ├── t0-regression/                # Fixtures + baselines
+│   ├── t1-spec/                      # veraPDF + pdf.js
+│   ├── t2-realworld/                 # GovDocs1
+│   ├── t3-stress/                    # SafeDocs (curado)
+│   ├── t4-ai-target/                 # PubMed Central
+│   ├── t5-quality/                   # OmniDocBench
+│   ├── t6-adversarial/              # Malformed/malicious
+│   └── results/                      # JSON reports (gitignored)
+└── docs/                              # Community docs
+```
+
+### Reglas de Organizacion (ESTRICTAS)
+
+| Contenido | Ubicacion |
+|-----------|-----------|
+| PDFs generados | `oxidize-pdf-core/examples/results/` |
+| Archivos .rs de ejemplos | `oxidize-pdf-core/examples/` (flat) |
+| Unit tests | `oxidize-pdf-core/tests/` |
+| Corpus tests | `oxidize-pdf-core/tests/t0_*.rs` ... `t6_*.rs` |
+| Scripts Python | `tools/analysis/` o `tools/scripts/` |
+| Herramientas Rust debug | `dev-tools/` |
+
+**PROHIBIDO**: ejemplos en workspace root, PDFs dispersos, `test-pdfs/` (deprecated)
+
+---
+
+## ROADMAP POR TRIMESTRE
+
+### Q1 2025: ISO FUNDAMENTALS — COMPLETADO
+- PNG & transparency
+- CJK text extraction
+- Corruption recovery
+- Stack overflow protection
+
+### Q2 2025: AI/ML INTEGRATION — COMPLETADO
+- Document Chunking para RAG
+- LLM-Optimized Formats
+- Semantic Entity Tagging
+- Invoice Text Extraction API
+- Table Detection
+- Structured Data Extraction
+
+### Q3 2025: QUALITY & STABILITY — COMPLETADO
+- Unwrap Elimination (51)
+- Kerning Normalization
+- UTF-8 Panic Fix
+- Code Quality Sprints 1-3
+
+### Q4 2025: MAINTENANCE & POLISH — COMPLETADO
+- ISO Compliance Matrix Curation (Sprint 4)
+- BDC/XRef fixes (v1.6.6)
+- Cleanup sprint
+- Encryption RC4 (v1.6.7)
+
+### Q1 2026: SECURITY & ADVANCED FEATURES — 90% COMPLETADO
+- ✅ AES-256 R5/R6 encryption
+- ✅ CID/Type0 full font embedding
+- ✅ Coverage 54% → 72%
+- ✅ PDF/A Validation
+- ✅ Digital Signatures (6 fases)
+- ✅ JBIG2 decoder pure Rust (9 fases)
+- ✅ Dependency updates
+- ✅ Float sort safety (Rust 1.81+)
+- ✅ Decompression bomb protection
+- 🔄 Corpus 7K test infrastructure (en progreso)
+- ⏳ PDF Editor (feature branch creada)
+
+### Q2 2026: CONSOLIDACION (PLANIFICADO)
+- oxidize-pdf-dotnet bump a v2.0.0 + MIT + Windows .dll
+- README v2.0.0 con feature set real
+- Coverage 72% → 80%+ (cuando haya ganas)
+- Corpus T0/T1 validados y mergeados
+
+---
+
+## LECCIONES APRENDIDAS
+
+### Test Coverage
+1. **Test Quality != Code Coverage** - Smoke tests son inutiles para coverage
+2. **API Coverage != Code Coverage** - Testear API publica no mejora coverage
+3. **Priorizar Pure Logic** - Math, transformaciones, parsers (no I/O)
+4. **Siempre Medir** - Correr tarpaulin ANTES y DESPUES de agregar tests
+
+### Module Selection (ROI)
+
+| Alto ROI | Bajo ROI |
+|----------|----------|
+| <200 lineas | >500 lineas |
+| Pure math/conversiones | I/O, file operations |
+| 30-85% coverage actual | <20% o >90% |
+| Sin deps externas | Requiere PDFs/fonts reales |
+
+### Corpus Testing
+- **Streaming runner** esencial para 7K+ PDFs (previene OOM)
+- **Thread-per-file** con timeout 30s protege contra loops infinitos
+- **Graceful skip** cuando corpus no disponible (CI sigue funcionando)
+- **Dual-layer decompression** (size + ratio) para proteccion completa
+
+---
+
+## LIMITACIONES CONOCIDAS
+
+| Issue | Impacto | Estado |
+|-------|---------|--------|
+| 2 PDFs malformados | VERY LOW | Violaciones genuinas de formato, no bugs |
+
+**TODO RESUELTO**:
+- ~~Encrypted PDFs~~ → AES-256 R5/R6 completo
+- ~~CID/Type0 fonts~~ → Full embedding
+- ~~PNG compression~~ → Todos tests passing
+- ~~CFF fonts Firefox~~ → CIDToGIDMap fix
+
+---
+
+## DOCUMENTACION REFERENCIAS
+
+| Doc | Ubicacion |
+|-----|-----------|
+| Architecture | `docs/ARCHITECTURE.md` |
+| Invoice Extraction | `docs/INVOICE_EXTRACTION_GUIDE.md` |
+| Lints | `docs/LINTS.md` |
+| Roadmap | `.private/ROADMAP_MASTER.md` |
+| Corpus README | `test-corpus/README.md` |
+
+---
+
+## PARA CLAUDE CODE
+
+### Workflow
+1. Leer este archivo primero (estado actual)
+2. Verificar branch correcto
+3. Implementar segun estructura de archivos
+4. Tests obligatorios
+5. Actualizar este archivo
+
+### NO Hacer
+- Features fuera roadmap sin preguntar
+- Cambiar estructura de archivos sin discutir
+- Skip tests
+- Commits sin tests passing
+
+---
+
+**Ultima actualizacion**: 2026-03-04
+**Proxima review**: Despues de mergear profiling branch y completar dotnet v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [2.3.4] - 2026-03-26
+
+### Fixed
+- **CJK font not displayed correctly in Table** (#160) — CJK glyphs now render with correct fonts in table cells
+- **Table cell text alignment** (#162) — Text is now correctly centered/aligned within table cells
+- **CellData accessibility** (#163) — CellData fields are now publicly accessible for downstream consumers
+
+## [2.3.3] - 2026-03-21
+
+### Fixed
+- **CID-keyed fonts with CMaps for CJK text extraction** (#157) — Proper CMap lookup for CID-keyed fonts, enabling correct CJK text extraction
+- **SMask references during overlay** (#156) — Resolve SMask (soft mask) references from source PDF when applying overlays/watermarks
+
+## [2.3.2] - 2026-03-15
+
+### Added
+- **`ExtractionProfile::Rag`** — Dedicated RAG extraction profile with `rag_chunks_with_profile` for optimized chunking
+- **OPS-005: Overlay/watermark PDF operation** — Apply PDF pages as overlays or watermarks on existing documents
+- **`Image::from_file`** — Load images directly from file paths, XObject stream externalization, reordered exports
+
+### Fixed
+- **RAG quality review round 2** — 10 findings resolved (error semantics, allocations, docs)
+
+## [2.3.1] - 2026-03-14
+
+### Fixed
+- **RAG quality review** — Improved error semantics, reduced allocations, better docs and page ordering in RAG pipeline
+
+## [2.3.0] - 2026-03-14
+
+### Added
+- **RagChunk API** — One-liner RAG pipeline with full metadata: `PdfDocument::rag_chunks()` extracts semantically chunked content ready for embedding
+
+## [2.2.0] - 2026-03-14
+
+### Added
+- **Encryption on write** — Full write-side encryption support for RC4-40, RC4-128, AES-128 (R4), AES-256 (R5/R6) with per-object key derivation
+- **ElementGraph** — Index-based element relationships (parent/child/next/prev) — no lifetimes, Send+Sync
+- **HybridChunker v2** — Agnostic merge policy, sentence splitting for oversized chunks, `full_text()` with heading context
+- **Improved table detection** — Region segmentation (multiple tables/page), `min_table_confidence`, anti-list heuristic
+
+## [2.1.0] - 2026-03-09
+
+### Added
+- **Pipeline Architecture v2** — Complete 7-phase document intelligence pipeline with 66 TDD tests
+  - Phase 1: Element type system (Title, Header, Footer, NarrativeText, Table, ListItem, KeyValue, Image)
+  - Phase 2: VibeCoding convenience API on `PdfDocument`
+  - Phase 3: Partition fragments into typed elements with confidence scores
+  - Phase 4: Reading order strategies (Simple + XY-Cut)
+  - Phase 5: Semantic chunking with element boundaries
+  - Phase 6: Deprecate `ai::` free functions in favor of `PdfDocument` methods
+  - Phase 7: Integration tests and VibeCoding golden paths
+- **Pipeline profiling infrastructure** and performance baseline
+
 ## [2.0.0] - 2026-03-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/advanced_tables/mod.rs
+++ b/oxidize-pdf-core/src/advanced_tables/mod.rs
@@ -39,7 +39,7 @@ mod table_renderer;
 pub use cell_style::{BorderStyle, CellAlignment, CellStyle, Padding};
 pub use error::TableError;
 pub use header_builder::{HeaderBuilder, HeaderCell};
-pub use table_builder::{AdvancedTable, AdvancedTableBuilder, Column};
+pub use table_builder::{AdvancedTable, AdvancedTableBuilder, CellData, Column, RowData};
 pub use table_renderer::TableRenderer;
 
 use crate::error::PdfError;

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -5,6 +5,8 @@ use crate::page::Page;
 use crate::page_labels::PageLabelTree;
 use crate::semantic::{BoundingBox, EntityType, RelationType, SemanticEntity};
 use crate::structure::{NamedDestinations, OutlineTree, StructTree};
+// Alias to avoid collision with crate::fonts::FontMetrics (PDF font objects)
+use crate::text::metrics::{register_custom_font_metrics, FontMetrics as TextMeasurementMetrics};
 use crate::text::FontEncoding;
 use crate::writer::PdfWriter;
 use chrono::{DateTime, Local, Utc};
@@ -424,10 +426,29 @@ impl Document {
         let name = name.into();
         let font = CustomFont::from_bytes(&name, data)?;
 
-        // TODO: Implement automatic font metrics registration
-        // This needs to be properly integrated with the font metrics system
+        // Extract glyph widths before moving font into the cache
+        // Convert from font units to 1/1000 em units used by text::metrics
+        let units_per_em = font.metrics.units_per_em as f64;
+        let char_width_map: std::collections::HashMap<char, u16> = font
+            .glyph_mapping
+            .char_widths_iter()
+            .map(|(ch, width_font_units)| {
+                let width_1000 = ((width_font_units as f64 * 1000.0) / units_per_em).round() as u16;
+                (ch, width_1000)
+            })
+            .collect();
 
-        self.custom_fonts.add_font(name, font)?;
+        // Add to font cache first — if this fails, no metrics are registered (consistent state)
+        self.custom_fonts.add_font(name.clone(), font)?;
+
+        // Register text measurement metrics only after successful cache insertion
+        if !char_width_map.is_empty() {
+            let sum: u32 = char_width_map.values().map(|&w| w as u32).sum();
+            let default_width = (sum / char_width_map.len() as u32) as u16;
+            let text_metrics = TextMeasurementMetrics::from_char_map(char_width_map, default_width);
+            register_custom_font_metrics(name, text_metrics);
+        }
+
         Ok(())
     }
 

--- a/oxidize-pdf-core/src/fonts/ttf_parser.rs
+++ b/oxidize-pdf-core/src/fonts/ttf_parser.rs
@@ -52,6 +52,19 @@ impl GlyphMapping {
         self.char_to_glyph(ch)
             .and_then(|glyph| self.get_glyph_width(glyph))
     }
+
+    /// Iterate over all mapped characters with their widths in font units.
+    /// Yields `(char, width_in_font_units)` for each character that has both
+    /// a cmap mapping and a glyph width entry.
+    pub fn char_widths_iter(&self) -> impl Iterator<Item = (char, u16)> + '_ {
+        self.char_to_glyph
+            .iter()
+            .filter_map(move |(&code_point, &glyph_id)| {
+                let ch = char::from_u32(code_point)?;
+                let width = self.glyph_widths.get(&glyph_id).copied()?;
+                Some((ch, width))
+            })
+    }
 }
 
 /// TTF table record
@@ -599,5 +612,36 @@ mod tests {
         assert_eq!(mapping.glyph_to_char(65), Some('A'));
         assert_eq!(mapping.glyph_to_char(66), Some('B'));
         assert_eq!(mapping.glyph_to_char(67), None);
+    }
+
+    #[test]
+    fn test_char_widths_iter_yields_all_mapped_chars() {
+        let mut m = GlyphMapping::default();
+        m.add_mapping('A', 1);
+        m.set_glyph_width(1, 700);
+        m.add_mapping('B', 2);
+        m.set_glyph_width(2, 600);
+
+        let mut pairs: Vec<(char, u16)> = m.char_widths_iter().collect();
+        pairs.sort_by_key(|&(ch, _)| ch);
+        assert_eq!(pairs, vec![('A', 700), ('B', 600)]);
+    }
+
+    #[test]
+    fn test_char_widths_iter_skips_chars_without_width() {
+        let mut m = GlyphMapping::default();
+        m.add_mapping('C', 3); // mapped but no width set
+        m.add_mapping('D', 4);
+        m.set_glyph_width(4, 500); // only D has width
+
+        let pairs: Vec<(char, u16)> = m.char_widths_iter().collect();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0], ('D', 500));
+    }
+
+    #[test]
+    fn test_char_widths_iter_empty_on_empty_mapping() {
+        let m = GlyphMapping::default();
+        assert_eq!(m.char_widths_iter().count(), 0);
     }
 }

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -80,16 +80,34 @@ pub struct GraphicsContext {
     clipping_region: ClippingRegion,
     // Font management
     font_manager: Option<Arc<FontManager>>,
-    // State stack for save/restore
-    state_stack: Vec<(Color, Color)>,
+    // State stack for save/restore (fill_color, stroke_color, font_name, font_size, is_custom_font)
+    state_stack: Vec<(Color, Color, Option<String>, f64, bool)>,
     current_font_name: Option<String>,
     current_font_size: f64,
+    // Whether the current font is a custom (Type0/CID) font requiring Unicode encoding
+    is_custom_font: bool,
     // Character tracking for font subsetting
     used_characters: HashSet<char>,
     // Glyph mapping for Unicode fonts (Unicode code point -> Glyph ID)
     glyph_mapping: Option<HashMap<u32, u16>>,
     // Transparency group stack for nested groups
     transparency_stack: Vec<TransparencyGroupState>,
+}
+
+/// Encode a Unicode character as a CID hex value for Type0/Identity-H fonts.
+/// BMP characters (U+0000..U+FFFF) are written as 4-hex-digit values.
+/// Supplementary plane characters (U+10000..U+10FFFF) are written as UTF-16BE surrogate pairs.
+fn encode_char_as_cid(ch: char, buf: &mut String) {
+    let code = ch as u32;
+    if code <= 0xFFFF {
+        write!(buf, "{:04X}", code).expect("Writing to string should never fail");
+    } else {
+        // UTF-16BE surrogate pair for supplementary planes
+        let adjusted = code - 0x10000;
+        let high = ((adjusted >> 10) & 0x3FF) + 0xD800;
+        let low = (adjusted & 0x3FF) + 0xDC00;
+        write!(buf, "{:04X}{:04X}", high, low).expect("Writing to string should never fail");
+    }
 }
 
 impl Default for GraphicsContext {
@@ -124,6 +142,7 @@ impl GraphicsContext {
             state_stack: Vec::new(),
             current_font_name: None,
             current_font_size: 12.0,
+            is_custom_font: false,
             used_characters: HashSet::new(),
             glyph_mapping: None,
             transparency_stack: Vec::new(),
@@ -364,19 +383,27 @@ impl GraphicsContext {
     pub fn save_state(&mut self) -> &mut Self {
         self.operations.push_str("q\n");
         self.save_clipping_state();
-        // Save color state
-        self.state_stack
-            .push((self.current_color, self.stroke_color));
+        // Save color + font state
+        self.state_stack.push((
+            self.current_color,
+            self.stroke_color,
+            self.current_font_name.clone(),
+            self.current_font_size,
+            self.is_custom_font,
+        ));
         self
     }
 
     pub fn restore_state(&mut self) -> &mut Self {
         self.operations.push_str("Q\n");
         self.restore_clipping_state();
-        // Restore color state
-        if let Some((fill, stroke)) = self.state_stack.pop() {
+        // Restore color + font state
+        if let Some((fill, stroke, font_name, font_size, is_custom)) = self.state_stack.pop() {
             self.current_color = fill;
             self.stroke_color = stroke;
+            self.current_font_name = font_name;
+            self.current_font_size = font_size;
+            self.is_custom_font = is_custom;
         }
         self
     }
@@ -681,15 +708,17 @@ impl GraphicsContext {
         writeln!(&mut self.operations, "/{} {} Tf", font.pdf_name(), size)
             .expect("Writing to string should never fail");
 
-        // Track font name and size for Unicode detection and proper font handling
+        // Track font name, size, and type for Unicode detection and proper font handling
         match &font {
             Font::Custom(name) => {
                 self.current_font_name = Some(name.clone());
                 self.current_font_size = size;
+                self.is_custom_font = true;
             }
             _ => {
                 self.current_font_name = Some(font.pdf_name());
                 self.current_font_size = size;
+                self.is_custom_font = false;
             }
         }
 
@@ -704,21 +733,38 @@ impl GraphicsContext {
     }
 
     /// Show text
+    ///
+    /// For custom (Type0/CID) fonts, text is encoded as Unicode code points (CIDs).
+    /// BMP characters (U+0000..U+FFFF) are written as 4-hex-digit values.
+    /// Supplementary plane characters (U+10000..U+10FFFF) use UTF-16BE surrogate pairs.
+    /// For standard fonts, text is encoded as literal PDF strings.
     pub fn show_text(&mut self, text: &str) -> Result<&mut Self> {
-        // Escape special characters in PDF string
-        self.operations.push('(');
-        for ch in text.chars() {
-            match ch {
-                '(' => self.operations.push_str("\\("),
-                ')' => self.operations.push_str("\\)"),
-                '\\' => self.operations.push_str("\\\\"),
-                '\n' => self.operations.push_str("\\n"),
-                '\r' => self.operations.push_str("\\r"),
-                '\t' => self.operations.push_str("\\t"),
-                _ => self.operations.push(ch),
+        // Track used characters for font subsetting
+        self.used_characters.extend(text.chars());
+
+        if self.is_custom_font {
+            // For custom fonts (CJK/Type0), encode as hex string with Unicode code points as CIDs
+            self.operations.push('<');
+            for ch in text.chars() {
+                encode_char_as_cid(ch, &mut self.operations);
             }
+            self.operations.push_str("> Tj\n");
+        } else {
+            // For standard fonts, escape special characters in PDF literal string
+            self.operations.push('(');
+            for ch in text.chars() {
+                match ch {
+                    '(' => self.operations.push_str("\\("),
+                    ')' => self.operations.push_str("\\)"),
+                    '\\' => self.operations.push_str("\\\\"),
+                    '\n' => self.operations.push_str("\\n"),
+                    '\r' => self.operations.push_str("\\r"),
+                    '\t' => self.operations.push_str("\\t"),
+                    _ => self.operations.push(ch),
+                }
+            }
+            self.operations.push_str(") Tj\n");
         }
-        self.operations.push_str(") Tj\n");
         Ok(self)
     }
 
@@ -1072,8 +1118,13 @@ impl GraphicsContext {
 
     /// Set the current font to a custom font
     pub fn set_custom_font(&mut self, font_name: &str, size: f64) -> &mut Self {
+        // Emit Tf operator to the content stream (consistent with set_font)
+        writeln!(&mut self.operations, "/{} {} Tf", font_name, size)
+            .expect("Writing to string should never fail");
+
         self.current_font_name = Some(font_name.to_string());
         self.current_font_size = size;
+        self.is_custom_font = true;
 
         // Try to get the glyph mapping from the font manager
         if let Some(ref font_manager) = self.font_manager {
@@ -1096,34 +1147,9 @@ impl GraphicsContext {
         // Track used characters for font subsetting
         self.used_characters.extend(text.chars());
 
-        // Check if we're using a custom font (which will be Type0/Unicode)
-        // Custom fonts are those that are not the standard PDF fonts (Helvetica, Times, etc.)
-        let using_custom_font = if let Some(ref font_name) = self.current_font_name {
-            // If font name doesn't start with standard PDF font names, it's custom
-            !matches!(
-                font_name.as_str(),
-                "Helvetica"
-                    | "Times"
-                    | "Courier"
-                    | "Symbol"
-                    | "ZapfDingbats"
-                    | "Helvetica-Bold"
-                    | "Helvetica-Oblique"
-                    | "Helvetica-BoldOblique"
-                    | "Times-Roman"
-                    | "Times-Bold"
-                    | "Times-Italic"
-                    | "Times-BoldItalic"
-                    | "Courier-Bold"
-                    | "Courier-Oblique"
-                    | "Courier-BoldOblique"
-            )
-        } else {
-            false
-        };
-
-        // Detect if text needs Unicode encoding
-        let needs_unicode = text.chars().any(|c| c as u32 > 255) || using_custom_font;
+        // Detect if text needs Unicode encoding: custom fonts always use hex,
+        // and text with non-Latin-1 characters also needs Unicode encoding
+        let needs_unicode = self.is_custom_font || text.chars().any(|c| c as u32 > 255);
 
         // Use appropriate encoding based on content and font type
         if needs_unicode {
@@ -1234,26 +1260,11 @@ impl GraphicsContext {
         writeln!(&mut self.operations, "{:.2} {:.2} Td", x, y)
             .expect("Writing to string should never fail");
 
-        // IMPORTANT: For Type0 fonts with Identity-H encoding, we write CIDs (Character IDs),
-        // NOT GlyphIDs. The CIDToGIDMap in the font handles the CID -> GlyphID conversion.
-        // In our case, we use Unicode code points as CIDs.
+        // For Type0 fonts with Identity-H encoding, write Unicode code points as CIDs.
+        // The CIDToGIDMap in the font handles the CID → GlyphID conversion.
         self.operations.push('<');
-
         for ch in text.chars() {
-            let code = ch as u32;
-
-            // For Type0 fonts with Identity-H encoding, write the Unicode code point as CID
-            // The CIDToGIDMap will handle the conversion to the actual glyph ID
-            if code <= 0xFFFF {
-                // Write the Unicode code point as a 2-byte hex value (CID)
-                write!(&mut self.operations, "{:04X}", code)
-                    .expect("Writing to string should never fail");
-            } else {
-                // Characters outside BMP - use replacement character
-                // Most PDF viewers don't handle supplementary planes well
-                write!(&mut self.operations, "FFFD").expect("Writing to string should never fail");
-                // Unicode replacement character
-            }
+            encode_char_as_cid(ch, &mut self.operations);
         }
         self.operations.push_str("> Tj\n");
 
@@ -1355,25 +1366,7 @@ impl GraphicsContext {
             // Use 2-byte hex encoding for CIDs with identity mapping
             self.operations.push('<');
             for ch in text.chars() {
-                let code = ch as u32;
-
-                // Handle all Unicode characters
-                if code <= 0xFFFF {
-                    // Direct identity mapping for BMP characters
-                    write!(&mut self.operations, "{:04X}", code)
-                        .expect("Writing to string should never fail");
-                } else if code <= 0x10FFFF {
-                    // For characters outside BMP - use surrogate pairs
-                    let code = code - 0x10000;
-                    let high = ((code >> 10) & 0x3FF) + 0xD800;
-                    let low = (code & 0x3FF) + 0xDC00;
-                    write!(&mut self.operations, "{:04X}{:04X}", high, low)
-                        .expect("Writing to string should never fail");
-                } else {
-                    // Invalid Unicode - use replacement character
-                    write!(&mut self.operations, "FFFD")
-                        .expect("Writing to string should never fail");
-                }
+                encode_char_as_cid(ch, &mut self.operations);
             }
             self.operations.push_str("> Tj\n");
         } else {
@@ -2809,6 +2802,97 @@ mod tests {
         ctx.set_custom_font("CustomFont", 14.0);
         assert_eq!(ctx.current_font_name, Some("CustomFont".to_string()));
         assert_eq!(ctx.current_font_size, 14.0);
+        assert!(ctx.is_custom_font);
+    }
+
+    #[test]
+    fn test_show_text_standard_font_uses_literal_string() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Helvetica, 12.0);
+        assert!(!ctx.is_custom_font);
+
+        ctx.begin_text();
+        ctx.set_text_position(10.0, 20.0);
+        ctx.show_text("Hello World").unwrap();
+        ctx.end_text();
+
+        let ops = ctx.operations();
+        assert!(ops.contains("(Hello World) Tj"));
+        assert!(!ops.contains("<"));
+    }
+
+    #[test]
+    fn test_show_text_custom_font_uses_hex_encoding() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("NotoSansCJK".to_string()), 12.0);
+        assert!(ctx.is_custom_font);
+
+        ctx.begin_text();
+        ctx.set_text_position(10.0, 20.0);
+        // CJK characters: 你好 (U+4F60 U+597D)
+        ctx.show_text("你好").unwrap();
+        ctx.end_text();
+
+        let ops = ctx.operations();
+        // Must be hex-encoded, not literal
+        assert!(
+            ops.contains("<4F60597D> Tj"),
+            "Expected hex encoding for CJK text, got: {}",
+            ops
+        );
+        assert!(!ops.contains("(你好)"));
+    }
+
+    #[test]
+    fn test_show_text_custom_font_ascii_still_hex() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("MyFont".to_string()), 10.0);
+
+        ctx.begin_text();
+        ctx.set_text_position(0.0, 0.0);
+        // Even ASCII text should be hex-encoded when using custom font
+        ctx.show_text("AB").unwrap();
+        ctx.end_text();
+
+        let ops = ctx.operations();
+        // A=0x0041, B=0x0042
+        assert!(
+            ops.contains("<00410042> Tj"),
+            "Expected hex encoding for ASCII in custom font, got: {}",
+            ops
+        );
+    }
+
+    #[test]
+    fn test_show_text_tracks_used_characters() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("CJKFont".to_string()), 12.0);
+
+        ctx.begin_text();
+        ctx.show_text("你好A").unwrap();
+        ctx.end_text();
+
+        assert!(ctx.used_characters.contains(&'你'));
+        assert!(ctx.used_characters.contains(&'好'));
+        assert!(ctx.used_characters.contains(&'A'));
+    }
+
+    #[test]
+    fn test_is_custom_font_toggles_correctly() {
+        let mut ctx = GraphicsContext::new();
+        assert!(!ctx.is_custom_font);
+
+        ctx.set_font(Font::Custom("CJK".to_string()), 12.0);
+        assert!(ctx.is_custom_font);
+
+        ctx.set_font(Font::Helvetica, 12.0);
+        assert!(!ctx.is_custom_font);
+
+        ctx.set_custom_font("AnotherCJK", 14.0);
+        assert!(ctx.is_custom_font);
+
+        ctx.set_font(Font::CourierBold, 10.0);
+        assert!(!ctx.is_custom_font);
     }
 
     #[test]
@@ -3325,5 +3409,130 @@ mod tests {
         assert!(output.contains("cm\n")); // transformations
         assert!(output.contains("BT\n")); // text begin
         assert!(output.contains("ET\n")); // text end
+    }
+
+    // ====== PHASE 5: set_custom_font emits Tf operator ======
+
+    #[test]
+    fn test_set_custom_font_emits_tf_operator() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_custom_font("NotoSansCJK", 14.0);
+
+        let ops = ctx.operations();
+        assert!(
+            ops.contains("/NotoSansCJK 14 Tf"),
+            "set_custom_font should emit Tf operator, got: {}",
+            ops
+        );
+    }
+
+    // ====== PHASE 3: unified custom font detection in draw_text ======
+
+    #[test]
+    fn test_draw_text_uses_is_custom_font_flag() {
+        let mut ctx = GraphicsContext::new();
+        // Name matches a standard font, but set via set_custom_font → flag is true
+        ctx.set_custom_font("Helvetica", 12.0);
+        ctx.clear(); // clear the Tf operator from set_custom_font
+
+        ctx.draw_text("A", 10.0, 20.0).unwrap();
+        let ops = ctx.operations();
+        // Must use hex encoding because is_custom_font=true
+        assert!(
+            ops.contains("<0041> Tj"),
+            "draw_text with is_custom_font=true should use hex, got: {}",
+            ops
+        );
+    }
+
+    #[test]
+    fn test_draw_text_standard_font_uses_literal() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Helvetica, 12.0);
+        ctx.clear();
+
+        ctx.draw_text("Hello", 10.0, 20.0).unwrap();
+        let ops = ctx.operations();
+        assert!(
+            ops.contains("(Hello) Tj"),
+            "draw_text with standard font should use literal, got: {}",
+            ops
+        );
+    }
+
+    // ====== PHASE 2: surrogate pairs for SMP characters ======
+
+    #[test]
+    fn test_show_text_smp_character_uses_surrogate_pairs() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("Emoji".to_string()), 12.0);
+
+        ctx.begin_text();
+        ctx.set_text_position(0.0, 0.0);
+        // U+1F600 (GRINNING FACE) → surrogate pair: D83D DE00
+        ctx.show_text("\u{1F600}").unwrap();
+        ctx.end_text();
+
+        let ops = ctx.operations();
+        assert!(
+            ops.contains("<D83DDE00> Tj"),
+            "SMP character should use UTF-16BE surrogate pair, got: {}",
+            ops
+        );
+        assert!(
+            !ops.contains("FFFD"),
+            "SMP character must NOT be replaced with FFFD"
+        );
+    }
+
+    // ====== PHASE 1: save/restore font state ======
+
+    #[test]
+    fn test_save_restore_preserves_font_state() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("CJK".to_string()), 12.0);
+        assert!(ctx.is_custom_font);
+        assert_eq!(ctx.current_font_name, Some("CJK".to_string()));
+        assert_eq!(ctx.current_font_size, 12.0);
+
+        ctx.save_state();
+        ctx.set_font(Font::Helvetica, 10.0);
+        assert!(!ctx.is_custom_font);
+        assert_eq!(ctx.current_font_name, Some("Helvetica".to_string()));
+
+        ctx.restore_state();
+        assert!(
+            ctx.is_custom_font,
+            "is_custom_font must be restored after restore_state"
+        );
+        assert_eq!(ctx.current_font_name, Some("CJK".to_string()));
+        assert_eq!(ctx.current_font_size, 12.0);
+    }
+
+    #[test]
+    fn test_save_restore_mixed_font_encoding() {
+        let mut ctx = GraphicsContext::new();
+        ctx.set_font(Font::Custom("CJK".to_string()), 12.0);
+
+        // Simulate table cell pattern: save → change font → text → restore → text
+        ctx.save_state();
+        ctx.set_font(Font::Helvetica, 10.0);
+        ctx.begin_text();
+        ctx.show_text("Hello").unwrap();
+        ctx.end_text();
+        ctx.restore_state();
+
+        // After restore, CJK font should be active again
+        ctx.begin_text();
+        ctx.show_text("你好").unwrap();
+        ctx.end_text();
+
+        let ops = ctx.operations();
+        // After restore, text must be hex-encoded (custom font restored)
+        assert!(
+            ops.contains("<4F60597D> Tj"),
+            "After restore_state, CJK text should use hex encoding, got: {}",
+            ops
+        );
     }
 }

--- a/oxidize-pdf-core/src/text/metrics.rs
+++ b/oxidize-pdf-core/src/text/metrics.rs
@@ -1,5 +1,4 @@
 use crate::text::Font;
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -12,18 +11,26 @@ pub struct FontMetrics {
 }
 
 impl FontMetrics {
-    fn new(default_width: u16) -> Self {
+    pub fn new(default_width: u16) -> Self {
         Self {
             widths: HashMap::new(),
             default_width,
         }
     }
 
-    fn with_widths(mut self, widths: &[(char, u16)]) -> Self {
+    pub fn with_widths(mut self, widths: &[(char, u16)]) -> Self {
         for &(ch, width) in widths {
             self.widths.insert(ch, width);
         }
         self
+    }
+
+    /// Create metrics from a pre-built character width map
+    pub fn from_char_map(widths: HashMap<char, u16>, default_width: u16) -> Self {
+        Self {
+            widths,
+            default_width,
+        }
     }
 
     pub fn char_width(&self, ch: char) -> u16 {
@@ -32,7 +39,7 @@ impl FontMetrics {
 }
 
 // Dynamic registry for custom font metrics
-lazy_static! {
+lazy_static::lazy_static! {
     static ref CUSTOM_FONT_METRICS: RwLock<HashMap<String, FontMetrics>> =
         RwLock::new(HashMap::new());
 }
@@ -135,15 +142,6 @@ lazy_static::lazy_static! {
     };
 }
 
-impl FontMetrics {
-    fn clone(&self) -> Self {
-        Self {
-            widths: self.widths.clone(),
-            default_width: self.default_width,
-        }
-    }
-}
-
 /// Measure the width of a text string in a given font and size
 pub fn measure_text(text: &str, font: Font, font_size: f64) -> f64 {
     if font.is_symbolic() {
@@ -202,8 +200,18 @@ pub fn split_into_words(text: &str) -> Vec<&str> {
 
 /// Register metrics for a custom font
 pub fn register_custom_font_metrics(font_name: String, metrics: FontMetrics) {
-    if let Ok(mut custom_metrics) = CUSTOM_FONT_METRICS.write() {
-        custom_metrics.insert(font_name, metrics);
+    match CUSTOM_FONT_METRICS.write() {
+        Ok(mut custom_metrics) => {
+            custom_metrics.insert(font_name, metrics);
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Font metrics registry lock is poisoned; \
+                 could not register metrics for font '{}': {}",
+                font_name,
+                e
+            );
+        }
     }
 }
 
@@ -247,11 +255,18 @@ fn get_font_metrics(font: &Font) -> FontMetrics {
     }
 }
 
-/// Create default metrics for a custom font (fallback when no specific metrics available)
-pub fn create_default_custom_metrics() -> FontMetrics {
-    // Use Helvetica-like metrics as a reasonable default for unknown custom fonts
-    // This prevents panics while providing functional text measurement
-    FontMetrics::new(556).with_widths(&[
+/// Create default metrics for a custom font (fallback when no specific metrics available).
+/// Result is cached via `lazy_static` — the expensive CJK range insertion (~6,500 entries)
+/// only happens once. Subsequent calls return a clone.
+pub(crate) fn create_default_custom_metrics() -> FontMetrics {
+    lazy_static::lazy_static! {
+        static ref DEFAULT_CUSTOM_METRICS: FontMetrics = build_default_custom_metrics();
+    }
+    DEFAULT_CUSTOM_METRICS.clone()
+}
+
+fn build_default_custom_metrics() -> FontMetrics {
+    let mut metrics = FontMetrics::new(556).with_widths(&[
         (' ', 278),
         ('!', 278),
         ('"', 355),
@@ -347,16 +362,27 @@ pub fn create_default_custom_metrics() -> FontMetrics {
         ('|', 260),
         ('}', 334),
         ('~', 584),
-        // Add basic CJK character support with reasonable estimates
-        ('你', 1000),
-        ('好', 1000),
-        ('世', 1000),
-        ('界', 1000),
-        ('中', 1000),
-        ('文', 1000),
-        ('测', 1000),
-        ('试', 1000),
-    ])
+    ]);
+
+    // CJK characters are full-width (1000 units). Insert defaults for common ranges
+    // so that even without registered font metrics, CJK text measurement is reasonable.
+    let cjk_ranges: &[(u32, u32)] = &[
+        (0x3000, 0x303F), // CJK Symbols and Punctuation
+        (0x3040, 0x309F), // Hiragana
+        (0x30A0, 0x30FF), // Katakana
+        (0x4E00, 0x9FFF), // CJK Unified Ideographs
+        (0xF900, 0xFAFF), // CJK Compatibility Ideographs
+        (0xFF00, 0xFFEF), // Halfwidth and Fullwidth Forms
+    ];
+    for &(start, end) in cjk_ranges {
+        for code_point in start..=end {
+            if let Some(ch) = char::from_u32(code_point) {
+                metrics.widths.insert(ch, 1000);
+            }
+        }
+    }
+
+    metrics
 }
 
 #[cfg(test)]
@@ -739,6 +765,23 @@ mod tests {
         assert_eq!(metrics.char_width('0'), 556);
         assert_eq!(metrics.char_width('你'), 1000); // CJK
         assert_eq!(metrics.default_width, 556);
+    }
+
+    #[test]
+    fn test_create_default_custom_metrics_is_cached() {
+        // With lazy_static caching, repeated calls should be fast (clone only).
+        // Without caching, each call does ~6,500 HashMap inserts.
+        use std::time::Instant;
+        let start = Instant::now();
+        for _ in 0..1000 {
+            let _ = create_default_custom_metrics();
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 50,
+            "1000 calls took {}ms; expected < 50ms with caching",
+            elapsed.as_millis()
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/tests/table_integration_test.rs
+++ b/oxidize-pdf-core/tests/table_integration_test.rs
@@ -1,5 +1,9 @@
 //! Integration tests for table functionality
 
+use oxidize_pdf::advanced_tables::{CellData, RowData};
+use oxidize_pdf::text::metrics::{
+    get_custom_font_metrics, measure_text, register_custom_font_metrics, FontMetrics,
+};
 use oxidize_pdf::text::{HeaderStyle, Table, TableCell, TableOptions, TextAlign};
 use oxidize_pdf::writer::WriterConfig;
 use oxidize_pdf::{Color, Document, Font, Page, Result};
@@ -466,4 +470,147 @@ fn test_table_with_standard_font_uses_literal_encoding() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Issue #162: CJK text not aligned center in table cell.
+/// When custom font metrics are registered, measure_text should use actual widths
+/// instead of Helvetica-like fallbacks, producing correct centering.
+#[test]
+fn test_measure_text_uses_registered_custom_font_metrics() {
+    // Register a custom font with known CJK widths
+    let mut widths = std::collections::HashMap::new();
+    // CJK chars should be full-width (1000 units)
+    for ch in "测试中文长文本居中对齐".chars() {
+        widths.insert(ch, 1000u16);
+    }
+    // ASCII chars half-width
+    widths.insert(' ', 500);
+    for ch in 'a'..='z' {
+        widths.insert(ch, 500);
+    }
+    let metrics = FontMetrics::from_char_map(widths, 500);
+    register_custom_font_metrics("TestCJKFont162".to_string(), metrics);
+
+    let font = Font::Custom("TestCJKFont162".to_string());
+
+    // Measure CJK text: 11 chars × 1000 units × (10.5 / 1000) = 115.5
+    let cjk_text = "测试中文长文本居中对齐";
+    let cjk_width = measure_text(cjk_text, font.clone(), 10.5);
+    let expected_cjk_width = 11.0 * 10.5; // 11 CJK chars × full-width
+    assert!(
+        (cjk_width - expected_cjk_width).abs() < 0.01,
+        "CJK text width should be {expected_cjk_width}, got {cjk_width}"
+    );
+
+    // Measure ASCII text: 4 chars × 500 units × (10.5 / 1000) = 21.0
+    let ascii_width = measure_text("test", font, 10.5);
+    let expected_ascii_width = 4.0 * 500.0 * 10.5 / 1000.0;
+    assert!(
+        (ascii_width - expected_ascii_width).abs() < 0.01,
+        "ASCII text width should be {expected_ascii_width}, got {ascii_width}"
+    );
+
+    // CJK text should be wider than ASCII text of same length
+    assert!(
+        cjk_width > ascii_width,
+        "CJK text ({cjk_width}) should be wider than ASCII text ({ascii_width})"
+    );
+}
+
+/// Issue #162: Default custom font metrics should treat CJK chars as full-width (1000).
+#[test]
+fn test_default_custom_metrics_cjk_width() {
+    // Use an unregistered font name to trigger default metrics creation
+    let font = Font::Custom("UnregisteredFontForCJKTest".to_string());
+
+    // CJK character '中' (U+4E2D) should use 1000 width, not 556 (Helvetica default)
+    let cjk_width = measure_text("中", font.clone(), 10.0);
+    let expected = 1000.0 * 10.0 / 1000.0; // 10.0
+    assert!(
+        (cjk_width - expected).abs() < 0.01,
+        "CJK char '中' should measure {expected}, got {cjk_width}"
+    );
+
+    // ASCII 'A' should still use Helvetica-like width (667)
+    let ascii_width = measure_text("A", font, 10.0);
+    let expected_ascii = 667.0 * 10.0 / 1000.0; // 6.67
+    assert!(
+        (ascii_width - expected_ascii).abs() < 0.01,
+        "ASCII 'A' should measure {expected_ascii}, got {ascii_width}"
+    );
+}
+
+/// Issue #163: CellData and RowData must be accessible from public API.
+#[test]
+fn test_celldata_accessible_and_span_works() {
+    // Verify CellData can be constructed and used
+    let cell = CellData::new("Hello").colspan(3).rowspan(2);
+
+    assert_eq!(cell.content, "Hello");
+    assert_eq!(cell.colspan, 3);
+    assert_eq!(cell.rowspan, 2);
+
+    // colspan(0) should clamp to 1 (minimum, not maximum)
+    let cell_zero = CellData::new("Zero span").colspan(0);
+    assert_eq!(cell_zero.colspan, 1, "colspan(0) should clamp to minimum 1");
+
+    // rowspan(0) should clamp to 1
+    let cell_zero_row = CellData::new("Zero row span").rowspan(0);
+    assert_eq!(
+        cell_zero_row.rowspan, 1,
+        "rowspan(0) should clamp to minimum 1"
+    );
+}
+
+/// Issue #163: RowData must be accessible and constructable from CellData.
+#[test]
+fn test_rowdata_from_cells() {
+    let cells = vec![
+        CellData::new("Cell 1").colspan(2),
+        CellData::new("Cell 2"),
+        CellData::new("Cell 3").rowspan(3),
+    ];
+
+    let row = RowData::from_cells(cells);
+    assert_eq!(row.cells.len(), 3);
+    assert_eq!(row.cells[0].colspan, 2);
+    assert_eq!(row.cells[1].colspan, 1); // default
+    assert_eq!(row.cells[2].rowspan, 3);
+}
+
+/// Quality item #4: default_width should be computed as average, not hardcoded 500.
+#[test]
+fn test_from_char_map_default_width_is_average() {
+    let mut widths = std::collections::HashMap::new();
+    widths.insert('A', 700u16);
+    widths.insert('B', 600u16);
+    widths.insert('C', 500u16);
+    // Average = (700 + 600 + 500) / 3 = 600
+    let avg: u16 = 600;
+    let metrics = FontMetrics::from_char_map(widths, avg);
+    // Unknown char 'Z' should use the average as default
+    assert_eq!(
+        metrics.char_width('Z'),
+        600,
+        "default_width should reflect the font's average width, not a hardcoded value"
+    );
+}
+
+/// Quality item #1: add_font_from_bytes must not leave metrics registered on failure.
+#[test]
+fn test_add_font_from_bytes_no_metrics_on_failure() {
+    let font_name = "FailTestFont_unique_162_163";
+    assert!(
+        get_custom_font_metrics(font_name).is_none(),
+        "metrics must not exist before the call"
+    );
+
+    let mut doc = Document::new();
+    // Invalid font data — parsing will fail
+    let result = doc.add_font_from_bytes(font_name, vec![0u8; 16]);
+    assert!(result.is_err(), "invalid font data should produce an error");
+    assert!(
+        get_custom_font_metrics(font_name).is_none(),
+        "metrics must NOT be registered when add_font_from_bytes fails"
+    );
 }

--- a/oxidize-pdf-core/tests/table_integration_test.rs
+++ b/oxidize-pdf-core/tests/table_integration_test.rs
@@ -1,6 +1,7 @@
 //! Integration tests for table functionality
 
 use oxidize_pdf::text::{HeaderStyle, Table, TableCell, TableOptions, TextAlign};
+use oxidize_pdf::writer::WriterConfig;
 use oxidize_pdf::{Color, Document, Font, Page, Result};
 use std::fs;
 use tempfile::TempDir;
@@ -382,5 +383,87 @@ fn test_table_with_custom_fonts() -> Result<()> {
     doc.save(&file_path)?;
 
     assert!(file_path.exists());
+    Ok(())
+}
+
+/// Issue #160: CJK font not displayed correctly in Table
+/// Verifies that Table with Font::Custom uses hex-encoded CID strings
+/// instead of literal PDF strings, which is required for Type0/CJK fonts.
+#[test]
+fn test_table_with_custom_font_uses_hex_encoding() -> Result<()> {
+    let mut doc = Document::new();
+    doc.set_title("CJK Table Font Test - Issue #160");
+
+    let mut page = Page::a4();
+
+    let mut table = Table::new(vec![200.0, 200.0]);
+    table.set_position(50.0, 700.0);
+
+    let mut options = TableOptions::default();
+    options.font = Font::Custom("NotoSansCJK".to_string());
+    options.font_size = 12.0;
+    table.set_options(options);
+
+    // Add row with CJK text: 你好 (U+4F60 U+597D)
+    table.add_row(vec!["你好".to_string(), "世界".to_string()])?;
+
+    page.add_table(&table)?;
+    doc.add_page(page);
+
+    // Disable stream compression so we can inspect raw content stream
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let pdf_bytes = doc.to_bytes_with_config(config)?;
+    let pdf_content = String::from_utf8_lossy(&pdf_bytes);
+
+    // The content stream must contain hex-encoded CIDs with Tj operator
+    // 你=U+4F60, 好=U+597D → <4F60597D> Tj
+    // 世=U+4E16, 界=U+754C → <4E16754C> Tj
+    assert!(
+        pdf_content.contains("<4F60597D> Tj"),
+        "PDF should contain hex-encoded CJK text '你好' as <4F60597D> Tj operator"
+    );
+    assert!(
+        pdf_content.contains("<4E16754C> Tj"),
+        "PDF should contain hex-encoded CJK text '世界' as <4E16754C> Tj operator"
+    );
+
+    // Must NOT contain literal CJK characters in PDF string syntax
+    assert!(
+        !pdf_content.contains("(你好)"),
+        "PDF must not contain literal CJK in parenthesized string"
+    );
+
+    Ok(())
+}
+
+/// Regression test: standard font tables must use literal encoding, not hex.
+#[test]
+fn test_table_with_standard_font_uses_literal_encoding() -> Result<()> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    let mut table = Table::new(vec![200.0]);
+    table.set_position(50.0, 700.0);
+    // Default font is Helvetica (standard)
+    table.add_row(vec!["Hello World".to_string()])?;
+
+    page.add_table(&table)?;
+    doc.add_page(page);
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let pdf_bytes = doc.to_bytes_with_config(config)?;
+    let pdf_content = String::from_utf8_lossy(&pdf_bytes);
+
+    assert!(
+        pdf_content.contains("(Hello World) Tj"),
+        "Standard font table must use literal string encoding"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- **CJK font rendering in tables** (#160) — CJK glyphs now use correct fonts in table cells
- **Table cell text alignment** (#162) — Text correctly centered/aligned within cells
- **CellData public accessibility** (#163) — CellData fields exposed for downstream consumers
- **Changelog backfill** — Added missing entries for v2.1.0 through v2.3.3

## Changelog
See [CHANGELOG.md](CHANGELOG.md) for full details.

## Test plan
- [x] 6253 unit tests passing, 0 failures
- [ ] Verify CJK table rendering with test PDFs
- [ ] Verify CellData fields are accessible from external crate
- [ ] Tag v2.3.4 and publish to crates.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)