### PR TITLE
fix(fonts): TTF subset post v3.0 + FlateDecode CIDToGIDMap — closes #165 size gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [2.5.4] - 2026-04-21
+
+### Fixed
+- **TTF subset `post` table no longer copies glyph names** (#165) — `truetype_subsetter` was embedding the original font's `post` v2.0 table verbatim, which for CJK fonts carries ~370 KB of Pascal-string glyph names that PDF never consults (ToUnicode + CIDToGIDMap drive rendering). Subsets now always emit a 32-byte `post` v3.0 header, preserving the italic/underline/memory metrics from the original.
+- **CIDToGIDMap stream now FlateDecode-compressed** (#165) — The Type0/CIDFontType2 glyph-index map was written as a raw uncompressed stream. It is dimensioned to the highest codepoint in use and is mostly zeros, so Flate compression shrinks it by 95-99%. For CJK documents a 131 KB map becomes ~340 bytes.
+
+### Impact
+Measured on the user's reported snippet with `SourceHanSansTC-Regular.ttf` (33 MB):
+
+| Release | PDF size | vs krilla (48 KB) |
+|---|---|---|
+| v2.5.3 | 145 KB | +203 % |
+| **v2.5.4** | **19 KB** | **-60 % (smaller)** |
+
+The two fixes are independent and compound: the CJK TTF case drops from 145 KB to 19 KB, the Roboto Latin TTF case drops from 24 KB to 8 KB.
+
+### Added
+- 5 new content-verifying TDD tests in `font_subset_post_and_cidtogidmap_test.rs` covering post version/length, CIDToGIDMap `/Filter /FlateDecode`, Flate compression ratio, and end-to-end PDF size regression.
+- `examples/issue_165_repro.rs` — diagnostic script reproducing the user's exact snippet for local validation.
+
 ## [2.5.3] - 2026-04-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.3"
+version = "2.5.4"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/examples/issue_165_repro.rs
+++ b/oxidize-pdf-core/examples/issue_165_repro.rs
@@ -1,0 +1,109 @@
+//! Reproduces the snippet in Issue #165 to verify end-to-end size impact of
+//! the post v3.0 + CIDToGIDMap FlateDecode fixes.
+//!
+//! Runs two variants:
+//! - OTF (CFF) with SourceHanSansSC-Regular.otf, same text as the user's case.
+//! - TTF (glyf) with Roboto-Regular.ttf as a proxy (we don't ship a CJK TTF).
+//!
+//! Usage:
+//!   cargo run --example issue_165_repro --features compression
+//!
+//! This is a **diagnostic script**, not a test — it prints sizes but makes no
+//! assertions. Size regressions are guarded by the integration tests in
+//! `tests/font_subset_post_and_cidtogidmap_test.rs`.
+
+use oxidize_pdf::{Document, Font, Page};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ----- OTF / CFF path -----
+    let otf_path = "../test-pdfs/SourceHanSansSC-Regular.otf";
+    if let Ok(font_data) = std::fs::read(otf_path) {
+        let original_len = font_data.len();
+        let mut doc = Document::new();
+        doc.add_font_from_bytes("SourceHanSans", font_data)?;
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Custom("SourceHanSans".to_string()), 10.5)
+            .at(30.0, 535.0)
+            .write("Rust 擁有完整的技術文件、友善的編譯器與清晰的錯誤訊息，還整合了一流的工具 — 包含套件管理工具、")?;
+        page.text()
+            .set_font(Font::Custom("SourceHanSans".to_string()), 10.5)
+            .at(30.0, 515.0)
+            .write(
+                "建構工具、支援多種編輯器的自動補齊、型別檢測、自動格式化程式碼，以及更多等等。",
+            )?;
+        doc.add_page(page);
+        let bytes = doc.to_bytes()?;
+        std::fs::write("/tmp/issue165_repro_otf.pdf", &bytes)?;
+        println!(
+            "OTF/CFF: original={} KB, PDF={} KB (v2.5.3 was 62 KB, krilla 59 KB)",
+            original_len / 1024,
+            bytes.len() / 1024
+        );
+    } else {
+        println!("SKIPPED OTF: {} not found", otf_path);
+    }
+
+    // ----- TTF / glyf path: user's exact TTF font if available -----
+    // SourceHanSansTC-Regular.ttf is not shipped in the repo (16+ MB). The
+    // fixture is kept at /tmp/issue165_v253/SourceHanSansTC-Regular.ttf for
+    // local reproduction of the user's case. If absent, fall back to Roboto
+    // as a Latin-TTF smoke test.
+    let cjk_ttf_path = "/tmp/issue165_v253/SourceHanSansTC-Regular.ttf";
+    let user_text_line1 = "Rust 擁有完整的技術文件、友善的編譯器與清晰的錯誤訊息，還整合了一流的工具 — 包含套件管理工具、";
+    let user_text_line2 =
+        "建構工具、支援多種編輯器的自動補齊、型別檢測、自動格式化程式碼，以及更多等等。";
+
+    if let Ok(font_data) = std::fs::read(cjk_ttf_path) {
+        let original_len = font_data.len();
+        let mut doc = Document::new();
+        doc.add_font_from_bytes("SourceHanSansTC", font_data)?;
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Custom("SourceHanSansTC".to_string()), 10.5)
+            .at(30.0, 535.0)
+            .write(user_text_line1)?;
+        page.text()
+            .set_font(Font::Custom("SourceHanSansTC".to_string()), 10.5)
+            .at(30.0, 515.0)
+            .write(user_text_line2)?;
+        doc.add_page(page);
+        let bytes = doc.to_bytes()?;
+        std::fs::write("/tmp/issue165_repro_cjk_ttf.pdf", &bytes)?;
+        println!(
+            "TTF/glyf CJK: original={} KB, PDF={} KB (user reported 307 KB on v2.5.3, krilla 48 KB)",
+            original_len / 1024,
+            bytes.len() / 1024
+        );
+    } else {
+        println!("SKIPPED CJK TTF: {} not found", cjk_ttf_path);
+    }
+
+    let ttf_path = "../test-pdfs/Roboto-Regular.ttf";
+    if let Ok(font_data) = std::fs::read(ttf_path) {
+        let original_len = font_data.len();
+        let mut doc = Document::new();
+        doc.add_font_from_bytes("Roboto", font_data)?;
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Custom("Roboto".to_string()), 10.5)
+            .at(30.0, 535.0)
+            .write("Rust has complete documentation, a friendly compiler and clear error messages, plus top-tier tools.")?;
+        page.text()
+            .set_font(Font::Custom("Roboto".to_string()), 10.5)
+            .at(30.0, 515.0)
+            .write("Build tools, multi-editor autocomplete, type detection, automatic formatting, and much more.")?;
+        doc.add_page(page);
+        let bytes = doc.to_bytes()?;
+        std::fs::write("/tmp/issue165_repro_ttf.pdf", &bytes)?;
+        println!(
+            "TTF/glyf Latin: original={} KB, PDF={} KB (Roboto proxy)",
+            original_len / 1024,
+            bytes.len() / 1024
+        );
+    } else {
+        println!("SKIPPED Latin TTF: {} not found", ttf_path);
+    }
+
+    Ok(())
+}

--- a/oxidize-pdf-core/src/text/fonts/truetype_subsetter.rs
+++ b/oxidize-pdf-core/src/text/fonts/truetype_subsetter.rs
@@ -152,6 +152,36 @@ fn calculate_checksum(data: &[u8]) -> u32 {
     sum
 }
 
+/// Build a `post` table version 3.0 header (32 bytes, no glyph names).
+///
+/// The PDF spec (ISO 32000-1 §9.6.6 and §9.7) does not consult the `post`
+/// table during rendering — character-to-glyph resolution is driven by
+/// `ToUnicode` CMap and `CIDToGIDMap`, and glyph names aren't read when
+/// drawing. Emitting version 3.0 (which has no glyph names section) saves
+/// the full Pascal-string name table, which for large CJK fonts can be
+/// hundreds of KB of unreachable data.
+///
+/// If the original font has a post table with a valid 32-byte header, its
+/// italic/underline/memory-use metrics are preserved (bytes 4..32). The
+/// only change is overriding the version field to 0x00030000.
+///
+/// If the original post is missing or truncated, a zeroed 32-byte header
+/// is emitted (version 3.0 + zeros for the remaining fields). This matches
+/// what every PDF viewer does with fonts whose post table is irrelevant.
+fn build_post_v3_header(original_post: Option<&[u8]>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(32);
+    out.extend_from_slice(&0x0003_0000u32.to_be_bytes());
+    if let Some(src) = original_post.filter(|s| s.len() >= 32) {
+        // Copy italicAngle, underlinePosition, underlineThickness, isFixedPitch,
+        // minMemType42, maxMemType42, minMemType1, maxMemType1 (bytes 4..32).
+        out.extend_from_slice(&src[4..32]);
+    } else {
+        out.resize(32, 0);
+    }
+    debug_assert_eq!(out.len(), 32);
+    out
+}
+
 /// Result of font subsetting operation
 pub struct SubsetResult {
     /// Subsetted font data
@@ -686,9 +716,13 @@ impl TrueTypeSubsetter {
         let head_table = self.get_table_data(b"head")?;
         let hhea_table = self.update_hhea_table(num_glyphs)?;
         let maxp_table = self.get_original_maxp(num_glyphs)?;
-        let post_table = self
-            .get_table_data(b"post")
-            .unwrap_or_else(|_| vec![0x00, 0x03, 0x00, 0x00]); // Version 3.0
+        // Always emit post version 3.0 (32-byte header, no glyph names).
+        // PDF never consults the post table's glyph names — character-to-glyph
+        // resolution is driven by ToUnicode + CIDToGIDMap, and glyph names
+        // aren't read during rendering. Copying the original post (v2.0 for
+        // most CJK fonts) embeds ~370 KB of unused Pascal name strings and
+        // was the dominant size source in Issue #165's TTF path.
+        let post_table = build_post_v3_header(self.get_table_data(b"post").ok().as_deref());
 
         let tables_to_write: Vec<(&[u8; 4], Vec<u8>)> = vec![
             (b"glyf", glyf),

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1508,11 +1508,32 @@ impl<W: Write> PdfWriter<W> {
             let cid_to_gid_map =
                 self.generate_cid_to_gid_map(font, subset_glyph_mapping.as_ref())?;
             if !cid_to_gid_map.is_empty() {
-                // Write the CIDToGIDMap as a stream
+                // Write the CIDToGIDMap as a stream, FlateDecode-compressed
+                // when possible. The raw map is dimensioned to the highest
+                // codepoint in use and is mostly zeros (only mapped code
+                // points carry a 2-byte GID), so Flate compression typically
+                // crushes it by 95-99%. For CJK-heavy documents this is the
+                // difference between a 130 KB map (Issue #165) and a ~1 KB
+                // stream.
                 let cid_to_gid_map_id = self.allocate_object_id();
-                let mut map_dict = Dictionary::new();
-                map_dict.set("Length", Object::Integer(cid_to_gid_map.len() as i64));
-                let map_stream = Object::Stream(map_dict, cid_to_gid_map);
+                let map_dict = Dictionary::new();
+                #[cfg(feature = "compression")]
+                let map_stream = if self.config.compress_streams {
+                    let mut stream =
+                        crate::objects::Stream::with_dictionary(map_dict, cid_to_gid_map);
+                    stream.compress_flate()?;
+                    Object::Stream(stream.dictionary().clone(), stream.data().to_vec())
+                } else {
+                    let mut d = map_dict;
+                    d.set("Length", Object::Integer(cid_to_gid_map.len() as i64));
+                    Object::Stream(d, cid_to_gid_map)
+                };
+                #[cfg(not(feature = "compression"))]
+                let map_stream = {
+                    let mut d = map_dict;
+                    d.set("Length", Object::Integer(cid_to_gid_map.len() as i64));
+                    Object::Stream(d, cid_to_gid_map)
+                };
                 self.write_object(cid_to_gid_map_id, map_stream)?;
                 cid_font.set("CIDToGIDMap", Object::Reference(cid_to_gid_map_id));
             } else {

--- a/oxidize-pdf-core/tests/font_subset_post_and_cidtogidmap_test.rs
+++ b/oxidize-pdf-core/tests/font_subset_post_and_cidtogidmap_test.rs
@@ -1,0 +1,387 @@
+//! TDD tests for Issue #165 follow-up fixes:
+//!
+//! - **Bug #1**: `post` table must be rewritten as version 3.0 (32 bytes) in
+//!   TTF subsets. Previously the subsetter copied the original font's `post`
+//!   table verbatim, which for CJK fonts means ~370 KB of glyph names that
+//!   PDF never consults.
+//! - **Bug #2**: the CIDToGIDMap stream (CIDFontType2 only) must be
+//!   FlateDecode-compressed. Previously it was emitted as raw binary which
+//!   for high-codepoint characters added ~130 KB of sparse zero-filled map.
+//!
+//! Tests use the real `Roboto-Regular.ttf` fixture (post v2, 3387 glyph names)
+//! so they exercise the exact code path the user reported, without requiring
+//! a CJK TTF fixture that we don't ship in the repo.
+
+use oxidize_pdf::text::fonts::truetype_subsetter::subset_font;
+use oxidize_pdf::{Document, Font, Page};
+use std::collections::HashSet;
+
+const ROBOTO_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+
+fn load_fixture(path: &str) -> Option<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|_| eprintln!("SKIPPED: {} not found", path))
+        .ok()
+}
+
+// =============================================================================
+// Minimal SFNT / PDF helpers (test-local; duplicating here keeps tests
+// self-contained without exposing parser internals).
+// =============================================================================
+
+fn u16_be(b: &[u8], off: usize) -> u16 {
+    u16::from_be_bytes([b[off], b[off + 1]])
+}
+
+fn u32_be(b: &[u8], off: usize) -> u32 {
+    u32::from_be_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+
+/// Locate a table in a SFNT (TTF/OTF) byte buffer. Returns (offset, length).
+fn find_sfnt_table(font: &[u8], tag: &[u8; 4]) -> Option<(usize, usize)> {
+    if font.len() < 12 {
+        return None;
+    }
+    let num_tables = u16_be(font, 4) as usize;
+    for i in 0..num_tables {
+        let entry = 12 + i * 16;
+        if entry + 16 > font.len() {
+            return None;
+        }
+        if &font[entry..entry + 4] == tag {
+            let offset = u32_be(font, entry + 8) as usize;
+            let length = u32_be(font, entry + 12) as usize;
+            return Some((offset, length));
+        }
+    }
+    None
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len()).find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+/// Locate object `N 0 obj ... endobj` and return the (header_start, stream_start,
+/// stream_end, endobj_end) offsets plus the dict body slice.
+struct PdfObjectRef<'a> {
+    dict_body: &'a [u8],
+    stream: Option<&'a [u8]>,
+}
+
+fn locate_object<'a>(pdf: &'a [u8], obj_num: u32) -> Option<PdfObjectRef<'a>> {
+    let needle = format!("{} 0 obj", obj_num);
+    let start = find_subslice(pdf, needle.as_bytes())?;
+    let header_end = start + needle.len();
+    let endobj_rel = find_subslice(&pdf[header_end..], b"endobj")?;
+    let obj_end = header_end + endobj_rel;
+    let obj_bytes = &pdf[header_end..obj_end];
+
+    // Locate dict bounds: first `<<` to matching `>>` (top-level).
+    let dict_start = find_subslice(obj_bytes, b"<<")?;
+    // Walk to find matching >>
+    let mut depth = 1usize;
+    let mut i = dict_start + 2;
+    while i + 1 < obj_bytes.len() {
+        if &obj_bytes[i..i + 2] == b"<<" {
+            depth += 1;
+            i += 2;
+        } else if &obj_bytes[i..i + 2] == b">>" {
+            depth -= 1;
+            i += 2;
+            if depth == 0 {
+                break;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    let dict_body = &obj_bytes[dict_start + 2..i - 2];
+
+    // Optional stream
+    let stream = find_subslice(&obj_bytes[i..], b"stream").map(|rel| {
+        let mut s = i + rel + b"stream".len();
+        if obj_bytes.get(s) == Some(&b'\r') {
+            s += 1;
+        }
+        if obj_bytes.get(s) == Some(&b'\n') {
+            s += 1;
+        }
+        let e = find_subslice(&obj_bytes[s..], b"endstream").unwrap_or(obj_bytes.len() - s);
+        // Trim trailing EOL
+        let mut end = s + e;
+        while end > s && (obj_bytes[end - 1] == b'\n' || obj_bytes[end - 1] == b'\r') {
+            end -= 1;
+        }
+        &obj_bytes[s..end]
+    });
+
+    Some(PdfObjectRef { dict_body, stream })
+}
+
+// =============================================================================
+// Bug #1: post table must be version 3.0 (32 bytes) in subset output
+// =============================================================================
+
+/// When subsetting Roboto-Regular.ttf (post v2, 3387 glyph names, ~37 KB),
+/// the output subset font MUST emit `post` version 3.0 (header-only, 32 bytes).
+/// PDF does not use glyph names from the post table — rendering is resolved
+/// through ToUnicode + CIDToGIDMap — so carrying the Pascal name strings is
+/// pure bloat. For CJK fonts (56K glyphs) the impact is ~370 KB of waste.
+#[test]
+fn test_ttf_subset_emits_post_version_3_0() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let used: HashSet<char> = "ABC".chars().collect();
+    let result = subset_font(font_data.clone(), &used).expect("subsetting must succeed");
+
+    // Confirm pre-condition on the fixture: original font has post v2 with
+    // many glyph names. If someone swaps the fixture for a post-v3 font this
+    // test becomes vacuous, so assert the pre-condition explicitly.
+    let (orig_post_off, orig_post_len) =
+        find_sfnt_table(&font_data, b"post").expect("Roboto must have a post table");
+    let orig_version = u32_be(&font_data, orig_post_off);
+    assert_eq!(
+        orig_version, 0x00020000,
+        "fixture sanity: Roboto post must be version 2.0 for the test to be meaningful"
+    );
+    assert!(
+        orig_post_len > 10_000,
+        "fixture sanity: Roboto post is expected to be >10 KB with glyph names, got {} bytes",
+        orig_post_len
+    );
+
+    // Subset output must carry a post table...
+    let (post_off, post_len) =
+        find_sfnt_table(&result.font_data, b"post").expect("subset must include post table");
+
+    // ...of version 3.0...
+    let version = u32_be(&result.font_data, post_off);
+    assert_eq!(
+        version, 0x00030000,
+        "subset post table must be version 3.0 (header-only), got 0x{:08x}",
+        version
+    );
+
+    // ...and header-only (32 bytes, no numGlyphs / glyphNameIndex / Pascal names).
+    assert_eq!(
+        post_len, 32,
+        "subset post table (v3.0) must be exactly 32 bytes, got {}",
+        post_len
+    );
+}
+
+/// Guard against regressions that would copy the original `post` into the
+/// subset. This test is deliberately strict on size: any attempt to embed
+/// per-glyph name data would blow past 64 bytes.
+#[test]
+fn test_ttf_subset_post_table_strictly_bounded() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let used: HashSet<char> = "Hello".chars().collect();
+    let result = subset_font(font_data, &used).expect("subsetting must succeed");
+    let (_, post_len) =
+        find_sfnt_table(&result.font_data, b"post").expect("post table must be present");
+
+    assert!(
+        post_len <= 64,
+        "subset post table must fit in <= 64 bytes (v3.0 header-only), got {}",
+        post_len
+    );
+}
+
+// =============================================================================
+// Bug #2: CIDToGIDMap stream must be FlateDecode-compressed
+// =============================================================================
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_cid_to_gid_map_stream_has_flate_filter() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes must succeed");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 12.0)
+        .at(50.0, 500.0)
+        .write("AB")
+        .expect("writing must succeed");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation must succeed");
+
+    // Find the CIDFont dict: it contains `/Subtype /CIDFontType2` and
+    // `/CIDToGIDMap N 0 R`. Resolve that N and inspect its stream dict.
+    let key = b"/CIDToGIDMap";
+    let key_pos = find_subslice(&pdf_bytes, key).expect("CIDToGIDMap must be referenced");
+    let tail = &pdf_bytes[key_pos + key.len()..];
+    // Skip whitespace
+    let mut cursor = 0;
+    while cursor < tail.len() && tail[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    // If the value is `/Identity`, the map has been inlined as a name and the
+    // test is not applicable — skip. In practice Roboto + ASCII produces a
+    // small binary map, not Identity.
+    if tail[cursor..].starts_with(b"/Identity") {
+        eprintln!("SKIPPED: CIDToGIDMap is /Identity, no stream to compress");
+        return;
+    }
+    let start = cursor;
+    while cursor < tail.len() && tail[cursor].is_ascii_digit() {
+        cursor += 1;
+    }
+    let obj_num: u32 = std::str::from_utf8(&tail[start..cursor])
+        .expect("ascii digits")
+        .parse()
+        .expect("parseable object number");
+
+    let obj = locate_object(&pdf_bytes, obj_num).expect("CIDToGIDMap target object must exist");
+
+    assert!(
+        find_subslice(obj.dict_body, b"/Filter").is_some()
+            && find_subslice(obj.dict_body, b"/FlateDecode").is_some(),
+        "CIDToGIDMap stream dictionary must declare /Filter /FlateDecode; \
+         got dict body: {:?}",
+        std::str::from_utf8(obj.dict_body).unwrap_or("<non-utf8>")
+    );
+
+    let stream = obj.stream.expect("CIDToGIDMap must be a stream object");
+    assert!(!stream.is_empty(), "CIDToGIDMap stream must not be empty");
+}
+
+/// After Flate-compressing a CIDToGIDMap that is mostly zeros (only a handful
+/// of codepoints have non-zero glyph IDs), the on-disk stream must be at
+/// least an order of magnitude smaller than the declared uncompressed size.
+///
+/// The uncompressed map is (max_codepoint + 1) * 2 bytes. For Roboto + a few
+/// ASCII chars the uncompressed size is small, so this test uses a codepoint
+/// set that forces a larger uncompressed map (Latin-1 Supplement) and asserts
+/// that Flate compression leaves it below 10% of the uncompressed size.
+#[cfg(feature = "compression")]
+#[test]
+fn test_cid_to_gid_map_compression_ratio_below_10_percent() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes must succeed");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 12.0)
+        .at(50.0, 500.0)
+        // ÿ (U+00FF) forces max_codepoint = 255 => uncompressed map = 512 bytes
+        // of which only ~10 entries are non-zero. Flate should crush this.
+        .write("Café ÿ")
+        .expect("writing Latin-1 text must succeed");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation must succeed");
+
+    // Locate CIDToGIDMap target object
+    let key_pos =
+        find_subslice(&pdf_bytes, b"/CIDToGIDMap").expect("CIDToGIDMap must be referenced");
+    let tail = &pdf_bytes[key_pos + b"/CIDToGIDMap".len()..];
+    let mut cursor = 0;
+    while cursor < tail.len() && tail[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    if tail[cursor..].starts_with(b"/Identity") {
+        eprintln!("SKIPPED: CIDToGIDMap is /Identity");
+        return;
+    }
+    let start = cursor;
+    while cursor < tail.len() && tail[cursor].is_ascii_digit() {
+        cursor += 1;
+    }
+    let obj_num: u32 = std::str::from_utf8(&tail[start..cursor])
+        .expect("ascii digits")
+        .parse()
+        .expect("parseable object number");
+
+    let obj = locate_object(&pdf_bytes, obj_num).expect("CIDToGIDMap target must exist");
+    let stream = obj.stream.expect("must be a stream");
+
+    // Pull the `/Length1`-free dict's `/Length` to compare against the
+    // compressed stream length — but cheaper: decompress and compare.
+    use flate2::read::ZlibDecoder;
+    use std::io::Read;
+    let mut dec = ZlibDecoder::new(stream);
+    let mut decompressed = Vec::new();
+    dec.read_to_end(&mut decompressed)
+        .expect("stream must be valid Flate data");
+
+    let compressed_len = stream.len() as f64;
+    let uncompressed_len = decompressed.len() as f64;
+    assert!(uncompressed_len > 0.0, "uncompressed CIDToGIDMap is empty");
+
+    let ratio = compressed_len / uncompressed_len;
+    assert!(
+        ratio < 0.10,
+        "Flate-compressed CIDToGIDMap ({} bytes) must be < 10% of uncompressed ({} bytes); ratio {:.4}",
+        stream.len(),
+        decompressed.len(),
+        ratio
+    );
+}
+
+// =============================================================================
+// Combined end-to-end regression: Roboto + pangram must fit under 25 KB
+// =============================================================================
+
+/// This is the combined regression guard for Bug #1 + Bug #2.
+/// Roboto-Regular.ttf is a 515 KB Latin TTF. Subset to ~35 unique characters
+/// (a pangram) and embedded with both post v3.0 and FlateDecode-compressed
+/// CIDToGIDMap, the output PDF must fit comfortably under 25 KB.
+///
+/// The previous ceiling of 50 KB (set in v2.5.3 by
+/// `test_roboto_ttf_pdf_end_to_end_under_50kb`) still passes both before and
+/// after these fixes because Roboto's post table is "only" ~37 KB (vs
+/// ~373 KB for CJK fonts). The 25 KB bound here exercises the size budget
+/// tighter and will catch either bug regressing.
+#[cfg(feature = "compression")]
+#[test]
+fn test_roboto_ttf_pdf_end_to_end_under_25kb_combined_fixes() {
+    let font_data = match load_fixture(ROBOTO_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let text = "The quick brown fox jumps over the lazy dog.";
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes must succeed");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 12.0)
+        .at(50.0, 500.0)
+        .write(text)
+        .expect("writing text must succeed");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("PDF generation must succeed");
+    assert!(
+        pdf_bytes.len() < 25_000,
+        "Roboto TTF PDF with post v3.0 + FlateDecode CIDToGIDMap must be under 25 KB, got {} bytes",
+        pdf_bytes.len()
+    );
+}


### PR DESCRIPTION
## Summary

Two regressions in the TTF/CIDFontType2 embedding path were the remaining size source flagged by @sparkyandrew in #165. With both fixes applied, the user's reported case (SourceHanSansTC-Regular.ttf, user's snippet) drops from **145 KB → 19 KB**, now smaller than krilla's 48 KB reference.

**post table** (`truetype_subsetter.rs`) — subset was copying the original font's post v2.0 verbatim. For CJK fonts that's ~370 KB of Pascal glyph-name strings that PDF never consults. Now always emits a 32-byte post v3.0 header, preserving italic/underline/memory metrics.

**CIDToGIDMap stream** (`pdf_writer/mod.rs`) — written as a raw uncompressed stream. Dimensioned to the highest codepoint in use and mostly zeros, so it Flate-compresses 95-99%. For the CJK case: 131 KB → 342 bytes. Gated behind the existing `compression` feature + `config.compress_streams`.

## Impact (measured on `SourceHanSansTC-Regular.ttf`, user's exact snippet)

| Release | PDF size | vs krilla (48 KB) |
|---|---|---|
| v2.5.3 | 145 KB | +203 % |
| **v2.5.4** | **19 KB** | **-60 % (smaller)** |

Roboto Latin TTF also benefits: 24 KB → 8 KB (-66 %). The CFF/OTF path is unchanged (it doesn't use `post` or CIDToGIDMap).

## Test plan

- [x] 5 new content-verifying TDD tests in `font_subset_post_and_cidtogidmap_test.rs` — all failing before fix, all passing after
- [x] Full workspace test suite: 8325 pass / 0 fail / 67 ignored
- [x] Pre-commit hooks (fmt + clippy + build + tests) passed on both commits
- [x] `examples/issue_165_repro.rs` reproduces the user's snippet for manual validation
- [ ] @sparkyandrew re-tests against v2.5.4 once released (no auto-comment on #165 yet)

## Notes

- Version bumped to v2.5.4 in a separate commit.
- Does not address the OTF path (already at parity with krilla in v2.5.3).
- No release/tag actions included — that's a separate authorization step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)