### PR TITLE
fix(writer): emit OpenAction/ViewerPreferences/Names/PageLabels in catalog (2.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [2.5.5] - 2026-04-21
+
+### Fixed
+- **`/OpenAction` now reaches the PDF catalog** — `Document::set_open_action()` was stored on the document but `write_catalog()` in `pdf_writer/mod.rs` never serialised it (ISO 32000-1 §7.7.2 Table 28). Now emitted as an inline action dictionary via `Action::to_dict()`.
+- **`/ViewerPreferences` now reaches the PDF catalog** — same bug class as `/OpenAction`. The preference dictionary (HideToolbar, PageLayout, Direction, etc.) was built by `Document::set_viewer_preferences()` but dropped on write (ISO 32000-1 §7.7.2 Table 28, §12.2). Now emitted as an inline dictionary via `ViewerPreferences::to_dict()`.
+- **`/Names` (named destinations) now reaches the PDF catalog** — `Document::set_named_destinations()` stored a `NamedDestinations` wrapper but the catalog never referenced it, so no reader could resolve named destinations (ISO 32000-1 §7.7.2 Table 28, §7.7.4 Table 31, §12.3.2.3). The writer now emits the name tree and a Name Dictionary as indirect objects and references the Name Dictionary from `/Names`.
+- **`/PageLabels` now reaches the PDF catalog** — `Document::set_page_labels()` stored a `PageLabelTree` but the catalog never referenced it, so custom page numbering was dropped (ISO 32000-1 §7.7.2 Table 28, §12.4.2). The number tree is now written as an indirect object.
+- **Page label dictionaries emit `/S` (numbering style) per spec** — `PageLabel::to_dict()` previously emitted the style under `/Type` (e.g. `/Type /D`). Per ISO 32000-1 §12.4.2 Table 159 the numbering style shall be carried by `/S`; `/Type`, when present, shall be the constant name `PageLabel`. The writer now emits `/Type /PageLabel` + `/S /<style>`, so conforming viewers actually recognise the numbering style. `PageLabel::from_dict()` prefers `/S` and tolerates legacy `/Type`-carrying-style dicts for backward-compatible round-trip.
+
+### Added
+- `src/writer/pdf_writer/tests/catalog_entries_tests.rs` — 5 content-verifying TDD tests that serialise a real `Document` and assert each catalog entry (plus the characteristic payload: `/S /GoTo`, `/HideToolbar true`, `(target)` name tree key, `/S /D`) reaches the PDF bytes. Includes a combined-entry regression guarding against future refactors that could drop one entry while keeping the others.
+
+### Impact
+The C# wrapper `oxidize-pdf-dotnet` (and any other binding) can now expose these four catalog features; previously the setters accepted values that were silently discarded during serialisation.
+
 ## [2.5.4] - 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/page_labels/page_label.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label.rs
@@ -129,11 +129,20 @@ impl PageLabel {
     }
 
     /// Convert to PDF dictionary
+    ///
+    /// Encodes the label per ISO 32000-1 §12.4.2 Table 159:
+    /// - `/Type` — optional name, when present shall be `PageLabel`.
+    /// - `/S`    — numbering style (`D`/`R`/`r`/`A`/`a`); absent when the
+    ///            label has no numeric portion (style `None`).
+    /// - `/P`    — optional prefix string.
+    /// - `/St`   — optional integer starting value (default 1).
     pub fn to_dict(&self) -> Dictionary {
         let mut dict = Dictionary::new();
 
-        if let Some(type_name) = self.style.to_pdf_name() {
-            dict.set("Type", Object::Name(type_name.to_string()));
+        dict.set("Type", Object::Name("PageLabel".to_string()));
+
+        if let Some(style_name) = self.style.to_pdf_name() {
+            dict.set("S", Object::Name(style_name.to_string()));
         }
 
         if let Some(prefix) = &self.prefix {
@@ -283,9 +292,15 @@ mod tests {
 
     #[test]
     fn test_to_dict() {
+        // Per ISO 32000-1 §12.4.2 Table 159, the numbering style is /S (not
+        // /Type). /Type is optional and must be PageLabel when present.
         let label = PageLabel::decimal();
         let dict = label.to_dict();
-        assert_eq!(dict.get("Type"), Some(&Object::Name("D".to_string())));
+        assert_eq!(
+            dict.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict.get("S"), Some(&Object::Name("D".to_string())));
         assert!(dict.get("P").is_none());
         assert!(dict.get("St").is_none());
 
@@ -293,7 +308,11 @@ mod tests {
             .with_prefix("p. ")
             .starting_at(5);
         let dict = label.to_dict();
-        assert_eq!(dict.get("Type"), Some(&Object::Name("R".to_string())));
+        assert_eq!(
+            dict.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict.get("S"), Some(&Object::Name("R".to_string())));
         assert_eq!(dict.get("P"), Some(&Object::String("p. ".to_string())));
         assert_eq!(dict.get("St"), Some(&Object::Integer(5)));
     }
@@ -451,7 +470,11 @@ mod tests {
         // Test dictionary generation with all combinations
         let label1 = PageLabel::new(PageLabelStyle::DecimalArabic);
         let dict1 = label1.to_dict();
-        assert_eq!(dict1.get("Type"), Some(&Object::Name("D".to_string())));
+        assert_eq!(
+            dict1.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict1.get("S"), Some(&Object::Name("D".to_string())));
         assert!(dict1.get("P").is_none()); // No prefix
         assert!(dict1.get("St").is_none()); // Default start (1)
 
@@ -459,17 +482,26 @@ mod tests {
             .with_prefix("Section ")
             .starting_at(10);
         let dict2 = label2.to_dict();
-        assert_eq!(dict2.get("Type"), Some(&Object::Name("A".to_string())));
+        assert_eq!(
+            dict2.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict2.get("S"), Some(&Object::Name("A".to_string())));
         assert_eq!(
             dict2.get("P"),
             Some(&Object::String("Section ".to_string()))
         );
         assert_eq!(dict2.get("St"), Some(&Object::Integer(10)));
 
-        // Test prefix-only (no Type field)
+        // Prefix-only dicts still carry /Type PageLabel (§12.4.2 recommends
+        // it), but have no /S entry because the numbering style is None.
         let label3 = PageLabel::prefix_only("Index");
         let dict3 = label3.to_dict();
-        assert!(dict3.get("Type").is_none());
+        assert_eq!(
+            dict3.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert!(dict3.get("S").is_none());
         assert_eq!(dict3.get("P"), Some(&Object::String("Index".to_string())));
     }
 

--- a/oxidize-pdf-core/src/page_labels/page_label_tree.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label_tree.rs
@@ -94,18 +94,24 @@ impl PageLabelTree {
                 _ => continue,
             };
 
-            // Parse label from dictionary
-            let style = if let Some(Object::Name(type_name)) = label_dict.get("Type") {
-                match type_name.as_str() {
-                    "D" => PageLabelStyle::DecimalArabic,
-                    "r" => PageLabelStyle::UppercaseRoman,
-                    "R" => PageLabelStyle::LowercaseRoman,
-                    "A" => PageLabelStyle::UppercaseLetters,
-                    "a" => PageLabelStyle::LowercaseLetters,
-                    _ => PageLabelStyle::None,
-                }
-            } else {
-                PageLabelStyle::None
+            // Parse numbering style per ISO 32000-1 §12.4.2 Table 159.
+            // Spec key is /S; accept a legacy /Type-carrying-style as a
+            // tolerant fallback so documents written by older versions of
+            // this crate still round-trip.
+            let style_name = match label_dict.get("S") {
+                Some(Object::Name(s)) => Some(s.as_str()),
+                _ => match label_dict.get("Type") {
+                    Some(Object::Name(t)) if t != "PageLabel" => Some(t.as_str()),
+                    _ => None,
+                },
+            };
+            let style = match style_name {
+                Some("D") => PageLabelStyle::DecimalArabic,
+                Some("r") => PageLabelStyle::UppercaseRoman,
+                Some("R") => PageLabelStyle::LowercaseRoman,
+                Some("A") => PageLabelStyle::UppercaseLetters,
+                Some("a") => PageLabelStyle::LowercaseLetters,
+                _ => PageLabelStyle::None,
             };
 
             let mut label = PageLabel::new(style);

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -930,6 +930,11 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("OpenAction", Object::Dictionary(action.to_dict()));
         }
 
+        // /ViewerPreferences — ISO 32000-1 §7.7.2 Table 28, detailed in §12.2
+        if let Some(prefs) = &document.viewer_preferences {
+            catalog.set("ViewerPreferences", Object::Dictionary(prefs.to_dict()));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -925,6 +925,11 @@ impl<W: Write> PdfWriter<W> {
         // Reference it in catalog
         catalog.set("Metadata", Object::Reference(metadata_id));
 
+        // /OpenAction — ISO 32000-1 §7.7.2 Table 28
+        if let Some(action) = &document.open_action {
+            catalog.set("OpenAction", Object::Dictionary(action.to_dict()));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -951,6 +951,15 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("Names", Object::Reference(names_dict_id));
         }
 
+        // /PageLabels — ISO 32000-1 §7.7.2 Table 28, §12.4.2.
+        // The value is a number tree; we emit it as an indirect object so
+        // large documents can grow without reshuffling the catalog.
+        if let Some(page_labels) = &document.page_labels {
+            let labels_id = self.allocate_object_id();
+            self.write_object(labels_id, Object::Dictionary(page_labels.to_dict()))?;
+            catalog.set("PageLabels", Object::Reference(labels_id));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -935,6 +935,22 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("ViewerPreferences", Object::Dictionary(prefs.to_dict()));
         }
 
+        // /Names — ISO 32000-1 §7.7.4 Table 31 (Name Dictionary).
+        // The /Dests sub-entry is the name tree for named destinations
+        // (§12.3.2.3). Both the name tree and the Name Dictionary are
+        // written as indirect objects.
+        if let Some(named_dests) = &document.named_destinations {
+            let dests_tree_id = self.allocate_object_id();
+            self.write_object(dests_tree_id, Object::Dictionary(named_dests.to_dict()))?;
+
+            let mut names_dict = Dictionary::new();
+            names_dict.set("Dests", Object::Reference(dests_tree_id));
+            let names_dict_id = self.allocate_object_id();
+            self.write_object(names_dict_id, Object::Dictionary(names_dict))?;
+
+            catalog.set("Names", Object::Reference(names_dict_id));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
@@ -4303,5 +4303,6 @@ mod comprehensive_tests {
     }
 }
 
+mod catalog_entries_tests;
 mod form_filling_tests;
 mod incremental_update_tests;

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -96,6 +96,47 @@ mod catalog_entries_tests {
     }
 
     #[test]
+    fn test_write_catalog_includes_all_four_entries_simultaneously() {
+        // Regression: the four catalog entries are emitted as independent
+        // `if let` blocks, so a bug in one could suppress another. This
+        // test exercises the full cross-product by enabling all four
+        // features on the same Document and asserts each entry — and its
+        // characteristic payload — survives serialisation.
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+
+        document.set_open_action(Action::goto(Destination::fit(PageDestination::PageNumber(
+            0,
+        ))));
+        document.set_viewer_preferences(ViewerPreferences::new().hide_toolbar(true));
+        let mut dests = NamedDestinations::new();
+        dests.add_destination(
+            "combined-target".to_string(),
+            Destination::fit(PageDestination::PageNumber(0)).to_array(),
+        );
+        document.set_named_destinations(dests);
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::new(PageLabelStyle::DecimalArabic));
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        // OpenAction
+        assert!(content.contains("/OpenAction"));
+        assert!(content.contains("/S /GoTo"));
+        // ViewerPreferences
+        assert!(content.contains("/ViewerPreferences"));
+        assert!(content.contains("/HideToolbar true"));
+        // Names (named destinations)
+        assert!(content.contains("/Names"));
+        assert!(content.contains("/Dests"));
+        assert!(content.contains("(combined-target)"));
+        // PageLabels
+        assert!(content.contains("/PageLabels"));
+        assert!(content.contains("/S /D"));
+    }
+
+    #[test]
     fn test_write_catalog_includes_page_labels() {
         let mut document = Document::new();
         document.add_page(Page::a4());

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -1,0 +1,45 @@
+// Rigorous tests for catalog entries emitted by write_catalog().
+// Covers ISO 32000-1 §7.7.2 entries that Document exposes via setters:
+//   /OpenAction, /ViewerPreferences, /Names (Dests), /PageLabels.
+//
+// NO SMOKE TESTS — every test serialises a real Document and inspects the
+// bytes to verify the catalog entry is present with the expected shape.
+
+#[cfg(test)]
+mod catalog_entries_tests {
+    use crate::actions::Action;
+    use crate::document::Document;
+    use crate::page::Page;
+    use crate::structure::{Destination, PageDestination};
+    use crate::writer::PdfWriter;
+
+    fn serialize(document: &mut Document) -> String {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = PdfWriter::new_with_writer(&mut buffer);
+            writer.write_document(document).unwrap();
+        }
+        String::from_utf8_lossy(&buffer).into_owned()
+    }
+
+    #[test]
+    fn test_write_catalog_includes_open_action() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.set_open_action(Action::goto(Destination::fit(PageDestination::PageNumber(
+            0,
+        ))));
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/OpenAction"),
+            "catalog should emit /OpenAction when Document::open_action is set"
+        );
+        // GoTo action dict must carry /S /GoTo per ISO 32000-1 §12.6.4.2
+        assert!(
+            content.contains("/S /GoTo"),
+            "open action dict should serialize as a /GoTo action (/S /GoTo)"
+        );
+    }
+}

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -10,6 +10,7 @@ mod catalog_entries_tests {
     use crate::actions::Action;
     use crate::document::Document;
     use crate::page::Page;
+    use crate::page_labels::{PageLabel, PageLabelStyle, PageLabelTree};
     use crate::structure::{Destination, NamedDestinations, PageDestination};
     use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
@@ -91,6 +92,30 @@ mod catalog_entries_tests {
             content.contains("(target)"),
             "named destination key should appear as a string in the name tree \
              (expected (target))"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_page_labels() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::new(PageLabelStyle::DecimalArabic));
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        // /PageLabels in the catalog is a number tree (ISO 32000-1 §7.7.2
+        // Table 28, §12.4.2).
+        assert!(
+            content.contains("/PageLabels"),
+            "catalog should emit /PageLabels when set on Document"
+        );
+        // Per ISO 32000-1 §12.4.2 Table 159 the numbering style entry is
+        // named /S (not /Type).
+        assert!(
+            content.contains("/S /D"),
+            "decimal page label dict should serialise as /S /D per spec"
         );
     }
 }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -10,7 +10,7 @@ mod catalog_entries_tests {
     use crate::actions::Action;
     use crate::document::Document;
     use crate::page::Page;
-    use crate::structure::{Destination, PageDestination};
+    use crate::structure::{Destination, NamedDestinations, PageDestination};
     use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
 
@@ -59,6 +59,38 @@ mod catalog_entries_tests {
         assert!(
             content.contains("/HideToolbar true"),
             "viewer prefs dict should serialize /HideToolbar true (ISO 32000-1 §12.2)"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_named_destinations() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut dests = NamedDestinations::new();
+        dests.add_destination(
+            "target".to_string(),
+            Destination::fit(PageDestination::PageNumber(0)).to_array(),
+        );
+        document.set_named_destinations(dests);
+
+        let content = serialize(&mut document);
+
+        // /Names in the catalog is a Name Dictionary (ISO 32000-1 §7.7.4,
+        // Table 31). Its /Dests entry is the name tree for named
+        // destinations (§12.3.2.3).
+        assert!(
+            content.contains("/Names"),
+            "catalog should emit /Names when named destinations are set"
+        );
+        assert!(
+            content.contains("/Dests"),
+            "/Names dictionary must contain /Dests for named destinations"
+        );
+        // The name tree leaf exposes the entry key as a string literal.
+        assert!(
+            content.contains("(target)"),
+            "named destination key should appear as a string in the name tree \
+             (expected (target))"
         );
     }
 }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -11,6 +11,7 @@ mod catalog_entries_tests {
     use crate::document::Document;
     use crate::page::Page;
     use crate::structure::{Destination, PageDestination};
+    use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
 
     fn serialize(document: &mut Document) -> String {
@@ -40,6 +41,24 @@ mod catalog_entries_tests {
         assert!(
             content.contains("/S /GoTo"),
             "open action dict should serialize as a /GoTo action (/S /GoTo)"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_viewer_preferences() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.set_viewer_preferences(ViewerPreferences::new().hide_toolbar(true));
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/ViewerPreferences"),
+            "catalog should emit /ViewerPreferences when set on Document"
+        );
+        assert!(
+            content.contains("/HideToolbar true"),
+            "viewer prefs dict should serialize /HideToolbar true (ISO 32000-1 §12.2)"
         );
     }
 }


### PR DESCRIPTION
## Summary

Four `Document` setters (`set_open_action`, `set_viewer_preferences`, `set_named_destinations`, `set_page_labels`) stored values that `write_catalog()` in `pdf_writer/mod.rs` never serialised, so the corresponding PDF catalog entries were silently dropped. Binding consumers such as `oxidize-pdf-dotnet` therefore could not expose those features, although the Rust API suggested they worked.

This PR wires all four entries through to the PDF catalog per ISO 32000-1 §7.7.2 Table 28, and fixes one spec-compliance bug inside `PageLabel::to_dict` uncovered along the way.

### Fixed
- `/OpenAction` emitted as an inline action dictionary (`Action::to_dict`).
- `/ViewerPreferences` emitted as an inline preferences dictionary.
- `/Names` (named destinations) emitted as a Name Dictionary referencing the name tree — both as indirect objects (§7.7.4 Table 31, §12.3.2.3).
- `/PageLabels` emitted as an indirect number-tree object (§12.4.2).
- `PageLabel::to_dict` now emits `/Type /PageLabel` + `/S /<style>` per §12.4.2 Table 159 (was `/Type /<style>`, which conforming viewers could not recognise). `PageLabel::from_dict` prefers `/S` and tolerates legacy `/Type`-carrying-style dicts for round-trip with documents produced by oxidize-pdf ≤ 2.5.4.

### Added
- `src/writer/pdf_writer/tests/catalog_entries_tests.rs` — 5 content-verifying TDD tests (one per entry + a combined-entry regression). Each test serialises a real `Document` and asserts the characteristic payload (`/S /GoTo`, `/HideToolbar true`, `(target)` name-tree key, `/S /D`) reaches the PDF bytes. No smoke tests.

### Release
- Cargo workspace bumped to `2.5.5`.
- `CHANGELOG.md` updated.

## Test plan
- [x] `cargo test --workspace --features compression` — 8330 passed / 0 failed
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] Each new test first observed failing (RED) before implementation (GREEN), per strict TDD

🤖 Generated with [Claude Code](https://claude.com/claude-code)