### PR TITLE
fix(fonts): CID-keyed CFF font subsetting — text now renders (#165)

### DIFF
--- a/oxidize-pdf-core/src/text/fonts/cff_subsetter.rs
+++ b/oxidize-pdf-core/src/text/fonts/cff_subsetter.rs
@@ -183,10 +183,13 @@ impl<'a> Iterator for CffDictScanner<'a> {
 
 /// Result of CFF font subsetting
 pub struct CffSubsetResult {
-    /// Complete OTF file with subsetted CFF table
+    /// Font data: raw CFF bytes for CID-keyed fonts, OTF for non-CID fonts
     pub font_data: Vec<u8>,
     /// Unicode codepoint → new GID mapping
     pub glyph_mapping: HashMap<u32, u16>,
+    /// True if font_data is raw CFF (embed with /CIDFontType0C),
+    /// false if it's a full OTF (embed with /OpenType)
+    pub is_raw_cff: bool,
 }
 
 /// Subset a CFF/OpenType font to include only the specified characters.
@@ -292,17 +295,40 @@ pub fn subset_cff_font(
             return Ok(CffSubsetResult {
                 font_data: font_data.to_vec(),
                 glyph_mapping: filtered_mapping,
+                is_raw_cff: false,
             });
         }
     };
 
-    // Reconstruct OTF with the new CFF table
-    let new_font = otf.rebuild(font_data, b"CFF ", &new_cff)?;
+    // Check if CFF is CID-keyed by looking at the Top DICT for FDArray/FDSelect.
+    // CID-keyed: embed raw CFF with /Subtype /CIDFontType0C (industry standard).
+    // Non-CID: embed as OTF with /Subtype /OpenType.
+    let top_dict_index_for_check = parse_cff_index(cff_data, {
+        let name_idx = parse_cff_index(cff_data, cff_data[2] as usize)?;
+        name_idx.end_offset()
+    })?;
+    let td_bytes = top_dict_index_for_check
+        .get_item(0, cff_data)
+        .unwrap_or(&[]);
+    let td_offsets = parse_top_dict(td_bytes);
+    let is_cid = td_offsets.fd_array_offset.is_some() || td_offsets.fd_select_offset.is_some();
 
-    Ok(CffSubsetResult {
-        font_data: new_font,
-        glyph_mapping: new_glyph_mapping,
-    })
+    if is_cid {
+        // CID-keyed: return raw CFF bytes directly
+        Ok(CffSubsetResult {
+            font_data: new_cff,
+            glyph_mapping: new_glyph_mapping,
+            is_raw_cff: true,
+        })
+    } else {
+        // Non-CID: wrap in OTF
+        let new_font = otf.rebuild_subset(font_data, &new_cff, needed_gids.len() as u16)?;
+        Ok(CffSubsetResult {
+            font_data: new_font,
+            glyph_mapping: new_glyph_mapping,
+            is_raw_cff: false,
+        })
+    }
 }
 
 // =============================================================================
@@ -311,7 +337,6 @@ pub fn subset_cff_font(
 
 struct OtfTableEntry {
     tag: [u8; 4],
-    checksum: u32,
     offset: u32,
     length: u32,
 }
@@ -344,12 +369,10 @@ impl OtfFile {
         for i in 0..num_tables {
             let base = 12 + i * 16;
             let tag = [data[base], data[base + 1], data[base + 2], data[base + 3]];
-            let checksum = read_u32(data, base + 4)?;
             let offset = read_u32(data, base + 8)?;
             let length = read_u32(data, base + 12)?;
             tables.push(OtfTableEntry {
                 tag,
-                checksum,
                 offset,
                 length,
             });
@@ -371,20 +394,48 @@ impl OtfFile {
             })
     }
 
-    /// Rebuild the OTF file, replacing the data for `replaced_tag` with `new_data`.
-    /// All other tables are copied verbatim from `original`.
-    fn rebuild(
+    /// Rebuild the OTF file replacing the CFF table and patching maxp, hhea, hmtx,
+    /// and cmap to match the actual glyph count after subsetting.
+    /// This is critical: if maxp reports 65K glyphs but CFF has 5, viewers reject the font.
+    /// Tables required for a valid CIDFontType0 font embedded in PDF.
+    /// Everything else (GSUB, GPOS, vmtx, vhea, VORG, DSIG, GDEF, BASE, name, post, OS/2)
+    /// is not needed for rendering and can be dropped to save space.
+    const REQUIRED_TABLES: &'static [&'static [u8; 4]] =
+        &[b"CFF ", b"head", b"maxp", b"hhea", b"hmtx", b"cmap"];
+
+    fn rebuild_subset(
         &self,
         original: &[u8],
-        replaced_tag: &[u8; 4],
-        new_data: &[u8],
+        new_cff: &[u8],
+        new_glyph_count: u16,
     ) -> ParseResult<Vec<u8>> {
-        let num_tables = self.tables.len() as u16;
+        // Build patched versions of tables that depend on glyph count
+        let patched_maxp = self.patch_maxp(original, new_glyph_count);
+        let patched_hhea = self.patch_hhea(original, new_glyph_count);
+        let patched_hmtx = self.truncate_hmtx(original, new_glyph_count);
+        let minimal_cmap = Self::build_minimal_cmap();
 
-        // Header size: 12 bytes (sfnt header) + 16 bytes per table entry
+        // Map of tag → replacement data
+        let replacements: std::collections::HashMap<&[u8; 4], &[u8]> = [
+            (b"CFF ", new_cff as &[u8]),
+            (b"maxp", patched_maxp.as_deref().unwrap_or(&[])),
+            (b"hhea", patched_hhea.as_deref().unwrap_or(&[])),
+            (b"hmtx", patched_hmtx.as_deref().unwrap_or(&[])),
+            (b"cmap", &minimal_cmap as &[u8]),
+        ]
+        .into_iter()
+        .filter(|(_, data)| !data.is_empty())
+        .collect();
+
+        // Only keep required tables — drop GSUB, GPOS, vmtx, vhea, etc.
+        let kept_tables: Vec<&OtfTableEntry> = self
+            .tables
+            .iter()
+            .filter(|e| Self::REQUIRED_TABLES.iter().any(|t| *t == &e.tag))
+            .collect();
+        let num_tables = kept_tables.len() as u16;
         let header_size = 12 + num_tables as usize * 16;
 
-        // Compute floor(log2(num_tables)) using integer bit math
         let entry_selector = if num_tables > 0 {
             (u16::BITS - num_tables.leading_zeros() - 1) as u16
         } else {
@@ -393,18 +444,16 @@ impl OtfFile {
         let search_range = (1u16 << entry_selector) * 16;
         let range_shift = num_tables * 16 - search_range;
 
-        // First pass: determine each table's offset in the new file
-        // Tables are written in their original order, 4-byte aligned.
-        let mut offsets: Vec<u32> = Vec::with_capacity(self.tables.len());
+        // Determine offsets
+        let mut offsets: Vec<u32> = Vec::with_capacity(kept_tables.len());
         let mut current = header_size;
-        for entry in &self.tables {
-            // Align to 4-byte boundary
+        for entry in &kept_tables {
             while current % 4 != 0 {
                 current += 1;
             }
             offsets.push(current as u32);
-            let len = if &entry.tag == replaced_tag {
-                new_data.len()
+            let len = if let Some(data) = replacements.get(&entry.tag) {
+                data.len()
             } else {
                 entry.length as usize
             };
@@ -414,18 +463,18 @@ impl OtfFile {
         let total_size = current;
         let mut out = vec![0u8; total_size];
 
-        // Write OTF header
+        // Write header
         out[0..4].copy_from_slice(&self.sfnt_version.to_be_bytes());
         out[4..6].copy_from_slice(&num_tables.to_be_bytes());
         out[6..8].copy_from_slice(&search_range.to_be_bytes());
         out[8..10].copy_from_slice(&entry_selector.to_be_bytes());
         out[10..12].copy_from_slice(&range_shift.to_be_bytes());
 
-        // Write table directory and table data
-        for (i, entry) in self.tables.iter().enumerate() {
+        // Write tables
+        for (i, entry) in kept_tables.iter().enumerate() {
             let offset = offsets[i] as usize;
-            let table_data: &[u8] = if &entry.tag == replaced_tag {
-                new_data
+            let table_data: &[u8] = if let Some(data) = replacements.get(&entry.tag) {
+                data
             } else {
                 let src_start = entry.offset as usize;
                 let src_end = src_start + entry.length as usize;
@@ -441,12 +490,7 @@ impl OtfFile {
                 &original[src_start..src_end]
             };
 
-            // Recompute checksum for this table
-            let checksum = if &entry.tag == replaced_tag {
-                otf_checksum(new_data)
-            } else {
-                entry.checksum
-            };
+            let checksum = otf_checksum(table_data);
 
             // Directory entry
             let dir_base = 12 + i * 16;
@@ -460,29 +504,23 @@ impl OtfFile {
             out[offset..offset + table_data.len()].copy_from_slice(table_data);
         }
 
-        // Set head.checkSumAdjustment per OTF spec §5.2.8:
-        //   1. Zero the checkSumAdjustment field (bytes 8-11 of the head table).
-        //   2. Calculate checksum of the entire font file.
-        //   3. Set checkSumAdjustment = 0xB1B0AFBA - total_checksum.
-        let head_tag = b"head";
-        if let Some((head_idx, _)) = self
-            .tables
+        // Fix head.checkSumAdjustment
+        if let Some((head_idx, _)) = kept_tables
             .iter()
             .enumerate()
-            .find(|(_, e)| &e.tag == head_tag)
+            .find(|(_, e)| &e.tag == b"head")
         {
             let head_offset = offsets[head_idx] as usize;
-            // head table must be at least 12 bytes for checkSumAdjustment at offset 8
             if head_offset + 12 <= out.len() {
-                // Step 1: zero checkSumAdjustment before computing file checksum
                 out[head_offset + 8..head_offset + 12].copy_from_slice(&[0u8; 4]);
-                // Step 2: compute file checksum
                 let total_checksum = otf_checksum(&out);
-                // Step 3: write adjustment
                 let adjustment = 0xB1B0_AFBAu32.wrapping_sub(total_checksum);
                 out[head_offset + 8..head_offset + 12].copy_from_slice(&adjustment.to_be_bytes());
-                // Update head table checksum in the directory entry to reflect the new content
-                let head_len = self.tables[head_idx].length as usize;
+                let head_len = if replacements.contains_key(b"head") {
+                    replacements[b"head"].len()
+                } else {
+                    kept_tables[head_idx].length as usize
+                };
                 let new_head_checksum = otf_checksum(&out[head_offset..head_offset + head_len]);
                 let dir_base = 12 + head_idx * 16;
                 out[dir_base + 4..dir_base + 8].copy_from_slice(&new_head_checksum.to_be_bytes());
@@ -490,6 +528,85 @@ impl OtfFile {
         }
 
         Ok(out)
+    }
+
+    /// Patch maxp table: update numGlyphs field (offset 4, 2 bytes).
+    fn patch_maxp(&self, original: &[u8], new_glyph_count: u16) -> Option<Vec<u8>> {
+        let entry = self.tables.iter().find(|e| &e.tag == b"maxp")?;
+        let start = entry.offset as usize;
+        let end = start + entry.length as usize;
+        if end > original.len() || entry.length < 6 {
+            return None;
+        }
+        let mut patched = original[start..end].to_vec();
+        patched[4..6].copy_from_slice(&new_glyph_count.to_be_bytes());
+        Some(patched)
+    }
+
+    /// Patch hhea table: update numberOfHMetrics (offset 34, 2 bytes).
+    fn patch_hhea(&self, original: &[u8], new_glyph_count: u16) -> Option<Vec<u8>> {
+        let entry = self.tables.iter().find(|e| &e.tag == b"hhea")?;
+        let start = entry.offset as usize;
+        let end = start + entry.length as usize;
+        if end > original.len() || entry.length < 36 {
+            return None;
+        }
+        let mut patched = original[start..end].to_vec();
+        patched[34..36].copy_from_slice(&new_glyph_count.to_be_bytes());
+        Some(patched)
+    }
+
+    /// Truncate hmtx to only include entries for new_glyph_count glyphs.
+    /// Each entry is 4 bytes (advanceWidth u16 + lsb i16).
+    fn truncate_hmtx(&self, original: &[u8], new_glyph_count: u16) -> Option<Vec<u8>> {
+        let entry = self.tables.iter().find(|e| &e.tag == b"hmtx")?;
+        let start = entry.offset as usize;
+        let needed = new_glyph_count as usize * 4;
+        let available = entry.length as usize;
+        let take = needed.min(available);
+        let end = start + take;
+        if end > original.len() {
+            return None;
+        }
+        Some(original[start..end].to_vec())
+    }
+
+    /// Build a minimal cmap table: Format 4 with only the terminal 0xFFFF segment.
+    /// For CIDFontType0 with Identity-H, the PDF viewer resolves CID→GID via the
+    /// CFF charset, not the OTF cmap. A minimal cmap satisfies OTF validation.
+    fn build_minimal_cmap() -> Vec<u8> {
+        let mut cmap = Vec::new();
+        // cmap header: version=0, numTables=1
+        cmap.extend_from_slice(&0u16.to_be_bytes()); // version
+        cmap.extend_from_slice(&1u16.to_be_bytes()); // numTables
+                                                     // Encoding record: platformID=3 (Windows), encodingID=1 (Unicode BMP)
+        cmap.extend_from_slice(&3u16.to_be_bytes()); // platformID
+        cmap.extend_from_slice(&1u16.to_be_bytes()); // encodingID
+        cmap.extend_from_slice(&12u32.to_be_bytes()); // offset to subtable
+
+        // Format 4 subtable with single terminal segment (0xFFFF)
+        let seg_count: u16 = 1;
+        let seg_count_x2 = seg_count * 2;
+        let length: u16 = 14 + seg_count_x2 * 4; // header(14) + 4 arrays of seg_count entries
+        cmap.extend_from_slice(&4u16.to_be_bytes()); // format
+        cmap.extend_from_slice(&length.to_be_bytes()); // length
+        cmap.extend_from_slice(&0u16.to_be_bytes()); // language
+        cmap.extend_from_slice(&seg_count_x2.to_be_bytes()); // segCountX2
+        cmap.extend_from_slice(&2u16.to_be_bytes()); // searchRange
+        cmap.extend_from_slice(&0u16.to_be_bytes()); // entrySelector
+        cmap.extend_from_slice(&0u16.to_be_bytes()); // rangeShift
+                                                     // endCode
+        cmap.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        // reservedPad
+        cmap.extend_from_slice(&0u16.to_be_bytes());
+        // startCode
+        cmap.extend_from_slice(&0xFFFFu16.to_be_bytes());
+        // idDelta
+        cmap.extend_from_slice(&1u16.to_be_bytes());
+        // idRangeOffset
+        cmap.extend_from_slice(&0u16.to_be_bytes());
+
+        cmap
     }
 }
 
@@ -1301,8 +1418,9 @@ fn subset_cid_cff_table(
                     let start = priv_off as usize;
                     let end = (start + priv_size as usize).min(cff.len());
                     let pb = cff[start..end].to_vec();
-                    // Locate Local Subr INDEX: first try op 19 from Private DICT (CFF spec),
-                    // then fall back to heuristic (parse INDEX immediately after Private DICT).
+                    // Keep the Local Subr INDEX — CharStrings use callsubr to
+                    // reference subroutines that contain the actual glyph outlines.
+                    // Without them, glyphs fail to render in PDF viewers.
                     let ls = if let Some(subrs_rel) = parse_local_subrs_offset(&pb) {
                         let subrs_abs = start + subrs_rel;
                         match parse_cff_index(cff, subrs_abs) {
@@ -1332,6 +1450,29 @@ fn subset_cid_cff_table(
         });
     }
 
+    // Patch op 19 (Subrs) in each Private DICT BEFORE offset calculation.
+    // The Local Subr INDEX is placed immediately after the Private DICT,
+    // so op 19 must equal the Private DICT's length. This must happen before
+    // the two-pass assembly because patching can change the Private DICT size.
+    for fd in &mut fd_data_list {
+        if !fd.local_subr_bytes.is_empty() {
+            let orig_len = fd.private_bytes.len();
+            // Two-step patch: first patch with a dummy value to stabilize the size
+            // (encode_cff_int_5byte always produces 5 bytes), then patch with the
+            // actual offset which equals the Private DICT's new length.
+            patch_private_subrs_offset(&mut fd.private_bytes, 0);
+            let after_first = fd.private_bytes.len();
+            let subrs_offset = after_first as i32;
+            patch_private_subrs_offset(&mut fd.private_bytes, subrs_offset);
+            tracing::debug!(
+                "Private DICT patch: {} → {} bytes, op19={}",
+                orig_len,
+                fd.private_bytes.len(),
+                subrs_offset
+            );
+        }
+    }
+
     // --- Two-pass offset assembly ---
     // Layout:
     //   [0] Header
@@ -1346,6 +1487,8 @@ fn subset_cid_cff_table(
     //   [9..] Private DICTs (one per needed FD)
 
     let name_bytes = name_index.raw_bytes(cff);
+    // Keep String INDEX and Global Subr INDEX — CharStrings may reference
+    // global subrs via callgsubr, and some DICTs reference string SIDs.
     let string_bytes = string_index.raw_bytes(cff);
     let global_subr_bytes = global_subr_index.raw_bytes(cff);
 
@@ -1829,6 +1972,48 @@ fn parse_local_subrs_offset(private_dict: &[u8]) -> Option<usize> {
         }
     }
     None
+}
+
+/// Patch the Subrs operator (op 19) in a Private DICT to point to `new_offset`.
+/// The offset is relative to the start of the Private DICT data.
+/// If op 19 doesn't exist but local subrs are present, appends it.
+fn patch_private_subrs_offset(private_dict: &mut Vec<u8>, new_offset: i32) {
+    // Scan for op 19 and replace its operand
+    let mut scanner = CffDictScanner::new(private_dict);
+    let mut op19_operand_start: Option<usize> = None;
+    let mut op19_end: Option<usize> = None;
+    let mut operand_start = 0usize;
+
+    loop {
+        let token = match scanner.next() {
+            Some(t) => t,
+            None => break,
+        };
+        match token {
+            CffDictToken::Operand(_) => {}
+            CffDictToken::EscapedOperator(_) => {
+                operand_start = scanner.position();
+            }
+            CffDictToken::Operator(b) => {
+                if b == 19 {
+                    op19_operand_start = Some(operand_start);
+                    op19_end = Some(scanner.position());
+                }
+                operand_start = scanner.position();
+            }
+        }
+    }
+
+    if let (Some(start), Some(end)) = (op19_operand_start, op19_end) {
+        // Replace: remove old operand+op19, insert new operand+op19
+        let mut replacement = encode_cff_int_5byte(new_offset).to_vec();
+        replacement.push(19); // op 19
+        private_dict.splice(start..end, replacement);
+    } else {
+        // No op 19 found — append it
+        private_dict.extend_from_slice(&encode_cff_int_5byte(new_offset));
+        private_dict.push(19);
+    }
 }
 
 /// Read a CFF Charset table from the CFF table.

--- a/oxidize-pdf-core/src/text/fonts/truetype_subsetter.rs
+++ b/oxidize-pdf-core/src/text/fonts/truetype_subsetter.rs
@@ -85,6 +85,22 @@ pub fn should_skip_subsetting(font_size: usize, char_count: usize) -> bool {
     font_size < SUBSETTING_SIZE_THRESHOLD && char_count < SUBSETTING_CHAR_THRESHOLD
 }
 
+/// Filter a full cmap mapping to only include codepoints in `used_chars`.
+/// Used when the font is not subsetted (full font embedded) to avoid leaking
+/// unused entries into the W array and CIDToGIDMap.
+fn filter_mapping_to_used(
+    mappings: &HashMap<u32, u16>,
+    used_chars: &HashSet<char>,
+) -> HashMap<u32, u16> {
+    used_chars
+        .iter()
+        .filter_map(|ch| {
+            let cp = *ch as u32;
+            mappings.get(&cp).map(|&gid| (cp, gid))
+        })
+        .collect()
+}
+
 /// Table record for font directory
 struct TableRecord {
     tag: [u8; 4],
@@ -142,6 +158,9 @@ pub struct SubsetResult {
     pub font_data: Vec<u8>,
     /// Unicode to GlyphID mapping for the subsetted font
     pub glyph_mapping: HashMap<u32, u16>,
+    /// True if font_data is raw CFF bytes (embed with /CIDFontType0C),
+    /// false if it's OTF or TrueType (embed with /OpenType or /FontFile2)
+    pub is_raw_cff: bool,
 }
 
 /// Extract component glyph IDs from a composite glyph's raw data.
@@ -295,7 +314,8 @@ impl TrueTypeSubsetter {
         if should_skip_subsetting(self.font_data.len(), used_chars.len()) {
             return Ok(SubsetResult {
                 font_data: self.font_data.clone(),
-                glyph_mapping: cmap.mappings.clone(),
+                glyph_mapping: filter_mapping_to_used(&cmap.mappings, used_chars),
+                is_raw_cff: false,
             });
         }
 
@@ -325,13 +345,10 @@ impl TrueTypeSubsetter {
                 "  Keeping full font (using {:.1}% of glyphs)",
                 subset_ratio * 100.0
             );
-            // Return the full font with COMPLETE mapping to support all characters
-            // Even though we're not subsetting the font data, we need all mappings
-            // for proper CIDToGIDMap generation
-
             return Ok(SubsetResult {
                 font_data: self.font_data.clone(),
-                glyph_mapping: cmap.mappings.clone(), // Use complete mapping
+                glyph_mapping: filter_mapping_to_used(&cmap.mappings, used_chars),
+                is_raw_cff: false,
             });
         }
 
@@ -353,13 +370,15 @@ impl TrueTypeSubsetter {
                     return Ok(SubsetResult {
                         font_data: result.font_data,
                         glyph_mapping: result.glyph_mapping,
+                        is_raw_cff: result.is_raw_cff,
                     });
                 }
                 Err(e) => {
                     tracing::debug!("  CFF subsetting failed: {:?}, using full font", e);
                     return Ok(SubsetResult {
                         font_data: self.font_data.clone(),
-                        glyph_mapping: cmap.mappings.clone(),
+                        glyph_mapping: filter_mapping_to_used(&cmap.mappings, used_chars),
+                        is_raw_cff: false,
                     });
                 }
             }
@@ -398,14 +417,15 @@ impl TrueTypeSubsetter {
                 Ok(SubsetResult {
                     font_data: subset_font_data,
                     glyph_mapping: new_cmap,
+                    is_raw_cff: false,
                 })
             }
             Err(e) => {
                 tracing::debug!("  Subsetting failed: {:?}, using full font as fallback", e);
-                // Fallback to full font if subsetting fails
                 Ok(SubsetResult {
                     font_data: self.font_data.clone(),
                     glyph_mapping: cmap.mappings.clone(),
+                    is_raw_cff: false,
                 })
             }
         }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1362,49 +1362,47 @@ impl<W: Write> PdfWriter<W> {
         // Write font file (embedded TTF data with subsetting for large fonts)
         // Keep track of the glyph mapping if we subset the font
         // IMPORTANT: We need the ORIGINAL font for width calculations, not the subset
-        let (font_data_to_embed, subset_glyph_mapping, original_font_for_widths) =
+        let (font_data_to_embed, subset_glyph_mapping, original_font_for_widths, embed_as_raw_cff) =
             if font.data.len() > 100_000 && !used_chars.is_empty() {
-                // Large font - try to subset it
                 match crate::text::fonts::truetype_subsetter::subset_font(
                     font.data.clone(),
                     &used_chars,
                 ) {
-                    Ok(subset_result) => {
-                        // Successfully subsetted - keep both font data and mapping
-                        // Also keep reference to original font for width calculations
-                        (
-                            subset_result.font_data,
-                            Some(subset_result.glyph_mapping),
-                            font.clone(),
-                        )
-                    }
+                    Ok(subset_result) => (
+                        subset_result.font_data,
+                        Some(subset_result.glyph_mapping),
+                        font.clone(),
+                        subset_result.is_raw_cff,
+                    ),
                     Err(_) => {
-                        // Subsetting failed, use original if under 25MB
                         if font.data.len() < 25_000_000 {
-                            (font.data.clone(), None, font.clone())
+                            (font.data.clone(), None, font.clone(), false)
                         } else {
-                            // Too large even for fallback
-                            (Vec::new(), None, font.clone())
+                            (Vec::new(), None, font.clone(), false)
                         }
                     }
                 }
             } else {
-                // Small font or no character tracking - use as-is
-                (font.data.clone(), None, font.clone())
+                (font.data.clone(), None, font.clone(), false)
             };
 
         if !font_data_to_embed.is_empty() {
             let mut font_file_dict = Dictionary::new();
-            // Add appropriate properties based on font format
-            match font.format {
-                crate::fonts::FontFormat::OpenType => {
-                    // CFF/OpenType fonts use FontFile3 with OpenType subtype
-                    font_file_dict.set("Subtype", Object::Name("OpenType".to_string()));
-                    font_file_dict.set("Length1", Object::Integer(font_data_to_embed.len() as i64));
-                }
-                crate::fonts::FontFormat::TrueType => {
-                    // TrueType fonts use FontFile2 with Length1
-                    font_file_dict.set("Length1", Object::Integer(font_data_to_embed.len() as i64));
+            if embed_as_raw_cff {
+                // CID-keyed CFF: embed raw CFF bytes with /CIDFontType0C
+                // This is the industry standard for CID fonts in PDF.
+                font_file_dict.set("Subtype", Object::Name("CIDFontType0C".to_string()));
+            } else {
+                match font.format {
+                    crate::fonts::FontFormat::OpenType => {
+                        font_file_dict.set("Subtype", Object::Name("OpenType".to_string()));
+                        font_file_dict
+                            .set("Length1", Object::Integer(font_data_to_embed.len() as i64));
+                    }
+                    crate::fonts::FontFormat::TrueType => {
+                        font_file_dict
+                            .set("Length1", Object::Integer(font_data_to_embed.len() as i64));
+                    }
                 }
             }
             let font_stream_obj = Object::Stream(font_file_dict, font_data_to_embed);

--- a/oxidize-pdf-core/tests/cff_subsetter_test.rs
+++ b/oxidize-pdf-core/tests/cff_subsetter_test.rs
@@ -263,29 +263,38 @@ fn build_minimal_cff_otf(num_glyphs: u16) -> Vec<u8> {
 // =============================================================================
 
 #[test]
-fn test_cff_font_subsetting_does_not_panic() {
-    let font_data = build_minimal_cff_otf(100);
-    let used: HashSet<char> = "ABC".chars().collect();
-    let result = subset_font(font_data, &used);
-    assert!(
-        result.is_ok(),
-        "subset_font must not fail for CFF: {:?}",
-        result.err()
-    );
-}
-
-#[test]
-fn test_cff_font_subset_preserves_glyph_mapping_for_used_chars() {
+fn test_cff_small_font_mapping_filtered_to_used_chars() {
+    // Small fonts (<100KB) are not subsetted, but the mapping must be filtered
+    // to only include the used characters (not the full cmap).
     let font_data = build_minimal_cff_otf(100);
     let used: HashSet<char> = "AB".chars().collect();
     let result = subset_font(font_data, &used).unwrap();
-    assert!(
-        result.glyph_mapping.contains_key(&('A' as u32)),
-        "Mapping must contain 'A'"
+
+    // Mapping must have exactly 2 entries (only the used chars)
+    assert_eq!(
+        result.glyph_mapping.len(),
+        2,
+        "Mapping should have exactly 2 entries for 'AB', got {}",
+        result.glyph_mapping.len()
     );
+
+    // Both chars must be present with non-zero GIDs
+    let gid_a = *result
+        .glyph_mapping
+        .get(&('A' as u32))
+        .expect("Mapping must contain 'A'");
+    let gid_b = *result
+        .glyph_mapping
+        .get(&('B' as u32))
+        .expect("Mapping must contain 'B'");
+    assert_ne!(gid_a, 0, "'A' must not map to .notdef (GID 0)");
+    assert_ne!(gid_b, 0, "'B' must not map to .notdef (GID 0)");
+    assert_ne!(gid_a, gid_b, "'A' and 'B' must have different GIDs");
+
+    // Chars NOT used must NOT be in the mapping
     assert!(
-        result.glyph_mapping.contains_key(&('B' as u32)),
-        "Mapping must contain 'B'"
+        !result.glyph_mapping.contains_key(&('Z' as u32)),
+        "Unused char 'Z' should not be in glyph mapping"
     );
 }
 
@@ -478,7 +487,7 @@ fn build_large_cff_table(num_glyphs: u16) -> Vec<u8> {
 }
 
 #[test]
-fn test_cff_subset_reduces_size_for_large_font() {
+fn test_cff_subset_reduces_size_and_preserves_mapping() {
     let font_data = build_large_cff_otf();
     let original_size = font_data.len();
     assert!(
@@ -490,27 +499,62 @@ fn test_cff_subset_reduces_size_for_large_font() {
     let used: HashSet<char> = "AB".chars().collect();
     let result = subset_font(font_data, &used).unwrap();
 
-    // The subset should be significantly smaller
+    // Size: 2 glyphs + .notdef from a 10,000 glyph font should be <5% of original
     assert!(
-        result.font_data.len() < original_size / 2,
-        "CFF subset ({} bytes) must be < 50% of original ({} bytes)",
+        result.font_data.len() < original_size / 20,
+        "CFF subset ({} bytes) should be <5% of original ({} bytes) for 2 chars out of 10,000",
         result.font_data.len(),
         original_size
+    );
+
+    // Mapping must be exactly the 2 used chars
+    assert_eq!(
+        result.glyph_mapping.len(),
+        2,
+        "Glyph mapping should have exactly 2 entries for 2 used chars, got {}",
+        result.glyph_mapping.len()
+    );
+    assert!(result.glyph_mapping.contains_key(&('A' as u32)));
+    assert!(result.glyph_mapping.contains_key(&('B' as u32)));
+
+    // Subsetted font must be a valid OTF (starts with 'OTTO' signature)
+    assert!(
+        result.font_data.len() >= 4,
+        "Subset font data too small to be valid OTF"
+    );
+    let sfnt = u32::from_be_bytes([
+        result.font_data[0],
+        result.font_data[1],
+        result.font_data[2],
+        result.font_data[3],
+    ]);
+    assert_eq!(
+        sfnt, 0x4F54544F,
+        "Subset font must have OTTO signature, got {:#010X}",
+        sfnt
     );
 }
 
 #[test]
-fn test_cff_subset_notdef_always_included() {
+fn test_cff_subset_only_keeps_used_glyphs() {
     let font_data = build_large_cff_otf();
     let used: HashSet<char> = "A".chars().collect();
     let result = subset_font(font_data, &used).unwrap();
 
-    // The subset font must be parseable and smaller than original
-    // (GID 0 .notdef + GID for 'A' = 2 glyphs max)
+    // Mapping: exactly 1 char
+    assert_eq!(
+        result.glyph_mapping.len(),
+        1,
+        "Should have exactly 1 glyph mapping entry, got {}",
+        result.glyph_mapping.len()
+    );
+    let gid = result.glyph_mapping[&('A' as u32)];
+    assert_eq!(gid, 1, "'A' should be GID 1 (after .notdef at GID 0)");
+
+    // No mapping for unused chars
     assert!(
-        result.font_data.len() < 50_000,
-        "Subset with 1 char should be small, got {} bytes",
-        result.font_data.len()
+        !result.glyph_mapping.contains_key(&('B' as u32)),
+        "Unused char 'B' should not be in mapping"
     );
 }
 
@@ -578,80 +622,223 @@ fn test_usize_to_cff_offset_overflow() {
 }
 
 #[test]
-fn test_cid_subset_small_font_round_trip() {
-    // Verify that subsetting a small CFF font still produces a valid, parseable result
-    // and preserves the glyph mapping for all used characters.
+fn test_small_font_mapping_filtered_exact_count() {
+    // Small font (<100KB) is not subsetted, but mapping must contain
+    // exactly the used chars — no more, no less.
     let font_data = build_minimal_cff_otf(50);
-    let original_len = font_data.len();
 
     let used: HashSet<char> = "ABC".chars().collect();
     let result = subset_font(font_data, &used).expect("subset_font must not fail");
 
-    // Glyph mapping must be present for all used characters
-    for ch in "ABC".chars() {
-        assert!(
-            result.glyph_mapping.contains_key(&(ch as u32)),
-            "Glyph mapping must contain '{}' (codepoint {})",
-            ch,
-            ch as u32
-        );
-    }
-
-    // The subsetted font must be non-empty and smaller than or equal to the original
-    assert!(
-        !result.font_data.is_empty(),
-        "Subsetted font data must not be empty"
+    // Mapping must have exactly 3 entries
+    assert_eq!(
+        result.glyph_mapping.len(),
+        3,
+        "Mapping should have exactly 3 entries for 'ABC', got {}",
+        result.glyph_mapping.len()
     );
+
+    // Each used char must be present with a distinct, non-zero GID
+    let a = result.glyph_mapping[&('A' as u32)];
+    let b = result.glyph_mapping[&('B' as u32)];
+    let c = result.glyph_mapping[&('C' as u32)];
+    assert!(a != 0 && b != 0 && c != 0, "GIDs must be non-zero");
+    assert!(a != b && b != c && a != c, "All GIDs must be distinct");
+
+    // Unused chars must not be present
     assert!(
-        result.font_data.len() <= original_len,
-        "Subsetted font ({} bytes) should not be larger than original ({} bytes)",
-        result.font_data.len(),
-        original_len
+        !result.glyph_mapping.contains_key(&('D' as u32)),
+        "Unused 'D' should not be in mapping"
+    );
+}
+
+// =============================================================================
+// OTF table coherence helpers
+// =============================================================================
+
+/// Find an OTF table by tag. Returns (offset, length).
+fn find_otf_table(otf_data: &[u8], target_tag: &[u8; 4]) -> Option<(usize, usize)> {
+    let num_tables = u16::from_be_bytes([otf_data[4], otf_data[5]]) as usize;
+    for i in 0..num_tables {
+        let dir = 12 + i * 16;
+        if &otf_data[dir..dir + 4] == target_tag {
+            let offset = u32::from_be_bytes([
+                otf_data[dir + 8],
+                otf_data[dir + 9],
+                otf_data[dir + 10],
+                otf_data[dir + 11],
+            ]) as usize;
+            let length = u32::from_be_bytes([
+                otf_data[dir + 12],
+                otf_data[dir + 13],
+                otf_data[dir + 14],
+                otf_data[dir + 15],
+            ]) as usize;
+            return Some((offset, length));
+        }
+    }
+    None
+}
+
+/// Parse numGlyphs from the maxp table.
+fn read_maxp_num_glyphs(otf_data: &[u8]) -> u16 {
+    let (offset, _) = find_otf_table(otf_data, b"maxp").expect("maxp table not found");
+    u16::from_be_bytes([otf_data[offset + 4], otf_data[offset + 5]])
+}
+
+// =============================================================================
+// Diagnostic tests: OTF table coherence after CFF subsetting
+// These expose WHY text doesn't display — viewers reject fonts where
+// maxp/hmtx/hhea report 65K glyphs but the CFF only has 5.
+// =============================================================================
+
+#[test]
+fn test_synthetic_cff_subset_maxp_coherent() {
+    // maxp.numGlyphs must match actual glyph count after subsetting.
+    let font_data = build_large_cff_otf();
+
+    let used: HashSet<char> = "AB".chars().collect();
+    let result = subset_font(font_data, &used).unwrap();
+
+    let maxp_glyphs = read_maxp_num_glyphs(&result.font_data);
+    // .notdef + A + B = 3
+    assert_eq!(
+        maxp_glyphs, 3,
+        "maxp.numGlyphs should be 3 (.notdef + 2 chars), got {}",
+        maxp_glyphs
+    );
+}
+
+#[test]
+fn test_cid_subset_is_raw_cff_not_otf() {
+    // CID-keyed CFF fonts must be embedded as raw CFF (not OTF wrapper)
+    // with /Subtype /CIDFontType0C. OTF wrapper causes maxp/hmtx/hhea
+    // incoherence that makes viewers reject the font.
+    let font_data = match load_cid_font() {
+        Some(d) => d,
+        None => return,
+    };
+
+    // Original is OTF (OTTO signature)
+    assert_eq!(
+        &font_data[0..4],
+        b"OTTO",
+        "Precondition: original must be OTF"
+    );
+
+    let used_chars: HashSet<char> = "你好世界".chars().collect();
+    let result = subset_font(font_data.clone(), &used_chars).expect("subsetting must succeed");
+
+    // Subset must NOT be OTF — it must be raw CFF (starts with CFF header: major=1, minor=0)
+    assert_ne!(
+        &result.font_data[0..4],
+        b"OTTO",
+        "CID subset must be raw CFF, not OTF wrapper"
+    );
+    assert_eq!(
+        result.font_data[0], 1,
+        "CFF header major version must be 1, got {}",
+        result.font_data[0]
+    );
+    assert_eq!(
+        result.font_data[1], 0,
+        "CFF header minor version must be 0, got {}",
+        result.font_data[1]
+    );
+
+    // Verify is_raw_cff flag
+    let cff_result =
+        oxidize_pdf::text::fonts::cff_subsetter::subset_cff_font(&font_data, &used_chars)
+            .expect("CFF subsetting must succeed");
+    assert!(
+        cff_result.is_raw_cff,
+        "CID-keyed font subset must set is_raw_cff=true"
     );
 }
 
 // =============================================================================
 // Real CID-keyed font subsetting tests (Issue #165)
+// Requires: test-pdfs/SourceHanSansSC-Regular.otf (16MB CID-keyed CFF font)
 // =============================================================================
 
-#[test]
-fn test_cid_font_subsetting_reduces_file_size() {
-    // Issue #165: SourceHanSansSC is a CID-keyed CFF font (16MB).
-    // Subsetting to 4 characters should dramatically reduce size.
-    let font_path = "../test-pdfs/SourceHanSansSC-Regular.otf";
-    if !std::path::Path::new(font_path).exists() {
-        return; // Skip if fixture not available (CI without large test files)
+const CID_FONT_PATH: &str = "../test-pdfs/SourceHanSansSC-Regular.otf";
+
+fn load_cid_font() -> Option<Vec<u8>> {
+    if std::path::Path::new(CID_FONT_PATH).exists() {
+        Some(std::fs::read(CID_FONT_PATH).unwrap())
+    } else {
+        eprintln!("SKIPPED: CID font fixture not found at {}", CID_FONT_PATH);
+        None
     }
-    let font_data = std::fs::read(font_path).unwrap();
+}
+
+#[test]
+fn test_cid_font_subset_size_proportional_to_used_chars() {
+    // Issue #165: 4 Chinese characters from a 65K+ glyph font (16MB).
+    // krilla produces 17KB for the same content. We should be <500KB
+    // (allowing for OTF overhead tables that aren't subsetted).
+    let font_data = match load_cid_font() {
+        Some(d) => d,
+        None => return,
+    };
+    let original_size = font_data.len();
 
     let used_chars: HashSet<char> = "你好世界".chars().collect();
+    let result = subset_font(font_data, &used_chars).expect("CID subsetting must succeed");
 
-    let result =
-        subset_font(font_data.clone(), &used_chars).expect("CID font subsetting should not error");
+    // The subset should contain exactly 4 glyph mappings
+    assert_eq!(
+        result.glyph_mapping.len(),
+        used_chars.len(),
+        "Glyph mapping should have exactly {} entries (one per used char), got {}",
+        used_chars.len(),
+        result.glyph_mapping.len()
+    );
 
-    let original_size = font_data.len();
+    // All new GIDs must be > 0 and sequential
+    let mut new_gids: Vec<u16> = result.glyph_mapping.values().copied().collect();
+    new_gids.sort();
+    let expected: Vec<u16> = (1..=used_chars.len() as u16).collect();
+    assert_eq!(
+        new_gids,
+        expected,
+        "New GIDs should be sequential [1..={}], got {:?}",
+        used_chars.len(),
+        new_gids
+    );
+
+    // Size: subset must be dramatically smaller than the 16MB original.
+    // Currently ~1MB due to full Local Subr INDEXes for needed FDs.
+    // Reference: krilla produces 17KB (it subsets Local Subrs).
+    // TODO: Implement Local Subr subsetting to reach <100KB.
     let subset_size = result.font_data.len();
-
-    // Threshold updated from 10% to 15%: spec-compliant Local Subr INDEX detection
-    // via Private DICT op 19 correctly includes per-FD local subrs that the previous
-    // heuristic (looking immediately after Private DICT) was missing.
     assert!(
-        subset_size < original_size * 15 / 100,
-        "Subset ({subset_size} bytes) should be <15% of original ({original_size} bytes). \
-         If equal, subsetting is not working for CID-keyed fonts."
+        subset_size < 1_200_000,
+        "Subset for 4 chars should be <1.2MB, got {} bytes ({:.1}KB). \
+         Original: {} bytes ({:.1}MB). Reduction: {:.1}%",
+        subset_size,
+        subset_size as f64 / 1024.0,
+        original_size,
+        original_size as f64 / 1_048_576.0,
+        (1.0 - subset_size as f64 / original_size as f64) * 100.0
     );
 }
 
 #[test]
-fn test_cid_font_subsetting_produces_valid_pdf() {
-    // End-to-end: load CID font → create PDF → verify file size is reasonable
+fn test_cid_font_pdf_round_trip_text_is_readable() {
+    // Issue #165 core bug: user reports Chinese text "is not displayed".
+    // This test generates a PDF with CJK text, parses it back, and verifies
+    // the text is actually extractable — not just that the file is small.
+    use oxidize_pdf::parser::{PdfDocument, PdfReader};
     use oxidize_pdf::{Document, Font, Page};
+    use std::io::Cursor;
 
-    let font_path = "../test-pdfs/SourceHanSansSC-Regular.otf";
-    if !std::path::Path::new(font_path).exists() {
-        return; // Skip if fixture not available
-    }
-    let font_data = std::fs::read(font_path).unwrap();
+    let font_data = match load_cid_font() {
+        Some(d) => d,
+        None => return,
+    };
+
+    let test_text = "你好世界";
 
     let mut doc = Document::new();
     doc.add_font_from_bytes("SourceHanSC", font_data)
@@ -661,31 +848,122 @@ fn test_cid_font_subsetting_produces_valid_pdf() {
     page.text()
         .set_font(Font::Custom("SourceHanSC".to_string()), 10.5)
         .at(30.0, 535.0)
-        .write("你好世界")
+        .write(test_text)
         .expect("Writing CJK text should succeed");
     doc.add_page(page);
 
-    let bytes = doc.to_bytes().expect("PDF generation should succeed");
+    let pdf_bytes = doc.to_bytes().expect("PDF generation should succeed");
 
-    // A PDF with 4 CJK characters should be far less than the full 16MB font.
-    // Threshold updated to 3MB: spec-compliant Local Subr INDEX detection via
-    // Private DICT op 19 correctly includes per-FD local subrs, adding ~300KB
-    // versus the previous heuristic that missed them.
+    // Parse the generated PDF back
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("Generated PDF must be parseable");
+    let parsed_doc = PdfDocument::new(reader);
+
+    // Extract text from page 0
+    let extracted = parsed_doc
+        .extract_text_from_page(0)
+        .expect("Text extraction from generated PDF should succeed");
+
+    // The extracted text must contain the Chinese characters we wrote
+    for ch in test_text.chars() {
+        assert!(
+            extracted.text.contains(ch),
+            "Extracted text must contain '{}' (U+{:04X}). \
+             Full extracted text: '{}'",
+            ch,
+            ch as u32,
+            extracted.text
+        );
+    }
+}
+
+#[test]
+fn test_cid_font_pdf_size_comparable_to_competitors() {
+    // Issue #165: user reports 2MB output vs krilla's 17KB for same content.
+    // This reproduces the user's exact scenario from the issue.
+    use oxidize_pdf::{Document, Font, Page};
+
+    let font_data = match load_cid_font() {
+        Some(d) => d,
+        None => return,
+    };
+
+    // User's exact test text from issue #165 (67 unique characters)
+    let text_line1 = "Rust 擁有完整的技術文件、友善的編譯器與清晰的錯誤訊息，還整合了一流的工具 — 包含套件管理工具、";
+    let text_line2 =
+        "建構工具、支援多種編輯器的自動補齊、型別檢測、自動格式化程式碼，以及更多等等。";
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("SourceHanSC", font_data)
+        .expect("Font loading should succeed");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("SourceHanSC".to_string()), 10.5)
+        .at(30.0, 535.0)
+        .write(text_line1)
+        .expect("Writing line 1");
+    page.text()
+        .set_font(Font::Custom("SourceHanSC".to_string()), 10.5)
+        .at(30.0, 515.0)
+        .write(text_line2)
+        .expect("Writing line 2");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation should succeed");
+
+    // Fixed from 2MB → ~1MB. Local Subr INDEXes still dominate size.
+    // Reference: krilla produces 17KB (it subsets Local Subrs).
+    // TODO: Implement Local Subr subsetting to reach <200KB.
     assert!(
-        bytes.len() < 3_000_000,
-        "PDF with 4 CJK chars should be <3MB, got {} bytes ({:.1}MB). \
-         Full font is likely embedded without subsetting.",
-        bytes.len(),
-        bytes.len() as f64 / 1_048_576.0
+        pdf_bytes.len() < 1_200_000,
+        "PDF with ~67 CJK chars should be <1.2MB, got {} bytes ({:.1}KB). \
+         Was 2MB before fix. Reference: krilla 17KB (subsets Local Subrs).",
+        pdf_bytes.len(),
+        pdf_bytes.len() as f64 / 1024.0
+    );
+}
+
+#[test]
+fn test_cid_font_content_stream_has_correct_hex_encoding() {
+    // Verify the content stream encodes Chinese chars as UTF-16BE hex strings
+    // that match the Identity-H CID values (CID = Unicode codepoint).
+    use oxidize_pdf::{Document, Font, Page};
+
+    let font_data = match load_cid_font() {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("SourceHanSC", font_data)
+        .expect("Font loading should succeed");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("SourceHanSC".to_string()), 10.5)
+        .at(30.0, 535.0)
+        .write("你好")
+        .expect("Writing CJK text");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation should succeed");
+    let content = String::from_utf8_lossy(&pdf_bytes);
+
+    // '你' = U+4F60 → UTF-16BE = 4F60
+    // '好' = U+597D → UTF-16BE = 597D
+    // Content stream should contain hex string <4F60597D> Tj
+    assert!(
+        content.contains("4F60") && content.contains("597D"),
+        "Content stream must contain UTF-16BE hex for '你' (4F60) and '好' (597D). \
+         This verifies Identity-H encoding is used correctly."
     );
 }
 
 #[test]
 fn test_non_cid_cff_font_subsetting_with_real_fixture() {
-    // Verify subsetting also works for non-CID OTF/CFF fonts with real fixture
     let font_path = "../test-pdfs/SourceSans3-Regular.otf";
     if !std::path::Path::new(font_path).exists() {
-        // Skip if fixture doesn't exist
+        eprintln!("SKIPPED: Non-CID fixture not found at {}", font_path);
         return;
     }
 
@@ -695,14 +973,29 @@ fn test_non_cid_cff_font_subsetting_with_real_fixture() {
     let result = subset_font(font_data.clone(), &used_chars)
         .expect("Non-CID CFF font subsetting should succeed");
 
+    // Exact mapping: "Hello" has 4 unique chars (H, e, l, o)
+    let unique_chars: HashSet<char> = "Hello".chars().collect();
+    assert_eq!(
+        result.glyph_mapping.len(),
+        unique_chars.len(),
+        "Mapping should have {} entries (unique chars in 'Hello'), got {}",
+        unique_chars.len(),
+        result.glyph_mapping.len()
+    );
+
+    for ch in unique_chars {
+        assert!(
+            result.glyph_mapping.contains_key(&(ch as u32)),
+            "Mapping must contain '{}' (U+{:04X})",
+            ch,
+            ch as u32
+        );
+        let gid = result.glyph_mapping[&(ch as u32)];
+        assert_ne!(gid, 0, "'{}' must not map to .notdef (GID 0)", ch);
+    }
+
     let original_size = font_data.len();
     let subset_size = result.font_data.len();
-
-    // Non-CID subsetting keeps CharStrings for used glyphs + other OTF tables verbatim.
-    // The OTF file contains many tables (cmap, hmtx, etc.) that are not subsetted,
-    // so the total reduction depends on how much of the file is CFF vs other tables.
-    // SourceSans3: ~162KB CFF + ~172KB other tables = ~334KB total.
-    // After subsetting, CFF drops dramatically; other tables stay. Expect <75% total.
     assert!(
         subset_size < (original_size * 3 / 4),
         "Non-CID CFF subset ({subset_size}) should be <75% of original ({original_size})"


### PR DESCRIPTION
## Summary
- **CID-keyed CFF fonts (SourceHanSansSC, etc.) now render correctly** in PDF viewers
- Embed raw CFF with `/Subtype /CIDFontType0C` instead of OTF wrapper (was causing maxp/hmtx incoherence → viewers rejected the font)
- Patch Private DICT op 19 (Subrs offset) to point to correct Local Subr INDEX position in subset
- Filter glyph mapping to only used characters (was leaking full cmap with 65K+ entries)

## Before / After
| Metric | Before | After |
|--------|--------|-------|
| Chinese text rendering | Not displayed | Renders correctly |
| PDF size (67 CJK chars) | 2MB (or 16MB without subsetting) | ~1MB |
| Glyph mapping entries | 65K+ (full cmap leak) | Only used chars |

## Known Limitation
File size is ~1MB due to full Local Subr INDEXes for needed FDs (~900KB). Further reduction to <100KB requires Local Subr subsetting (future work). Reference: krilla produces 17KB for same content.

## Test plan
- [x] `test_cid_font_pdf_round_trip_text_is_readable` — generates PDF, parses back, extracts Chinese text
- [x] `test_cid_font_content_stream_has_correct_hex_encoding` — verifies Identity-H UTF-16BE encoding
- [x] `test_cid_subset_is_raw_cff_not_otf` — verifies raw CFF output (not OTF wrapper)
- [x] `test_cid_font_subset_size_proportional_to_used_chars` — 94% size reduction from 16MB
- [x] `test_cid_font_pdf_size_comparable_to_competitors` — PDF < 1.2MB (was 2MB)
- [x] 28 total CFF tests pass, 0 smoke tests
- [x] Full workspace: 0 failures, clippy clean
- [x] Visual verification: PDF opens correctly in Claude's PDF reader

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)