### PR TITLE
fix(fonts): filter ToUnicode CMap to used chars + FlateDecode

### DIFF
--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1500,9 +1500,22 @@ impl<W: Write> PdfWriter<W> {
 
         self.write_object(descendant_font_id, Object::Dictionary(cid_font))?;
 
-        // Write ToUnicode CMap
+        // Write ToUnicode CMap. The CMap is filtered to the characters that
+        // actually appear in the document (via `document_used_chars`) and the
+        // stream is FlateDecode-compressed when the `compression` feature and
+        // writer config allow it. The unfiltered, uncompressed version used to
+        // dominate PDF output (~14 KB for a 2-char Latin document).
         let cmap_data = self.generate_tounicode_cmap_from_font(font);
         let cmap_dict = Dictionary::new();
+        #[cfg(feature = "compression")]
+        let cmap_stream = if self.config.compress_streams {
+            let mut stream = crate::objects::Stream::with_dictionary(cmap_dict, cmap_data);
+            stream.compress_flate()?;
+            Object::Stream(stream.dictionary().clone(), stream.data().to_vec())
+        } else {
+            Object::Stream(cmap_dict, cmap_data)
+        };
+        #[cfg(not(feature = "compression"))]
         let cmap_stream = Object::Stream(cmap_dict, cmap_data);
         self.write_object(to_unicode_id, cmap_stream)?;
 
@@ -1804,89 +1817,37 @@ impl<W: Write> PdfWriter<W> {
         cmap.push_str("<0000> <FFFF>\n");
         cmap.push_str("endcodespacerange\n");
 
-        // Try to get actual mappings from the font
-        let mut mappings = Vec::new();
-        let mut has_font_mappings = false;
+        // Build the set of code points that must appear in the ToUnicode CMap.
+        // With Identity-H encoding, CID == Unicode, so each used character
+        // produces a single `<CID> <unicode>` entry. If the document tracked
+        // no used characters (legacy path), fall back to the font's full cmap
+        // filtered to the BMP — but that path is a backstop, not the norm.
+        let used_codepoints: Option<std::collections::HashSet<u32>> =
+            self.document_used_chars.as_ref().map(|chars| {
+                chars
+                    .iter()
+                    .map(|c| *c as u32)
+                    .filter(|cp| *cp <= 0xFFFF)
+                    .collect()
+            });
 
-        if let Ok(tt_font) = TrueTypeFont::parse(font.data.clone()) {
+        let mut mappings: Vec<(u32, u32)> = Vec::new();
+
+        if let Some(used) = &used_codepoints {
+            // Fast path: every used codepoint maps to itself under Identity-H.
+            for cp in used {
+                mappings.push((*cp, *cp));
+            }
+        } else if let Ok(tt_font) = TrueTypeFont::parse(font.data.clone()) {
+            // Legacy backstop: no used-char tracking, emit every font mapping.
             if let Ok(cmap_tables) = tt_font.parse_cmap() {
-                // Find the best cmap table (prefer Format 12 for CJK)
                 if let Some(cmap_table) = CmapSubtable::select_best_or_first(&cmap_tables) {
-                    // For Identity-H encoding, we use Unicode code points as CIDs
-                    // So the ToUnicode CMap should map CID (=Unicode) → Unicode
                     for (&unicode, &glyph_id) in &cmap_table.mappings {
                         if glyph_id > 0 && unicode <= 0xFFFF {
-                            // Only non-.notdef glyphs
-                            // Map CID (which is Unicode value) to Unicode
                             mappings.push((unicode, unicode));
                         }
                     }
-                    has_font_mappings = true;
                 }
-            }
-        }
-
-        // If we couldn't get font mappings, use identity mapping for common ranges
-        if !has_font_mappings {
-            // Basic Latin and Latin-1 Supplement (0x0020-0x00FF)
-            for i in 0x0020..=0x00FF {
-                mappings.push((i, i));
-            }
-
-            // Latin Extended-A (0x0100-0x017F)
-            for i in 0x0100..=0x017F {
-                mappings.push((i, i));
-            }
-
-            // CJK Unicode ranges - CRITICAL for CJK font support
-            // Hiragana (Japanese)
-            for i in 0x3040..=0x309F {
-                mappings.push((i, i));
-            }
-
-            // Katakana (Japanese)
-            for i in 0x30A0..=0x30FF {
-                mappings.push((i, i));
-            }
-
-            // CJK Unified Ideographs (Chinese, Japanese, Korean)
-            for i in 0x4E00..=0x9FFF {
-                mappings.push((i, i));
-            }
-
-            // Hangul Syllables (Korean)
-            for i in 0xAC00..=0xD7AF {
-                mappings.push((i, i));
-            }
-
-            // Common symbols and punctuation
-            for i in 0x2000..=0x206F {
-                mappings.push((i, i));
-            }
-
-            // Mathematical symbols
-            for i in 0x2200..=0x22FF {
-                mappings.push((i, i));
-            }
-
-            // Arrows
-            for i in 0x2190..=0x21FF {
-                mappings.push((i, i));
-            }
-
-            // Box drawing
-            for i in 0x2500..=0x259F {
-                mappings.push((i, i));
-            }
-
-            // Geometric shapes
-            for i in 0x25A0..=0x25FF {
-                mappings.push((i, i));
-            }
-
-            // Miscellaneous symbols
-            for i in 0x2600..=0x26FF {
-                mappings.push((i, i));
             }
         }
 

--- a/oxidize-pdf-core/tests/font_subset_pdf_round_trip_test.rs
+++ b/oxidize-pdf-core/tests/font_subset_pdf_round_trip_test.rs
@@ -183,3 +183,149 @@ fn test_mixed_cff_and_ttf_pdf_round_trip() {
     assert_all_chars_extracted(&extracted.text, cff_text);
     assert_all_chars_extracted(&extracted.text, ttf_text);
 }
+
+// =============================================================================
+// ToUnicode CMap size tests (fix/tounicode-cmap-bloat)
+//
+// The writer previously emitted a ToUnicode CMap entry for every glyph in the
+// embedded font (up to ~14 KB for SourceSans3 Latin, including Cyrillic and
+// Latin-Extended code points that weren't used). These tests guard the
+// filtered-and-compressed behaviour: only used chars appear, and the stream
+// is FlateDecode-compressed.
+// =============================================================================
+
+/// Locate the ToUnicode CMap stream in the generated PDF and return
+/// `(dict_body, decoded_cmap_text)`. If the stream carries /Filter
+/// /FlateDecode the bytes are decompressed before being returned.
+/// Returns `None` if no CMap stream is found.
+fn find_tounicode_stream(pdf: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    // Walk every stream in the PDF. The ToUnicode CMap is the one whose
+    // (post-filter) body starts with "/CIDInit /ProcSet".
+    // Use ">>\nstream\n" as the anchor so we don't match the tail of
+    // "endstream\n" (which literally contains "stream\n").
+    let stream_marker = b">>\nstream\n";
+    let mut cursor = 0;
+    while let Some(rel) = pdf[cursor..]
+        .windows(stream_marker.len())
+        .position(|w| w == stream_marker)
+    {
+        let stream_start = cursor + rel + stream_marker.len();
+        let end_rel = pdf[stream_start..]
+            .windows(b"\nendstream".len())
+            .position(|w| w == b"\nendstream")?;
+        let raw = &pdf[stream_start..stream_start + end_rel];
+        // The dict is everything from the last "<<" up to and including ">>"
+        // (the character just before "\nstream\n").
+        let dict_end_abs = cursor + rel + 2; // include ">>"
+        let dict_start = pdf[..dict_end_abs].windows(2).rposition(|w| w == b"<<")?;
+        let dict = &pdf[dict_start..dict_end_abs];
+
+        // Decode the stream body if it's FlateDecode; otherwise use raw.
+        let body = if std::str::from_utf8(dict)
+            .map(|s| s.contains("/FlateDecode"))
+            .unwrap_or(false)
+        {
+            match decompress_flate(raw) {
+                Some(d) => d,
+                None => {
+                    cursor = stream_start + end_rel;
+                    continue;
+                }
+            }
+        } else {
+            raw.to_vec()
+        };
+
+        if body.starts_with(b"/CIDInit /ProcSet") {
+            return Some((dict.to_vec(), body));
+        }
+        // Advance cursor past the full "\nendstream" to avoid re-matching
+        // "stream\n" inside it.
+        cursor = stream_start + end_rel + b"\nendstream".len();
+    }
+    None
+}
+
+#[cfg(feature = "compression")]
+fn decompress_flate(data: &[u8]) -> Option<Vec<u8>> {
+    oxidize_pdf::compression::decompress(data).ok()
+}
+
+#[cfg(not(feature = "compression"))]
+fn decompress_flate(_data: &[u8]) -> Option<Vec<u8>> {
+    None
+}
+
+#[test]
+fn test_tounicode_cmap_only_contains_used_characters() {
+    let font_data = match load_fixture(SOURCE_SANS_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let used_text = "AB"; // only 2 distinct characters
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("SourceSans3", font_data)
+        .expect("add_font_from_bytes must succeed");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("SourceSans3".to_string()), 12.0)
+        .at(50.0, 500.0)
+        .write(used_text)
+        .expect("writing must succeed");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation must succeed");
+    let (_dict, body) =
+        find_tounicode_stream(&pdf_bytes).expect("ToUnicode stream must exist in generated PDF");
+
+    // After decompression the CMap body should be small (header + ~2 entries).
+    // Before the fix it was 13967 bytes (all font glyphs).
+    assert!(
+        body.len() < 600,
+        "ToUnicode CMap decoded body must be under 600 bytes for a 2-char document, got {}",
+        body.len()
+    );
+
+    // Sanity: codepoints of unused characters must NOT appear as bfchar/bfrange
+    // entries. Pick a distinctive unused codepoint: U+FB01 (ligature fi).
+    let body_str = std::str::from_utf8(&body).expect("CMap is ASCII/Latin-1");
+    assert!(
+        !body_str.contains("FB01"),
+        "unused codepoint FB01 (fi ligature) must not appear in ToUnicode CMap"
+    );
+    // Both of the used codepoints MUST appear.
+    assert!(body_str.contains("0041"), "used char 'A' (U+0041) missing");
+    assert!(body_str.contains("0042"), "used char 'B' (U+0042) missing");
+}
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_tounicode_cmap_stream_is_flatedecoded() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes must succeed");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 12.0)
+        .at(50.0, 500.0)
+        .write("AB")
+        .expect("writing must succeed");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation must succeed");
+    let (dict, _stream) = find_tounicode_stream(&pdf_bytes).expect("ToUnicode stream must exist");
+
+    let dict_str = std::str::from_utf8(&dict).expect("dict is ASCII");
+    assert!(
+        dict_str.contains("/Filter") && dict_str.contains("/FlateDecode"),
+        "ToUnicode stream dictionary must declare /Filter /FlateDecode. Got dict: {:?}",
+        dict_str
+    );
+}


### PR DESCRIPTION
## Summary

The ToUnicode CMap generator emitted an entry for **every glyph** in the embedded
font's cmap table (~14 KB for SourceSans3 Latin, ~65 K entries for CJK fonts),
and the resulting stream was written uncompressed. For small documents the
CMap dominated PDF output — 40 % of total bytes for a 2-char Latin PDF.

### Fix

1. Read `document_used_chars` in `generate_tounicode_cmap_from_font` and emit
   `<cid> <unicode>` entries only for code points that actually appear in the
   document. Under Identity-H, CID == Unicode.
2. Wrap the ToUnicode stream with `Stream::compress_flate()` when the
   `compression` feature and writer config allow it. CMap bodies with
   repetitive `<XXXX> <XXXX>` entries compress ~70 %.

## Impact

Measured on SourceSans3 + 2 Latin chars:
- ToUnicode body: **13,967 B uncompressed → ~400 B decoded / ~200 B compressed**.

End-to-end PDF sizes after this fix alone:

| Case | Before | After this PR |
|---|---|---|
| SourceSans3 CFF (2 Latin) | 34.5 KB | 20-21 KB |
| SourceHanSansSC CJK (30 chars) | 41 KB | 12.9 KB (1.30x vs krilla) |

## Test plan

- [x] `test_tounicode_cmap_only_contains_used_characters` parses generated PDF, decompresses ToUnicode stream, asserts decoded body < 600 B, used codepoints present, unused (U+FB01) absent
- [x] `test_tounicode_cmap_stream_is_flatedecoded` asserts stream dictionary declares `/Filter /FlateDecode`
- [x] Existing round-trip tests still pass (text extraction preserved)
- [x] Full test suite: 6307 lib + ~1780 integration, 0 failures

## Related

Part of the response to #165 (companion to #191).

**Merge note**: expect a trivial conflict in `tests/font_subset_pdf_round_trip_test.rs` if #191 lands first — both PRs add distinct test sections that coexist cleanly. Resolution: keep both sections. A local preview merge at `preview/combined-fixes` was validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)