### PR TITLE
release: merge develop → main (2.5.5 catalog fixes + chunker disjointness fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [Unreleased]
-
-### Fixed
-- **`HybridChunker::chunk()` now emits element-disjoint chunks** — prior to this release the chunker accumulated content across emissions: any flush (type boundary, `merge_adjacent=false`, or size overflow) re-injected the just-flushed elements back into the working buffer via the `overlap_tokens` branch of `flush_buffer`. The consequence was that each emitted chunk contained a prefix of the previous chunk. For a one-page document with a title followed by three paragraphs the chunker produced `[title]` and `[title, p1, p2, p3]` instead of a single merged chunk (or two disjoint chunks). This made `PdfDocument::rag_chunks()` output unusable for vector-store ingestion: content was duplicated quadratically in document size. `flush_buffer` now empties the buffer unconditionally and never reinjects elements. Element-level overlap was incompatible with the RAG disjointness invariant; the `overlap_tokens` config field is preserved for API compatibility but is currently a no-op (reserved for a future text-level overlap implementation).
-- Hardened three previously shape-only tests (`test_overlap_chunks_preserve_heading_context`, `test_hybrid_chunk_with_graph_splits_large_section`, `test_hybrid_chunk_with_graph_handles_preamble`) to assert pairwise chunk-text disjointness and that each source paragraph appears in exactly one chunk.
-
-### Added
-- `tests/hybrid_chunker_disjoint_test.rs` — four regression scenarios covering the accumulating-chunks bug: title+paragraphs under default config, size-overflow flushes, `merge_adjacent=false` with `overlap_tokens>0`, and an end-to-end PDF generated programmatically, parsed back, and chunked via `rag_chunks()`.
-
 ## [2.5.5] - 2026-04-21
 
 ### Fixed
@@ -23,12 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/Names` (named destinations) now reaches the PDF catalog** — `Document::set_named_destinations()` stored a `NamedDestinations` wrapper but the catalog never referenced it, so no reader could resolve named destinations (ISO 32000-1 §7.7.2 Table 28, §7.7.4 Table 31, §12.3.2.3). The writer now emits the name tree and a Name Dictionary as indirect objects and references the Name Dictionary from `/Names`.
 - **`/PageLabels` now reaches the PDF catalog** — `Document::set_page_labels()` stored a `PageLabelTree` but the catalog never referenced it, so custom page numbering was dropped (ISO 32000-1 §7.7.2 Table 28, §12.4.2). The number tree is now written as an indirect object.
 - **Page label dictionaries emit `/S` (numbering style) per spec** — `PageLabel::to_dict()` previously emitted the style under `/Type` (e.g. `/Type /D`). Per ISO 32000-1 §12.4.2 Table 159 the numbering style shall be carried by `/S`; `/Type`, when present, shall be the constant name `PageLabel`. The writer now emits `/Type /PageLabel` + `/S /<style>`, so conforming viewers actually recognise the numbering style. `PageLabel::from_dict()` prefers `/S` and tolerates legacy `/Type`-carrying-style dicts for backward-compatible round-trip.
+- **`HybridChunker::chunk()` now emits element-disjoint chunks** — the chunker was accumulating content across emissions: any flush (type boundary, `merge_adjacent=false`, or size overflow) re-injected the just-flushed elements back into the working buffer via the `overlap_tokens` branch of `flush_buffer`. The consequence was that each emitted chunk contained a prefix of the previous chunk. For a one-page document with a title followed by three paragraphs the chunker produced `[title]` and `[title, p1, p2, p3]` instead of a single merged chunk (or two disjoint chunks). This made `PdfDocument::rag_chunks()` output unusable for vector-store ingestion: content was duplicated quadratically in document size. `flush_buffer` now empties the buffer unconditionally and never reinjects elements. Element-level overlap was incompatible with the RAG disjointness invariant; the `overlap_tokens` config field is preserved for API compatibility but is currently a no-op (reserved for a future text-level overlap implementation).
+- Hardened three previously shape-only chunker tests (`test_overlap_chunks_preserve_heading_context`, `test_hybrid_chunk_with_graph_splits_large_section`, `test_hybrid_chunk_with_graph_handles_preamble`) to assert pairwise chunk-text disjointness and that each source paragraph appears in exactly one chunk.
 
 ### Added
 - `src/writer/pdf_writer/tests/catalog_entries_tests.rs` — 5 content-verifying TDD tests that serialise a real `Document` and assert each catalog entry (plus the characteristic payload: `/S /GoTo`, `/HideToolbar true`, `(target)` name tree key, `/S /D`) reaches the PDF bytes. Includes a combined-entry regression guarding against future refactors that could drop one entry while keeping the others.
+- `tests/hybrid_chunker_disjoint_test.rs` — four regression scenarios covering the accumulating-chunks bug: title+paragraphs under default config, size-overflow flushes, `merge_adjacent=false` with `overlap_tokens>0`, and an end-to-end PDF generated programmatically, parsed back, and chunked via `rag_chunks()`.
 
 ### Impact
-The C# wrapper `oxidize-pdf-dotnet` (and any other binding) can now expose these four catalog features; previously the setters accepted values that were silently discarded during serialisation.
+The C# wrapper `oxidize-pdf-dotnet` (and any other binding) can now expose these four catalog features; previously the setters accepted values that were silently discarded during serialisation. RAG consumers of `PdfDocument::rag_chunks()` (`oxidize-python`, `llama-index-readers-oxidize-pdf`) will produce correct, non-duplicating chunk output for vector stores.
 
 ## [2.5.4] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [2.5.5] - 2026-04-21
+
+### Fixed
+- **`/OpenAction` now reaches the PDF catalog** — `Document::set_open_action()` was stored on the document but `write_catalog()` in `pdf_writer/mod.rs` never serialised it (ISO 32000-1 §7.7.2 Table 28). Now emitted as an inline action dictionary via `Action::to_dict()`.
+- **`/ViewerPreferences` now reaches the PDF catalog** — same bug class as `/OpenAction`. The preference dictionary (HideToolbar, PageLayout, Direction, etc.) was built by `Document::set_viewer_preferences()` but dropped on write (ISO 32000-1 §7.7.2 Table 28, §12.2). Now emitted as an inline dictionary via `ViewerPreferences::to_dict()`.
+- **`/Names` (named destinations) now reaches the PDF catalog** — `Document::set_named_destinations()` stored a `NamedDestinations` wrapper but the catalog never referenced it, so no reader could resolve named destinations (ISO 32000-1 §7.7.2 Table 28, §7.7.4 Table 31, §12.3.2.3). The writer now emits the name tree and a Name Dictionary as indirect objects and references the Name Dictionary from `/Names`.
+- **`/PageLabels` now reaches the PDF catalog** — `Document::set_page_labels()` stored a `PageLabelTree` but the catalog never referenced it, so custom page numbering was dropped (ISO 32000-1 §7.7.2 Table 28, §12.4.2). The number tree is now written as an indirect object.
+- **Page label dictionaries emit `/S` (numbering style) per spec** — `PageLabel::to_dict()` previously emitted the style under `/Type` (e.g. `/Type /D`). Per ISO 32000-1 §12.4.2 Table 159 the numbering style shall be carried by `/S`; `/Type`, when present, shall be the constant name `PageLabel`. The writer now emits `/Type /PageLabel` + `/S /<style>`, so conforming viewers actually recognise the numbering style. `PageLabel::from_dict()` prefers `/S` and tolerates legacy `/Type`-carrying-style dicts for backward-compatible round-trip.
+
+### Added
+- `src/writer/pdf_writer/tests/catalog_entries_tests.rs` — 5 content-verifying TDD tests that serialise a real `Document` and assert each catalog entry (plus the characteristic payload: `/S /GoTo`, `/HideToolbar true`, `(target)` name tree key, `/S /D`) reaches the PDF bytes. Includes a combined-entry regression guarding against future refactors that could drop one entry while keeping the others.
+
+### Impact
+The C# wrapper `oxidize-pdf-dotnet` (and any other binding) can now expose these four catalog features; previously the setters accepted values that were silently discarded during serialisation.
+
 ## [2.5.4] - 2026-04-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+- **`HybridChunker::chunk()` now emits element-disjoint chunks** — prior to this release the chunker accumulated content across emissions: any flush (type boundary, `merge_adjacent=false`, or size overflow) re-injected the just-flushed elements back into the working buffer via the `overlap_tokens` branch of `flush_buffer`. The consequence was that each emitted chunk contained a prefix of the previous chunk. For a one-page document with a title followed by three paragraphs the chunker produced `[title]` and `[title, p1, p2, p3]` instead of a single merged chunk (or two disjoint chunks). This made `PdfDocument::rag_chunks()` output unusable for vector-store ingestion: content was duplicated quadratically in document size. `flush_buffer` now empties the buffer unconditionally and never reinjects elements. Element-level overlap was incompatible with the RAG disjointness invariant; the `overlap_tokens` config field is preserved for API compatibility but is currently a no-op (reserved for a future text-level overlap implementation).
+- Hardened three previously shape-only tests (`test_overlap_chunks_preserve_heading_context`, `test_hybrid_chunk_with_graph_splits_large_section`, `test_hybrid_chunk_with_graph_handles_preamble`) to assert pairwise chunk-text disjointness and that each source paragraph appears in exactly one chunk.
+
+### Added
+- `tests/hybrid_chunker_disjoint_test.rs` — four regression scenarios covering the accumulating-chunks bug: title+paragraphs under default config, size-overflow flushes, `merge_adjacent=false` with `overlap_tokens>0`, and an end-to-end PDF generated programmatically, parsed back, and chunked via `rag_chunks()`.
+
 ## [2.5.5] - 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/page_labels/page_label.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label.rs
@@ -129,11 +129,20 @@ impl PageLabel {
     }
 
     /// Convert to PDF dictionary
+    ///
+    /// Encodes the label per ISO 32000-1 §12.4.2 Table 159:
+    /// - `/Type` — optional name, when present shall be `PageLabel`.
+    /// - `/S`    — numbering style (`D`/`R`/`r`/`A`/`a`); absent when the
+    ///            label has no numeric portion (style `None`).
+    /// - `/P`    — optional prefix string.
+    /// - `/St`   — optional integer starting value (default 1).
     pub fn to_dict(&self) -> Dictionary {
         let mut dict = Dictionary::new();
 
-        if let Some(type_name) = self.style.to_pdf_name() {
-            dict.set("Type", Object::Name(type_name.to_string()));
+        dict.set("Type", Object::Name("PageLabel".to_string()));
+
+        if let Some(style_name) = self.style.to_pdf_name() {
+            dict.set("S", Object::Name(style_name.to_string()));
         }
 
         if let Some(prefix) = &self.prefix {
@@ -283,9 +292,15 @@ mod tests {
 
     #[test]
     fn test_to_dict() {
+        // Per ISO 32000-1 §12.4.2 Table 159, the numbering style is /S (not
+        // /Type). /Type is optional and must be PageLabel when present.
         let label = PageLabel::decimal();
         let dict = label.to_dict();
-        assert_eq!(dict.get("Type"), Some(&Object::Name("D".to_string())));
+        assert_eq!(
+            dict.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict.get("S"), Some(&Object::Name("D".to_string())));
         assert!(dict.get("P").is_none());
         assert!(dict.get("St").is_none());
 
@@ -293,7 +308,11 @@ mod tests {
             .with_prefix("p. ")
             .starting_at(5);
         let dict = label.to_dict();
-        assert_eq!(dict.get("Type"), Some(&Object::Name("R".to_string())));
+        assert_eq!(
+            dict.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict.get("S"), Some(&Object::Name("R".to_string())));
         assert_eq!(dict.get("P"), Some(&Object::String("p. ".to_string())));
         assert_eq!(dict.get("St"), Some(&Object::Integer(5)));
     }
@@ -451,7 +470,11 @@ mod tests {
         // Test dictionary generation with all combinations
         let label1 = PageLabel::new(PageLabelStyle::DecimalArabic);
         let dict1 = label1.to_dict();
-        assert_eq!(dict1.get("Type"), Some(&Object::Name("D".to_string())));
+        assert_eq!(
+            dict1.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict1.get("S"), Some(&Object::Name("D".to_string())));
         assert!(dict1.get("P").is_none()); // No prefix
         assert!(dict1.get("St").is_none()); // Default start (1)
 
@@ -459,17 +482,26 @@ mod tests {
             .with_prefix("Section ")
             .starting_at(10);
         let dict2 = label2.to_dict();
-        assert_eq!(dict2.get("Type"), Some(&Object::Name("A".to_string())));
+        assert_eq!(
+            dict2.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert_eq!(dict2.get("S"), Some(&Object::Name("A".to_string())));
         assert_eq!(
             dict2.get("P"),
             Some(&Object::String("Section ".to_string()))
         );
         assert_eq!(dict2.get("St"), Some(&Object::Integer(10)));
 
-        // Test prefix-only (no Type field)
+        // Prefix-only dicts still carry /Type PageLabel (§12.4.2 recommends
+        // it), but have no /S entry because the numbering style is None.
         let label3 = PageLabel::prefix_only("Index");
         let dict3 = label3.to_dict();
-        assert!(dict3.get("Type").is_none());
+        assert_eq!(
+            dict3.get("Type"),
+            Some(&Object::Name("PageLabel".to_string()))
+        );
+        assert!(dict3.get("S").is_none());
         assert_eq!(dict3.get("P"), Some(&Object::String("Index".to_string())));
     }
 

--- a/oxidize-pdf-core/src/page_labels/page_label_tree.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label_tree.rs
@@ -94,18 +94,24 @@ impl PageLabelTree {
                 _ => continue,
             };
 
-            // Parse label from dictionary
-            let style = if let Some(Object::Name(type_name)) = label_dict.get("Type") {
-                match type_name.as_str() {
-                    "D" => PageLabelStyle::DecimalArabic,
-                    "r" => PageLabelStyle::UppercaseRoman,
-                    "R" => PageLabelStyle::LowercaseRoman,
-                    "A" => PageLabelStyle::UppercaseLetters,
-                    "a" => PageLabelStyle::LowercaseLetters,
-                    _ => PageLabelStyle::None,
-                }
-            } else {
-                PageLabelStyle::None
+            // Parse numbering style per ISO 32000-1 §12.4.2 Table 159.
+            // Spec key is /S; accept a legacy /Type-carrying-style as a
+            // tolerant fallback so documents written by older versions of
+            // this crate still round-trip.
+            let style_name = match label_dict.get("S") {
+                Some(Object::Name(s)) => Some(s.as_str()),
+                _ => match label_dict.get("Type") {
+                    Some(Object::Name(t)) if t != "PageLabel" => Some(t.as_str()),
+                    _ => None,
+                },
+            };
+            let style = match style_name {
+                Some("D") => PageLabelStyle::DecimalArabic,
+                Some("r") => PageLabelStyle::UppercaseRoman,
+                Some("R") => PageLabelStyle::LowercaseRoman,
+                Some("A") => PageLabelStyle::UppercaseLetters,
+                Some("a") => PageLabelStyle::LowercaseLetters,
+                _ => PageLabelStyle::None,
             };
 
             let mut label = PageLabel::new(style);

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -51,7 +51,15 @@ pub enum MergePolicy {
 pub struct HybridChunkConfig {
     /// Maximum tokens per chunk (approximate — uses word count as proxy).
     pub max_tokens: usize,
-    /// Number of overlap tokens between consecutive chunks.
+    /// Reserved for future text-level overlap. Currently ignored.
+    ///
+    /// Prior versions used this to copy elements from the end of a flushed
+    /// chunk back into the working buffer, which produced chunks with
+    /// overlapping element sets and violated the disjointness invariant
+    /// required by RAG ingestion (see
+    /// `tests/hybrid_chunker_disjoint_test.rs`). The field is preserved for
+    /// API compatibility; if a text-level overlap is reintroduced later it
+    /// will honor this value.
     pub overlap_tokens: usize,
     /// Whether to merge adjacent elements of the same type (Paragraph+Paragraph, ListItem+ListItem).
     pub merge_adjacent: bool,
@@ -337,32 +345,17 @@ impl HybridChunker {
         buffer_tokens: &mut usize,
         buffer_heading: &mut Option<String>,
     ) {
+        // Emit the accumulated buffer as a single chunk and reset all
+        // accumulation state. The chunker's contract is that its emitted
+        // chunks are element-disjoint — every source Element appears in
+        // exactly one chunk. Re-injecting flushed elements back into the
+        // buffer (as the old "overlap_tokens" branch did) would violate
+        // that contract and, under type-boundary flushes, duplicates the
+        // whole just-emitted chunk into the next one. See the regression
+        // suite in tests/hybrid_chunker_disjoint_test.rs.
         let flushed = std::mem::take(buffer);
         let heading = buffer_heading.take();
-
-        // Compute overlap BEFORE moving flushed into the chunk (avoids clone)
-        if self.config.overlap_tokens > 0 {
-            let mut overlap_tokens = 0usize;
-            let mut overlap_elements = Vec::new();
-
-            for elem in flushed.iter().rev() {
-                let t = estimate_tokens(&elem.display_text());
-                if overlap_tokens + t > self.config.overlap_tokens && !overlap_elements.is_empty() {
-                    break;
-                }
-                overlap_elements.push(elem.clone());
-                overlap_tokens += t;
-            }
-
-            overlap_elements.reverse();
-            *buffer = overlap_elements;
-            *buffer_tokens = overlap_tokens;
-            if let Some(first) = buffer.first() {
-                *buffer_heading = first.metadata().parent_heading.clone();
-            }
-        } else {
-            *buffer_tokens = 0;
-        }
+        *buffer_tokens = 0;
 
         chunks.push(HybridChunk {
             elements: flushed,

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -930,6 +930,11 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("OpenAction", Object::Dictionary(action.to_dict()));
         }
 
+        // /ViewerPreferences — ISO 32000-1 §7.7.2 Table 28, detailed in §12.2
+        if let Some(prefs) = &document.viewer_preferences {
+            catalog.set("ViewerPreferences", Object::Dictionary(prefs.to_dict()));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -925,6 +925,11 @@ impl<W: Write> PdfWriter<W> {
         // Reference it in catalog
         catalog.set("Metadata", Object::Reference(metadata_id));
 
+        // /OpenAction — ISO 32000-1 §7.7.2 Table 28
+        if let Some(action) = &document.open_action {
+            catalog.set("OpenAction", Object::Dictionary(action.to_dict()));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -951,6 +951,15 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("Names", Object::Reference(names_dict_id));
         }
 
+        // /PageLabels — ISO 32000-1 §7.7.2 Table 28, §12.4.2.
+        // The value is a number tree; we emit it as an indirect object so
+        // large documents can grow without reshuffling the catalog.
+        if let Some(page_labels) = &document.page_labels {
+            let labels_id = self.allocate_object_id();
+            self.write_object(labels_id, Object::Dictionary(page_labels.to_dict()))?;
+            catalog.set("PageLabels", Object::Reference(labels_id));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -935,6 +935,22 @@ impl<W: Write> PdfWriter<W> {
             catalog.set("ViewerPreferences", Object::Dictionary(prefs.to_dict()));
         }
 
+        // /Names — ISO 32000-1 §7.7.4 Table 31 (Name Dictionary).
+        // The /Dests sub-entry is the name tree for named destinations
+        // (§12.3.2.3). Both the name tree and the Name Dictionary are
+        // written as indirect objects.
+        if let Some(named_dests) = &document.named_destinations {
+            let dests_tree_id = self.allocate_object_id();
+            self.write_object(dests_tree_id, Object::Dictionary(named_dests.to_dict()))?;
+
+            let mut names_dict = Dictionary::new();
+            names_dict.set("Dests", Object::Reference(dests_tree_id));
+            let names_dict_id = self.allocate_object_id();
+            self.write_object(names_dict_id, Object::Dictionary(names_dict))?;
+
+            catalog.set("Names", Object::Reference(names_dict_id));
+        }
+
         self.write_object(catalog_id, Object::Dictionary(catalog))?;
         Ok(())
     }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
@@ -4303,5 +4303,6 @@ mod comprehensive_tests {
     }
 }
 
+mod catalog_entries_tests;
 mod form_filling_tests;
 mod incremental_update_tests;

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -96,6 +96,47 @@ mod catalog_entries_tests {
     }
 
     #[test]
+    fn test_write_catalog_includes_all_four_entries_simultaneously() {
+        // Regression: the four catalog entries are emitted as independent
+        // `if let` blocks, so a bug in one could suppress another. This
+        // test exercises the full cross-product by enabling all four
+        // features on the same Document and asserts each entry — and its
+        // characteristic payload — survives serialisation.
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+
+        document.set_open_action(Action::goto(Destination::fit(PageDestination::PageNumber(
+            0,
+        ))));
+        document.set_viewer_preferences(ViewerPreferences::new().hide_toolbar(true));
+        let mut dests = NamedDestinations::new();
+        dests.add_destination(
+            "combined-target".to_string(),
+            Destination::fit(PageDestination::PageNumber(0)).to_array(),
+        );
+        document.set_named_destinations(dests);
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::new(PageLabelStyle::DecimalArabic));
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        // OpenAction
+        assert!(content.contains("/OpenAction"));
+        assert!(content.contains("/S /GoTo"));
+        // ViewerPreferences
+        assert!(content.contains("/ViewerPreferences"));
+        assert!(content.contains("/HideToolbar true"));
+        // Names (named destinations)
+        assert!(content.contains("/Names"));
+        assert!(content.contains("/Dests"));
+        assert!(content.contains("(combined-target)"));
+        // PageLabels
+        assert!(content.contains("/PageLabels"));
+        assert!(content.contains("/S /D"));
+    }
+
+    #[test]
     fn test_write_catalog_includes_page_labels() {
         let mut document = Document::new();
         document.add_page(Page::a4());

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -1,0 +1,45 @@
+// Rigorous tests for catalog entries emitted by write_catalog().
+// Covers ISO 32000-1 §7.7.2 entries that Document exposes via setters:
+//   /OpenAction, /ViewerPreferences, /Names (Dests), /PageLabels.
+//
+// NO SMOKE TESTS — every test serialises a real Document and inspects the
+// bytes to verify the catalog entry is present with the expected shape.
+
+#[cfg(test)]
+mod catalog_entries_tests {
+    use crate::actions::Action;
+    use crate::document::Document;
+    use crate::page::Page;
+    use crate::structure::{Destination, PageDestination};
+    use crate::writer::PdfWriter;
+
+    fn serialize(document: &mut Document) -> String {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = PdfWriter::new_with_writer(&mut buffer);
+            writer.write_document(document).unwrap();
+        }
+        String::from_utf8_lossy(&buffer).into_owned()
+    }
+
+    #[test]
+    fn test_write_catalog_includes_open_action() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.set_open_action(Action::goto(Destination::fit(PageDestination::PageNumber(
+            0,
+        ))));
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/OpenAction"),
+            "catalog should emit /OpenAction when Document::open_action is set"
+        );
+        // GoTo action dict must carry /S /GoTo per ISO 32000-1 §12.6.4.2
+        assert!(
+            content.contains("/S /GoTo"),
+            "open action dict should serialize as a /GoTo action (/S /GoTo)"
+        );
+    }
+}

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -10,6 +10,7 @@ mod catalog_entries_tests {
     use crate::actions::Action;
     use crate::document::Document;
     use crate::page::Page;
+    use crate::page_labels::{PageLabel, PageLabelStyle, PageLabelTree};
     use crate::structure::{Destination, NamedDestinations, PageDestination};
     use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
@@ -91,6 +92,30 @@ mod catalog_entries_tests {
             content.contains("(target)"),
             "named destination key should appear as a string in the name tree \
              (expected (target))"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_page_labels() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::new(PageLabelStyle::DecimalArabic));
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        // /PageLabels in the catalog is a number tree (ISO 32000-1 §7.7.2
+        // Table 28, §12.4.2).
+        assert!(
+            content.contains("/PageLabels"),
+            "catalog should emit /PageLabels when set on Document"
+        );
+        // Per ISO 32000-1 §12.4.2 Table 159 the numbering style entry is
+        // named /S (not /Type).
+        assert!(
+            content.contains("/S /D"),
+            "decimal page label dict should serialise as /S /D per spec"
         );
     }
 }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -10,7 +10,7 @@ mod catalog_entries_tests {
     use crate::actions::Action;
     use crate::document::Document;
     use crate::page::Page;
-    use crate::structure::{Destination, PageDestination};
+    use crate::structure::{Destination, NamedDestinations, PageDestination};
     use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
 
@@ -59,6 +59,38 @@ mod catalog_entries_tests {
         assert!(
             content.contains("/HideToolbar true"),
             "viewer prefs dict should serialize /HideToolbar true (ISO 32000-1 §12.2)"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_named_destinations() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut dests = NamedDestinations::new();
+        dests.add_destination(
+            "target".to_string(),
+            Destination::fit(PageDestination::PageNumber(0)).to_array(),
+        );
+        document.set_named_destinations(dests);
+
+        let content = serialize(&mut document);
+
+        // /Names in the catalog is a Name Dictionary (ISO 32000-1 §7.7.4,
+        // Table 31). Its /Dests entry is the name tree for named
+        // destinations (§12.3.2.3).
+        assert!(
+            content.contains("/Names"),
+            "catalog should emit /Names when named destinations are set"
+        );
+        assert!(
+            content.contains("/Dests"),
+            "/Names dictionary must contain /Dests for named destinations"
+        );
+        // The name tree leaf exposes the entry key as a string literal.
+        assert!(
+            content.contains("(target)"),
+            "named destination key should appear as a string in the name tree \
+             (expected (target))"
         );
     }
 }

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -11,6 +11,7 @@ mod catalog_entries_tests {
     use crate::document::Document;
     use crate::page::Page;
     use crate::structure::{Destination, PageDestination};
+    use crate::viewer_preferences::ViewerPreferences;
     use crate::writer::PdfWriter;
 
     fn serialize(document: &mut Document) -> String {
@@ -40,6 +41,24 @@ mod catalog_entries_tests {
         assert!(
             content.contains("/S /GoTo"),
             "open action dict should serialize as a /GoTo action (/S /GoTo)"
+        );
+    }
+
+    #[test]
+    fn test_write_catalog_includes_viewer_preferences() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.set_viewer_preferences(ViewerPreferences::new().hide_toolbar(true));
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/ViewerPreferences"),
+            "catalog should emit /ViewerPreferences when set on Document"
+        );
+        assert!(
+            content.contains("/HideToolbar true"),
+            "viewer prefs dict should serialize /HideToolbar true (ISO 32000-1 §12.2)"
         );
     }
 }

--- a/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
@@ -1,0 +1,303 @@
+//! Regression tests for `HybridChunker::chunk()` disjointness.
+//!
+//! The chunker MUST emit chunks whose element lists are pairwise disjoint:
+//! the same source `Element` may not appear in two chunks, and the
+//! concatenation of all chunks' element lists must equal the input element
+//! list (modulo sentence-splitting of oversized paragraphs, which are
+//! regenerated from source text and therefore do not share identity with
+//! any input element).
+//!
+//! These tests exercise the bug that was observed on v2.5.4, where every
+//! non-size-overflow flush re-injected the just-flushed elements back into
+//! the working buffer via the "overlap" branch in `flush_buffer()`. The
+//! consequence was quadratic content duplication: each chunk i+1 contained
+//! a prefix of chunk i, making the output unusable for RAG ingestion.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{
+    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+    MergePolicy,
+};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+// ─── Helpers to build synthetic elements ─────────────────────────────────────
+
+fn title(text: &str, page: u32, y: f64) -> Element {
+    Element::Title(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(50.0, y, 500.0, 18.0),
+            parent_heading: Some(text.to_string()),
+            ..Default::default()
+        },
+    })
+}
+
+fn paragraph(text: &str, page: u32, y: f64, heading: Option<&str>) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata {
+            page,
+            bbox: ElementBBox::new(50.0, y, 500.0, 12.0),
+            parent_heading: heading.map(String::from),
+            ..Default::default()
+        },
+    })
+}
+
+// Return the textual "identity" of an element so we can detect duplicates
+// without relying on object identity. For Paragraph/Title/Header/etc. this
+// is the raw text; for tables/images it is a type-tag + bbox snapshot.
+fn element_identity(e: &Element) -> String {
+    let bbox = e.bbox();
+    format!(
+        "{}|p={}|x={:.1}|y={:.1}|w={:.1}|h={:.1}|t={}",
+        e.type_name(),
+        e.page(),
+        bbox.x,
+        bbox.y,
+        bbox.width,
+        bbox.height,
+        e.display_text()
+    )
+}
+
+fn assert_chunks_disjoint(chunks: &[oxidize_pdf::pipeline::HybridChunk]) {
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let ti = chunks[i].text();
+            let tj = chunks[j].text();
+            assert!(
+                !ti.is_empty() && !tj.is_empty(),
+                "chunks must have non-empty text"
+            );
+            assert!(
+                !tj.contains(&ti),
+                "chunk[{}].text() is a substring of chunk[{}].text():\n  i={:?}\n  j={:?}",
+                i,
+                j,
+                ti,
+                tj
+            );
+            assert!(
+                !ti.contains(&tj),
+                "chunk[{}].text() is a substring of chunk[{}].text():\n  i={:?}\n  j={:?}",
+                j,
+                i,
+                tj,
+                ti
+            );
+        }
+    }
+}
+
+fn assert_coverage_equals_input(chunks: &[oxidize_pdf::pipeline::HybridChunk], input: &[Element]) {
+    let mut input_ids: Vec<String> = input.iter().map(element_identity).collect();
+    input_ids.sort();
+
+    let mut chunk_ids: Vec<String> = chunks
+        .iter()
+        .flat_map(|c| c.elements().iter().map(element_identity))
+        .collect();
+    chunk_ids.sort();
+
+    assert_eq!(
+        chunk_ids, input_ids,
+        "concat of chunk elements must equal input element list (no duplication, no loss)"
+    );
+}
+
+// ─── Synthetic repro: Title + paragraphs, default config (overlap > 0) ───────
+
+#[test]
+fn synthetic_title_then_paragraphs_emits_disjoint_chunks() {
+    // Default config: max_tokens=512, overlap_tokens=50, merge_adjacent=true,
+    // merge_policy=AnyInlineContent. Title + three paragraphs trivially fit
+    // under max_tokens, so the output must contain each source element
+    // exactly once across all chunks.
+    let elements = vec![
+        title("HEAD ALPHA", 0, 750.0),
+        paragraph("Para1 words words words.", 0, 720.0, Some("HEAD ALPHA")),
+        paragraph("Para2 words words words.", 0, 700.0, Some("HEAD ALPHA")),
+        paragraph("Para3 words words words.", 0, 680.0, Some("HEAD ALPHA")),
+    ];
+
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+
+    assert!(!chunks.is_empty(), "must produce at least one chunk");
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+
+    // Spec also accepts a single merged chunk as correct. Verify we never
+    // produce more chunks than source elements (which would mean duplication).
+    assert!(
+        chunks.len() <= elements.len(),
+        "chunk count ({}) must not exceed element count ({}) — excess indicates leaked overlap",
+        chunks.len(),
+        elements.len()
+    );
+}
+
+// ─── Synthetic repro: size overflow with merge enabled ───────────────────────
+
+#[test]
+fn synthetic_overflow_flushes_emit_disjoint_chunks() {
+    // Small max_tokens forces multiple overflow flushes. Each paragraph is
+    // ~3 tokens; max_tokens=5 means at most one paragraph per chunk. Prior
+    // to the fix, the overlap branch re-injected the last flushed paragraph
+    // back into the buffer, causing each chunk to contain the previous
+    // paragraph as well.
+    let elements: Vec<Element> = (0..6)
+        .map(|i| {
+            paragraph(
+                &format!("Para{} three tokens.", i),
+                0,
+                700.0 - i as f64 * 20.0,
+                None,
+            )
+        })
+        .collect();
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 5,
+        overlap_tokens: 3,
+        merge_adjacent: true,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&elements);
+
+    assert!(!chunks.is_empty());
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+    assert_eq!(
+        chunks.len(),
+        elements.len(),
+        "each 3-token paragraph must become its own chunk under max_tokens=5"
+    );
+}
+
+// ─── Synthetic repro: merge_adjacent=false + overlap > 0 ─────────────────────
+
+#[test]
+fn synthetic_merge_disabled_with_overlap_still_disjoint() {
+    // merge_adjacent=false was previously the worst-case: every element
+    // triggered a flush, and the overlap branch copied the just-flushed
+    // element back into the buffer, so every chunk contained the prior
+    // element too.
+    let elements: Vec<Element> = (0..5)
+        .map(|i| {
+            paragraph(
+                &format!("Paragraph number {} with some words.", i),
+                0,
+                800.0 - i as f64 * 20.0,
+                Some("Section A"),
+            )
+        })
+        .collect();
+
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 20,
+        overlap_tokens: 5,
+        merge_adjacent: false,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&elements);
+
+    assert_eq!(
+        chunks.len(),
+        elements.len(),
+        "with merge disabled, chunker must emit exactly one chunk per element"
+    );
+    assert_chunks_disjoint(&chunks);
+    assert_coverage_equals_input(&chunks, &elements);
+    for chunk in &chunks {
+        assert_eq!(
+            chunk.elements().len(),
+            1,
+            "with merge disabled, each chunk must contain exactly one element"
+        );
+        assert_eq!(chunk.heading_context.as_deref(), Some("Section A"));
+    }
+}
+
+// ─── End-to-end: build a PDF, parse it, chunk it ─────────────────────────────
+
+#[test]
+fn end_to_end_pdf_produces_disjoint_chunks() {
+    // Build a PDF: one page with a 16pt bold title + three 11pt body
+    // paragraphs. Parse it back via PdfDocument::rag_chunks() and assert
+    // disjointness on the resulting RagChunks.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 750.0)
+        .write("HEAD ALPHA")
+        .unwrap();
+
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 700.0)
+        .write("Para1 body paragraph alpha content line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 680.0)
+        .write("Para2 body paragraph bravo content line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 660.0)
+        .write("Para3 body paragraph charlie content line.")
+        .unwrap();
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+    assert!(!chunks.is_empty(), "must emit at least one chunk");
+
+    // Check disjointness pairwise on the RagChunk texts.
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let ti = &chunks[i].text;
+            let tj = &chunks[j].text;
+            assert!(
+                !tj.contains(ti.as_str()),
+                "rag chunk[{}].text is substring of rag chunk[{}].text:\n  i={:?}\n  j={:?}",
+                i,
+                j,
+                ti,
+                tj
+            );
+            assert!(
+                !ti.contains(tj.as_str()),
+                "rag chunk[{}].text is substring of rag chunk[{}].text:\n  i={:?}\n  j={:?}",
+                j,
+                i,
+                tj,
+                ti
+            );
+        }
+    }
+
+    // Each body paragraph's unique marker must appear in exactly one chunk.
+    for marker in &["alpha content", "bravo content", "charlie content"] {
+        let occurrences: usize = chunks.iter().filter(|c| c.text.contains(marker)).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker {:?} must appear in exactly one chunk, found in {}",
+            marker, occurrences
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/hybrid_chunking_graph_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_graph_test.rs
@@ -67,6 +67,18 @@ fn test_hybrid_chunk_with_graph_splits_large_section() {
     for chunk in &chunks {
         assert_eq!(chunk.heading_context.as_deref(), Some("Big Section"));
     }
+
+    // Each body paragraph must appear in exactly one chunk — the split must
+    // not duplicate content across chunks.
+    for i in 0..20 {
+        let needle = format!("paragraph {} with enough words", i);
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "body paragraph {} must appear in exactly one sub-chunk, found {}",
+            i, hits
+        );
+    }
 }
 
 #[test]
@@ -81,8 +93,30 @@ fn test_hybrid_chunk_with_graph_handles_preamble() {
     let chunker = HybridChunker::default();
     let chunks = chunker.chunk_with_graph(&elements, &graph);
 
-    // Should produce at least 2 chunks: preamble + section
     assert!(!chunks.is_empty());
+
+    // Preamble must appear in a chunk with no heading_context.
+    let preamble_chunk = chunks
+        .iter()
+        .find(|c| c.text().contains("Preamble text before any heading."));
+    assert!(preamble_chunk.is_some(), "preamble chunk must be present");
+    assert!(preamble_chunk.unwrap().heading_context.is_none());
+
+    // Section content must appear exactly once, in a chunk whose heading_context
+    // is "Section One". The preamble must not appear in that section chunk.
+    for marker in &["Preamble text before any heading.", "Section content here."] {
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(marker)).count();
+        assert_eq!(hits, 1, "{:?} must appear in exactly one chunk", marker);
+    }
+    let section_chunk = chunks
+        .iter()
+        .find(|c| c.text().contains("Section content here."))
+        .unwrap();
+    assert_eq!(
+        section_chunk.heading_context.as_deref(),
+        Some("Section One")
+    );
+    assert!(!section_chunk.text().contains("Preamble text"));
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -226,7 +226,10 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         .any(|e| matches!(e, Element::Table(_))));
 }
 
-// Cycle 6.7
+// Cycle 6.7 — with overlap_tokens > 0, chunks must still be element-disjoint.
+// Prior to the disjointness fix, overlap_tokens caused the flusher to re-inject
+// the just-flushed elements back into the working buffer, producing chunks that
+// each contained a prefix of the previous chunk (quadratic content duplication).
 #[test]
 fn test_overlap_chunks_preserve_heading_context() {
     let elements: Vec<Element> = (0..20)
@@ -252,6 +255,32 @@ fn test_overlap_chunks_preserve_heading_context() {
     assert!(chunks.len() > 1);
     for chunk in &chunks {
         assert_eq!(chunk.heading_context.as_deref(), Some("Section A"));
+    }
+
+    // Every paragraph must appear in exactly one chunk.
+    for i in 0..20 {
+        let needle = format!("Paragraph number {} with", i);
+        let hits: usize = chunks.iter().filter(|c| c.text().contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "paragraph {} must appear in exactly one chunk, found {}",
+            i, hits
+        );
+    }
+
+    // No chunk's text may be a substring of another's.
+    for i in 0..chunks.len() {
+        for j in (i + 1)..chunks.len() {
+            let (a, b) = (chunks[i].text(), chunks[j].text());
+            assert!(
+                !b.contains(&a) && !a.contains(&b),
+                "chunks [{}] and [{}] overlap:\n  a={:?}\n  b={:?}",
+                i,
+                j,
+                a,
+                b
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Merges develop into main. Two logically independent fixes accumulated since v2.5.4:

## 1. `[2.5.5]` — Catalog write regressions (#197, already versioned)

- `/OpenAction`, `/ViewerPreferences`, `/Names`, `/PageLabels` now reach the PDF catalog (ISO 32000-1 §7.7.2 Table 28) — previously built by `Document::set_*()` but silently dropped by `write_catalog()` before serialisation.
- `PageLabel::to_dict()` emits `/S` (numbering style) per ISO 32000-1 §12.4.2 Table 159; `/Type` now correctly carries the constant name `PageLabel` and `from_dict()` tolerates the legacy layout for backward-compatible round-trip.
- `Cargo.toml` bumped to `2.5.5` on develop (commit `628e1fc`). **Merging this PR is the release trigger for v2.5.5** (tag + crate publish).

## 2. `[Unreleased]` — `HybridChunker::chunk()` disjointness (#198)

- `flush_buffer` re-injected flushed elements back into the working buffer via the `overlap_tokens` branch on every flush (type boundary, `merge_adjacent=false`, or size overflow). For a title + 3 paragraphs the chunker emitted `[title]` then `[title, p1, p2, p3]` — quadratic content duplication as N grows, making `PdfDocument::rag_chunks()` unusable for vector-store ingestion.
- Fix: `flush_buffer` now empties the buffer unconditionally; no element-level overlap (element overlap is fundamentally incompatible with the RAG disjointness contract — overlap in RAG is a text-level concept). `overlap_tokens` stays in the config as reserved-for-future-text-level-overlap.
- **Not yet versioned.** The fix is under `[Unreleased]` in `CHANGELOG.md`; `Cargo.toml` is still at 2.5.5. Options when merging:
  - **A** — merge as-is, tag `v2.5.5` on main (catalog release). Chunker fix rides on main as unreleased until the next bump.
  - **B** — before merging this PR, bump Cargo.toml to `2.5.6`, move `[Unreleased]` → `[2.5.6]` on develop, force-update develop, then merge. Single tag `v2.5.6` covers both fixes.

## Test plan

- [x] `cargo test --lib` — 6312/6312 pass on develop tip. (One unrelated flaky timing test in `text::metrics` under parallel load; passes in isolation, not touched by any commit in this range.)
- [x] Chunker integration suites on develop tip: `hybrid_chunker_disjoint_test` (4), `hybrid_chunking_test` (13), `hybrid_chunking_graph_test` (4), `hybrid_chunking_v2_test` (11), `rag_chunk_test` (7), `rag_pipeline_test` (6). All green.
- [x] Catalog regression tests (from #197) already green on develop.
- [x] `cargo clippy --lib -- -D warnings` clean for the lib.

## Downstream (post-merge + tag)

`oxidize-python`, `oxidize-pdf-dotnet`, and `llama-index-readers-oxidize-pdf` all need new releases pulling the new crate version before advertising "RAG-ready" chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)