### PR TITLE
feat: RAG-aligned editing + FlowLayout engine

### DIFF
--- a/.private/ROADMAP_MASTER.md
+++ b/.private/ROADMAP_MASTER.md
@@ -1,5 +1,5 @@
 # ROADMAP MASTER - oxidize-pdf
-**Ultima actualizacion**: 2026-03-29 (quality review + bug fixes #167, #174)
+**Ultima actualizacion**: 2026-04-05 (cleanup: feature/pdf-editor borrada, rag-aligned-editing actualizada con develop)
 **Horizonte**: Sin deadline — roadmap es orientativo, no vinculante
 **Owner**: bzsanti
 **Repositorio**: https://github.com/bzsanti/oxidizePdf
@@ -9,8 +9,8 @@
 ## ESTADO ACTUAL
 
 ### Posicion en Roadmap
-- **Version**: v2.4.1 released (tag v2.4.1 en main)
-- **Sprint Actual**: Bug fixes — TextFlow width (#167), PNG rendering (#174)
+- **Version**: v2.4.3 released (tag v2.4.3 en main)
+- **Sprint Actual**: CID CFF font subsetting fix (#165)
 - **Tests**: 6,261 passing (lib), clippy limpio
 - **Coverage**: 72.14%
 - **Quality Grade**: A (95/100)
@@ -30,6 +30,8 @@
 
 | Version | Fecha | Highlights |
 |---------|-------|------------|
+| v2.4.3 | 2026-04-04 | CID CFF font subsetting fix (#165): raw CFF embedding, Private DICT Subrs patching, glyph mapping filter |
+| v2.4.2 | 2026-04-02 | TTF tittle offset fix, TextFlow width (#167), PNG rendering (#174) |
 | v2.4.1 | 2026-03-29 | 14 quality fixes (CFF scanner, overflow protection, measure_text &Font, cmap consolidation, PNG fix, TextFlow width), table system overhaul, CID font subsetting |
 | v2.4.0 | 2026-03-27 | CFF font subsetting, cmap Format 12, multilingual corpus tests |
 | v2.3.4 | 2026-03-25 | Table improvements (#162, #163), CJK table font fix (#160) |
@@ -103,7 +105,6 @@
 - **#160** - CJK font NOT displayed correctly in Table (fix en rama `fix/issue-160-cjk-table-font`, pendiente PR+merge)
 - Feature branches activas:
   - `fix/issue-160-cjk-table-font` — fix encoding CJK en GraphicsContext::show_text
-  - `feature/pdf-editor` — nueva feature de edicion (AnnotationInjector, PageManipulator)
 
 ### Cerrados (2026)
 - **#159** - Release v2.3.3 (PR merged)
@@ -194,8 +195,11 @@
 - extraction.rs:618 panic con Cold_Email_Hacks.pdf cuando detect_columns: true
 - Afecta ExtractionProfile::Academic
 
-### 4. feature/pdf-editor
-- Rama activa con AnnotationInjector y PageManipulator (no mergeada)
+### 4. Optimizar tamaño CID CFF subset (Local Subr subsetting)
+- Actualmente ~1MB por font CID (Local Subr INDEXes completos para FDs necesarios)
+- Competencia (krilla): 17KB para el mismo contenido
+- Requiere: parser de CharStrings Type 2 para detectar callsubr/callgsubr, seguir referencias recursivamente, y emitir solo los subrs usados
+- Impacto estimado: de ~1MB a <100KB
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "aes",
  "bitflags",

--- a/oxidize-pdf-core/src/layout/document_builder.rs
+++ b/oxidize-pdf-core/src/layout/document_builder.rs
@@ -1,0 +1,115 @@
+use crate::error::Result;
+use crate::graphics::Image;
+use crate::layout::{FlowLayout, PageConfig, RichText};
+use crate::text::{Font, Table};
+use crate::Document;
+use std::sync::Arc;
+
+/// High-level builder for creating multi-page PDF documents with automatic layout.
+///
+/// Wraps [`FlowLayout`] with an owned-chaining API so you can build a complete
+/// document in a single expression.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use oxidize_pdf::layout::DocumentBuilder;
+/// use oxidize_pdf::Font;
+///
+/// let mut doc = DocumentBuilder::a4()
+///     .add_text("Invoice #001", Font::HelveticaBold, 18.0)
+///     .add_spacer(10.0)
+///     .add_text("Date: 2026-04-09", Font::Helvetica, 12.0)
+///     .build()
+///     .unwrap();
+///
+/// doc.save("invoice.pdf").unwrap();
+/// ```
+pub struct DocumentBuilder {
+    layout: FlowLayout,
+}
+
+impl DocumentBuilder {
+    /// Create a builder with A4 page size and default 72pt margins.
+    pub fn a4() -> Self {
+        Self {
+            layout: FlowLayout::new(PageConfig::a4()),
+        }
+    }
+
+    /// Create a builder with custom page configuration.
+    pub fn new(config: PageConfig) -> Self {
+        Self {
+            layout: FlowLayout::new(config),
+        }
+    }
+
+    /// Add a text block with default line height (1.2).
+    pub fn add_text(mut self, text: &str, font: Font, font_size: f64) -> Self {
+        self.layout.add_text(text, font, font_size);
+        self
+    }
+
+    /// Add a text block with custom line height.
+    pub fn add_text_with_line_height(
+        mut self,
+        text: &str,
+        font: Font,
+        font_size: f64,
+        line_height: f64,
+    ) -> Self {
+        self.layout
+            .add_text_with_line_height(text, font, font_size, line_height);
+        self
+    }
+
+    /// Add vertical spacing in points.
+    pub fn add_spacer(mut self, points: f64) -> Self {
+        self.layout.add_spacer(points);
+        self
+    }
+
+    /// Add a table.
+    pub fn add_table(mut self, table: Table) -> Self {
+        self.layout.add_table(table);
+        self
+    }
+
+    /// Add an image scaled to fit within max dimensions, left-aligned.
+    pub fn add_image(
+        mut self,
+        name: &str,
+        image: Arc<Image>,
+        max_width: f64,
+        max_height: f64,
+    ) -> Self {
+        self.layout.add_image(name, image, max_width, max_height);
+        self
+    }
+
+    /// Add an image scaled to fit, centered horizontally.
+    pub fn add_image_centered(
+        mut self,
+        name: &str,
+        image: Arc<Image>,
+        max_width: f64,
+        max_height: f64,
+    ) -> Self {
+        self.layout
+            .add_image_centered(name, image, max_width, max_height);
+        self
+    }
+
+    /// Add a single line of mixed-style text.
+    pub fn add_rich_text(mut self, rich: RichText) -> Self {
+        self.layout.add_rich_text(rich);
+        self
+    }
+
+    /// Build the document, creating pages as needed for all added elements.
+    pub fn build(self) -> Result<Document> {
+        let mut doc = Document::new();
+        self.layout.build_into(&mut doc)?;
+        Ok(doc)
+    }
+}

--- a/oxidize-pdf-core/src/layout/flow.rs
+++ b/oxidize-pdf-core/src/layout/flow.rs
@@ -1,0 +1,375 @@
+use crate::error::Result;
+use crate::graphics::Image;
+use crate::layout::image_utils::fit_image_dimensions;
+use crate::layout::RichText;
+use crate::page::Margins;
+use crate::page_tables::PageTables;
+use crate::text::text_block::measure_text_block;
+use crate::text::{Font, Table, TextAlign, TextFlowContext};
+use crate::{Document, Page};
+use std::sync::Arc;
+
+/// Page dimensions and margins for FlowLayout.
+#[derive(Debug, Clone)]
+pub struct PageConfig {
+    pub width: f64,
+    pub height: f64,
+    pub margin_left: f64,
+    pub margin_right: f64,
+    pub margin_top: f64,
+    pub margin_bottom: f64,
+}
+
+impl PageConfig {
+    /// Create a config with explicit dimensions and margins.
+    pub fn new(
+        width: f64,
+        height: f64,
+        margin_left: f64,
+        margin_right: f64,
+        margin_top: f64,
+        margin_bottom: f64,
+    ) -> Self {
+        let config = Self {
+            width,
+            height,
+            margin_left,
+            margin_right,
+            margin_top,
+            margin_bottom,
+        };
+        debug_assert!(
+            config.content_width() > 0.0,
+            "margins ({} + {}) exceed page width ({})",
+            margin_left,
+            margin_right,
+            width
+        );
+        debug_assert!(
+            config.usable_height() > 0.0,
+            "margins ({} + {}) exceed page height ({})",
+            margin_top,
+            margin_bottom,
+            height
+        );
+        config
+    }
+
+    /// A4 page (595×842 pts) with default 72pt margins.
+    pub fn a4() -> Self {
+        Self::new(595.0, 842.0, 72.0, 72.0, 72.0, 72.0)
+    }
+
+    /// A4 page with custom uniform margins on all sides.
+    pub fn a4_with_margins(left: f64, right: f64, top: f64, bottom: f64) -> Self {
+        Self::new(595.0, 842.0, left, right, top, bottom)
+    }
+
+    /// Available width for content (page width minus left and right margins).
+    pub fn content_width(&self) -> f64 {
+        self.width - self.margin_left - self.margin_right
+    }
+
+    /// Available height for content (page height minus top and bottom margins).
+    pub fn usable_height(&self) -> f64 {
+        self.height - self.margin_top - self.margin_bottom
+    }
+
+    fn start_y(&self) -> f64 {
+        self.height - self.margin_top
+    }
+
+    fn create_page(&self) -> Page {
+        let mut page = Page::new(self.width, self.height);
+        page.set_margins(
+            self.margin_left,
+            self.margin_right,
+            self.margin_top,
+            self.margin_bottom,
+        );
+        page
+    }
+
+    fn to_margins(&self) -> Margins {
+        Margins {
+            left: self.margin_left,
+            right: self.margin_right,
+            top: self.margin_top,
+            bottom: self.margin_bottom,
+        }
+    }
+}
+
+/// An element that can be placed in a FlowLayout.
+#[derive(Debug)]
+pub enum FlowElement {
+    /// A block of word-wrapped text.
+    Text {
+        text: String,
+        font: Font,
+        font_size: f64,
+        line_height: f64,
+    },
+    /// Vertical space in points.
+    Spacer(f64),
+    /// A simple table.
+    Table(Table),
+    /// A single line of mixed-style text.
+    RichText { rich: RichText, line_height: f64 },
+    /// An image scaled to fit within max dimensions, preserving aspect ratio.
+    /// Uses `Arc<Image>` to avoid cloning the pixel buffer when building.
+    Image {
+        name: String,
+        image: Arc<Image>,
+        max_width: f64,
+        max_height: f64,
+        center: bool,
+    },
+}
+
+impl FlowElement {
+    /// Calculate the height this element will occupy.
+    fn measure_height(&self, content_width: f64) -> f64 {
+        match self {
+            FlowElement::Text {
+                text,
+                font,
+                font_size,
+                line_height,
+            } => {
+                let metrics =
+                    measure_text_block(text, font, *font_size, *line_height, content_width);
+                metrics.height
+            }
+            FlowElement::Spacer(h) => *h,
+            FlowElement::Table(table) => table.get_height(),
+            FlowElement::RichText { rich, line_height } => rich.max_font_size() * line_height,
+            FlowElement::Image {
+                image,
+                max_width,
+                max_height,
+                ..
+            } => {
+                let (_, h) =
+                    fit_image_dimensions(image.width(), image.height(), *max_width, *max_height);
+                h
+            }
+        }
+    }
+}
+
+/// Automatic flow layout engine with page break support.
+///
+/// Manages a vertical cursor and a list of elements. When an element
+/// would overflow the current page's bottom margin, a new page is
+/// created automatically.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use oxidize_pdf::{Document, Font};
+/// use oxidize_pdf::layout::{FlowLayout, PageConfig};
+///
+/// let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+/// let mut layout = FlowLayout::new(config);
+/// layout.add_text("Hello World", Font::Helvetica, 12.0);
+/// layout.add_spacer(20.0);
+/// layout.add_text("Second paragraph", Font::Helvetica, 12.0);
+///
+/// let mut doc = Document::new();
+/// layout.build_into(&mut doc).unwrap();
+/// ```
+pub struct FlowLayout {
+    config: PageConfig,
+    elements: Vec<FlowElement>,
+}
+
+impl FlowLayout {
+    /// Create a new FlowLayout with the given page configuration.
+    pub fn new(config: PageConfig) -> Self {
+        Self {
+            config,
+            elements: Vec::new(),
+        }
+    }
+
+    /// Add a text block. Uses default line_height of 1.2.
+    pub fn add_text(&mut self, text: &str, font: Font, font_size: f64) -> &mut Self {
+        self.elements.push(FlowElement::Text {
+            text: text.to_string(),
+            font,
+            font_size,
+            line_height: 1.2,
+        });
+        self
+    }
+
+    /// Add a text block with custom line height.
+    pub fn add_text_with_line_height(
+        &mut self,
+        text: &str,
+        font: Font,
+        font_size: f64,
+        line_height: f64,
+    ) -> &mut Self {
+        self.elements.push(FlowElement::Text {
+            text: text.to_string(),
+            font,
+            font_size,
+            line_height,
+        });
+        self
+    }
+
+    /// Add vertical spacing in points.
+    pub fn add_spacer(&mut self, points: f64) -> &mut Self {
+        self.elements.push(FlowElement::Spacer(points));
+        self
+    }
+
+    /// Add a table.
+    pub fn add_table(&mut self, table: Table) -> &mut Self {
+        self.elements.push(FlowElement::Table(table));
+        self
+    }
+
+    /// Add an image scaled to fit within max dimensions, left-aligned.
+    /// Wraps the image in `Arc` internally to avoid expensive buffer clones.
+    pub fn add_image(
+        &mut self,
+        name: &str,
+        image: Arc<Image>,
+        max_width: f64,
+        max_height: f64,
+    ) -> &mut Self {
+        self.elements.push(FlowElement::Image {
+            name: name.to_string(),
+            image,
+            max_width,
+            max_height,
+            center: false,
+        });
+        self
+    }
+
+    /// Add an image scaled to fit within max dimensions, centered horizontally.
+    /// Wraps the image in `Arc` internally to avoid expensive buffer clones.
+    pub fn add_image_centered(
+        &mut self,
+        name: &str,
+        image: Arc<Image>,
+        max_width: f64,
+        max_height: f64,
+    ) -> &mut Self {
+        self.elements.push(FlowElement::Image {
+            name: name.to_string(),
+            image,
+            max_width,
+            max_height,
+            center: true,
+        });
+        self
+    }
+
+    /// Add a single line of mixed-style text.
+    pub fn add_rich_text(&mut self, rich: RichText) -> &mut Self {
+        self.elements.push(FlowElement::RichText {
+            rich,
+            line_height: 1.2,
+        });
+        self
+    }
+
+    /// Build all elements into the document, creating pages as needed.
+    ///
+    /// **Limitation**: Elements taller than `PageConfig::usable_height()` (e.g., a very
+    /// large table) will overflow past the bottom margin on a single page. They are not
+    /// split across pages.
+    pub fn build_into(&self, doc: &mut Document) -> Result<()> {
+        let content_width = self.config.content_width();
+        let mut current_page = self.config.create_page();
+        let mut cursor_y = self.config.start_y();
+
+        for element in &self.elements {
+            let needed_height = element.measure_height(content_width);
+
+            // Page break: if element doesn't fit and we've already placed something
+            if cursor_y - needed_height < self.config.margin_bottom
+                && cursor_y < self.config.start_y()
+            {
+                doc.add_page(current_page);
+                current_page = self.config.create_page();
+                cursor_y = self.config.start_y();
+            }
+
+            match element {
+                FlowElement::Text {
+                    text,
+                    font,
+                    font_size,
+                    line_height,
+                } => {
+                    let mut text_flow = TextFlowContext::new(
+                        self.config.width,
+                        self.config.height,
+                        self.config.to_margins(),
+                    );
+                    text_flow
+                        .set_font(font.clone(), *font_size)
+                        .set_line_height(*line_height)
+                        .set_alignment(TextAlign::Left)
+                        .at(self.config.margin_left, cursor_y - font_size * line_height);
+                    text_flow.write_wrapped(text)?;
+                    current_page.add_text_flow(&text_flow);
+                }
+                FlowElement::Spacer(_) => {
+                    // Spacers only consume vertical space, no rendering needed
+                }
+                FlowElement::Table(table) => {
+                    current_page.add_simple_table(
+                        table,
+                        self.config.margin_left,
+                        cursor_y - needed_height,
+                    )?;
+                }
+                FlowElement::RichText { rich, line_height } => {
+                    let ops = rich.render_operations(
+                        self.config.margin_left,
+                        cursor_y - rich.max_font_size() * line_height,
+                    );
+                    current_page.append_raw_content(ops.as_bytes());
+                }
+                FlowElement::Image {
+                    name,
+                    image,
+                    max_width,
+                    max_height,
+                    center,
+                } => {
+                    let (w, h) = fit_image_dimensions(
+                        image.width(),
+                        image.height(),
+                        *max_width,
+                        *max_height,
+                    );
+                    let x = if *center {
+                        crate::layout::image_utils::centered_image_x(
+                            self.config.margin_left,
+                            content_width,
+                            w,
+                        )
+                    } else {
+                        self.config.margin_left
+                    };
+                    current_page.add_image(name.clone(), Image::clone(image));
+                    current_page.draw_image(name, x, cursor_y - h, w, h)?;
+                }
+            }
+
+            cursor_y -= needed_height;
+        }
+
+        doc.add_page(current_page);
+        Ok(())
+    }
+}

--- a/oxidize-pdf-core/src/layout/image_utils.rs
+++ b/oxidize-pdf-core/src/layout/image_utils.rs
@@ -1,0 +1,81 @@
+/// Calculate dimensions that fit an image within a bounding box while preserving aspect ratio.
+///
+/// Given the original image dimensions in pixels and a maximum bounding box in points,
+/// returns the final (width, height) in points that fits within the box without distortion.
+///
+/// # Arguments
+///
+/// * `img_width` - Original image width in pixels
+/// * `img_height` - Original image height in pixels
+/// * `max_width` - Maximum allowed width in points
+/// * `max_height` - Maximum allowed height in points
+///
+/// # Returns
+///
+/// `(final_width, final_height)` in points, preserving the original aspect ratio.
+///
+/// # Example
+///
+/// ```rust
+/// use oxidize_pdf::layout::fit_image_dimensions;
+///
+/// // 400×200 image into 200×300 box → width-constrained → 200×100
+/// let (w, h) = fit_image_dimensions(400, 200, 200.0, 300.0);
+/// assert!((w - 200.0).abs() < 0.001);
+/// assert!((h - 100.0).abs() < 0.001);
+/// ```
+pub fn fit_image_dimensions(
+    img_width: u32,
+    img_height: u32,
+    max_width: f64,
+    max_height: f64,
+) -> (f64, f64) {
+    if img_width == 0 || img_height == 0 {
+        return (0.0, 0.0);
+    }
+
+    let ratio = img_width as f64 / img_height as f64;
+
+    // Try fitting by height constraint
+    let w_from_h = max_height * ratio;
+    if w_from_h <= max_width {
+        (w_from_h, max_height)
+    } else {
+        // Fit by width constraint
+        let h_from_w = max_width / ratio;
+        (max_width, h_from_w)
+    }
+}
+
+/// Calculate the x coordinate to center an image horizontally within the content area.
+///
+/// # Arguments
+///
+/// * `margin_left` - Left margin in points
+/// * `content_width` - Available content width in points (page width - left margin - right margin)
+/// * `image_width` - Width of the image to center in points
+///
+/// # Returns
+///
+/// The x coordinate where the image should be placed.
+pub fn centered_image_x(margin_left: f64, content_width: f64, image_width: f64) -> f64 {
+    margin_left + (content_width - image_width).max(0.0) / 2.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero_dimensions() {
+        assert_eq!(fit_image_dimensions(0, 100, 200.0, 200.0), (0.0, 0.0));
+        assert_eq!(fit_image_dimensions(100, 0, 200.0, 200.0), (0.0, 0.0));
+    }
+
+    #[test]
+    fn test_square_image_in_square_box() {
+        let (w, h) = fit_image_dimensions(500, 500, 100.0, 100.0);
+        assert!((w - 100.0).abs() < 0.001);
+        assert!((h - 100.0).abs() < 0.001);
+    }
+}

--- a/oxidize-pdf-core/src/layout/mod.rs
+++ b/oxidize-pdf-core/src/layout/mod.rs
@@ -1,0 +1,9 @@
+mod document_builder;
+mod flow;
+mod image_utils;
+mod rich_text;
+
+pub use document_builder::DocumentBuilder;
+pub use flow::{FlowElement, FlowLayout, PageConfig};
+pub use image_utils::{centered_image_x, fit_image_dimensions};
+pub use rich_text::{RichText, TextSpan};

--- a/oxidize-pdf-core/src/layout/rich_text.rs
+++ b/oxidize-pdf-core/src/layout/rich_text.rs
@@ -1,0 +1,160 @@
+use crate::text::{measure_text, Font};
+use crate::Color;
+use std::fmt::Write;
+
+/// A styled text segment with its own font, size, and color.
+#[derive(Debug, Clone)]
+pub struct TextSpan {
+    pub text: String,
+    pub font: Font,
+    pub font_size: f64,
+    pub color: Color,
+}
+
+impl TextSpan {
+    /// Create a new text span.
+    pub fn new(text: &str, font: Font, font_size: f64, color: Color) -> Self {
+        Self {
+            text: text.to_string(),
+            font,
+            font_size,
+            color,
+        }
+    }
+
+    /// Measure the width of this span in points.
+    pub fn measure_width(&self) -> f64 {
+        measure_text(&self.text, &self.font, self.font_size)
+    }
+}
+
+/// A line of mixed-style text composed of multiple [`TextSpan`]s.
+///
+/// Each span can have a different font, size, and color. The entire
+/// RichText renders as a single line (no word-wrapping).
+///
+/// # Example
+///
+/// ```rust
+/// use oxidize_pdf::layout::{RichText, TextSpan};
+/// use oxidize_pdf::{Color, Font};
+///
+/// let rich = RichText::new(vec![
+///     TextSpan::new("Total: ", Font::HelveticaBold, 14.0, Color::black()),
+///     TextSpan::new("$1,234.56", Font::Helvetica, 14.0, Color::gray(0.3)),
+/// ]);
+/// assert_eq!(rich.spans().len(), 2);
+/// assert!(rich.total_width() > 0.0);
+/// ```
+#[derive(Debug)]
+pub struct RichText {
+    spans: Vec<TextSpan>,
+}
+
+impl RichText {
+    /// Create a RichText from a list of spans.
+    pub fn new(spans: Vec<TextSpan>) -> Self {
+        Self { spans }
+    }
+
+    /// Total width of all spans combined.
+    pub fn total_width(&self) -> f64 {
+        self.spans.iter().map(|s| s.measure_width()).sum()
+    }
+
+    /// Maximum font size across all spans (determines line height).
+    pub fn max_font_size(&self) -> f64 {
+        self.spans
+            .iter()
+            .map(|s| s.font_size)
+            .fold(0.0_f64, f64::max)
+    }
+
+    /// Access the spans.
+    pub fn spans(&self) -> &[TextSpan] {
+        &self.spans
+    }
+
+    /// Generate PDF operators to render this rich text at position (x, y).
+    ///
+    /// Produces a single BT/ET block with per-span font/color/text changes.
+    pub(crate) fn render_operations(&self, x: f64, y: f64) -> String {
+        if self.spans.is_empty() {
+            return String::new();
+        }
+
+        let mut ops = String::new();
+        ops.push_str("BT\n");
+        writeln!(&mut ops, "{x:.2} {y:.2} Td").expect("write to String");
+
+        for span in &self.spans {
+            // Set color
+            match span.color {
+                Color::Rgb(r, g, b) => {
+                    writeln!(&mut ops, "{r:.3} {g:.3} {b:.3} rg").expect("write to String");
+                }
+                Color::Gray(gray) => {
+                    writeln!(&mut ops, "{gray:.3} g").expect("write to String");
+                }
+                Color::Cmyk(c, m, y, k) => {
+                    writeln!(&mut ops, "{c:.3} {m:.3} {y:.3} {k:.3} k").expect("write to String");
+                }
+            }
+
+            // Set font
+            writeln!(
+                &mut ops,
+                "/{} {:.2} Tf",
+                span.font.pdf_name(),
+                span.font_size
+            )
+            .expect("write to String");
+
+            // Show text with escaping
+            ops.push('(');
+            for ch in span.text.chars() {
+                match ch {
+                    '(' => ops.push_str("\\("),
+                    ')' => ops.push_str("\\)"),
+                    '\\' => ops.push_str("\\\\"),
+                    '\n' => ops.push_str("\\n"),
+                    '\r' => ops.push_str("\\r"),
+                    '\t' => ops.push_str("\\t"),
+                    _ => ops.push(ch),
+                }
+            }
+            ops.push_str(") Tj\n");
+        }
+
+        ops.push_str("ET\n");
+        ops
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_rich_text() {
+        let rt = RichText::new(vec![]);
+        assert_eq!(rt.total_width(), 0.0);
+        assert_eq!(rt.max_font_size(), 0.0);
+        assert!(rt.render_operations(0.0, 0.0).is_empty());
+    }
+
+    #[test]
+    fn test_render_operations_contains_bt_et() {
+        let rt = RichText::new(vec![TextSpan::new(
+            "Hello",
+            Font::Helvetica,
+            12.0,
+            Color::black(),
+        )]);
+        let ops = rt.render_operations(50.0, 700.0);
+        assert!(ops.starts_with("BT\n"));
+        assert!(ops.ends_with("ET\n"));
+        assert!(ops.contains("(Hello) Tj"));
+        assert!(ops.contains("/Helvetica 12.00 Tf"));
+    }
+}

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -190,6 +190,7 @@ pub mod fonts;
 pub mod forms;
 pub mod geometry;
 pub mod graphics;
+pub mod layout;
 pub mod memory;
 pub mod metadata;
 pub mod objects;
@@ -228,11 +229,16 @@ pub use document::{Document, DocumentMetadata};
 pub use error::{OxidizePdfError, PdfError, Result};
 pub use geometry::{Point, Rectangle};
 pub use graphics::{Color, ColorSpace, GraphicsContext, Image, ImageFormat, MaskType};
+pub use layout::{
+    centered_image_x, fit_image_dimensions, DocumentBuilder, FlowElement, FlowLayout, PageConfig,
+    RichText, TextSpan,
+};
 pub use page::{Margins, Page};
 pub use page_lists::{ListStyle, ListType, PageLists};
 pub use page_tables::{PageTables, TableStyle};
 pub use text::{
     measure_text,
+    measure_text_block,
     split_into_words,
     BulletStyle,
     Font,
@@ -258,6 +264,7 @@ pub use text::{
     TableCell,
     TableOptions,
     TextAlign,
+    TextBlockMetrics,
     TextContext,
     TextFlowContext,
     UnorderedList,

--- a/oxidize-pdf-core/src/operations/chunk_page_mapper.rs
+++ b/oxidize-pdf-core/src/operations/chunk_page_mapper.rs
@@ -1,0 +1,85 @@
+//! Chunk-to-page mapper for RAG-aligned PDF editing
+//!
+//! Maps `DocumentChunk` page numbers to PDF page indices and extracts
+//! only the pages relevant to retrieved chunks.
+
+use std::io::Cursor;
+
+use crate::ai::chunking::DocumentChunk;
+
+use super::OperationError;
+use super::OperationResult;
+
+/// Maps RAG chunks to their corresponding PDF pages and extracts relevant pages.
+pub struct ChunkPageMapper;
+
+impl ChunkPageMapper {
+    /// Get the 0-indexed page indices covered by the given chunks.
+    ///
+    /// Chunk `page_numbers` are 1-indexed (matching the chunker convention).
+    /// Returns sorted, deduplicated, 0-indexed page indices.
+    pub fn pages_for_chunks(chunks: &[&DocumentChunk]) -> Vec<usize> {
+        let mut pages: Vec<usize> = chunks
+            .iter()
+            .flat_map(|c| c.page_numbers.iter())
+            .filter(|&&p| p > 0)
+            .map(|&p| p - 1) // 1-indexed → 0-indexed
+            .collect();
+        pages.sort();
+        pages.dedup();
+        pages
+    }
+
+    /// Extract only the pages referenced by the given chunks into a new PDF.
+    ///
+    /// # Arguments
+    ///
+    /// * `pdf_bytes` - The original PDF file bytes
+    /// * `chunks` - Chunks whose pages should be extracted
+    ///
+    /// # Returns
+    ///
+    /// The new PDF bytes containing only the relevant pages.
+    pub fn extract_pages_for_chunks(
+        pdf_bytes: &[u8],
+        chunks: &[&DocumentChunk],
+    ) -> OperationResult<Vec<u8>> {
+        let page_indices = Self::pages_for_chunks(chunks);
+
+        if page_indices.is_empty() {
+            return Err(OperationError::NoPagesToProcess);
+        }
+
+        let cursor = Cursor::new(pdf_bytes);
+        let reader = crate::parser::PdfReader::new(cursor)
+            .map_err(|e| OperationError::ParseError(e.to_string()))?;
+        let document = reader.into_document();
+
+        let page_count = document
+            .page_count()
+            .map_err(|e| OperationError::ParseError(e.to_string()))?
+            as usize;
+
+        // Validate indices
+        for &idx in &page_indices {
+            if idx >= page_count {
+                return Err(OperationError::PageIndexOutOfBounds(idx, page_count));
+            }
+        }
+
+        let mut output_doc = crate::document::Document::new();
+
+        for &page_idx in &page_indices {
+            let parsed_page = document
+                .get_page(page_idx as u32)
+                .map_err(|e| OperationError::ParseError(e.to_string()))?;
+
+            let page = crate::page::Page::from_parsed_with_content(&parsed_page, &document)
+                .map_err(|e| OperationError::ParseError(e.to_string()))?;
+
+            output_doc.add_page(page);
+        }
+
+        output_doc.to_bytes().map_err(OperationError::PdfError)
+    }
+}

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides high-level operations for manipulating PDF documents
 //! such as splitting, merging, rotating pages, and reordering.
 
+pub mod chunk_page_mapper;
 pub mod extract_images;
 pub mod merge;
 pub mod overlay;
@@ -11,8 +12,11 @@ pub mod page_extraction;
 pub mod pdf_ocr_converter;
 pub mod reorder;
 pub mod rotate;
+pub mod semantic_redactor;
+pub mod source_highlighter;
 pub mod split;
 
+pub use chunk_page_mapper::ChunkPageMapper;
 pub use extract_images::{
     extract_images_from_pages, extract_images_from_pdf, ExtractImagesOptions, ExtractedImage,
     ImageExtractor,
@@ -30,6 +34,14 @@ pub use reorder::{
     ReorderOptions,
 };
 pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions, RotationAngle};
+pub use semantic_redactor::{
+    RedactionConfig, RedactionEntry, RedactionReport, RedactionStyle, SemanticRedactor,
+    SemanticRedactorError, SemanticRedactorResult,
+};
+pub use source_highlighter::{
+    fragment_to_highlight_rect, HighlightStyle, IndexedFragment, SourceHighlighter,
+    SourceHighlighterError, SourceHighlighterResult, TextPositionIndex,
+};
 pub use split::{split_into_pages, split_pdf, PdfSplitter, SplitMode, SplitOptions};
 
 use crate::error::PdfError;

--- a/oxidize-pdf-core/src/operations/semantic_redactor.rs
+++ b/oxidize-pdf-core/src/operations/semantic_redactor.rs
@@ -1,0 +1,254 @@
+//! Semantic redactor for RAG-aligned PDF editing
+//!
+//! Draws opaque rectangles over content identified by `SemanticEntity` bounding boxes,
+//! removing sensitive information (PII, confidential data) before LLM ingestion while
+//! preserving document structure for retrieval.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use crate::graphics::Color;
+use crate::semantic::{EntityType, SemanticEntity};
+use crate::text::Font;
+
+/// Visual style for redacted regions.
+#[derive(Debug, Clone)]
+pub enum RedactionStyle {
+    /// Opaque black rectangle covering the content
+    BlackBox,
+    /// Black rectangle with white placeholder text on top
+    Placeholder(String),
+}
+
+impl Default for RedactionStyle {
+    fn default() -> Self {
+        Self::BlackBox
+    }
+}
+
+/// Configuration for what and how to redact.
+#[derive(Debug, Clone)]
+pub struct RedactionConfig {
+    /// Entity types to redact (empty = redact nothing)
+    pub entity_types: Vec<EntityType>,
+    /// Visual style for redacted areas
+    pub style: RedactionStyle,
+}
+
+impl Default for RedactionConfig {
+    fn default() -> Self {
+        Self {
+            entity_types: Vec::new(),
+            style: RedactionStyle::BlackBox,
+        }
+    }
+}
+
+impl RedactionConfig {
+    /// Create a new empty config.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set entity types to redact.
+    pub fn with_types(mut self, types: Vec<EntityType>) -> Self {
+        self.entity_types = types;
+        self
+    }
+
+    /// Set the redaction style.
+    pub fn with_style(mut self, style: RedactionStyle) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+/// A record of a single redaction applied.
+#[derive(Debug, Clone)]
+pub struct RedactionEntry {
+    /// ID of the redacted entity
+    pub entity_id: String,
+    /// Type of the redacted entity
+    pub entity_type: EntityType,
+    /// Page number (1-indexed, matching BoundingBox convention)
+    pub page: u32,
+}
+
+/// Report of all redactions applied to a document.
+#[derive(Debug)]
+pub struct RedactionReport {
+    entries: Vec<RedactionEntry>,
+}
+
+impl RedactionReport {
+    /// Total number of redactions applied.
+    pub fn redacted_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Filter entries by entity type.
+    pub fn by_type(&self, entity_type: &EntityType) -> Vec<&RedactionEntry> {
+        self.entries
+            .iter()
+            .filter(|e| &e.entity_type == entity_type)
+            .collect()
+    }
+
+    /// Unique pages affected by redactions (1-indexed).
+    pub fn pages_affected(&self) -> Vec<u32> {
+        let mut pages: Vec<u32> = self.entries.iter().map(|e| e.page).collect();
+        pages.sort();
+        pages.dedup();
+        pages
+    }
+
+    /// All entries in the report.
+    pub fn entries(&self) -> &[RedactionEntry] {
+        &self.entries
+    }
+}
+
+/// Errors that can occur during semantic redaction.
+#[derive(Debug, thiserror::Error)]
+pub enum SemanticRedactorError {
+    /// Failed to parse the input PDF
+    #[error("parse failed: {0}")]
+    ParseFailed(String),
+
+    /// Failed to reconstruct a page
+    #[error("page reconstruction failed: {0}")]
+    PageReconstructionFailed(String),
+
+    /// Failed to write the output PDF
+    #[error("write failed: {0}")]
+    WriteFailed(String),
+}
+
+/// Result type for semantic redactor operations.
+pub type SemanticRedactorResult<T> = Result<T, SemanticRedactorError>;
+
+/// Redacts sensitive content from PDFs based on semantic entity bounding boxes.
+///
+/// Given PDF bytes and a set of `SemanticEntity`s with bounding boxes, this
+/// draws opaque rectangles over the specified entity types, producing a
+/// redacted PDF suitable for LLM ingestion.
+pub struct SemanticRedactor;
+
+impl SemanticRedactor {
+    /// Redact entities from a PDF, returning the modified bytes and a report.
+    ///
+    /// # Arguments
+    ///
+    /// * `pdf_bytes` - The original PDF file bytes
+    /// * `entities` - Semantic entities with bounding boxes
+    /// * `config` - What to redact and how
+    ///
+    /// # Returns
+    ///
+    /// A tuple of (modified PDF bytes, redaction report).
+    pub fn redact(
+        pdf_bytes: &[u8],
+        entities: &[SemanticEntity],
+        config: RedactionConfig,
+    ) -> SemanticRedactorResult<(Vec<u8>, RedactionReport)> {
+        // Filter entities by configured types
+        let to_redact: Vec<&SemanticEntity> = if config.entity_types.is_empty() {
+            Vec::new()
+        } else {
+            entities
+                .iter()
+                .filter(|e| config.entity_types.contains(&e.entity_type))
+                .collect()
+        };
+
+        // If nothing to redact, return original bytes
+        if to_redact.is_empty() {
+            return Ok((
+                pdf_bytes.to_vec(),
+                RedactionReport {
+                    entries: Vec::new(),
+                },
+            ));
+        }
+
+        // Group entities by page (BoundingBox.page is 1-indexed)
+        let mut by_page: HashMap<u32, Vec<&SemanticEntity>> = HashMap::new();
+        for entity in &to_redact {
+            by_page.entry(entity.bounds.page).or_default().push(entity);
+        }
+
+        // Parse the PDF
+        let cursor = Cursor::new(pdf_bytes);
+        let reader = crate::parser::PdfReader::new(cursor)
+            .map_err(|e| SemanticRedactorError::ParseFailed(e.to_string()))?;
+        let document = reader.into_document();
+
+        let page_count = document
+            .page_count()
+            .map_err(|e| SemanticRedactorError::PageReconstructionFailed(e.to_string()))?;
+
+        let mut output_doc = crate::document::Document::new();
+        let mut report_entries = Vec::new();
+
+        for page_idx in 0..page_count {
+            let parsed_page = document
+                .get_page(page_idx)
+                .map_err(|e| SemanticRedactorError::PageReconstructionFailed(e.to_string()))?;
+
+            let mut page = crate::page::Page::from_parsed_with_content(&parsed_page, &document)
+                .map_err(|e| SemanticRedactorError::PageReconstructionFailed(e.to_string()))?;
+
+            // page_idx is 0-indexed, BoundingBox.page is 1-indexed
+            let page_num_1indexed = (page_idx + 1) as u32;
+
+            if let Some(page_entities) = by_page.get(&page_num_1indexed) {
+                for entity in page_entities {
+                    let bbox = &entity.bounds;
+
+                    // Draw opaque black rectangle over the entity
+                    page.graphics()
+                        .set_fill_color(Color::black())
+                        .rect(
+                            bbox.x as f64,
+                            bbox.y as f64,
+                            bbox.width as f64,
+                            bbox.height as f64,
+                        )
+                        .fill();
+
+                    // If placeholder style, add white text on top
+                    if let RedactionStyle::Placeholder(ref text) = config.style {
+                        let font_size = (bbox.height as f64 * 0.6).min(10.0).max(4.0);
+                        let text_ctx = page.text();
+                        text_ctx.set_font(Font::Helvetica, font_size);
+                        text_ctx.set_fill_color(Color::white());
+                        text_ctx.at(
+                            bbox.x as f64 + 2.0,
+                            bbox.y as f64 + (bbox.height as f64 - font_size) / 2.0,
+                        );
+                        let _ = text_ctx.write(text);
+                    }
+
+                    report_entries.push(RedactionEntry {
+                        entity_id: entity.id.clone(),
+                        entity_type: entity.entity_type.clone(),
+                        page: page_num_1indexed,
+                    });
+                }
+            }
+
+            output_doc.add_page(page);
+        }
+
+        let output_bytes = output_doc
+            .to_bytes()
+            .map_err(|e| SemanticRedactorError::WriteFailed(e.to_string()))?;
+
+        Ok((
+            output_bytes,
+            RedactionReport {
+                entries: report_entries,
+            },
+        ))
+    }
+}

--- a/oxidize-pdf-core/src/operations/source_highlighter.rs
+++ b/oxidize-pdf-core/src/operations/source_highlighter.rs
@@ -1,0 +1,563 @@
+//! Source highlighter for RAG-aligned PDF editing
+//!
+//! Provides `TextPositionIndex` to map character offsets from `DocumentChunk`
+//! to PDF coordinates, and `SourceHighlighter` to highlight retrieved chunks
+//! in the original PDF.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use crate::ai::chunking::DocumentChunk;
+use crate::annotations::MarkupAnnotation;
+use crate::geometry::{Point, Rectangle};
+use crate::graphics::Color;
+use crate::text::extraction::{ExtractedText, ExtractionOptions, TextFragment};
+
+/// PAGE_SEPARATOR matches the chunker's concatenation: pages joined with "\n\n"
+const PAGE_SEPARATOR: &str = "\n\n";
+
+/// Entry in the position index mapping a text fragment to its char offset
+/// in the full concatenated document text.
+#[derive(Debug, Clone)]
+pub struct IndexedFragment {
+    /// 0-indexed page number
+    pub page: usize,
+    /// Character offset where this fragment starts in the full document text
+    pub start_char: usize,
+    /// Character offset where this fragment ends (exclusive) in the full document text
+    pub end_char: usize,
+    /// X coordinate in PDF page coordinates
+    pub x: f64,
+    /// Y coordinate in PDF page coordinates
+    pub y: f64,
+    /// Width of the text fragment
+    pub width: f64,
+    /// Height of the text fragment
+    pub height: f64,
+}
+
+impl IndexedFragment {
+    /// Convert this fragment's position to a `Rectangle` suitable for annotations.
+    pub fn to_rectangle(&self) -> Rectangle {
+        Rectangle::from_position_and_size(self.x, self.y, self.width, self.height)
+    }
+}
+
+/// Maps character offsets in concatenated document text to PDF coordinates.
+///
+/// Built from per-page `ExtractedText` (with `preserve_layout: true`),
+/// this index allows mapping a character range (like those in `DocumentChunk`)
+/// back to the physical locations on PDF pages.
+#[derive(Debug)]
+pub struct TextPositionIndex {
+    /// Indexed fragments sorted by start_char
+    entries: Vec<IndexedFragment>,
+    /// Character offset where each page starts in the concatenated text
+    page_offsets: Vec<usize>,
+}
+
+impl TextPositionIndex {
+    /// Build an index from per-page extracted text.
+    ///
+    /// Pages are concatenated with `"\n\n"` separators (matching the chunker).
+    /// For each page's `TextFragment`, we find its position in the page text
+    /// and compute the global character offset.
+    pub fn build(pages: &[ExtractedText]) -> Self {
+        let mut entries = Vec::new();
+        let mut page_offsets = Vec::new();
+        let mut global_offset: usize = 0;
+
+        for (page_idx, page) in pages.iter().enumerate() {
+            page_offsets.push(global_offset);
+
+            // Track position within the page text for incremental search
+            let page_text = &page.text;
+            let mut search_from: usize = 0;
+
+            for fragment in &page.fragments {
+                if fragment.text.is_empty() {
+                    continue;
+                }
+
+                // Find this fragment's text within the page text, starting from
+                // where the last fragment ended (incremental search)
+                if let Some(pos_in_page) = page_text[search_from..].find(&fragment.text) {
+                    let local_offset = search_from + pos_in_page;
+                    let frag_len = fragment.text.len();
+
+                    entries.push(IndexedFragment {
+                        page: page_idx,
+                        start_char: global_offset + local_offset,
+                        end_char: global_offset + local_offset + frag_len,
+                        x: fragment.x,
+                        y: fragment.y,
+                        width: fragment.width,
+                        height: fragment.height,
+                    });
+
+                    // Advance search position past this fragment
+                    search_from = local_offset + frag_len;
+                }
+            }
+
+            // Advance global offset: page text length + separator
+            global_offset += page_text.len();
+            if page_idx < pages.len() - 1 {
+                global_offset += PAGE_SEPARATOR.len();
+            }
+        }
+
+        Self {
+            entries,
+            page_offsets,
+        }
+    }
+
+    /// Find all fragments whose character range overlaps with `[start, end)`.
+    pub fn fragments_for_range(&self, start: usize, end: usize) -> Vec<&IndexedFragment> {
+        if start >= end {
+            return Vec::new();
+        }
+
+        self.entries
+            .iter()
+            .filter(|e| e.start_char < end && e.end_char > start)
+            .collect()
+    }
+
+    /// Get the character offset where a given page starts.
+    pub fn page_offset(&self, page: usize) -> Option<usize> {
+        self.page_offsets.get(page).copied()
+    }
+
+    /// Total number of indexed fragments.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// All indexed entries (for inspection/testing).
+    pub fn entries(&self) -> &[IndexedFragment] {
+        &self.entries
+    }
+}
+
+/// Convert a `TextFragment` position to a `Rectangle` for highlight annotations.
+pub fn fragment_to_highlight_rect(frag: &TextFragment) -> Rectangle {
+    Rectangle::new(
+        Point::new(frag.x, frag.y),
+        Point::new(frag.x + frag.width, frag.y + frag.height),
+    )
+}
+
+// =============================================================================
+// SourceHighlighter API
+// =============================================================================
+
+/// Style configuration for highlight annotations.
+#[derive(Debug, Clone)]
+pub struct HighlightStyle {
+    /// Color of the highlight (default: yellow)
+    pub color: Color,
+    /// Opacity of the highlight (0.0 = transparent, 1.0 = opaque; default: 0.5)
+    pub opacity: f64,
+}
+
+impl Default for HighlightStyle {
+    fn default() -> Self {
+        Self {
+            color: Color::Rgb(1.0, 1.0, 0.0), // Yellow
+            opacity: 0.5,
+        }
+    }
+}
+
+impl HighlightStyle {
+    /// Create a new HighlightStyle with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the highlight color.
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Set the highlight opacity.
+    pub fn with_opacity(mut self, opacity: f64) -> Self {
+        self.opacity = opacity;
+        self
+    }
+}
+
+/// Errors that can occur during source highlighting.
+#[derive(Debug, thiserror::Error)]
+pub enum SourceHighlighterError {
+    /// Failed to extract text from the PDF
+    #[error("text extraction failed: {0}")]
+    TextExtractionFailed(String),
+
+    /// Failed to reconstruct a page from the parsed PDF
+    #[error("page reconstruction failed: {0}")]
+    PageReconstructionFailed(String),
+
+    /// Failed to write the output PDF
+    #[error("write failed: {0}")]
+    WriteFailed(String),
+}
+
+/// Result type for source highlighter operations.
+pub type SourceHighlighterResult<T> = Result<T, SourceHighlighterError>;
+
+/// Highlights text regions in a PDF corresponding to retrieved RAG chunks.
+///
+/// Given PDF bytes and a set of `DocumentChunk`s (from the chunker), this
+/// produces a new PDF with highlight annotations over the text regions
+/// that correspond to each chunk.
+pub struct SourceHighlighter;
+
+impl SourceHighlighter {
+    /// Highlight the given chunks in the PDF, returning the modified PDF bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `pdf_bytes` - The original PDF file bytes
+    /// * `chunks` - Chunks to highlight (with position metadata from the chunker)
+    /// * `style` - Visual style for the highlights
+    ///
+    /// # Returns
+    ///
+    /// The modified PDF bytes with highlight annotations added.
+    pub fn highlight_chunks(
+        pdf_bytes: &[u8],
+        chunks: &[&DocumentChunk],
+        style: HighlightStyle,
+    ) -> SourceHighlighterResult<Vec<u8>> {
+        if chunks.is_empty() {
+            return Ok(pdf_bytes.to_vec());
+        }
+
+        // 1. Parse the PDF
+        let cursor = Cursor::new(pdf_bytes);
+        let reader = crate::parser::PdfReader::new(cursor)
+            .map_err(|e| SourceHighlighterError::TextExtractionFailed(e.to_string()))?;
+        let document = reader.into_document();
+
+        // 2. Extract text with position information
+        let options = ExtractionOptions {
+            preserve_layout: true,
+            ..Default::default()
+        };
+        let extracted_pages = document
+            .extract_text_with_options(options)
+            .map_err(|e| SourceHighlighterError::TextExtractionFailed(e.to_string()))?;
+
+        // 3. Build the position index
+        let index = TextPositionIndex::build(&extracted_pages);
+
+        // 4. For each chunk, find matching fragments and group by page
+        let mut annotations_by_page: HashMap<usize, Vec<Rectangle>> = HashMap::new();
+
+        for chunk in chunks {
+            let start = chunk.metadata.position.start_char;
+            let end = chunk.metadata.position.end_char;
+
+            for frag in index.fragments_for_range(start, end) {
+                annotations_by_page
+                    .entry(frag.page)
+                    .or_default()
+                    .push(frag.to_rectangle());
+            }
+        }
+
+        // 5. Reconstruct the document with annotations
+        let page_count = document
+            .page_count()
+            .map_err(|e| SourceHighlighterError::PageReconstructionFailed(e.to_string()))?;
+
+        let mut output_doc = crate::document::Document::new();
+
+        for page_idx in 0..page_count {
+            let parsed_page = document
+                .get_page(page_idx)
+                .map_err(|e| SourceHighlighterError::PageReconstructionFailed(e.to_string()))?;
+
+            let mut page = crate::page::Page::from_parsed_with_content(&parsed_page, &document)
+                .map_err(|e| SourceHighlighterError::PageReconstructionFailed(e.to_string()))?;
+
+            // Add highlight annotations for this page
+            if let Some(rects) = annotations_by_page.get(&(page_idx as usize)) {
+                for rect in rects {
+                    let highlight =
+                        MarkupAnnotation::highlight(*rect).with_color(style.color.clone());
+                    page.add_annotation(highlight.to_annotation());
+                }
+            }
+
+            output_doc.add_page(page);
+        }
+
+        // 6. Write to bytes
+        output_doc
+            .to_bytes()
+            .map_err(|e| SourceHighlighterError::WriteFailed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: create a TextFragment with given text and position
+    fn make_fragment(text: &str, x: f64, y: f64, width: f64, height: f64) -> TextFragment {
+        TextFragment {
+            text: text.to_string(),
+            x,
+            y,
+            width,
+            height,
+            font_size: 12.0,
+            font_name: None,
+            is_bold: false,
+            is_italic: false,
+            color: None,
+            space_decisions: Vec::new(),
+        }
+    }
+
+    /// Helper: create ExtractedText from fragments, building text by joining fragment texts
+    fn make_extracted(fragments: Vec<TextFragment>) -> ExtractedText {
+        let text = fragments
+            .iter()
+            .map(|f| f.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        ExtractedText { text, fragments }
+    }
+
+    #[test]
+    fn test_index_single_fragment() {
+        let page = ExtractedText {
+            text: "Hello".to_string(),
+            fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        assert_eq!(index.len(), 1);
+        let results = index.fragments_for_range(0, 5);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].start_char, 0);
+        assert_eq!(results[0].end_char, 5);
+        assert!((results[0].x - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_index_multiple_fragments() {
+        let page = ExtractedText {
+            text: "Hello World Test".to_string(),
+            fragments: vec![
+                make_fragment("Hello", 100.0, 700.0, 50.0, 12.0),
+                make_fragment("World", 160.0, 700.0, 55.0, 12.0),
+                make_fragment("Test", 225.0, 700.0, 40.0, 12.0),
+            ],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        assert_eq!(index.len(), 3);
+
+        // Query that overlaps only "World" (chars 6-11)
+        let results = index.fragments_for_range(6, 11);
+        assert_eq!(results.len(), 1);
+        assert!((results[0].x - 160.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_index_cross_page() {
+        let page1 = ExtractedText {
+            text: "Page one".to_string(),
+            fragments: vec![make_fragment("Page one", 72.0, 700.0, 80.0, 12.0)],
+        };
+        let page2 = ExtractedText {
+            text: "Page two".to_string(),
+            fragments: vec![make_fragment("Page two", 72.0, 700.0, 80.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page1, page2]);
+
+        assert_eq!(index.len(), 2);
+
+        // Page 1: "Page one" (0..8), separator "\n\n" (8..10), Page 2: "Page two" (10..18)
+        // Query that spans both pages
+        let results = index.fragments_for_range(5, 15);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].page, 0);
+        assert_eq!(results[1].page, 1);
+    }
+
+    #[test]
+    fn test_index_empty_range() {
+        let page = ExtractedText {
+            text: "Hello".to_string(),
+            fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        let results = index.fragments_for_range(2, 2);
+        assert!(results.is_empty(), "Empty range should return no results");
+    }
+
+    #[test]
+    fn test_index_exact_boundary() {
+        let page = ExtractedText {
+            text: "Hello".to_string(),
+            fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        // Exact boundaries [0, 5) should include the fragment
+        let results = index.fragments_for_range(0, 5);
+        assert_eq!(results.len(), 1);
+
+        // Range [5, 10) should NOT include it (fragment ends at 5)
+        let results = index.fragments_for_range(5, 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_index_no_overlap() {
+        let page = ExtractedText {
+            text: "Hello".to_string(),
+            fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        let results = index.fragments_for_range(100, 200);
+        assert!(
+            results.is_empty(),
+            "Query far beyond text should return nothing"
+        );
+    }
+
+    #[test]
+    fn test_fragment_to_highlight_rect_conversion() {
+        let frag = make_fragment("Test", 100.0, 500.0, 200.0, 15.0);
+        let rect = fragment_to_highlight_rect(&frag);
+
+        assert!((rect.lower_left.x - 100.0).abs() < 0.01);
+        assert!((rect.lower_left.y - 500.0).abs() < 0.01);
+        assert!((rect.upper_right.x - 300.0).abs() < 0.01);
+        assert!((rect.upper_right.y - 515.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_index_build_from_extracted() {
+        let fragments = vec![
+            make_fragment("Alpha", 72.0, 750.0, 45.0, 12.0),
+            make_fragment("Beta", 130.0, 750.0, 35.0, 12.0),
+            make_fragment("Gamma", 180.0, 750.0, 50.0, 12.0),
+        ];
+        let page = make_extracted(fragments);
+        let index = TextPositionIndex::build(&[page]);
+
+        assert_eq!(index.len(), 3);
+        // All entries should have page 0
+        for entry in index.entries() {
+            assert_eq!(entry.page, 0);
+        }
+    }
+
+    #[test]
+    fn test_index_fragments_grouped_by_page() {
+        let page1 = ExtractedText {
+            text: "AAA".to_string(),
+            fragments: vec![make_fragment("AAA", 72.0, 700.0, 30.0, 12.0)],
+        };
+        let page2 = ExtractedText {
+            text: "BBB CCC".to_string(),
+            fragments: vec![
+                make_fragment("BBB", 72.0, 700.0, 30.0, 12.0),
+                make_fragment("CCC", 110.0, 700.0, 30.0, 12.0),
+            ],
+        };
+        let index = TextPositionIndex::build(&[page1, page2]);
+
+        // Query all
+        let all = index.fragments_for_range(0, 100);
+        assert_eq!(all.len(), 3);
+
+        let page0_frags: Vec<_> = all.iter().filter(|f| f.page == 0).collect();
+        let page1_frags: Vec<_> = all.iter().filter(|f| f.page == 1).collect();
+        assert_eq!(page0_frags.len(), 1);
+        assert_eq!(page1_frags.len(), 2);
+    }
+
+    #[test]
+    fn test_index_page_offsets() {
+        let page1 = ExtractedText {
+            text: "ABCDE".to_string(), // 5 chars
+            fragments: vec![make_fragment("ABCDE", 72.0, 700.0, 50.0, 12.0)],
+        };
+        let page2 = ExtractedText {
+            text: "FGHIJ".to_string(), // 5 chars
+            fragments: vec![make_fragment("FGHIJ", 72.0, 700.0, 50.0, 12.0)],
+        };
+        let page3 = ExtractedText {
+            text: "KLMNO".to_string(), // 5 chars
+            fragments: vec![make_fragment("KLMNO", 72.0, 700.0, 50.0, 12.0)],
+        };
+        let index = TextPositionIndex::build(&[page1, page2, page3]);
+
+        // Page 0 starts at 0
+        assert_eq!(index.page_offset(0), Some(0));
+        // Page 1 starts at 5 + 2 ("\n\n") = 7
+        assert_eq!(index.page_offset(1), Some(7));
+        // Page 2 starts at 7 + 5 + 2 = 14
+        assert_eq!(index.page_offset(2), Some(14));
+        // Page 3 doesn't exist
+        assert_eq!(index.page_offset(3), None);
+    }
+
+    #[test]
+    fn test_index_whitespace_only_fragments() {
+        let page = ExtractedText {
+            text: "Hello World".to_string(),
+            fragments: vec![
+                make_fragment("Hello", 72.0, 700.0, 50.0, 12.0),
+                make_fragment("", 130.0, 700.0, 10.0, 12.0), // empty fragment
+                make_fragment("World", 145.0, 700.0, 55.0, 12.0),
+            ],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        // Empty fragment should be skipped
+        assert_eq!(index.len(), 2);
+        let results = index.fragments_for_range(0, 20);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_index_preserves_order() {
+        let page = ExtractedText {
+            text: "AAA BBB CCC DDD".to_string(),
+            fragments: vec![
+                make_fragment("AAA", 72.0, 700.0, 30.0, 12.0),
+                make_fragment("BBB", 110.0, 700.0, 30.0, 12.0),
+                make_fragment("CCC", 150.0, 700.0, 30.0, 12.0),
+                make_fragment("DDD", 190.0, 700.0, 30.0, 12.0),
+            ],
+        };
+        let index = TextPositionIndex::build(&[page]);
+
+        let entries = index.entries();
+        for i in 1..entries.len() {
+            assert!(
+                entries[i].start_char >= entries[i - 1].start_char,
+                "Entries should be ordered by start_char"
+            );
+        }
+    }
+}

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -17,6 +17,7 @@ pub mod plaintext;
 pub mod structured;
 pub mod table;
 pub mod table_detection;
+pub mod text_block;
 pub mod validation;
 
 #[cfg(test)]
@@ -47,6 +48,7 @@ pub use ocr::{
 };
 pub use plaintext::{LineBreakMode, PlainTextConfig, PlainTextExtractor, PlainTextResult};
 pub use table::{HeaderStyle, Table, TableCell, TableOptions};
+pub use text_block::{compute_line_widths, measure_text_block, TextBlockMetrics};
 pub use validation::{MatchType, TextMatch, TextValidationResult, TextValidator};
 
 #[cfg(feature = "ocr-tesseract")]

--- a/oxidize-pdf-core/src/text/text_block.rs
+++ b/oxidize-pdf-core/src/text/text_block.rs
@@ -1,0 +1,130 @@
+use crate::text::{measure_text, split_into_words, Font};
+
+/// Result of measuring a text block before rendering.
+///
+/// Used to calculate how much vertical space a block of wrapped text
+/// will occupy, enabling layout decisions (page breaks, element positioning)
+/// before committing to rendering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextBlockMetrics {
+    /// Width of the longest line in points
+    pub width: f64,
+    /// Total height of the block in points (font_size × line_height × line_count)
+    pub height: f64,
+    /// Number of lines after word-wrapping
+    pub line_count: usize,
+}
+
+/// Computes wrapped line widths for a given text, font, size, and max width.
+///
+/// Returns a vector of line widths (one per wrapped line). This is the shared
+/// wrapping algorithm used by both `measure_text_block` and `TextFlowContext`.
+///
+/// Each "word" from `split_into_words` is placed on the current line if it fits;
+/// otherwise a new line is started. A single word wider than `max_width` is placed
+/// on its own line (it will exceed `max_width` but avoids infinite loops).
+pub fn compute_line_widths(text: &str, font: &Font, font_size: f64, max_width: f64) -> Vec<f64> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let words = split_into_words(text);
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    let mut line_widths: Vec<f64> = Vec::new();
+    let mut current_width = 0.0;
+
+    for word in &words {
+        let word_width = measure_text(word, font, font_size);
+
+        if current_width > 0.0 && current_width + word_width > max_width {
+            line_widths.push(current_width);
+            current_width = word_width;
+        } else {
+            current_width += word_width;
+        }
+    }
+
+    if current_width > 0.0 {
+        line_widths.push(current_width);
+    }
+
+    line_widths
+}
+
+/// Measures a block of word-wrapped text without rendering it.
+///
+/// Given a text string, font, font size, line height multiplier, and maximum
+/// width, computes how the text would be laid out with word wrapping and returns
+/// the resulting dimensions.
+///
+/// # Arguments
+///
+/// * `text` - The text to measure
+/// * `font` - The font to use for width calculations
+/// * `font_size` - Font size in points
+/// * `line_height` - Line height multiplier (e.g., 1.2 for 120% spacing)
+/// * `max_width` - Maximum width available for text in points
+///
+/// # Returns
+///
+/// A `TextBlockMetrics` with the measured `width`, `height`, and `line_count`.
+///
+/// # Example
+///
+/// ```rust
+/// use oxidize_pdf::text::text_block::measure_text_block;
+/// use oxidize_pdf::Font;
+///
+/// let metrics = measure_text_block("Hello World", &Font::Helvetica, 12.0, 1.2, 200.0);
+/// assert_eq!(metrics.line_count, 1);
+/// assert!(metrics.width > 0.0);
+/// assert!(metrics.height > 0.0);
+/// ```
+pub fn measure_text_block(
+    text: &str,
+    font: &Font,
+    font_size: f64,
+    line_height: f64,
+    max_width: f64,
+) -> TextBlockMetrics {
+    let line_widths = compute_line_widths(text, font, font_size, max_width);
+
+    let line_count = line_widths.len();
+    let width = line_widths.iter().copied().fold(0.0_f64, f64::max);
+    let height = line_count as f64 * font_size * line_height;
+
+    TextBlockMetrics {
+        width,
+        height,
+        line_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_line_widths_empty() {
+        let widths = compute_line_widths("", &Font::Helvetica, 12.0, 200.0);
+        assert!(widths.is_empty());
+    }
+
+    #[test]
+    fn test_compute_line_widths_single_word() {
+        let widths = compute_line_widths("Hello", &Font::Helvetica, 12.0, 500.0);
+        assert_eq!(widths.len(), 1);
+        assert!(widths[0] > 0.0);
+    }
+
+    #[test]
+    fn test_measure_text_block_empty() {
+        let m = measure_text_block("", &Font::Helvetica, 12.0, 1.2, 300.0);
+        assert_eq!(m.line_count, 0);
+        assert_eq!(m.width, 0.0);
+        assert_eq!(m.height, 0.0);
+    }
+}

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2407,18 +2407,18 @@ impl<W: Write> PdfWriter<W> {
 
         page_dict.set("Resources", Object::Dictionary(resources));
 
-        // Handle form widget annotations
-        if let Some(Object::Array(annots)) = page_dict.get("Annots") {
-            let mut new_annots = Vec::new();
+        // Collect all annotation references for the /Annots array
+        let mut annot_refs: Vec<Object> = Vec::new();
 
+        // 1. Process widget annotations already in page_dict (legacy form field path)
+        if let Some(Object::Array(annots)) = page_dict.get("Annots") {
             for annot in annots {
                 if let Object::Dictionary(ref annot_dict) = annot {
                     if let Some(Object::Name(subtype)) = annot_dict.get("Subtype") {
                         if subtype == "Widget" {
-                            // Process widget annotation
                             let widget_id = self.allocate_object_id();
                             self.write_object(widget_id, annot.clone())?;
-                            new_annots.push(Object::Reference(widget_id));
+                            annot_refs.push(Object::Reference(widget_id));
 
                             // Track widget for form fields
                             if let Some(Object::Name(_ft)) = annot_dict.get("FT") {
@@ -2435,12 +2435,37 @@ impl<W: Write> PdfWriter<W> {
                         }
                     }
                 }
-                new_annots.push(annot.clone());
+                annot_refs.push(annot.clone());
             }
+        }
 
-            if !new_annots.is_empty() {
-                page_dict.set("Annots", Object::Array(new_annots));
+        // 2. Write annotations from Page.annotations() (programmatic annotations)
+        //    Handles highlights, text notes, stamps, links, etc. added via
+        //    page.add_annotation(). Each is written as an indirect object.
+        for annotation in page.annotations() {
+            let annot_id = self.allocate_object_id();
+            let annot_dict = annotation.to_dict();
+            self.write_object(annot_id, Object::Dictionary(annot_dict))?;
+            annot_refs.push(Object::Reference(annot_id));
+
+            // Track widget annotations for AcroForm if they come through this path
+            if annotation.annotation_type == crate::annotations::AnnotationType::Widget {
+                if let Some(Object::String(field_name)) = annotation.properties.get("T") {
+                    self.field_widget_map
+                        .entry(field_name.clone())
+                        .or_default()
+                        .push(annot_id);
+                    self.field_id_map.insert(field_name.clone(), annot_id);
+                    self.form_field_ids.push(annot_id);
+                }
             }
+        }
+
+        // Set or remove /Annots based on whether we have any
+        if !annot_refs.is_empty() {
+            page_dict.set("Annots", Object::Array(annot_refs));
+        } else {
+            page_dict.remove("Annots");
         }
 
         self.write_object(page_id, Object::Dictionary(page_dict))?;

--- a/oxidize-pdf-core/tests/annotation_write_test.rs
+++ b/oxidize-pdf-core/tests/annotation_write_test.rs
@@ -1,0 +1,329 @@
+//! TDD Phase 0: Annotation Writing Pipeline Tests
+//!
+//! These tests verify that non-Widget annotations stored in Page.annotations
+//! are correctly written to the PDF output by the writer.
+//!
+//! The current writer only processes Widget annotations from the page dict.
+//! These tests must FAIL until the writer is modified to handle all annotation types.
+
+use oxidize_pdf::annotations::{Annotation, AnnotationType, MarkupAnnotation};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Helper: create a simple document, add annotations to a page, write to bytes
+fn create_pdf_with_annotations(annotations: Vec<Annotation>) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    // Add some text so the page isn't empty
+    {
+        let text = page.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("Test page with annotations");
+    }
+
+    for annot in annotations {
+        page.add_annotation(annot);
+    }
+
+    doc.add_page(page);
+    doc.to_bytes().expect("Failed to write PDF to bytes")
+}
+
+/// Helper: parse PDF bytes and count annotations on page 0 via get_page_annotations
+fn count_page_annotations(pdf_bytes: &[u8]) -> usize {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    doc.get_page_annotations(0).unwrap_or_default().len()
+}
+
+/// Helper: get annotation subtype at given index on page 0
+fn get_annotation_subtype(pdf_bytes: &[u8], index: usize) -> Option<String> {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let annots = doc.get_page_annotations(0).unwrap_or_default();
+    let annot = annots.get(index)?;
+    annot
+        .get("Subtype")
+        .and_then(|s| s.as_name())
+        .map(|n| n.0.clone())
+}
+
+/// Helper: check if annotation at index has a specific key
+fn annotation_has_key(pdf_bytes: &[u8], index: usize, key: &str) -> bool {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let annots = doc.get_page_annotations(0).unwrap_or_default();
+    annots
+        .get(index)
+        .map(|a| a.contains_key(key))
+        .unwrap_or(false)
+}
+
+/// Helper: get /Rect array values from annotation at index
+fn get_annotation_rect(pdf_bytes: &[u8], index: usize) -> Option<[f64; 4]> {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let annots = doc.get_page_annotations(0).unwrap_or_default();
+    let annot = annots.get(index)?;
+    let rect_obj = annot.get("Rect")?;
+    let rect_arr = rect_obj.as_array()?;
+
+    if rect_arr.len() != 4 {
+        return None;
+    }
+
+    let vals: Vec<f64> = (0..4)
+        .filter_map(|i| rect_arr.get(i).and_then(|v| v.as_real()))
+        .collect();
+
+    if vals.len() == 4 {
+        Some([vals[0], vals[1], vals[2], vals[3]])
+    } else {
+        None
+    }
+}
+
+/// Helper: get string field value from annotation
+fn get_annotation_string_field(pdf_bytes: &[u8], index: usize, field: &str) -> Option<String> {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let annots = doc.get_page_annotations(0).unwrap_or_default();
+    let annot = annots.get(index)?;
+    let val = annot.get(field)?;
+    val.as_string()
+        .map(|s| String::from_utf8_lossy(&s.0).to_string())
+}
+
+/// Helper: check if page has any annotations at all
+fn page_has_annotations(pdf_bytes: &[u8]) -> bool {
+    count_page_annotations(pdf_bytes) > 0
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+/// Test 1: A highlight annotation added to a page appears in the /Annots array
+/// of the written PDF with /Subtype /Highlight
+#[test]
+fn test_highlight_annotation_appears_in_annots_array() {
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 712.0));
+    let highlight = MarkupAnnotation::highlight(rect);
+    let annot = highlight.to_annotation();
+
+    let pdf_bytes = create_pdf_with_annotations(vec![annot]);
+
+    assert_eq!(
+        count_page_annotations(&pdf_bytes),
+        1,
+        "Page should have exactly 1 annotation in /Annots"
+    );
+    assert_eq!(
+        get_annotation_subtype(&pdf_bytes, 0),
+        Some("Highlight".to_string()),
+        "Annotation should have /Subtype /Highlight"
+    );
+}
+
+/// Test 2: Multiple annotations of different types are all written
+#[test]
+fn test_multiple_annotations_written() {
+    let rect1 = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 712.0));
+    let rect2 = Rectangle::new(Point::new(100.0, 680.0), Point::new(300.0, 692.0));
+    let rect3 = Rectangle::new(Point::new(100.0, 660.0), Point::new(300.0, 672.0));
+
+    let annots = vec![
+        MarkupAnnotation::highlight(rect1).to_annotation(),
+        MarkupAnnotation::underline(rect2).to_annotation(),
+        MarkupAnnotation::strikeout(rect3).to_annotation(),
+    ];
+
+    let pdf_bytes = create_pdf_with_annotations(annots);
+
+    assert_eq!(
+        count_page_annotations(&pdf_bytes),
+        3,
+        "Page should have exactly 3 annotations"
+    );
+    assert_eq!(
+        get_annotation_subtype(&pdf_bytes, 0),
+        Some("Highlight".to_string())
+    );
+    assert_eq!(
+        get_annotation_subtype(&pdf_bytes, 1),
+        Some("Underline".to_string())
+    );
+    assert_eq!(
+        get_annotation_subtype(&pdf_bytes, 2),
+        Some("StrikeOut".to_string())
+    );
+}
+
+/// Test 3: Annotation /Rect is written with correct coordinates
+#[test]
+fn test_annotation_rect_written_correctly() {
+    let rect = Rectangle::new(Point::new(72.0, 500.0), Point::new(200.0, 515.0));
+    let highlight = MarkupAnnotation::highlight(rect);
+    let annot = highlight.to_annotation();
+
+    let pdf_bytes = create_pdf_with_annotations(vec![annot]);
+
+    let written_rect = get_annotation_rect(&pdf_bytes, 0).expect("Annotation should have a /Rect");
+
+    assert!(
+        (written_rect[0] - 72.0).abs() < 0.01,
+        "x1 should be 72.0, got {}",
+        written_rect[0]
+    );
+    assert!(
+        (written_rect[1] - 500.0).abs() < 0.01,
+        "y1 should be 500.0, got {}",
+        written_rect[1]
+    );
+    assert!(
+        (written_rect[2] - 200.0).abs() < 0.01,
+        "x2 should be 200.0, got {}",
+        written_rect[2]
+    );
+    assert!(
+        (written_rect[3] - 515.0).abs() < 0.01,
+        "y2 should be 515.0, got {}",
+        written_rect[3]
+    );
+}
+
+/// Test 4: Highlight annotation has /QuadPoints written
+#[test]
+fn test_annotation_quad_points_written() {
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 712.0));
+    let highlight = MarkupAnnotation::highlight(rect);
+    let annot = highlight.to_annotation();
+
+    let pdf_bytes = create_pdf_with_annotations(vec![annot]);
+
+    assert!(
+        annotation_has_key(&pdf_bytes, 0, "QuadPoints"),
+        "Highlight annotation should have /QuadPoints"
+    );
+}
+
+/// Test 5: Annotation /C (color) is written with correct RGB values
+#[test]
+fn test_annotation_color_written() {
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 712.0));
+    let highlight = MarkupAnnotation::highlight(rect).with_color(Color::Rgb(1.0, 0.0, 0.0));
+    let annot = highlight.to_annotation();
+
+    let pdf_bytes = create_pdf_with_annotations(vec![annot]);
+
+    assert!(
+        annotation_has_key(&pdf_bytes, 0, "C"),
+        "Annotation should have /C (color) entry"
+    );
+}
+
+/// Test 6: Widget annotations (form fields) continue to work after refactor.
+/// We create a Widget annotation manually and a non-Widget annotation,
+/// and verify both appear in the output.
+#[test]
+fn test_widget_annotations_still_work_after_refactor() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    // Add text content
+    {
+        let text = page.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("Form page");
+    }
+
+    // Manually create a Widget annotation (simulating a form field)
+    let widget_rect = Rectangle::new(Point::new(72.0, 650.0), Point::new(272.0, 670.0));
+    let widget = Annotation::new(AnnotationType::Widget, widget_rect).with_contents("text_field_1");
+    page.add_annotation(widget);
+
+    // Add a non-widget (Highlight) annotation
+    let hl_rect = Rectangle::new(Point::new(100.0, 600.0), Point::new(300.0, 612.0));
+    let highlight = MarkupAnnotation::highlight(hl_rect).to_annotation();
+    page.add_annotation(highlight);
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("Failed to write PDF");
+
+    let annot_count = count_page_annotations(&pdf_bytes);
+    assert!(
+        annot_count >= 2,
+        "Page should have at least 2 annotations (widget + highlight), got {}",
+        annot_count
+    );
+
+    // Verify both types are present
+    let mut found_highlight = false;
+    let mut found_widget = false;
+    for i in 0..annot_count {
+        if let Some(subtype) = get_annotation_subtype(&pdf_bytes, i) {
+            if subtype == "Highlight" {
+                found_highlight = true;
+            }
+            if subtype == "Widget" {
+                found_widget = true;
+            }
+        }
+    }
+    assert!(found_highlight, "Should find a Highlight annotation");
+    assert!(found_widget, "Should find a Widget annotation");
+}
+
+/// Test 7: Page without annotations does NOT have any annotation entries
+#[test]
+fn test_empty_annotations_no_annots_key() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    {
+        let text = page.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("No annotations on this page");
+    }
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("Failed to write PDF");
+
+    assert!(
+        !page_has_annotations(&pdf_bytes),
+        "Page without annotations should NOT have any annotations"
+    );
+}
+
+/// Test 8: Annotation with /Contents string is written correctly
+#[test]
+fn test_annotation_with_contents_string() {
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 712.0));
+    let annot = Annotation::new(AnnotationType::Text, rect).with_contents("This is a comment");
+
+    let pdf_bytes = create_pdf_with_annotations(vec![annot]);
+
+    assert_eq!(count_page_annotations(&pdf_bytes), 1);
+    assert_eq!(
+        get_annotation_subtype(&pdf_bytes, 0),
+        Some("Text".to_string())
+    );
+
+    let contents = get_annotation_string_field(&pdf_bytes, 0, "Contents");
+    assert_eq!(
+        contents,
+        Some("This is a comment".to_string()),
+        "Annotation should have /Contents with the correct text"
+    );
+}

--- a/oxidize-pdf-core/tests/chunk_page_mapper_test.rs
+++ b/oxidize-pdf-core/tests/chunk_page_mapper_test.rs
@@ -1,0 +1,171 @@
+//! TDD Phase 4: ChunkPageMapper Integration Tests
+
+use oxidize_pdf::ai::chunking::{ChunkMetadata, ChunkPosition, DocumentChunk};
+use oxidize_pdf::operations::ChunkPageMapper;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Helper: create a DocumentChunk with given page_numbers (1-indexed)
+fn make_chunk_with_pages(page_numbers: Vec<usize>) -> DocumentChunk {
+    DocumentChunk {
+        id: format!("chunk_p{:?}", page_numbers),
+        content: "test".to_string(),
+        tokens: 1,
+        page_numbers: page_numbers.clone(),
+        chunk_index: 0,
+        metadata: ChunkMetadata {
+            position: ChunkPosition {
+                start_char: 0,
+                end_char: 4,
+                first_page: *page_numbers.first().unwrap_or(&1),
+                last_page: *page_numbers.last().unwrap_or(&1),
+            },
+            confidence: 1.0,
+            sentence_boundary_respected: true,
+        },
+    }
+}
+
+/// Helper: create an N-page PDF with distinct text per page
+fn create_n_page_pdf(n: usize) -> Vec<u8> {
+    let mut doc = Document::new();
+    for i in 0..n {
+        let mut page = Page::a4();
+        {
+            let text = page.text();
+            text.set_font(Font::Helvetica, 12.0);
+            text.at(72.0, 700.0);
+            let _ = text.write(&format!("Content of page {}", i + 1));
+        }
+        doc.add_page(page);
+    }
+    doc.to_bytes().expect("create PDF")
+}
+
+/// Helper: get page count from bytes
+fn get_page_count(pdf_bytes: &[u8]) -> u32 {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("parse");
+    reader.into_document().page_count().unwrap()
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+/// Test 1: Single chunk with page_numbers=[3] → [2] (0-indexed)
+#[test]
+fn test_pages_for_single_chunk() {
+    let chunk = make_chunk_with_pages(vec![3]);
+    let pages = ChunkPageMapper::pages_for_chunks(&[&chunk]);
+    assert_eq!(
+        pages,
+        vec![2],
+        "page_numbers=[3] should map to [2] (0-indexed)"
+    );
+}
+
+/// Test 2: Overlapping pages from multiple chunks are deduplicated
+#[test]
+fn test_pages_for_multiple_chunks_overlap() {
+    let c1 = make_chunk_with_pages(vec![3, 4]);
+    let c2 = make_chunk_with_pages(vec![4, 5]);
+    let pages = ChunkPageMapper::pages_for_chunks(&[&c1, &c2]);
+    assert_eq!(
+        pages,
+        vec![2, 3, 4],
+        "Overlapping page 4 should be deduplicated"
+    );
+}
+
+/// Test 3: Empty chunks → empty pages
+#[test]
+fn test_pages_for_empty_chunks() {
+    let pages = ChunkPageMapper::pages_for_chunks(&[]);
+    assert!(pages.is_empty(), "No chunks should produce no pages");
+}
+
+/// Test 4: page_numbers=[1] → [0] (1-indexed to 0-indexed)
+#[test]
+fn test_pages_1_indexed_to_0_indexed() {
+    let chunk = make_chunk_with_pages(vec![1]);
+    let pages = ChunkPageMapper::pages_for_chunks(&[&chunk]);
+    assert_eq!(
+        pages,
+        vec![0],
+        "Page 1 (1-indexed) should become 0 (0-indexed)"
+    );
+}
+
+/// Test 5: Unsorted page numbers → sorted output
+#[test]
+fn test_pages_sorted() {
+    let c1 = make_chunk_with_pages(vec![5]);
+    let c2 = make_chunk_with_pages(vec![1]);
+    let c3 = make_chunk_with_pages(vec![3]);
+    let pages = ChunkPageMapper::pages_for_chunks(&[&c1, &c2, &c3]);
+    assert_eq!(pages, vec![0, 2, 4], "Output should be sorted");
+}
+
+/// Test 6: Extract pages from 3-page PDF, chunks reference pages 1 and 3 → output has 2 pages
+#[test]
+fn test_extract_pages_produces_correct_count() {
+    let pdf_bytes = create_n_page_pdf(3);
+    assert_eq!(get_page_count(&pdf_bytes), 3, "Precondition: 3 pages");
+
+    let c1 = make_chunk_with_pages(vec![1]);
+    let c3 = make_chunk_with_pages(vec![3]);
+
+    let output = ChunkPageMapper::extract_pages_for_chunks(&pdf_bytes, &[&c1, &c3])
+        .expect("extract should succeed");
+
+    let output_pages = get_page_count(&output);
+    assert_eq!(
+        output_pages, 2,
+        "Extracting pages 1 and 3 from 3-page PDF should produce 2 pages, got {}",
+        output_pages
+    );
+}
+
+/// Test 7: Extracted pages preserve text content
+#[test]
+fn test_extract_pages_preserves_content() {
+    let pdf_bytes = create_n_page_pdf(3);
+
+    let c2 = make_chunk_with_pages(vec![2]);
+    let output = ChunkPageMapper::extract_pages_for_chunks(&pdf_bytes, &[&c2])
+        .expect("extract should succeed");
+
+    // Parse output and extract text
+    let cursor = Cursor::new(&output);
+    let reader = PdfReader::new(cursor).expect("parse output");
+    let doc = reader.into_document();
+
+    let extracted = doc.extract_text().unwrap_or_default();
+    let full_text: String = extracted.iter().map(|e| e.text.as_str()).collect();
+
+    // Page 2 content should be present (it said "Content of page 2")
+    assert!(
+        full_text.contains("page 2") || full_text.contains("Content"),
+        "Extracted page should contain original text, got: '{}'",
+        full_text
+    );
+}
+
+/// Test 8: Empty chunks → NoPagesToProcess error
+#[test]
+fn test_extract_pages_empty_gives_error() {
+    let pdf_bytes = create_n_page_pdf(2);
+
+    let result = ChunkPageMapper::extract_pages_for_chunks(&pdf_bytes, &[]);
+    assert!(result.is_err(), "Empty chunks should return error");
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("No pages to process"),
+        "Error should mention 'No pages to process', got: '{}'",
+        err_msg
+    );
+}

--- a/oxidize-pdf-core/tests/common/mod.rs
+++ b/oxidize-pdf-core/tests/common/mod.rs
@@ -1,0 +1,12 @@
+/// Count the number of /Type /Page entries in PDF bytes (excluding /Type /Pages).
+pub fn count_pages(bytes: &[u8]) -> usize {
+    let content = String::from_utf8_lossy(bytes);
+    content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            (trimmed.contains("/Type /Page") || trimmed.contains("/Type/Page"))
+                && !trimmed.contains("/Pages")
+        })
+        .count()
+}

--- a/oxidize-pdf-core/tests/document_builder_tests.rs
+++ b/oxidize-pdf-core/tests/document_builder_tests.rs
@@ -1,0 +1,80 @@
+mod common;
+
+use oxidize_pdf::layout::DocumentBuilder;
+use oxidize_pdf::text::Table;
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::Font;
+
+#[test]
+fn test_document_builder_produces_valid_pdf() {
+    let mut doc = DocumentBuilder::a4()
+        .add_text("Invoice #001", Font::HelveticaBold, 18.0)
+        .add_spacer(10.0)
+        .add_text("Date: 2026-04-09", Font::Helvetica, 12.0)
+        .build()
+        .unwrap();
+
+    let bytes = doc.to_bytes().unwrap();
+    assert!(bytes.starts_with(b"%PDF"));
+    assert!(bytes.len() > 200);
+    assert_eq!(common::count_pages(&bytes), 1);
+}
+
+#[test]
+fn test_document_builder_text_appears() {
+    let mut doc = DocumentBuilder::a4()
+        .add_text("BUILDER_MARKER_XYZ789", Font::Helvetica, 12.0)
+        .build()
+        .unwrap();
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let bytes = doc.to_bytes_with_config(config).unwrap();
+    let content = String::from_utf8_lossy(&bytes);
+    assert!(
+        content.contains("BUILDER_MARKER_XYZ789"),
+        "marker text must appear in uncompressed PDF stream"
+    );
+}
+
+#[test]
+fn test_document_builder_multipage_with_table() {
+    let mut table = Table::new(vec![150.0, 150.0, 150.0]);
+    for i in 0..50 {
+        table
+            .add_row(vec![
+                format!("{}", i + 1),
+                format!("Item {}", i + 1),
+                format!("${:.2}", (i + 1) as f64 * 9.99),
+            ])
+            .unwrap();
+    }
+
+    let mut doc = DocumentBuilder::a4()
+        .add_text("INVOICE TITLE", Font::HelveticaBold, 20.0)
+        .add_spacer(20.0)
+        .add_table(table)
+        .build()
+        .unwrap();
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let bytes = doc.to_bytes_with_config(config).unwrap();
+    let content = String::from_utf8_lossy(&bytes);
+
+    assert!(
+        content.contains("INVOICE TITLE"),
+        "title must appear in PDF"
+    );
+
+    let pages = common::count_pages(&bytes);
+    assert!(
+        pages >= 2,
+        "50-row table should span >= 2 pages, got {}",
+        pages
+    );
+}

--- a/oxidize-pdf-core/tests/flow_layout_tests.rs
+++ b/oxidize-pdf-core/tests/flow_layout_tests.rs
@@ -1,0 +1,133 @@
+mod common;
+
+use oxidize_pdf::layout::{FlowLayout, PageConfig};
+use oxidize_pdf::text::Table;
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Document, Font};
+
+/// Generate PDF bytes with compression disabled for content inspection.
+fn to_uncompressed_bytes(doc: &mut Document) -> Vec<u8> {
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    doc.to_bytes_with_config(config).unwrap()
+}
+
+#[test]
+fn test_flow_layout_single_page() {
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut layout = FlowLayout::new(config);
+    layout.add_text("Hello World", Font::Helvetica, 12.0);
+
+    let mut doc = Document::new();
+    layout.build_into(&mut doc).unwrap();
+
+    let bytes = doc.to_bytes().unwrap();
+    assert!(bytes.starts_with(b"%PDF"));
+    assert_eq!(
+        common::count_pages(&bytes),
+        1,
+        "short text should produce exactly 1 page"
+    );
+}
+
+#[test]
+fn test_flow_layout_auto_page_break() {
+    // Small page: 200×200 pts, 20pt margins each side
+    // Usable height = 160pts; line at 14pt font × 1.2 = 16.8pts per line
+    // 20 lines = 336pts > 160pts → must create at least 2 pages
+    let config = PageConfig::new(200.0, 200.0, 20.0, 20.0, 20.0, 20.0);
+    let mut layout = FlowLayout::new(config);
+    for _ in 0..20 {
+        layout.add_text("This line takes space on the page.", Font::Helvetica, 14.0);
+    }
+
+    let mut doc = Document::new();
+    layout.build_into(&mut doc).unwrap();
+
+    let bytes = doc.to_bytes().unwrap();
+    let pages = common::count_pages(&bytes);
+    assert!(
+        pages >= 2,
+        "20 lines of 14pt text in a 200×200 page should produce >= 2 pages, got {}",
+        pages
+    );
+}
+
+#[test]
+fn test_flow_layout_spacer() {
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut layout = FlowLayout::new(config);
+    layout.add_text("First paragraph", Font::Helvetica, 12.0);
+    layout.add_spacer(30.0);
+    layout.add_text("Second paragraph", Font::Helvetica, 12.0);
+
+    let mut doc = Document::new();
+    layout.build_into(&mut doc).unwrap();
+
+    let bytes = to_uncompressed_bytes(&mut doc);
+    assert!(bytes.starts_with(b"%PDF"));
+    let content = String::from_utf8_lossy(&bytes);
+    assert!(
+        content.contains("First paragraph"),
+        "first text must appear in PDF stream"
+    );
+    assert!(
+        content.contains("Second paragraph"),
+        "second text must appear in PDF stream"
+    );
+}
+
+#[test]
+fn test_flow_layout_table_page_break() {
+    // Small page where text fills most of the space, then a table forces a break
+    let config = PageConfig::new(300.0, 200.0, 20.0, 20.0, 20.0, 20.0);
+    let mut layout = FlowLayout::new(config);
+
+    // Fill with text lines (8 lines × 16.8pts ≈ 134pts of 160 usable)
+    for _ in 0..8 {
+        layout.add_text("Line of text here.", Font::Helvetica, 12.0);
+    }
+
+    // Table of 3 rows — won't fit in remaining ~26pts
+    let mut table = Table::new(vec![80.0, 80.0, 80.0]);
+    table
+        .add_row(vec!["A".to_string(), "B".to_string(), "C".to_string()])
+        .unwrap();
+    table
+        .add_row(vec!["1".to_string(), "2".to_string(), "3".to_string()])
+        .unwrap();
+    table
+        .add_row(vec!["X".to_string(), "Y".to_string(), "Z".to_string()])
+        .unwrap();
+    layout.add_table(table);
+
+    let mut doc = Document::new();
+    layout.build_into(&mut doc).unwrap();
+
+    let bytes = doc.to_bytes().unwrap();
+    let pages = common::count_pages(&bytes);
+    assert!(
+        pages >= 2,
+        "table after near-full page should force page break, got {} pages",
+        pages
+    );
+}
+
+#[test]
+fn test_flow_layout_text_content_appears() {
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut layout = FlowLayout::new(config);
+    layout.add_text("UNIQUE_MARKER_ABC123", Font::Helvetica, 12.0);
+
+    let mut doc = Document::new();
+    layout.build_into(&mut doc).unwrap();
+
+    let bytes = to_uncompressed_bytes(&mut doc);
+    let content = String::from_utf8_lossy(&bytes);
+    assert!(
+        content.contains("UNIQUE_MARKER_ABC123"),
+        "marker text must appear in PDF stream"
+    );
+}

--- a/oxidize-pdf-core/tests/image_fitting_tests.rs
+++ b/oxidize-pdf-core/tests/image_fitting_tests.rs
@@ -1,0 +1,57 @@
+use oxidize_pdf::layout::{centered_image_x, fit_image_dimensions};
+
+#[test]
+fn test_fit_width_constrained() {
+    // 400×200 image (2:1 ratio) into 200×300 box → width constrains
+    let (w, h) = fit_image_dimensions(400, 200, 200.0, 300.0);
+    assert!(
+        (w - 200.0).abs() < 0.001,
+        "width should be 200.0, got {}",
+        w
+    );
+    assert!(
+        (h - 100.0).abs() < 0.001,
+        "height should be 100.0, got {}",
+        h
+    );
+}
+
+#[test]
+fn test_fit_height_constrained() {
+    // 200×400 image (1:2 ratio) into 300×150 box → height constrains
+    let (w, h) = fit_image_dimensions(200, 400, 300.0, 150.0);
+    assert!((w - 75.0).abs() < 0.001, "width should be 75.0, got {}", w);
+    assert!(
+        (h - 150.0).abs() < 0.001,
+        "height should be 150.0, got {}",
+        h
+    );
+}
+
+#[test]
+fn test_fit_exact() {
+    // 100×100 image into 100×100 box → fits exactly
+    let (w, h) = fit_image_dimensions(100, 100, 100.0, 100.0);
+    assert!(
+        (w - 100.0).abs() < 0.001,
+        "width should be 100.0, got {}",
+        w
+    );
+    assert!(
+        (h - 100.0).abs() < 0.001,
+        "height should be 100.0, got {}",
+        h
+    );
+}
+
+#[test]
+fn test_centered_x() {
+    // page_width=595, margins 50 each → content_width=495
+    // image_width=200 → x = 50 + (495 - 200) / 2 = 50 + 147.5 = 197.5
+    let x = centered_image_x(50.0, 495.0, 200.0);
+    assert!(
+        (x - 197.5).abs() < 0.001,
+        "centered x should be 197.5, got {}",
+        x
+    );
+}

--- a/oxidize-pdf-core/tests/layout_invoice_e2e_test.rs
+++ b/oxidize-pdf-core/tests/layout_invoice_e2e_test.rs
@@ -1,0 +1,78 @@
+mod common;
+
+use oxidize_pdf::layout::{DocumentBuilder, PageConfig, RichText, TextSpan};
+use oxidize_pdf::text::Table;
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Color, Font};
+
+#[test]
+fn test_invoice_e2e_multipage_with_all_features() {
+    // Header with rich text
+    let header = RichText::new(vec![
+        TextSpan::new("FACTURA ", Font::HelveticaBold, 20.0, Color::black()),
+        TextSpan::new(
+            "#2026-001",
+            Font::Helvetica,
+            20.0,
+            Color::rgb(0.3, 0.3, 0.3),
+        ),
+    ]);
+
+    // Table with 50 rows to force pagination
+    let mut table = Table::new(vec![60.0, 250.0, 80.0, 80.0]);
+    for i in 0..50 {
+        table
+            .add_row(vec![
+                format!("{}", i + 1),
+                format!("Servicio de consultoria #{}", i + 1),
+                "$150.00".into(),
+                format!("${:.2}", (i + 1) as f64 * 150.0),
+            ])
+            .unwrap();
+    }
+
+    // Total with rich text
+    let total_line = RichText::new(vec![
+        TextSpan::new("TOTAL: ", Font::HelveticaBold, 14.0, Color::black()),
+        TextSpan::new("$7,650.00", Font::Helvetica, 14.0, Color::black()),
+    ]);
+
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut doc = DocumentBuilder::new(config)
+        .add_rich_text(header)
+        .add_spacer(20.0)
+        .add_text("Cliente: ACME Corp", Font::Helvetica, 12.0)
+        .add_text("Fecha: 2026-04-09", Font::Helvetica, 12.0)
+        .add_spacer(15.0)
+        .add_table(table)
+        .add_spacer(10.0)
+        .add_rich_text(total_line)
+        .build()
+        .unwrap();
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let bytes = doc.to_bytes_with_config(config).unwrap();
+
+    assert!(bytes.starts_with(b"%PDF"), "must be valid PDF");
+
+    let content = String::from_utf8_lossy(&bytes);
+
+    // Content verification
+    assert!(content.contains("FACTURA"), "header rich text present");
+    assert!(content.contains("#2026-001"), "invoice number present");
+    assert!(content.contains("ACME Corp"), "client name present");
+    assert!(content.contains("2026-04-09"), "date present");
+    assert!(content.contains("TOTAL"), "total label present");
+    assert!(content.contains("$7,650.00"), "total amount present");
+
+    // Multi-page verification
+    let pages = common::count_pages(&bytes);
+    assert!(
+        pages >= 2,
+        "50-row invoice must span >= 2 pages, got {}",
+        pages
+    );
+}

--- a/oxidize-pdf-core/tests/rag_pipeline_integration_test.rs
+++ b/oxidize-pdf-core/tests/rag_pipeline_integration_test.rs
@@ -1,0 +1,224 @@
+//! TDD Phase 5: RAG Pipeline End-to-End Integration Tests
+//!
+//! These tests combine multiple RAG features (SourceHighlighter, SemanticRedactor,
+//! ChunkPageMapper) to verify they work together without corrupting PDF structure.
+
+use oxidize_pdf::ai::chunking::{ChunkMetadata, ChunkPosition, DocumentChunk};
+use oxidize_pdf::operations::{
+    ChunkPageMapper, HighlightStyle, RedactionConfig, SemanticRedactor, SourceHighlighter,
+};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::semantic::{BoundingBox, EntityMetadata, EntityType, SemanticEntity};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Helper: create a 2-page PDF with known content
+fn create_rag_test_pdf() -> Vec<u8> {
+    let mut doc = Document::new();
+
+    let mut page1 = Page::a4();
+    {
+        let text = page1.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("Introduction to the report by John Doe");
+        text.at(72.0, 680.0);
+        let _ = text.write("Contact: john@example.com");
+    }
+    doc.add_page(page1);
+
+    let mut page2 = Page::a4();
+    {
+        let text = page2.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("Section two with detailed analysis");
+        text.at(72.0, 680.0);
+        let _ = text.write("Conclusion and recommendations");
+    }
+    doc.add_page(page2);
+
+    doc.to_bytes().expect("create PDF")
+}
+
+fn make_chunk(content: &str, start: usize, end: usize, pages: Vec<usize>) -> DocumentChunk {
+    let first = *pages.first().unwrap_or(&1);
+    let last = *pages.last().unwrap_or(&1);
+    DocumentChunk {
+        id: format!("chunk_{start}"),
+        content: content.to_string(),
+        tokens: content.split_whitespace().count(),
+        page_numbers: pages,
+        chunk_index: 0,
+        metadata: ChunkMetadata {
+            position: ChunkPosition {
+                start_char: start,
+                end_char: end,
+                first_page: first,
+                last_page: last,
+            },
+            confidence: 1.0,
+            sentence_boundary_respected: true,
+        },
+    }
+}
+
+fn make_entity(
+    id: &str,
+    etype: EntityType,
+    page: u32,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+) -> SemanticEntity {
+    SemanticEntity {
+        id: id.to_string(),
+        entity_type: etype,
+        bounds: BoundingBox::new(x, y, w, h, page),
+        content: String::new(),
+        metadata: EntityMetadata::new(),
+        relationships: Vec::new(),
+    }
+}
+
+fn get_page_count(pdf_bytes: &[u8]) -> u32 {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("parse");
+    reader.into_document().page_count().unwrap()
+}
+
+fn extract_full_text(pdf_bytes: &[u8]) -> String {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("parse");
+    let doc = reader.into_document();
+    let extracted = doc.extract_text().unwrap_or_default();
+    extracted
+        .iter()
+        .map(|e| e.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+/// E2E Test 1: Full RAG cycle — create PDF, highlight chunks, verify annotations
+#[test]
+fn test_full_rag_cycle_highlight() {
+    let pdf_bytes = create_rag_test_pdf();
+
+    // Simulate RAG retrieval: 2 chunks from different pages
+    let chunk1 = make_chunk("Introduction to the report", 0, 26, vec![1]);
+    let chunk2 = make_chunk("Section two with detailed", 0, 25, vec![2]);
+
+    let output = SourceHighlighter::highlight_chunks(
+        &pdf_bytes,
+        &[&chunk1, &chunk2],
+        HighlightStyle::default(),
+    )
+    .expect("highlight should succeed");
+
+    // Output is valid PDF with same page count
+    assert_eq!(get_page_count(&output), 2, "Page count preserved");
+
+    // Text is still extractable (highlighting doesn't destroy content)
+    let text = extract_full_text(&output);
+    assert!(
+        !text.is_empty(),
+        "Text should still be extractable from highlighted PDF"
+    );
+}
+
+/// E2E Test 2: Full RAG cycle — redact PII entities, verify report and output
+#[test]
+fn test_full_rag_cycle_redact() {
+    let pdf_bytes = create_rag_test_pdf();
+
+    let entities = vec![
+        make_entity("name1", EntityType::PersonName, 1, 250.0, 695.0, 60.0, 15.0),
+        make_entity("email1", EntityType::Email, 1, 120.0, 675.0, 130.0, 15.0),
+    ];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName, EntityType::Email]);
+
+    let (output, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("redact should succeed");
+
+    // Verify report
+    assert_eq!(report.redacted_count(), 2, "Should redact 2 entities");
+    assert_eq!(report.by_type(&EntityType::PersonName).len(), 1);
+    assert_eq!(report.by_type(&EntityType::Email).len(), 1);
+    assert_eq!(report.pages_affected(), vec![1]);
+
+    // Output is different (redaction was applied)
+    assert_ne!(output, pdf_bytes, "Output should differ after redaction");
+
+    // Page count preserved
+    assert_eq!(get_page_count(&output), 2);
+}
+
+/// E2E Test 3: Highlighting doesn't corrupt PDF structure
+#[test]
+fn test_highlight_doesnt_corrupt_structure() {
+    let pdf_bytes = create_rag_test_pdf();
+    let original_pages = get_page_count(&pdf_bytes);
+    let original_text = extract_full_text(&pdf_bytes);
+
+    let chunk = make_chunk("Introduction", 0, 12, vec![1]);
+    let output =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &[&chunk], HighlightStyle::default())
+            .expect("highlight");
+
+    // Page count preserved
+    assert_eq!(
+        get_page_count(&output),
+        original_pages,
+        "Page count must not change"
+    );
+
+    // Text still extractable and contains original content
+    let output_text = extract_full_text(&output);
+    assert!(!output_text.is_empty(), "Text must still be extractable");
+
+    // Original text keywords should be present
+    // (exact match may differ due to re-encoding, but key words should survive)
+    for keyword in &["report", "analysis", "Conclusion"] {
+        if original_text.contains(keyword) {
+            assert!(
+                output_text.contains(keyword),
+                "Keyword '{}' should be preserved in output",
+                keyword
+            );
+        }
+    }
+}
+
+/// E2E Test 4: ChunkPageMapper round-trip — extract pages → re-parse → correct count
+#[test]
+fn test_chunk_page_mapper_round_trip() {
+    let pdf_bytes = create_rag_test_pdf();
+    assert_eq!(get_page_count(&pdf_bytes), 2, "Precondition: 2 pages");
+
+    // Extract only page 2
+    let chunk = make_chunk("Section two", 0, 11, vec![2]);
+    let output = ChunkPageMapper::extract_pages_for_chunks(&pdf_bytes, &[&chunk])
+        .expect("extract should succeed");
+
+    // Output should have exactly 1 page
+    assert_eq!(
+        get_page_count(&output),
+        1,
+        "Extracting page 2 should produce 1-page PDF"
+    );
+
+    // The extracted page should contain page 2 content
+    let text = extract_full_text(&output);
+    assert!(
+        text.contains("Section") || text.contains("analysis") || text.contains("Conclusion"),
+        "Extracted page should contain page 2 content, got: '{}'",
+        text
+    );
+}

--- a/oxidize-pdf-core/tests/rich_text_tests.rs
+++ b/oxidize-pdf-core/tests/rich_text_tests.rs
@@ -1,0 +1,105 @@
+use oxidize_pdf::layout::{DocumentBuilder, RichText, TextSpan};
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Color, Font};
+
+#[test]
+fn test_text_span_measures_width() {
+    let span = TextSpan::new("Hello", Font::Helvetica, 12.0, Color::black());
+    let expected = oxidize_pdf::measure_text("Hello", &Font::Helvetica, 12.0);
+    assert!(
+        (span.measure_width() - expected).abs() < 0.001,
+        "span width {:.3} should match measure_text {:.3}",
+        span.measure_width(),
+        expected
+    );
+}
+
+#[test]
+fn test_rich_text_total_width_is_sum() {
+    let rich = RichText::new(vec![
+        TextSpan::new("Hello ", Font::Helvetica, 12.0, Color::black()),
+        TextSpan::new("World", Font::HelveticaBold, 12.0, Color::black()),
+    ]);
+
+    let expected = oxidize_pdf::measure_text("Hello ", &Font::Helvetica, 12.0)
+        + oxidize_pdf::measure_text("World", &Font::HelveticaBold, 12.0);
+    assert!(
+        (rich.total_width() - expected).abs() < 0.001,
+        "total width {:.3} should be sum of spans {:.3}",
+        rich.total_width(),
+        expected
+    );
+}
+
+#[test]
+fn test_rich_text_renders_mixed_fonts() {
+    let rich = RichText::new(vec![
+        TextSpan::new("Total: ", Font::HelveticaBold, 14.0, Color::black()),
+        TextSpan::new("$1,234.56", Font::Helvetica, 14.0, Color::gray(0.3)),
+    ]);
+
+    let mut doc = DocumentBuilder::a4().add_rich_text(rich).build().unwrap();
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let bytes = doc.to_bytes_with_config(config).unwrap();
+    let content = String::from_utf8_lossy(&bytes);
+
+    assert!(
+        content.contains("Total: "),
+        "bold label must appear in stream"
+    );
+    assert!(content.contains("$1,234.56"), "value must appear in stream");
+    // Both fonts must be referenced
+    assert!(
+        content.contains("/Helvetica-Bold 14.00 Tf"),
+        "bold font must be set in stream"
+    );
+    assert!(
+        content.contains("/Helvetica 14.00 Tf"),
+        "regular font must be set in stream"
+    );
+}
+
+#[test]
+fn test_rich_text_in_document_builder() {
+    let rich = RichText::new(vec![
+        TextSpan::new(
+            "RICH_MARKER_",
+            Font::HelveticaBold,
+            16.0,
+            Color::rgb(1.0, 0.0, 0.0),
+        ),
+        TextSpan::new("FOUND", Font::Helvetica, 12.0, Color::black()),
+    ]);
+
+    let mut doc = DocumentBuilder::a4()
+        .add_text("Before rich text", Font::Helvetica, 12.0)
+        .add_spacer(10.0)
+        .add_rich_text(rich)
+        .add_spacer(10.0)
+        .add_text("After rich text", Font::Helvetica, 12.0)
+        .build()
+        .unwrap();
+
+    let config = WriterConfig {
+        compress_streams: false,
+        ..WriterConfig::default()
+    };
+    let bytes = doc.to_bytes_with_config(config).unwrap();
+    let content = String::from_utf8_lossy(&bytes);
+
+    assert!(bytes.starts_with(b"%PDF"));
+    assert!(content.contains("RICH_MARKER_"), "rich text label present");
+    assert!(content.contains("FOUND"), "rich text value present");
+    assert!(
+        content.contains("Before rich text"),
+        "text before rich text present"
+    );
+    assert!(
+        content.contains("After rich text"),
+        "text after rich text present"
+    );
+}

--- a/oxidize-pdf-core/tests/semantic_redactor_test.rs
+++ b/oxidize-pdf-core/tests/semantic_redactor_test.rs
@@ -1,0 +1,406 @@
+//! TDD Phase 3: SemanticRedactor Integration Tests
+//!
+//! These tests verify that SemanticRedactor correctly redacts content identified
+//! by SemanticEntity bounding boxes. Every test verifies actual output content.
+
+use oxidize_pdf::operations::{
+    RedactionConfig, RedactionStyle, SemanticRedactor, SemanticRedactorError,
+};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::semantic::{BoundingBox, EntityMetadata, EntityType, SemanticEntity};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Helper: create a simple 1-page PDF with text
+fn create_test_pdf() -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    {
+        let text = page.text();
+        text.set_font(Font::Helvetica, 12.0);
+        text.at(72.0, 700.0);
+        let _ = text.write("John Doe john@example.com 555-1234");
+    }
+    doc.add_page(page);
+    doc.to_bytes().expect("Failed to create test PDF")
+}
+
+/// Helper: create a 2-page PDF
+fn create_two_page_pdf() -> Vec<u8> {
+    let mut doc = Document::new();
+    for text_content in &["Page one content", "Page two content"] {
+        let mut page = Page::a4();
+        {
+            let text = page.text();
+            text.set_font(Font::Helvetica, 12.0);
+            text.at(72.0, 700.0);
+            let _ = text.write(text_content);
+        }
+        doc.add_page(page);
+    }
+    doc.to_bytes().expect("Failed to create test PDF")
+}
+
+/// Helper: create a SemanticEntity with given type and bounding box
+fn make_entity(
+    id: &str,
+    entity_type: EntityType,
+    page: u32,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+) -> SemanticEntity {
+    SemanticEntity {
+        id: id.to_string(),
+        entity_type,
+        bounds: BoundingBox::new(x, y, w, h, page),
+        content: String::new(),
+        metadata: EntityMetadata::new(),
+        relationships: Vec::new(),
+    }
+}
+
+/// Helper: get page count from PDF bytes
+fn get_page_count(pdf_bytes: &[u8]) -> u32 {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("parse");
+    let doc = reader.into_document();
+    doc.page_count().unwrap()
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+/// Test 1: Redaction produces a valid, parseable PDF with correct page count
+#[test]
+fn test_redact_produces_valid_pdf() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![make_entity(
+        "e1",
+        EntityType::PersonName,
+        1,
+        72.0,
+        695.0,
+        60.0,
+        15.0,
+    )];
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName]);
+
+    let (output, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("redact should succeed");
+
+    // Output must be parseable
+    let cursor = Cursor::new(&output);
+    let reader = PdfReader::new(cursor).expect("output must be parseable PDF");
+    let doc = reader.into_document();
+    assert_eq!(doc.page_count().unwrap(), 1, "Page count must be preserved");
+
+    // Report must reflect the redaction
+    assert_eq!(report.redacted_count(), 1, "Should have 1 redaction entry");
+}
+
+/// Test 2: Config with no entity types produces zero redactions and identical bytes
+#[test]
+fn test_redaction_config_default_redacts_nothing() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![make_entity(
+        "e1",
+        EntityType::PersonName,
+        1,
+        72.0,
+        695.0,
+        60.0,
+        15.0,
+    )];
+
+    // Default config has empty entity_types
+    let config = RedactionConfig::default();
+    let (output, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    assert_eq!(
+        report.redacted_count(),
+        0,
+        "Default config should redact nothing"
+    );
+    assert_eq!(
+        output, pdf_bytes,
+        "With no redactions, output should be identical to input"
+    );
+}
+
+/// Test 3: Config builder correctly stores entity types
+#[test]
+fn test_redaction_config_with_entity_types() {
+    let config = RedactionConfig::new()
+        .with_types(vec![EntityType::Email, EntityType::PhoneNumber])
+        .with_style(RedactionStyle::BlackBox);
+
+    assert_eq!(config.entity_types.len(), 2);
+    assert!(config.entity_types.contains(&EntityType::Email));
+    assert!(config.entity_types.contains(&EntityType::PhoneNumber));
+    assert!(matches!(config.style, RedactionStyle::BlackBox));
+}
+
+/// Test 4: Default RedactionStyle is BlackBox
+#[test]
+fn test_redaction_style_black_box_is_default() {
+    let style = RedactionStyle::default();
+    assert!(
+        matches!(style, RedactionStyle::BlackBox),
+        "Default style should be BlackBox, got {:?}",
+        style
+    );
+}
+
+/// Test 5: Placeholder style stores the replacement text
+#[test]
+fn test_redaction_style_placeholder_stores_text() {
+    let style = RedactionStyle::Placeholder("[REDACTED]".to_string());
+    match style {
+        RedactionStyle::Placeholder(text) => {
+            assert_eq!(text, "[REDACTED]");
+        }
+        _ => panic!("Expected Placeholder variant"),
+    }
+}
+
+/// Test 6: Empty entities list returns original bytes unchanged
+#[test]
+fn test_redact_no_entities_returns_original() {
+    let pdf_bytes = create_test_pdf();
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName]);
+
+    let (output, report) =
+        SemanticRedactor::redact(&pdf_bytes, &[], config).expect("should succeed");
+
+    assert_eq!(report.redacted_count(), 0);
+    assert_eq!(
+        output, pdf_bytes,
+        "Empty entities should return original bytes"
+    );
+}
+
+/// Test 7: Only entities matching configured types are redacted
+#[test]
+fn test_redact_filters_by_entity_type() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![
+        make_entity("name1", EntityType::PersonName, 1, 72.0, 695.0, 60.0, 15.0),
+        make_entity("email1", EntityType::Email, 1, 150.0, 695.0, 120.0, 15.0),
+        make_entity(
+            "phone1",
+            EntityType::PhoneNumber,
+            1,
+            290.0,
+            695.0,
+            70.0,
+            15.0,
+        ),
+    ];
+
+    // Only redact Email
+    let config = RedactionConfig::new().with_types(vec![EntityType::Email]);
+    let (_, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    assert_eq!(
+        report.redacted_count(),
+        1,
+        "Should only redact 1 entity (Email), got {}",
+        report.redacted_count()
+    );
+    assert_eq!(report.entries()[0].entity_type, EntityType::Email);
+    assert_eq!(report.entries()[0].entity_id, "email1");
+}
+
+/// Test 8: redacted_count() returns the correct number
+#[test]
+fn test_redaction_report_count() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![
+        make_entity("n1", EntityType::PersonName, 1, 72.0, 695.0, 60.0, 15.0),
+        make_entity("n2", EntityType::PersonName, 1, 72.0, 670.0, 60.0, 15.0),
+        make_entity("e1", EntityType::Email, 1, 150.0, 695.0, 120.0, 15.0),
+    ];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName, EntityType::Email]);
+    let (_, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    assert_eq!(
+        report.redacted_count(),
+        3,
+        "All 3 matching entities should be redacted"
+    );
+}
+
+/// Test 9: by_type() filters the report correctly
+#[test]
+fn test_redaction_report_by_type() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![
+        make_entity("n1", EntityType::PersonName, 1, 72.0, 695.0, 60.0, 15.0),
+        make_entity("n2", EntityType::PersonName, 1, 72.0, 670.0, 60.0, 15.0),
+        make_entity("e1", EntityType::Email, 1, 150.0, 695.0, 120.0, 15.0),
+    ];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName, EntityType::Email]);
+    let (_, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    let names = report.by_type(&EntityType::PersonName);
+    assert_eq!(names.len(), 2, "Should have 2 PersonName redactions");
+
+    let emails = report.by_type(&EntityType::Email);
+    assert_eq!(emails.len(), 1, "Should have 1 Email redaction");
+
+    let phones = report.by_type(&EntityType::PhoneNumber);
+    assert_eq!(phones.len(), 0, "Should have 0 PhoneNumber redactions");
+}
+
+/// Test 10: pages_affected() returns correct unique pages
+#[test]
+fn test_redaction_report_pages_affected() {
+    let pdf_bytes = create_two_page_pdf();
+    let entities = vec![
+        make_entity("e1", EntityType::PersonName, 1, 72.0, 695.0, 60.0, 15.0),
+        make_entity("e2", EntityType::PersonName, 1, 72.0, 670.0, 60.0, 15.0),
+        make_entity("e3", EntityType::PersonName, 2, 72.0, 695.0, 60.0, 15.0),
+    ];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName]);
+    let (_, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    let pages = report.pages_affected();
+    assert_eq!(pages, vec![1, 2], "Should affect pages 1 and 2");
+}
+
+/// Test 11: Error messages are descriptive with specific prefixes
+#[test]
+fn test_semantic_redactor_error_messages() {
+    let errors = vec![
+        (
+            SemanticRedactorError::ParseFailed("invalid header".to_string()),
+            "parse failed:",
+        ),
+        (
+            SemanticRedactorError::PageReconstructionFailed("missing MediaBox".to_string()),
+            "page reconstruction failed:",
+        ),
+        (
+            SemanticRedactorError::WriteFailed("disk full".to_string()),
+            "write failed:",
+        ),
+    ];
+
+    for (error, expected_prefix) in &errors {
+        let msg = error.to_string();
+        assert!(
+            msg.starts_with(expected_prefix),
+            "Expected prefix '{}', got: '{}'",
+            expected_prefix,
+            msg
+        );
+        assert!(
+            msg.len() > expected_prefix.len() + 2,
+            "Error should include inner message: '{}'",
+            msg
+        );
+    }
+}
+
+/// Test 12: BoundingBox page=1 (1-indexed) correctly maps to PDF page 0 (0-indexed)
+#[test]
+fn test_redact_entity_page_1_indexed_to_0_indexed() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![make_entity(
+        "e1",
+        EntityType::PersonName,
+        1, // 1-indexed
+        72.0,
+        695.0,
+        60.0,
+        15.0,
+    )];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName]);
+    let (output, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    // The redaction happened (1 entry) on page 1 (1-indexed)
+    assert_eq!(report.redacted_count(), 1);
+    assert_eq!(report.entries()[0].page, 1);
+
+    // Output is different from input (redaction was applied)
+    assert_ne!(
+        output, pdf_bytes,
+        "Output should differ from input after redaction"
+    );
+}
+
+/// Test 13: Multiple entities on the same page produce multiple report entries
+#[test]
+fn test_redact_multiple_entities_same_page() {
+    let pdf_bytes = create_test_pdf();
+    let entities = vec![
+        make_entity("e1", EntityType::Email, 1, 72.0, 695.0, 60.0, 15.0),
+        make_entity("e2", EntityType::Email, 1, 72.0, 670.0, 80.0, 15.0),
+        make_entity("e3", EntityType::Email, 1, 72.0, 645.0, 90.0, 15.0),
+    ];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::Email]);
+    let (_, report) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    assert_eq!(
+        report.redacted_count(),
+        3,
+        "3 entities on same page should produce 3 redaction entries"
+    );
+
+    // All on page 1
+    assert_eq!(report.pages_affected(), vec![1]);
+
+    // All have correct IDs
+    let ids: Vec<&str> = report
+        .entries()
+        .iter()
+        .map(|e| e.entity_id.as_str())
+        .collect();
+    assert!(ids.contains(&"e1"));
+    assert!(ids.contains(&"e2"));
+    assert!(ids.contains(&"e3"));
+}
+
+/// Test 14: Page count is preserved after redaction
+#[test]
+fn test_redact_preserves_page_count() {
+    let pdf_bytes = create_two_page_pdf();
+    let original_pages = get_page_count(&pdf_bytes);
+
+    let entities = vec![make_entity(
+        "e1",
+        EntityType::PersonName,
+        2,
+        72.0,
+        695.0,
+        60.0,
+        15.0,
+    )];
+
+    let config = RedactionConfig::new().with_types(vec![EntityType::PersonName]);
+    let (output, _) =
+        SemanticRedactor::redact(&pdf_bytes, &entities, config).expect("should succeed");
+
+    let output_pages = get_page_count(&output);
+    assert_eq!(
+        output_pages, original_pages,
+        "Page count should be preserved: expected {}, got {}",
+        original_pages, output_pages
+    );
+}

--- a/oxidize-pdf-core/tests/source_highlighter_test.rs
+++ b/oxidize-pdf-core/tests/source_highlighter_test.rs
@@ -1,0 +1,364 @@
+//! TDD Phase 2: SourceHighlighter Integration Tests
+//!
+//! These tests verify that SourceHighlighter correctly highlights text regions
+//! in a PDF corresponding to RAG chunks. Each test verifies actual output content
+//! (annotation counts, subtypes, coordinates) — not just absence of errors.
+
+use oxidize_pdf::ai::chunking::{ChunkMetadata, ChunkPosition, DocumentChunk};
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::operations::{
+    HighlightStyle, SourceHighlighter, SourceHighlighterError, TextPositionIndex,
+};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::{ExtractionOptions, Font};
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Helper: create a PDF with known text content on one page
+fn create_test_pdf(texts: &[(&str, f64, f64)]) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    {
+        let text_ctx = page.text();
+        text_ctx.set_font(Font::Helvetica, 12.0);
+        for &(content, x, y) in texts {
+            text_ctx.at(x, y);
+            let _ = text_ctx.write(content);
+        }
+    }
+    doc.add_page(page);
+    doc.to_bytes().expect("Failed to create test PDF")
+}
+
+/// Helper: create a synthetic DocumentChunk with position metadata
+fn make_chunk(
+    content: &str,
+    start_char: usize,
+    end_char: usize,
+    first_page: usize,
+    last_page: usize,
+) -> DocumentChunk {
+    DocumentChunk {
+        id: format!("chunk_{}", start_char),
+        content: content.to_string(),
+        tokens: content.split_whitespace().count(),
+        page_numbers: (first_page..=last_page).collect(),
+        chunk_index: 0,
+        metadata: ChunkMetadata {
+            position: ChunkPosition {
+                start_char,
+                end_char,
+                first_page,
+                last_page,
+            },
+            confidence: 1.0,
+            sentence_boundary_respected: true,
+        },
+    }
+}
+
+/// Helper: count annotations with a specific /Subtype on page 0 of a PDF
+fn count_annotations_by_subtype(pdf_bytes: &[u8], page_idx: u32, subtype: &str) -> usize {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let annots = doc.get_page_annotations(page_idx).unwrap_or_default();
+    annots
+        .iter()
+        .filter(|a| {
+            a.get("Subtype")
+                .and_then(|s| s.as_name())
+                .map(|n| n.0.as_str() == subtype)
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+/// Helper: get total annotation count across all pages
+fn count_total_annotations(pdf_bytes: &[u8]) -> usize {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("Failed to parse PDF");
+    let doc = reader.into_document();
+    let page_count = doc.page_count().unwrap_or(0);
+    (0..page_count)
+        .map(|i| doc.get_page_annotations(i).unwrap_or_default().len())
+        .sum()
+}
+
+/// Helper: extract text and build TextPositionIndex from PDF bytes,
+/// returning the number of indexed fragments
+fn count_indexed_fragments(pdf_bytes: &[u8]) -> usize {
+    let cursor = Cursor::new(pdf_bytes);
+    let reader = PdfReader::new(cursor).expect("parse");
+    let doc = reader.into_document();
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let extracted = doc.extract_text_with_options(options).unwrap_or_default();
+    let index = TextPositionIndex::build(&extracted);
+    index.len()
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+/// Test 1: Verifies that highlighting produces Highlight annotations in the output.
+/// First checks that the test PDF actually yields indexable fragments, then verifies
+/// the output PDF contains /Highlight annotations.
+#[test]
+fn test_highlight_produces_highlight_annotations() {
+    let pdf_bytes = create_test_pdf(&[("Hello World Test Content", 72.0, 700.0)]);
+
+    // Verify precondition: text extraction with preserve_layout produces fragments
+    let fragment_count = count_indexed_fragments(&pdf_bytes);
+    // If this assertion fails, it means our test PDF doesn't produce fragments
+    // with preserve_layout=true, which would make the highlighter tests vacuous.
+    assert!(
+        fragment_count > 0,
+        "Test precondition: PDF must produce indexable fragments (got {}). \
+         If this fails, the test PDF creation or extraction pipeline has a problem.",
+        fragment_count
+    );
+
+    // Create chunk covering the full extracted text range
+    let chunk = make_chunk("Hello World Test Content", 0, 24, 1, 1);
+    let result =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &[&chunk], HighlightStyle::default())
+            .expect("highlight_chunks should succeed");
+
+    // With fragments found, we MUST have Highlight annotations
+    let highlight_count = count_annotations_by_subtype(&result, 0, "Highlight");
+    assert!(
+        highlight_count > 0,
+        "With {} indexed fragments, output should have Highlight annotations, got 0",
+        fragment_count
+    );
+
+    // Either way, output must be a structurally valid PDF
+    let cursor = Cursor::new(&result);
+    assert!(PdfReader::new(cursor).is_ok(), "Output must be a valid PDF");
+}
+
+/// Test 2: Default HighlightStyle uses yellow (1,1,0) with 0.5 opacity
+#[test]
+fn test_highlight_style_default_is_yellow() {
+    let style = HighlightStyle::default();
+    match style.color {
+        Color::Rgb(r, g, b) => {
+            assert!((r - 1.0).abs() < 0.01, "Red should be 1.0, got {}", r);
+            assert!((g - 1.0).abs() < 0.01, "Green should be 1.0, got {}", g);
+            assert!((b - 0.0).abs() < 0.01, "Blue should be 0.0, got {}", b);
+        }
+        _ => panic!("Default color should be RGB, got {:?}", style.color),
+    }
+    assert!(
+        (style.opacity - 0.5).abs() < 0.01,
+        "Default opacity should be 0.5, got {}",
+        style.opacity
+    );
+}
+
+/// Test 3: Custom color is stored correctly through the builder
+#[test]
+fn test_highlight_style_custom_color() {
+    let style = HighlightStyle::new().with_color(Color::Rgb(1.0, 0.0, 0.0));
+    match style.color {
+        Color::Rgb(r, g, b) => {
+            assert!((r - 1.0).abs() < 0.01, "Red not set correctly");
+            assert!((g - 0.0).abs() < 0.01, "Green should be 0");
+            assert!((b - 0.0).abs() < 0.01, "Blue should be 0");
+        }
+        _ => panic!("Expected RGB color"),
+    }
+}
+
+/// Test 4: Multiple chunks produce more annotations than a single chunk.
+/// Verifies that the number of annotations scales with the number of chunks,
+/// not that it's a fixed smoke-test value.
+#[test]
+fn test_highlight_multiple_chunks_produce_more_annotations() {
+    let pdf_bytes = create_test_pdf(&[
+        ("First sentence here.", 72.0, 700.0),
+        ("Second sentence here.", 72.0, 680.0),
+        ("Third sentence here.", 72.0, 660.0),
+    ]);
+
+    // Single chunk
+    let chunk1 = make_chunk("First", 0, 5, 1, 1);
+    let single_result =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &[&chunk1], HighlightStyle::default())
+            .expect("single chunk");
+    let single_count = count_total_annotations(&single_result);
+
+    // Three chunks covering different text regions
+    let chunk2 = make_chunk("Second", 22, 28, 1, 1);
+    let chunk3 = make_chunk("Third", 44, 49, 1, 1);
+    let multi_result = SourceHighlighter::highlight_chunks(
+        &pdf_bytes,
+        &[&chunk1, &chunk2, &chunk3],
+        HighlightStyle::default(),
+    )
+    .expect("multiple chunks");
+    let multi_count = count_total_annotations(&multi_result);
+
+    // More chunks → more or equal annotations (never fewer)
+    assert!(
+        multi_count >= single_count,
+        "3 chunks ({} annotations) should produce >= annotations than 1 chunk ({})",
+        multi_count,
+        single_count
+    );
+}
+
+/// Test 5: Chunk with offsets beyond the document text produces zero annotations
+/// (not just "Ok" — verifies the actual annotation count is 0)
+#[test]
+fn test_highlight_out_of_range_produces_zero_annotations() {
+    let pdf_bytes = create_test_pdf(&[("Hello", 72.0, 700.0)]);
+
+    let chunk = make_chunk("nonexistent", 10000, 10100, 1, 1);
+    let result =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &[&chunk], HighlightStyle::default())
+            .expect("should succeed");
+
+    let annot_count = count_total_annotations(&result);
+    assert_eq!(
+        annot_count, 0,
+        "Out-of-range chunk should produce 0 annotations, got {}",
+        annot_count
+    );
+}
+
+/// Test 6: Page count and extractable text are preserved after highlighting
+#[test]
+fn test_highlight_preserves_page_count_and_text() {
+    let pdf_bytes = create_test_pdf(&[("Important content here", 72.0, 700.0)]);
+
+    let chunk = make_chunk("Important", 0, 9, 1, 1);
+    let result =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &[&chunk], HighlightStyle::default())
+            .expect("should succeed");
+
+    // Verify page count
+    let cursor = Cursor::new(&result);
+    let reader = PdfReader::new(cursor).expect("parse output");
+    let doc = reader.into_document();
+    assert_eq!(
+        doc.page_count().unwrap(),
+        1,
+        "Page count should be preserved"
+    );
+
+    // Verify text is still extractable (content preserved)
+    let extracted = doc.extract_text().unwrap_or_default();
+    assert!(
+        !extracted.is_empty(),
+        "Text should still be extractable from highlighted PDF"
+    );
+    // The extracted text should contain the original content
+    let full_text: String = extracted.iter().map(|e| e.text.as_str()).collect();
+    assert!(
+        full_text.contains("Important") || full_text.contains("content"),
+        "Original text content should be preserved, got: '{}'",
+        full_text
+    );
+}
+
+/// Test 7: Error variants produce specific, descriptive messages
+#[test]
+fn test_source_highlighter_error_messages_are_descriptive() {
+    let errors = vec![
+        (
+            SourceHighlighterError::TextExtractionFailed("CMap decode error".to_string()),
+            "text extraction failed",
+        ),
+        (
+            SourceHighlighterError::PageReconstructionFailed("missing MediaBox".to_string()),
+            "page reconstruction failed",
+        ),
+        (
+            SourceHighlighterError::WriteFailed("disk full".to_string()),
+            "write failed",
+        ),
+    ];
+
+    for (error, expected_prefix) in &errors {
+        let msg = error.to_string();
+        assert!(
+            msg.starts_with(expected_prefix),
+            "Error '{}' should start with '{}', got: '{}'",
+            std::any::type_name_of_val(error),
+            expected_prefix,
+            msg
+        );
+        // The inner message should be included
+        assert!(
+            msg.len() > expected_prefix.len() + 2,
+            "Error should include the inner message, got only: '{}'",
+            msg
+        );
+    }
+}
+
+/// Test 8: highlight_chunks accepts &[&DocumentChunk] and produces valid output
+#[test]
+fn test_highlight_chunks_accepts_ref_slice() {
+    let pdf_bytes = create_test_pdf(&[("Test", 72.0, 700.0)]);
+
+    let chunk = make_chunk("Test", 0, 4, 1, 1);
+    let chunks_vec: Vec<&DocumentChunk> = vec![&chunk];
+
+    let result =
+        SourceHighlighter::highlight_chunks(&pdf_bytes, &chunks_vec, HighlightStyle::default())
+            .expect("should accept &[&DocumentChunk]");
+
+    // Verify output is valid PDF (not just is_ok)
+    assert!(result.starts_with(b"%PDF"), "Output must be PDF");
+    let cursor = Cursor::new(&result);
+    let reader = PdfReader::new(cursor).expect("output must be parseable");
+    let doc = reader.into_document();
+    assert_eq!(doc.page_count().unwrap(), 1);
+}
+
+/// Test 9: Builder pattern on HighlightStyle chains correctly
+#[test]
+fn test_highlight_style_builder_chains() {
+    let style = HighlightStyle::new()
+        .with_color(Color::Rgb(0.0, 1.0, 0.0))
+        .with_opacity(0.8);
+
+    match style.color {
+        Color::Rgb(r, g, b) => {
+            assert!((r - 0.0).abs() < 0.01, "Red should be 0.0");
+            assert!((g - 1.0).abs() < 0.01, "Green should be 1.0");
+            assert!((b - 0.0).abs() < 0.01, "Blue should be 0.0");
+        }
+        _ => panic!("Expected RGB"),
+    }
+    assert!(
+        (style.opacity - 0.8).abs() < 0.01,
+        "Opacity should be 0.8, got {}",
+        style.opacity
+    );
+}
+
+/// Test 10: Empty chunk list returns original bytes (exact byte equality)
+#[test]
+fn test_highlight_empty_chunks_returns_original_bytes() {
+    let pdf_bytes = create_test_pdf(&[("No highlights", 72.0, 700.0)]);
+
+    let result = SourceHighlighter::highlight_chunks(&pdf_bytes, &[], HighlightStyle::default())
+        .expect("empty chunks should succeed");
+
+    assert_eq!(
+        result.len(),
+        pdf_bytes.len(),
+        "Empty chunk list should return bytes of same length"
+    );
+    assert_eq!(
+        result, pdf_bytes,
+        "Empty chunk list should return identical bytes"
+    );
+}

--- a/oxidize-pdf-core/tests/text_block_metrics_tests.rs
+++ b/oxidize-pdf-core/tests/text_block_metrics_tests.rs
@@ -1,0 +1,94 @@
+use oxidize_pdf::text::text_block::measure_text_block;
+use oxidize_pdf::{Font, Margins, TextAlign, TextFlowContext};
+
+#[test]
+fn test_single_line_no_wrap() {
+    let metrics = measure_text_block("Hello", &Font::Helvetica, 12.0, 1.2, 500.0);
+    assert_eq!(metrics.line_count, 1);
+    assert!(
+        (metrics.height - 14.4).abs() < 0.01,
+        "expected height ~14.4 (12.0 * 1.2), got {}",
+        metrics.height
+    );
+    assert!(metrics.width > 0.0);
+    assert!(metrics.width <= 500.0);
+}
+
+#[test]
+fn test_wraps_correctly() {
+    let text = "word word word word";
+    let metrics = measure_text_block(text, &Font::Helvetica, 12.0, 1.2, 60.0);
+    assert!(
+        metrics.line_count >= 2,
+        "expected >= 2 lines for '{}' in 60pt, got {}",
+        text,
+        metrics.line_count
+    );
+    assert!(
+        metrics.height > 14.4,
+        "multiline block must be taller than one line (14.4), got {}",
+        metrics.height
+    );
+    assert!(
+        metrics.width <= 60.0 + 0.001,
+        "width {} exceeds max_width 60.0",
+        metrics.width
+    );
+}
+
+#[test]
+fn test_empty_string() {
+    let metrics = measure_text_block("", &Font::Helvetica, 12.0, 1.2, 300.0);
+    assert_eq!(metrics.line_count, 0);
+    assert_eq!(metrics.width, 0.0);
+    assert_eq!(metrics.height, 0.0);
+}
+
+#[test]
+fn test_overlong_word() {
+    let metrics = measure_text_block(
+        "Pneumonoultramicroscopicsilicovolcanoconiosis",
+        &Font::Helvetica,
+        12.0,
+        1.2,
+        50.0,
+    );
+    assert_eq!(
+        metrics.line_count, 1,
+        "overlong single word stays on one line"
+    );
+    // width will exceed max_width — that's expected for unbreakable words
+    assert!(metrics.width > 50.0);
+}
+
+#[test]
+fn test_consistent_with_flow_context() {
+    let max_width = 200.0;
+    let font_size = 12.0;
+    let line_height = 1.2;
+    let text = "The quick brown fox jumps over the lazy dog and then runs away fast";
+
+    let metrics = measure_text_block(text, &Font::Helvetica, font_size, line_height, max_width);
+
+    // Render with TextFlowContext and count Td operators (= lines rendered)
+    let margins = Margins {
+        left: 50.0,
+        right: 50.0,
+        top: 50.0,
+        bottom: 50.0,
+    };
+    // page_width such that content_width = max_width: 200 + 50 + 50 = 300
+    let mut flow = TextFlowContext::new(300.0, 841.89, margins);
+    flow.set_font(Font::Helvetica, font_size)
+        .set_line_height(line_height)
+        .set_alignment(TextAlign::Left);
+    flow.write_wrapped(text).unwrap();
+    let ops = flow.operations().to_owned();
+    let td_count = ops.lines().filter(|l| l.ends_with(" Td")).count();
+
+    assert_eq!(
+        metrics.line_count, td_count,
+        "measure_text_block line_count {} != TextFlowContext Td count {}.\nOperations:\n{}",
+        metrics.line_count, td_count, ops
+    );
+}


### PR DESCRIPTION
## Summary
- **SourceHighlighter**: highlights RAG chunks in original PDF with /Highlight annotations
- **SemanticRedactor**: PII redaction via opaque rectangles + RedactionReport
- **ChunkPageMapper**: extracts only pages referenced by RAG chunks into a new PDF
- **FlowLayout engine**: vertical layout with automatic page breaks, DocumentBuilder, RichText, TextBlockMetrics, image fitting
- **Annotation writing pipeline**: fixed writer to output Page.annotations() as indirect objects

## Details
Closes the RAG cycle: parse → chunk → retrieve → **act on the original PDF**. No competitor (unstructured.io, LlamaParse, Docling, PyMuPDF4LLM) offers this natively.

27 files changed, ~3,900 lines added across source and tests.

## Test plan
- [x] 6,312 unit tests passing
- [x] Integration tests for all 3 RAG operations (highlighter, redactor, mapper)
- [x] FlowLayout tests: page breaks, multi-page, text wrapping measurement
- [x] DocumentBuilder E2E invoice test
- [x] RichText rendering with font/color verification
- [x] Image fitting aspect ratio tests
- [x] Clippy clean, cargo fmt verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)