### PR TITLE
fix(page_labels): correct /S case per ISO 32000-1 §12.4.2 Table 159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+- **Roman-numeral page label style now uses the correct case per ISO 32000-1 §12.4.2 Table 159** — `PageLabelStyle::UppercaseRoman` now emits `/S /R` and `PageLabelStyle::LowercaseRoman` emits `/S /r`. Prior to this fix the mapping was inverted in both directions: `to_pdf_name()` wrote the opposite case, and `PageLabelTree::from_dict()` read it back with the same inversion, so internal round-trips appeared to work but any spec-conforming viewer (Acrobat, Foxit, etc.) rendered the opposite case of what the Rust API promised (e.g. `roman_uppercase()` produced PDFs shown as "i, ii, iii"). Also affected behaviour: reading PDFs written by other tools — a document that correctly carried `/S /R` was parsed back as `LowercaseRoman`. Documents written by oxidize-pdf ≤ 2.5.5 were already rendered with the inverted case by conforming viewers; the fix aligns oxidize-pdf with the rest of the PDF ecosystem rather than changing what readers see. Non-Roman styles (`D`, `A`, `a`) were already correct.
+
+### Added
+- Four new content-verifying regression tests:
+  - `page_labels::page_label::tests::test_roman_format_and_pdf_name_agree_on_case` — asserts that `format(1)` and `to_pdf_name()` agree on case for every style, catching any future re-inversion at the source.
+  - `page_labels::page_label_tree::tests::test_from_dict_reads_roman_case_per_iso_spec` — parses synthetic `/S /R` and `/S /r` dicts and asserts the resulting labels render as `"I"` and `"i"` respectively.
+  - `writer::pdf_writer::tests::catalog_entries_tests::test_page_labels_uppercase_roman_emits_uppercase_s_name` and `..._lowercase_roman_emits_lowercase_s_name` — serialise a real `Document` and scan the PDF bytes for the correct `/S` name, guarding against any future writer-side inversion.
+
 ## [2.5.5] - 2026-04-21
 
 ### Fixed

--- a/oxidize-pdf-core/src/page_labels/page_label.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label.rs
@@ -20,12 +20,24 @@ pub enum PageLabelStyle {
 }
 
 impl PageLabelStyle {
-    /// Convert to PDF name
+    /// Convert to PDF name per ISO 32000-1 §12.4.2 Table 159.
+    ///
+    /// Mapping:
+    /// - `D` — decimal arabic
+    /// - `R` — **uppercase** roman
+    /// - `r` — **lowercase** roman
+    /// - `A` — uppercase letters
+    /// - `a` — lowercase letters
+    ///
+    /// A conforming viewer uses the /S name to decide the case of the
+    /// rendered numeral, so this mapping must match the case implied by
+    /// [`Self::format`] — otherwise the Rust side and the rendered PDF
+    /// disagree on case.
     pub fn to_pdf_name(&self) -> Option<&'static str> {
         match self {
             PageLabelStyle::DecimalArabic => Some("D"),
-            PageLabelStyle::UppercaseRoman => Some("r"),
-            PageLabelStyle::LowercaseRoman => Some("R"),
+            PageLabelStyle::UppercaseRoman => Some("R"),
+            PageLabelStyle::LowercaseRoman => Some("r"),
             PageLabelStyle::UppercaseLetters => Some("A"),
             PageLabelStyle::LowercaseLetters => Some("a"),
             PageLabelStyle::None => None,
@@ -312,7 +324,10 @@ mod tests {
             dict.get("Type"),
             Some(&Object::Name("PageLabel".to_string()))
         );
-        assert_eq!(dict.get("S"), Some(&Object::Name("R".to_string())));
+        // ISO 32000-1 §12.4.2 Table 159: lowercase roman numerals are
+        // encoded as /S /r (lowercase name). /R is reserved for the
+        // uppercase form.
+        assert_eq!(dict.get("S"), Some(&Object::Name("r".to_string())));
         assert_eq!(dict.get("P"), Some(&Object::String("p. ".to_string())));
         assert_eq!(dict.get("St"), Some(&Object::Integer(5)));
     }
@@ -354,12 +369,46 @@ mod tests {
 
     #[test]
     fn test_page_label_style_to_pdf_name() {
+        // ISO 32000-1 §12.4.2 Table 159: /R = uppercase, /r = lowercase.
         assert_eq!(PageLabelStyle::DecimalArabic.to_pdf_name(), Some("D"));
-        assert_eq!(PageLabelStyle::UppercaseRoman.to_pdf_name(), Some("r"));
-        assert_eq!(PageLabelStyle::LowercaseRoman.to_pdf_name(), Some("R"));
+        assert_eq!(PageLabelStyle::UppercaseRoman.to_pdf_name(), Some("R"));
+        assert_eq!(PageLabelStyle::LowercaseRoman.to_pdf_name(), Some("r"));
         assert_eq!(PageLabelStyle::UppercaseLetters.to_pdf_name(), Some("A"));
         assert_eq!(PageLabelStyle::LowercaseLetters.to_pdf_name(), Some("a"));
         assert_eq!(PageLabelStyle::None.to_pdf_name(), None);
+    }
+
+    #[test]
+    fn test_roman_format_and_pdf_name_agree_on_case() {
+        // ISO 32000-1 §12.4.2 Table 159 ties the /S name to the render
+        // case: /R = uppercase, /r = lowercase. The crate's own format()
+        // method decides which case the Rust side renders. These two
+        // views MUST agree: if format(1) emits "I" then /S must be /R,
+        // otherwise a spec-conforming viewer will render the opposite
+        // case of what format() claims.
+        //
+        // Regression guard for the v2.5.5 bug where UppercaseRoman
+        // mapped to /S /r (so `PageLabel::roman_uppercase()` produced
+        // PDFs that Acrobat rendered as "i, ii, iii").
+        let cases: &[(PageLabelStyle, &str, &str)] = &[
+            (PageLabelStyle::UppercaseRoman, "I", "R"),
+            (PageLabelStyle::LowercaseRoman, "i", "r"),
+            (PageLabelStyle::UppercaseLetters, "A", "A"),
+            (PageLabelStyle::LowercaseLetters, "a", "a"),
+        ];
+        for (style, expected_format_1, expected_pdf_name) in cases {
+            let formatted = style.format(1);
+            let pdf_name = style.to_pdf_name().expect("style has /S name");
+            assert_eq!(&formatted, expected_format_1, "format(1) for {:?}", style);
+            assert_eq!(pdf_name, *expected_pdf_name, "/S name for {:?}", style);
+            let format_upper = formatted == formatted.to_uppercase();
+            let pdf_upper = pdf_name == pdf_name.to_uppercase();
+            assert_eq!(
+                format_upper, pdf_upper,
+                "style {:?}: format(1)={:?} (upper={}) disagrees with /S /{} (upper={})",
+                style, formatted, format_upper, pdf_name, pdf_upper
+            );
+        }
     }
 
     #[test]

--- a/oxidize-pdf-core/src/page_labels/page_label_tree.rs
+++ b/oxidize-pdf-core/src/page_labels/page_label_tree.rs
@@ -105,10 +105,13 @@ impl PageLabelTree {
                     _ => None,
                 },
             };
+            // Per ISO 32000-1 §12.4.2 Table 159 the /S value is case
+            // sensitive: /R = uppercase Roman, /r = lowercase Roman;
+            // /A = uppercase letters, /a = lowercase letters.
             let style = match style_name {
                 Some("D") => PageLabelStyle::DecimalArabic,
-                Some("r") => PageLabelStyle::UppercaseRoman,
-                Some("R") => PageLabelStyle::LowercaseRoman,
+                Some("R") => PageLabelStyle::UppercaseRoman,
+                Some("r") => PageLabelStyle::LowercaseRoman,
                 Some("A") => PageLabelStyle::UppercaseLetters,
                 Some("a") => PageLabelStyle::LowercaseLetters,
                 _ => PageLabelStyle::None,
@@ -399,6 +402,51 @@ mod tests {
     }
 
     #[test]
+    fn test_from_dict_reads_roman_case_per_iso_spec() {
+        // ISO 32000-1 §12.4.2 Table 159 binds /S /R to uppercase Roman
+        // numerals and /S /r to lowercase. from_dict() must therefore
+        // map /R → UppercaseRoman and /r → LowercaseRoman. The v2.5.5
+        // reader was mirror-inverted to compensate for the inverted
+        // writer, so /R was read back as LowercaseRoman; external PDFs
+        // (written by other tools per spec) were interpreted upside
+        // down.
+        //
+        // We can't see the style enum directly (it is private to the
+        // PageLabel fields) so we assert on the rendered label, which
+        // calls format() under the hood — format() is the one thing
+        // that has always been correct.
+        fn build_tree(style_name: &str) -> PageLabelTree {
+            let mut label_dict = Dictionary::new();
+            label_dict.set("Type", Object::Name("PageLabel".to_string()));
+            label_dict.set("S", Object::Name(style_name.to_string()));
+
+            let mut nums = Array::new();
+            nums.push(Object::Integer(0));
+            nums.push(Object::Dictionary(label_dict));
+
+            let mut dict = Dictionary::new();
+            dict.set("Nums", Object::Array(nums.into()));
+            PageLabelTree::from_dict(&dict).expect("valid page label tree")
+        }
+
+        let upper = build_tree("R");
+        assert_eq!(
+            upper.get_label(0),
+            Some("I".to_string()),
+            "/S /R must be parsed as UppercaseRoman per ISO 32000-1 §12.4.2 \
+             Table 159 (viewer renders 'I', not 'i')"
+        );
+
+        let lower = build_tree("r");
+        assert_eq!(
+            lower.get_label(0),
+            Some("i".to_string()),
+            "/S /r must be parsed as LowercaseRoman per ISO 32000-1 §12.4.2 \
+             Table 159 (viewer renders 'i', not 'I')"
+        );
+    }
+
+    #[test]
     fn test_from_dict_with_prefix_and_start() {
         let mut label_dict = Dictionary::new();
         label_dict.set("Type", Object::Name("D".to_string()));
@@ -467,11 +515,16 @@ mod tests {
 
     #[test]
     fn test_from_dict_all_style_types() {
-        // Test r (uppercase roman)
+        // Exercises the legacy /Type-carrying-style fallback for each
+        // ISO 32000-1 §12.4.2 Table 159 style name. Asserts only that
+        // parsing succeeds; for the case-sensitive semantics of /R vs
+        // /r and /A vs /a see `test_from_dict_reads_roman_case_per_iso_spec`.
+
+        // Test r (lowercase roman)
         let mut label_dict1 = Dictionary::new();
         label_dict1.set("Type", Object::Name("r".to_string()));
 
-        // Test R (lowercase roman)
+        // Test R (uppercase roman)
         let mut label_dict2 = Dictionary::new();
         label_dict2.set("Type", Object::Name("R".to_string()));
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests/catalog_entries_tests.rs
@@ -159,4 +159,83 @@ mod catalog_entries_tests {
             "decimal page label dict should serialise as /S /D per spec"
         );
     }
+
+    #[test]
+    fn test_page_labels_uppercase_roman_emits_uppercase_s_name() {
+        // Per ISO 32000-1 §12.4.2 Table 159, /R means "uppercase Roman
+        // numerals" and /r means "lowercase Roman numerals". A
+        // spec-conforming viewer uses the /S name to decide the case of
+        // the rendered numeral, so the writer must emit /S /R for
+        // PageLabelStyle::UppercaseRoman — anything else makes the
+        // viewer render the opposite case of what the Rust API promised.
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::roman_uppercase());
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/S /R"),
+            "UppercaseRoman must serialise as /S /R per ISO 32000-1 §12.4.2 \
+             Table 159; PDF never emitted /S /R"
+        );
+        assert!(
+            !content.contains("/S /r"),
+            "UppercaseRoman must NOT emit /S /r (that is the lowercase style); \
+             /S /r found in output for a label built from roman_uppercase()"
+        );
+    }
+
+    #[test]
+    fn test_page_labels_lowercase_roman_emits_lowercase_s_name() {
+        // Mirror of the uppercase test: /S /r is the lowercase form per
+        // ISO 32000-1 §12.4.2 Table 159.
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::roman_lowercase());
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/S /r"),
+            "LowercaseRoman must serialise as /S /r per ISO 32000-1 §12.4.2 \
+             Table 159; PDF never emitted /S /r"
+        );
+        assert!(
+            !content.contains("/S /R"),
+            "LowercaseRoman must NOT emit /S /R (that is the uppercase style); \
+             /S /R found in output for a label built from roman_lowercase()"
+        );
+    }
+
+    #[test]
+    fn test_page_labels_mixed_roman_ranges_keep_correct_case() {
+        // Regression: a document that uses both roman cases in separate
+        // ranges must emit /S /R and /S /r side by side. The v2.5.5 bug
+        // made this doubly visible: a user who explicitly wanted front
+        // matter in uppercase and appendix in lowercase would get the
+        // opposite in a spec-conforming viewer.
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.add_page(Page::a4());
+        let mut labels = PageLabelTree::new();
+        labels.add_range(0, PageLabel::roman_uppercase());
+        labels.add_range(1, PageLabel::roman_lowercase());
+        document.set_page_labels(labels);
+
+        let content = serialize(&mut document);
+
+        assert!(
+            content.contains("/S /R"),
+            "mixed-case roman ranges must emit /S /R for the uppercase range"
+        );
+        assert!(
+            content.contains("/S /r"),
+            "mixed-case roman ranges must emit /S /r for the lowercase range"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fix inverted case mapping for Roman-numeral page labels. v2.5.5 shipped
`PageLabelStyle::to_pdf_name()` returning `/r` for `UppercaseRoman` and
`/R` for `LowercaseRoman` — opposite of ISO 32000-1 §12.4.2 Table 159.
`PageLabelTree::from_dict()` mirrored the same inversion, so internal
round-trips appeared correct but any spec-conforming viewer rendered
the opposite case of what the Rust API promised, and PDFs authored
elsewhere were interpreted upside down.

## Scope of the bug

The inversion sang in four places, hiding it from every existing test:

| File | Kind |
|---|---|
| `oxidize-pdf-core/src/page_labels/page_label.rs` (27-28) | write-side mapping (root cause) |
| `oxidize-pdf-core/src/page_labels/page_label_tree.rs` (110-111) | read-side mirror-inverted |
| `oxidize-pdf-core/src/page_labels/page_label.rs` (315) | osifying unit test (to_dict) |
| `oxidize-pdf-core/src/page_labels/page_label.rs` (358-359) | osifying unit test (to_pdf_name) |

Impact was user-visible: `PageLabelStyle::UppercaseRoman.format(1) == "I"`
but `UppercaseRoman.to_pdf_name() == "r"`, so a page labelled
`roman_uppercase()` rendered as "i, ii, iii" in Acrobat / Foxit / any
conforming viewer.

## What changed

- Flip `to_pdf_name()` to `/R` for `UppercaseRoman`, `/r` for `LowercaseRoman`.
- Flip `from_dict()` to the spec-correct case sensitivity.
- Invert asserts in `test_page_label_style_to_pdf_name` and `test_to_dict`.
- Add four content-verifying regression tests (bytes-level + unit-level).

## Compatibility

Documents written by oxidize-pdf ≤ 2.5.5 were already rendered with the
inverted case by conforming viewers; this fix aligns oxidize-pdf with the
rest of the PDF ecosystem, not against it.

## Test plan

- [x] `cargo test -p oxidize-pdf --lib page_labels::` — 45 passed
- [x] `cargo test -p oxidize-pdf --lib writer::pdf_writer::tests::catalog_entries_tests` — 8 passed
- [x] `cargo test --workspace --lib` — 6322 passed
- [x] `cargo test --workspace --tests` — full integration suite green
- [x] `cargo fmt --all` / pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)