### PR TITLE
fix(chunker): emit element-disjoint chunks — drop element-level overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+- **`HybridChunker::chunk()` now emits element-disjoint chunks** — prior to this release the chunker accumulated content across emissions: any flush (type boundary, `merge_adjacent=false`, or size overflow) re-injected the just-flushed elements back into the working buffer via the `overlap_tokens` branch of `flush_buffer`. The consequence was that each emitted chunk contained a prefix of the previous chunk. For a one-page document with a title followed by three paragraphs the chunker produced `[title]` and `[title, p1, p2, p3]` instead of a single merged chunk (or two disjoint chunks). This made `PdfDocument::rag_chunks()` output unusable for vector-store ingestion: content was duplicated quadratically in document size. `flush_buffer` now empties the buffer unconditionally and never reinjects elements. Element-level overlap was incompatible with the RAG disjointness invariant; the `overlap_tokens` config field is preserved for API compatibility but is currently a no-op (reserved for a future text-level overlap implementation).
+- Hardened three previously shape-only tests (`test_overlap_chunks_preserve_heading_context`, `test_hybrid_chunk_with_graph_splits_large_section`, `test_hybrid_chunk_with_graph_handles_preamble`) to assert pairwise chunk-text disjointness and that each source paragraph appears in exactly one chunk.
+
+### Added
+- `tests/hybrid_chunker_disjoint_test.rs` — four regression scenarios covering the accumulating-chunks bug: title+paragraphs under default config, size-overflow flushes, `merge_adjacent=false` with `overlap_tokens>0`, and an end-to-end PDF generated programmatically, parsed back, and chunked via `rag_chunks()`.
+
 ## [2.5.5] - 2026-04-21
 
 ### Fixed

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -51,7 +51,15 @@ pub enum MergePolicy {
 pub struct HybridChunkConfig {
     /// Maximum tokens per chunk (approximate — uses word count as proxy).
     pub max_tokens: usize,
-    /// Number of overlap tokens between consecutive chunks.
+    /// Reserved for future text-level overlap. Currently ignored.
+    ///
+    /// Prior versions used this to copy elements from the end of a flushed
+    /// chunk back into the working buffer, which produced chunks with
+    /// overlapping element sets and violated the disjointness invariant
+    /// required by RAG ingestion (see
+    /// `tests/hybrid_chunker_disjoint_test.rs`). The field is preserved for
+    /// API compatibility; if a text-level overlap is reintroduced later it
+    /// will honor this value.
     pub overlap_tokens: usize,
     /// Whether to merge adjacent elements of the same type (Paragraph+Paragraph, ListItem+ListItem).
     pub merge_adjacent: bool,
@@ -337,32 +345,17 @@ impl HybridChunker {
         buffer_tokens: &mut usize,
         buffer_heading: &mut Option<String>,
     ) {
+        // Emit the accumulated buffer as a single chunk and reset all
+        // accumulation state. The chunker's contract is that its emitted
+        // chunks are element-disjoint — every source Element appears in
+        // exactly one chunk. Re-injecting flushed elements back into the
+        // buffer (as the old "overlap_tokens" branch did) would violate
+        // that contract and, under type-boundary flushes, duplicates the
+        // whole just-emitted chunk into the next one. See the regression
+        // suite in tests/hybrid_chunker_disjoint_test.rs.
         let flushed = std::mem::take(buffer);
         let heading = buffer_heading.take();
-
-        // Compute overlap BEFORE moving flushed into the chunk (avoids clone)
-        if self.config.overlap_tokens > 0 {
-            let mut overlap_tokens = 0usize;
-            let mut overlap_elements = Vec::new();
-
-            for elem in flushed.iter().rev() {
-                let t = estimate_tokens(&elem.display_text());
-                if overlap_tokens + t > self.config.overlap_tokens && !overlap_elements.is_empty() {
-                    break;
-                }
-                overlap_elements.push(elem.clone());
-                overlap_tokens += t;
-            }
-
-            overlap_elements.reverse();
-            *buffer = overlap_elements;
-            *buffer_tokens = overlap_tokens;
-            if let Some(first) = buffer.first() {
-                *buffer_heading = first.metadata().parent_heading.clone();
-            }
-        } else {
-            *buffer_tokens = 0;
-        }
+        *buffer_tokens = 0;
 
         chunks.push(HybridChunk {
             elements: flushed,

--- a/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
@@ -1,0 +1,303 @@
+//! Regression tests for `HybridChunker::chunk()` disjointness.
+//!
+//! The chunker MUST emit chunks whose element lists are pairwise disjoint:
+//! the same source `Element` may not appear in two chunks, and the
+//! concatenation of all chunks' element lists must equal the input element
+//! list (modulo sentence-splitting of oversized paragraphs, which are
+//! regenerated from source text and therefore do not share identity with
+//! any input element).
+//!
+//! These tests exercise the bug that was observed on v2.5.4, where every
+//! non-size-overflow flush re-injected the just-flushed elements back into
+//! the working buffer via the "overlap" branch in `flush_buffer()`. The
+//! consequence was quadratic content duplication: each chunk i+1 contained
+//! a prefix of chunk i, making the output unusable for RAG ingestion.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{
+    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+    MergePolicy,
+};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+// ─── Helpers to build synthetic elements ─────────────────────────────────────
+
+fn title(text: &str, page: u32, y: f64) -> Element {
+    Element::Title(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(50.0, y, 500.0, 18.0),
+            parent_heading: Some(text.to_string()),
+            ..Default::default()
+        },
+    })
+}
+
+fn paragraph(text: &str, page: u32, y: f64, heading: Option<&str>) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(50.0, y, 500.0, 12.0),
+            parent_heading: heading.map(String::from),
+            ..Default::default()
+        },
+    })
+}
+
+// Return the textual "identity" of an element so we can detect duplicates
+// without relying on object identity. For Paragraph/Title/Header/etc. this
+// is the raw text; for tables/images it is a type-tag + bbox snapshot.
+fn element_identity(e: &Element) -> String {
+    let bbox = e.bbox();
+    format!(
+        "{}|p={}|x={:.1}|y={:.1}|w={:.1}|h={:.1}|t={}",
+        e.type_name(),
+        e.page(),
+        bbox.x,
+        bbox.y,
+        bbox.width,
+        bbox.height,
+        e.display_text()
+    )
+}
+
+fn assert_chunks_disjoint(chunks: &[oxidize_pdf::pipeline::HybridChunk]) {
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let ti = chunks[i].text();
+            let tj = chunks[j].text();
+            assert!(
+                !ti.is_empty() && !tj.is_empty(),
+                "chunks must have non-empty text"
+            );
+            assert!(
+                !tj.contains(&ti),
+                "chunk[{}].text() is a substring of chunk[{}].text():\n  i={:?}\n  j={:?}",
+                i,
+                j,
+                ti,
+                tj
+            );
+            assert!(
+                !ti.contains(&tj),
+                "chunk[{}].text() is a substring of chunk[{}].text():\n  i={:?}\n  j={:?}",
+                j,
+                i,
+                tj,
+                ti
+            );
+        }
+    }
+}
+
+fn assert_coverage_equals_input(chunks: &[oxidize_pdf::pipeline::HybridChunk], input: &[Element]) {
+    let mut input_ids: Vec<String> = input.iter().map(element_identity).collect();
+    input_ids.sort();
+
+    let mut chunk_ids: Vec<String> = chunks
+        .iter()
+        .flat_map(|c| c.elements().iter().map(element_identity))
+        .collect();
+    chunk_ids.sort();
+
+    assert_eq!(
+        chunk_ids, input_ids,
+        "concat of chunk elements must equal input element list (no duplication, no loss)"
+    );
+}
+
+// ─── Synthetic repro: Title + paragraphs, default config (overlap > 0) ───────
+
+#[test]
+fn synthetic_title_then_paragraphs_emits_disjoint_chunks() {
+    // Default config: max_tokens=512, overlap_tokens=50, merge_adjacent=true,
+    // merge_policy=AnyInlineContent. Title + three paragraphs trivially fit
+    // under max_tokens, so the output must contain each source element
+    // exactly once across all chunks.
+    let elements = vec![
+        title("HEAD ALPHA", 0, 750.0),
+        paragraph("Para1 words words words.", 0, 720.0, Some("HEAD ALPHA")),
+        paragraph("Para2 words words words.", 0, 700.0, Some("HEAD ALPHA")),
+        paragraph("Para3 words words words.", 0, 680.0, Some("HEAD ALPHA")),
+    ];
+
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+
+    assert!(!chunks.is_empty(), "must produce at least one chunk");
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+
+    // Spec also accepts a single merged chunk as correct. Verify we never
+    // produce more chunks than source elements (which would mean duplication).
+    assert!(
+        chunks.len() <= elements.len(),
+        "chunk count ({}) must not exceed element count ({}) — excess indicates leaked overlap",
+        chunks.len(),
+        elements.len()
+    );
+}
+
+// ─── Synthetic repro: size overflow with merge enabled ───────────────────────
+
+#[test]
+fn synthetic_overflow_flushes_emit_disjoint_chunks() {
+    // Small max_tokens forces multiple overflow flushes. Each paragraph is
+    // ~3 tokens; max_tokens=5 means at most one paragraph per chunk. Prior
+    // to the fix, the overlap branch re-injected the last flushed paragraph
+    // back into the buffer, causing each chunk to contain the previous
+    // paragraph as well.
+    let elements: Vec<Element> = (0..6)
+        .map(|i| {
+            paragraph(
+                &format!("Para{} three tokens.", i),
+                0,
+                700.0 - i as f64 * 20.0,
+                None,
+            )
+        })
+        .collect();
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 5,
+        overlap_tokens: 3,
+        merge_adjacent: true,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&elements);
+
+    assert!(!chunks.is_empty());
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+    assert_eq!(
+        chunks.len(),
+        elements.len(),
+        "each 3-token paragraph must become its own chunk under max_tokens=5"
+    );
+}
+
+// ─── Synthetic repro: merge_adjacent=false + overlap > 0 ─────────────────────
+
+#[test]
+fn synthetic_merge_disabled_with_overlap_still_disjoint() {
+    // merge_adjacent=false was previously the worst-case: every element
+    // triggered a flush, and the overlap branch copied the just-flushed
+    // element back into the buffer, so every chunk contained the prior
+    // element too.
+    let elements: Vec<Element> = (0..5)
+        .map(|i| {
+            paragraph(
+                &format!("Paragraph number {} with some words.", i),
+                0,
+                800.0 - i as f64 * 20.0,
+                Some("Section A"),
+            )
+        })
+        .collect();
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 20,
+        overlap_tokens: 5,
+        merge_adjacent: false,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&elements);
+
+    assert_eq!(
+        chunks.len(),
+        elements.len(),
+        "with merge disabled, chunker must emit exactly one chunk per element"
+    );
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+    for chunk in &chunks {
+        assert_eq!(
+            chunk.elements().len(),
+            1,
+            "with merge disabled, each chunk must contain exactly one element"
+        );
+        assert_eq!(chunk.heading_context.as_deref(), Some("Section A"));
+    }
+}
+
+// ─── End-to-end: build a PDF, parse it, chunk it ─────────────────────────────
+
+#[test]
+fn end_to_end_pdf_produces_disjoint_chunks() {
+    // Build a PDF: one page with a 16pt bold title + three 11pt body
+    // paragraphs. Parse it back via PdfDocument::rag_chunks() and assert
+    // disjointness on the resulting RagChunks.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 750.0)
+        .write("HEAD ALPHA")
+        .unwrap();
+
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 700.0)
+        .write("Para1 body paragraph alpha content line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 680.0)
+        .write("Para2 body paragraph bravo content line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 660.0)
+        .write("Para3 body paragraph charlie content line.")
+        .unwrap();
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+    assert!(!chunks.is_empty(), "must emit at least one chunk");
+
+    // Check disjointness pairwise on the RagChunk texts.
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let ti = &chunks[i].text;
+            let tj = &chunks[j].text;
+            assert!(
+                !tj.contains(ti.as_str()),
+                "rag chunk[{}].text is substring of rag chunk[{}].text:\n  i={:?}\n  j={:?}",
+                i,
+                j,
+                ti,
+                tj
+            );
+            assert!(
+                !ti.contains(tj.as_str()),
+                "rag chunk[{}].text is substring of rag chunk[{}].text:\n  i={:?}\n  j={:?}",
+                j,
+                i,
+                tj,
+                ti
+            );
+        }
+    }
+
+    // Each body paragraph's unique marker must appear in exactly one chunk.
+    for marker in &["alpha content", "bravo content", "charlie content"] {
+        let occurrences: usize = chunks.iter().filter(|c| c.text.contains(marker)).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker {:?} must appear in exactly one chunk, found in {}",
+            marker, occurrences
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/hybrid_chunking_graph_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_graph_test.rs
@@ -67,6 +67,18 @@ fn test_hybrid_chunk_with_graph_splits_large_section() {
     for chunk in &chunks {
         assert_eq!(chunk.heading_context.as_deref(), Some("Big Section"));
     }
+
+    // Each body paragraph must appear in exactly one chunk — the split must
+    // not duplicate content across chunks.
+    for i in 0..20 {
+        let needle = format!("paragraph {} with enough words", i);
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "body paragraph {} must appear in exactly one sub-chunk, found {}",
+            i, hits
+        );
+    }
 }
 
 #[test]
@@ -81,8 +93,30 @@ fn test_hybrid_chunk_with_graph_handles_preamble() {
     let chunker = HybridChunker::default();
     let chunks = chunker.chunk_with_graph(&elements, &graph);
 
-    // Should produce at least 2 chunks: preamble + section
     assert!(!chunks.is_empty());
+
+    // Preamble must appear in a chunk with no heading_context.
+    let preamble_chunk = chunks
+        .iter()
+        .find(|c| c.text().contains("Preamble text before any heading."));
+    assert!(preamble_chunk.is_some(), "preamble chunk must be present");
+    assert!(preamble_chunk.unwrap().heading_context.is_none());
+
+    // Section content must appear exactly once, in a chunk whose heading_context
+    // is "Section One". The preamble must not appear in that section chunk.
+    for marker in &["Preamble text before any heading.", "Section content here."] {
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(marker)).count();
+        assert_eq!(hits, 1, "{:?} must appear in exactly one chunk", marker);
+    }
+    let section_chunk = chunks
+        .iter()
+        .find(|c| c.text().contains("Section content here."))
+        .unwrap();
+    assert_eq!(
+        section_chunk.heading_context.as_deref(),
+        Some("Section One")
+    );
+    assert!(!section_chunk.text().contains("Preamble text"));
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -226,7 +226,10 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         .any(|e| matches!(e, Element::Table(_))));
 }
 
-// Cycle 6.7
+// Cycle 6.7 — with overlap_tokens > 0, chunks must still be element-disjoint.
+// Prior to the disjointness fix, overlap_tokens caused the flusher to re-inject
+// the just-flushed elements back into the working buffer, producing chunks that
+// each contained a prefix of the previous chunk (quadratic content duplication).
 #[test]
 fn test_overlap_chunks_preserve_heading_context() {
     let elements: Vec<Element> = (0..20)
@@ -252,6 +255,32 @@ fn test_overlap_chunks_preserve_heading_context() {
     assert!(chunks.len() > 1);
     for chunk in &chunks {
         assert_eq!(chunk.heading_context.as_deref(), Some("Section A"));
+    }
+
+    // Every paragraph must appear in exactly one chunk.
+    for i in 0..20 {
+        let needle = format!("Paragraph number {} with", i);
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "paragraph {} must appear in exactly one chunk, found {}",
+            i, hits
+        );
+    }
+
+    // No chunk's text may be a substring of another's.
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let (a, b) = (chunks[i].text(), chunks[j].text());
+            assert!(
+                !b.contains(&a) && !a.contains(&b),
+                "chunks [{}] and [{}] overlap:\n  a={:?}\n  b={:?}",
+                i,
+                j,
+                a,
+                b
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `HybridChunker::chunk()` was emitting overlapping chunks: every flush re-injected the just-flushed elements back into the working buffer via the `overlap_tokens` branch of `flush_buffer`. For a one-page document with a title and three paragraphs the chunker produced `[title]` then `[title, p1, p2, p3]` — the title appeared in both chunks. For N elements the total chunk content grew O(N²), making `PdfDocument::rag_chunks()` unusable for vector-store ingestion (`oxidize-python 0.4.2`, `oxidize-pdf-dotnet`, and the `llama-index-readers-oxidize-pdf` bridge all depend on this output).
- Fix removes the element-reinjection branch from `flush_buffer`. `overlap_tokens` stays in the config for API compatibility and is documented as reserved for a future text-level overlap (element-level overlap is fundamentally incompatible with the chunker's disjointness contract — overlap in RAG is a text-level concept, not a structural one).
- Three previously shape-only tests that were silently passing under the buggy behaviour are hardened to assert disjointness + coverage on real chunk content.

## Test plan

- [x] `tests/hybrid_chunker_disjoint_test.rs` added (committed BEFORE the fix in `69e44d9`): four scenarios covering title + paragraphs under default config, size-overflow flushes, `merge_adjacent=false` with `overlap_tokens>0`, and an end-to-end PDF built programmatically → parsed → chunked via `rag_chunks()`. All four FAIL on develop and PASS on `9a3e80e`.
- [x] Hardened `test_overlap_chunks_preserve_heading_context`, `test_hybrid_chunk_with_graph_splits_large_section`, and `test_hybrid_chunk_with_graph_handles_preamble` — each now asserts each source paragraph appears in exactly one chunk and no chunk's text is a substring of another's.
- [x] Chunker integration suites all pass: `hybrid_chunking_test` (13), `hybrid_chunking_graph_test` (4), `hybrid_chunking_v2_test` (11), `rag_chunk_test` (7), `rag_pipeline_test` (6), `hybrid_chunker_disjoint_test` (4).
- [x] `cargo test --lib` — 6312/6312 pass. (One unrelated flaky timing test — `text::metrics::tests::test_create_default_custom_metrics_is_cached`, hardware-sensitive — fires under parallel load, passes in isolation; not touched by this change.)
- [x] `cargo clippy --lib -- -D warnings` clean. `cargo clippy` on touched test files clean. (Pre-existing clippy warnings on develop unrelated to this PR live in `iso_curation_validation_tests` and `memory_optimization_integration`; not addressed here.)
- [x] `CHANGELOG.md` updated under `[Unreleased]`. Version NOT bumped — release to be cut separately.

## Downstream

After this lands in a crate release, `oxidize-python`, `oxidize-pdf-dotnet`, and `llama-index-readers-oxidize-pdf` will each need a new release pulling in the fix before advertising "RAG-ready" chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)