### PR TITLE
fix(forms): serialize FormManager.fields as indirect /AcroForm entries

### DIFF
--- a/oxidize-pdf-core/src/annotations/annotation.rs
+++ b/oxidize-pdf-core/src/annotations/annotation.rs
@@ -220,6 +220,13 @@ pub struct Annotation {
     pub color: Option<Color>,
     /// Page reference (set by manager)
     pub page: Option<ObjectReference>,
+    /// Parent form field reference for widget annotations that live as
+    /// children of an /AcroForm field (ISO 32000-1 §12.7.3.1).
+    ///
+    /// When set, serialization writes `/Parent <ref>` into the annotation
+    /// dictionary so that the widget is linked to the field it belongs to.
+    /// Only meaningful for `AnnotationType::Widget`; ignored otherwise.
+    pub field_parent: Option<ObjectReference>,
     /// Additional properties specific to annotation type
     pub properties: Dictionary,
 }
@@ -241,6 +248,7 @@ impl Annotation {
             border: None,
             color: None,
             page: None,
+            field_parent: None,
             properties: Dictionary::new(),
         }
     }
@@ -364,6 +372,13 @@ impl Annotation {
         // Page reference
         if let Some(page) = self.page {
             dict.set("P", Object::Reference(page));
+        }
+
+        // Parent form field (widget annotations only — ISO 32000-1 §12.7.3.1).
+        // Emitted before merging additional properties so any explicit
+        // `/Parent` already in `properties` takes precedence.
+        if let Some(parent_ref) = self.field_parent {
+            dict.set("Parent", Object::Reference(parent_ref));
         }
 
         // Merge additional properties

--- a/oxidize-pdf-core/src/annotations/annotation.rs
+++ b/oxidize-pdf-core/src/annotations/annotation.rs
@@ -226,7 +226,12 @@ pub struct Annotation {
     /// When set, serialization writes `/Parent <ref>` into the annotation
     /// dictionary so that the widget is linked to the field it belongs to.
     /// Only meaningful for `AnnotationType::Widget`; ignored otherwise.
-    pub field_parent: Option<ObjectReference>,
+    ///
+    /// Scoped to `pub(crate)` because setting a `/Parent` on a non-Widget
+    /// annotation is meaningless and (for encrypted / PDF/A output) risky.
+    /// External callers must go through [`Annotation::set_field_parent`],
+    /// which validates the annotation type.
+    pub(crate) field_parent: Option<ObjectReference>,
     /// Additional properties specific to annotation type
     pub properties: Dictionary,
 }
@@ -295,6 +300,29 @@ impl Annotation {
         for (key, value) in field_dict.iter() {
             self.properties.set(key, value.clone());
         }
+    }
+
+    /// Set the parent form-field reference for a Widget annotation.
+    ///
+    /// Widget annotations that live as children of an /AcroForm field
+    /// (ISO 32000-1 §12.7.3.1) must carry `/Parent` pointing at the
+    /// parent field dictionary. This setter records that relationship;
+    /// the writer remaps the placeholder to a real indirect-object id
+    /// at serialization time.
+    ///
+    /// Only meaningful for [`AnnotationType::Widget`]. In debug builds,
+    /// calling this on a non-Widget annotation is a programming error
+    /// and trips a `debug_assert!`. In release builds the setter still
+    /// stores the value, but `to_dict` will refuse to emit `/Parent`
+    /// for non-Widget annotations (defence in depth: the setter is the
+    /// primary gate; the emitter is the safety net).
+    pub fn set_field_parent(&mut self, parent: ObjectReference) {
+        debug_assert!(
+            matches!(self.annotation_type, AnnotationType::Widget),
+            "Annotation::set_field_parent should only be called on Widget annotations, got {:?}",
+            self.annotation_type
+        );
+        self.field_parent = Some(parent);
     }
 
     /// Convert to PDF dictionary
@@ -377,8 +405,17 @@ impl Annotation {
         // Parent form field (widget annotations only — ISO 32000-1 §12.7.3.1).
         // Emitted before merging additional properties so any explicit
         // `/Parent` already in `properties` takes precedence.
-        if let Some(parent_ref) = self.field_parent {
-            dict.set("Parent", Object::Reference(parent_ref));
+        //
+        // We gate on `annotation_type == Widget` as defence in depth even
+        // though `set_field_parent` already refuses non-Widget types: if
+        // someone flipped `annotation_type` after setting `field_parent`,
+        // emitting `/Parent` on, say, a Link would produce a malformed
+        // form hierarchy that most viewers silently tolerate but ISO
+        // 32000-1 §12.7.3.1 forbids.
+        if matches!(self.annotation_type, AnnotationType::Widget) {
+            if let Some(parent_ref) = self.field_parent {
+                dict.set("Parent", Object::Reference(parent_ref));
+            }
         }
 
         // Merge additional properties

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -130,6 +130,14 @@ impl Default for FormData {
 pub struct FormManager {
     /// Registered fields
     fields: HashMap<String, FormField>,
+    /// Placeholder `ObjectReference` returned to callers for each field,
+    /// keyed by field name. The reference is a *placeholder* — its object
+    /// number comes from the FormManager's local counter and is disjoint
+    /// from the writer's global object-id allocator. The writer builds a
+    /// placeholder → real-ObjectId map at serialization time so widget
+    /// annotations created via `Page::add_form_widget_with_ref` can
+    /// resolve their `/Parent` to the correct real id.
+    field_refs: HashMap<String, ObjectReference>,
     /// AcroForm dictionary
     acro_form: AcroForm,
     /// Next field ID
@@ -141,6 +149,7 @@ impl FormManager {
     pub fn new() -> Self {
         Self {
             fields: HashMap::new(),
+            field_refs: HashMap::new(),
             acro_form: AcroForm::new(),
             next_field_id: 1,
         }
@@ -172,11 +181,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -205,11 +214,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -238,11 +247,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -277,11 +286,11 @@ impl FormManager {
             }
         }
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -307,11 +316,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -337,11 +346,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -371,11 +380,11 @@ impl FormManager {
             form_field.add_widget(widget);
         }
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -417,6 +426,31 @@ impl FormManager {
     /// Get the number of fields managed by this FormManager
     pub fn field_count(&self) -> usize {
         self.fields.len()
+    }
+
+    /// Iterate over fields in a deterministic (alphabetical by name) order,
+    /// paired with the placeholder `ObjectReference` that was returned to
+    /// the caller when the field was added.
+    ///
+    /// The underlying storage is a `HashMap`, which has non-deterministic
+    /// iteration. Serializers that need reproducible output (diff-stable
+    /// `/AcroForm/Fields` arrays, object-id allocations, etc.) MUST use
+    /// this method instead of `fields().iter()`. The placeholder ref is
+    /// the one the writer uses to build the placeholder → real-id map
+    /// consumed by widget-annotation `/Parent` resolution.
+    pub fn iter_fields_sorted(
+        &self,
+    ) -> impl Iterator<Item = (&String, &FormField, ObjectReference)> {
+        let mut keys: Vec<&String> = self.fields.keys().collect();
+        keys.sort();
+        keys.into_iter().map(move |k| {
+            let field = self.fields.get(k).expect("key came from map");
+            let placeholder = *self
+                .field_refs
+                .get(k)
+                .expect("every field must have a placeholder ref");
+            (k, field, placeholder)
+        })
     }
 }
 

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -438,18 +438,42 @@ impl FormManager {
     /// this method instead of `fields().iter()`. The placeholder ref is
     /// the one the writer uses to build the placeholder → real-id map
     /// consumed by widget-annotation `/Parent` resolution.
-    pub fn iter_fields_sorted(
+    ///
+    /// Scoped to `pub(crate)` because the placeholder `ObjectReference` is
+    /// a writer-internal concept — leaking it in the public API would
+    /// couple external callers to a serialization detail that is expected
+    /// to evolve. Public iteration can go through [`FormManager::fields`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a streaming iterator of `Result` items. The only way an
+    /// error is produced is if the internal `fields` / `field_refs` maps
+    /// desynchronize — a "can't happen" invariant that every `add_*_field`
+    /// method is responsible for upholding. A desync surfaces as
+    /// [`PdfError::Internal`] rather than a panic so the writer hot path
+    /// stays panic-free (ISO 32000-1 conformance errors must remain
+    /// recoverable).
+    pub(crate) fn iter_fields_sorted(
         &self,
-    ) -> impl Iterator<Item = (&String, &FormField, ObjectReference)> {
+    ) -> impl Iterator<Item = Result<(&String, &FormField, ObjectReference)>> {
         let mut keys: Vec<&String> = self.fields.keys().collect();
         keys.sort();
         keys.into_iter().map(move |k| {
-            let field = self.fields.get(k).expect("key came from map");
-            let placeholder = *self
-                .field_refs
-                .get(k)
-                .expect("every field must have a placeholder ref");
-            (k, field, placeholder)
+            // `k` was just produced by `self.fields.keys()`, so this lookup
+            // cannot fail within the same borrow. We still avoid `expect`
+            // on a hot path and surface an `Internal` error instead of
+            // panicking — callers already propagate `Result<()>`.
+            let field = self.fields.get(k).ok_or_else(|| {
+                crate::error::PdfError::Internal(format!(
+                    "FormManager internal invariant broken: field '{k}' missing from fields map during sorted iteration"
+                ))
+            })?;
+            let placeholder = *self.field_refs.get(k).ok_or_else(|| {
+                crate::error::PdfError::Internal(format!(
+                    "FormManager internal invariant broken: field '{k}' has no placeholder ref (add_*_field forgot to populate field_refs?)"
+                ))
+            })?;
+            Ok((k, field, placeholder))
         })
     }
 }

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -936,6 +936,49 @@ impl Page {
         widget_ref
     }
 
+    /// Add a form field widget to the page and link it to an existing AcroForm field.
+    ///
+    /// Unlike [`Page::add_form_widget`], which expects the writer to track the
+    /// relationship implicitly via shared field names, this variant records
+    /// the `field_ref` as the widget's `/Parent` so the resulting PDF carries
+    /// an explicit widget→field link per ISO 32000-1 §12.7.3.1.
+    ///
+    /// This is the recommended path when the field itself was created via
+    /// [`crate::forms::FormManager`] (whose `add_text_field`, `add_combo_box`,
+    /// etc. return the field's `ObjectReference`): the field object is
+    /// serialized as an indirect object, and every widget placed on a page
+    /// points back to it through `/Parent`.
+    ///
+    /// # Arguments
+    ///
+    /// * `widget` - The widget appearance/geometry to place on the page.
+    /// * `field_ref` - The `ObjectReference` of the AcroForm field this
+    ///   widget belongs to (as returned by `FormManager::add_*`).
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success. The method currently cannot fail; the `Result`
+    /// return type is reserved for future validation.
+    pub fn add_form_widget_with_ref(
+        &mut self,
+        widget: Widget,
+        field_ref: ObjectReference,
+    ) -> crate::error::Result<()> {
+        // Convert widget to annotation, same as add_form_widget.
+        let mut annot = Annotation::new(crate::annotations::AnnotationType::Widget, widget.rect);
+
+        for (key, value) in widget.to_annotation_dict().iter() {
+            annot.properties.set(key, value.clone());
+        }
+
+        // Record the parent field reference so the writer emits
+        // `/Parent <field_ref>` in the widget annotation dictionary.
+        annot.field_parent = Some(field_ref);
+
+        self.annotations.push(annot);
+        Ok(())
+    }
+
     /// Sets the header for this page.
     ///
     /// # Example

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -973,7 +973,10 @@ impl Page {
 
         // Record the parent field reference so the writer emits
         // `/Parent <field_ref>` in the widget annotation dictionary.
-        annot.field_parent = Some(field_ref);
+        // Goes through the setter so the Widget-annotation-type invariant
+        // is enforced (debug_assert! in debug builds) — `field_parent` is
+        // `pub(crate)` precisely to prevent external callers bypassing it.
+        annot.set_field_parent(field_ref);
 
         self.annotations.push(annot);
         Ok(())

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -184,7 +184,7 @@ impl<W: Write> PdfWriter<W> {
         // refs returned by `FormManager::add_text_field`. This is the piece
         // that bridges the FormManager's local id counter and the writer's
         // global id allocator. See `form_field_placeholder_map` for details.
-        self.preallocate_form_manager_fields(document);
+        self.preallocate_form_manager_fields(document)?;
 
         // Write pages (they contain widget annotations and font references)
         self.write_pages(document, &font_refs)?;
@@ -910,16 +910,22 @@ impl<W: Write> PdfWriter<W> {
             }
 
             // Write each field dict into its reserved id.
-            let sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = form_manager
-                .iter_fields_sorted()
-                .map(|(_name, form_field, placeholder)| {
-                    let real_id = *self
-                        .form_field_placeholder_map
-                        .get(&placeholder)
-                        .expect("every sorted field must have a pre-allocated real id");
-                    (form_field.field_dict.clone(), real_id)
-                })
-                .collect();
+            // Surface a clean `PdfError` if the placeholder-ref → real-id
+            // map is missing any entry — a "can't happen" breach of the
+            // invariant established by `preallocate_form_manager_fields`,
+            // which must run before this function.
+            let mut sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = Vec::new();
+            for item in form_manager.iter_fields_sorted() {
+                let (name, form_field, placeholder) = item?;
+                let real_id = *self.form_field_placeholder_map.get(&placeholder).ok_or_else(
+                    || {
+                        PdfError::Internal(format!(
+                            "AcroForm writer internal invariant broken: field '{name}' (placeholder {placeholder}) has no pre-allocated real object id — preallocate_form_manager_fields must run before write_catalog"
+                        ))
+                    },
+                )?;
+                sorted.push((form_field.field_dict.clone(), real_id));
+            }
             for (field_dict, real_id) in sorted {
                 self.write_object(real_id, Object::Dictionary(field_dict))?;
             }
@@ -1353,16 +1359,18 @@ impl<W: Write> PdfWriter<W> {
     /// Iteration order is deterministic (alphabetical by field name) via
     /// `FormManager::iter_fields_sorted` so object-ID allocation — and
     /// therefore the byte-for-byte output — is reproducible across builds.
-    fn preallocate_form_manager_fields(&mut self, document: &Document) {
+    fn preallocate_form_manager_fields(&mut self, document: &Document) -> Result<()> {
         let Some(form_manager) = &document.form_manager else {
-            return;
+            return Ok(());
         };
 
-        for (_name, _form_field, placeholder) in form_manager.iter_fields_sorted() {
+        for item in form_manager.iter_fields_sorted() {
+            let (_name, _form_field, placeholder) = item?;
             let real_id = self.allocate_object_id();
             self.form_field_placeholder_map.insert(placeholder, real_id);
             self.form_manager_field_refs.push(real_id);
         }
+        Ok(())
     }
 
     fn write_form_fields(&mut self, document: &mut Document) -> Result<()> {
@@ -2567,14 +2575,20 @@ impl<W: Write> PdfWriter<W> {
             // from the writer's allocator). At this point the writer has
             // already pre-allocated real ids for every FormManager field
             // via `preallocate_form_manager_fields`, so we translate.
+            //
+            // We read `field_parent` straight off the struct instead of
+            // round-tripping through `annot_dict.get("Parent")`: the
+            // dictionary representation is what we're producing, not a
+            // source of truth. The struct field is authoritative and
+            // avoids matching on a value we just computed.
+            //
             // Widgets whose parent placeholder is NOT in the map (e.g.
-            // the caller supplied a hand-built ref) are left unchanged —
-            // not every `/Parent` necessarily comes from the FormManager.
-            if annotation.field_parent.is_some() {
-                if let Some(Object::Reference(parent_ref)) = annot_dict.get("Parent") {
-                    if let Some(real_id) = self.form_field_placeholder_map.get(parent_ref) {
-                        annot_dict.set("Parent", Object::Reference(*real_id));
-                    }
+            // the caller supplied a hand-built ref, or `field_parent` was
+            // set from outside the FormManager) are left unchanged — not
+            // every `/Parent` necessarily comes from the FormManager.
+            if let Some(placeholder) = annotation.field_parent {
+                if let Some(real_id) = self.form_field_placeholder_map.get(&placeholder) {
+                    annot_dict.set("Parent", Object::Reference(*real_id));
                 }
             }
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -102,6 +102,20 @@ pub struct PdfWriter<W: Write> {
     file_id: Option<Vec<u8>>,
     encryption_state: Option<WriterEncryptionState>,
     pending_encrypt_dict: Option<Dictionary>,
+    // FormManager field tracking:
+    //  * `form_field_placeholder_map` translates the placeholder
+    //    `ObjectReference` returned by `FormManager::add_text_field` et al.
+    //    (those use a local counter unaware of writer-side allocation) into
+    //    the real `ObjectId` chosen by `allocate_object_id`. Widgets created
+    //    via `Page::add_form_widget_with_ref` store the placeholder in
+    //    `Annotation::field_parent`; when the annotation dict is written we
+    //    remap it through this table so `/Parent` points at the real field.
+    //  * `form_manager_field_refs` is the ordered (alphabetical by field
+    //    name) list of real refs; it's appended to `document.acro_form.fields`
+    //    during `write_catalog` and is what ends up in
+    //    `/AcroForm/Fields`.
+    form_field_placeholder_map: HashMap<crate::objects::ObjectReference, ObjectId>,
+    form_manager_field_refs: Vec<crate::objects::ObjectReference>,
 }
 
 /// Holds the encryption key and encryptor for encrypting objects during write
@@ -137,6 +151,8 @@ impl<W: Write> PdfWriter<W> {
             file_id: None,
             encryption_state: None,
             pending_encrypt_dict: None,
+            form_field_placeholder_map: HashMap::new(),
+            form_manager_field_refs: Vec::new(),
         }
     }
 
@@ -161,6 +177,14 @@ impl<W: Write> PdfWriter<W> {
 
         // Write custom fonts first (so pages can reference them)
         let font_refs = self.write_fonts(document)?;
+
+        // Pre-allocate object IDs for every field owned by the FormManager
+        // BEFORE writing pages, so widget annotations on those pages can
+        // emit `/Parent <real_id>` instead of pointing at the placeholder
+        // refs returned by `FormManager::add_text_field`. This is the piece
+        // that bridges the FormManager's local id counter and the writer's
+        // global id allocator. See `form_field_placeholder_map` for details.
+        self.preallocate_form_manager_fields(document);
 
         // Write pages (they contain widget annotations and font references)
         self.write_pages(document, &font_refs)?;
@@ -861,12 +885,51 @@ impl<W: Write> PdfWriter<W> {
         catalog.set("Type", Object::Name("Catalog".to_string()));
         catalog.set("Pages", Object::Reference(pages_id));
 
-        // Process FormManager if present to update AcroForm
-        // We'll write the actual fields after pages are written
-        if let Some(_form_manager) = &document.form_manager {
-            // Ensure AcroForm exists
+        // Serialize fields owned by the FormManager (ISO 32000-1 §12.7.3).
+        //
+        // Before v2.5.6 this block did nothing: it bound `_form_manager`
+        // but never read its `fields` map, so only fields appended manually
+        // to `document.acro_form.fields` ever reached the output PDF. Any
+        // field created via `FormManager::add_text_field` / `add_combo_box`
+        // / etc. was silently dropped — exactly the gap the .NET wrapper
+        // hit.
+        //
+        // Object IDs for these fields were pre-allocated in
+        // `preallocate_form_manager_fields` (called before `write_pages`
+        // so widget `/Parent` refs could resolve). Here we only have to:
+        //   (a) write the field-body dict into each pre-allocated id, and
+        //   (b) append those ids to `document.acro_form.fields` so the
+        //       /AcroForm write block below emits
+        //       `/AcroForm/Fields [N 0 R ...]`.
+        //
+        // Iteration follows the same deterministic order used at
+        // pre-allocation time, so the order-vs-id pairing is stable.
+        if let Some(form_manager) = &document.form_manager {
             if document.acro_form.is_none() {
                 document.acro_form = Some(crate::forms::AcroForm::new());
+            }
+
+            // Write each field dict into its reserved id.
+            let sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = form_manager
+                .iter_fields_sorted()
+                .map(|(_name, form_field, placeholder)| {
+                    let real_id = *self
+                        .form_field_placeholder_map
+                        .get(&placeholder)
+                        .expect("every sorted field must have a pre-allocated real id");
+                    (form_field.field_dict.clone(), real_id)
+                })
+                .collect();
+            for (field_dict, real_id) in sorted {
+                self.write_object(real_id, Object::Dictionary(field_dict))?;
+            }
+
+            if let Some(acro) = document.acro_form.as_mut() {
+                for r in &self.form_manager_field_refs {
+                    if !acro.fields.contains(r) {
+                        acro.fields.push(*r);
+                    }
+                }
             }
         }
 
@@ -1276,6 +1339,30 @@ impl<W: Write> PdfWriter<W> {
 
         self.write_object(struct_tree_root_id, Object::Dictionary(struct_tree_root))?;
         Ok(struct_tree_root_id)
+    }
+
+    /// Reserve an `ObjectId` for every field owned by `document.form_manager`
+    /// and build the placeholder → real mapping used when widget annotations
+    /// are serialised (see `Annotation::field_parent`).
+    ///
+    /// Called once from `write_document` before `write_pages`, so widget
+    /// `/Parent` refs on pages resolve to real indirect objects. The field
+    /// bodies themselves are written later, in `write_catalog`, reusing
+    /// these pre-allocated IDs.
+    ///
+    /// Iteration order is deterministic (alphabetical by field name) via
+    /// `FormManager::iter_fields_sorted` so object-ID allocation — and
+    /// therefore the byte-for-byte output — is reproducible across builds.
+    fn preallocate_form_manager_fields(&mut self, document: &Document) {
+        let Some(form_manager) = &document.form_manager else {
+            return;
+        };
+
+        for (_name, _form_field, placeholder) in form_manager.iter_fields_sorted() {
+            let real_id = self.allocate_object_id();
+            self.form_field_placeholder_map.insert(placeholder, real_id);
+            self.form_manager_field_refs.push(real_id);
+        }
     }
 
     fn write_form_fields(&mut self, document: &mut Document) -> Result<()> {
@@ -2472,7 +2559,25 @@ impl<W: Write> PdfWriter<W> {
         //    page.add_annotation(). Each is written as an indirect object.
         for annotation in page.annotations() {
             let annot_id = self.allocate_object_id();
-            let annot_dict = annotation.to_dict();
+            let mut annot_dict = annotation.to_dict();
+
+            // Remap `/Parent` from FormManager placeholder → real ObjectId.
+            // `Annotation::field_parent` stores the placeholder ref returned
+            // by FormManager::add_*_field (which uses a counter disjoint
+            // from the writer's allocator). At this point the writer has
+            // already pre-allocated real ids for every FormManager field
+            // via `preallocate_form_manager_fields`, so we translate.
+            // Widgets whose parent placeholder is NOT in the map (e.g.
+            // the caller supplied a hand-built ref) are left unchanged —
+            // not every `/Parent` necessarily comes from the FormManager.
+            if annotation.field_parent.is_some() {
+                if let Some(Object::Reference(parent_ref)) = annot_dict.get("Parent") {
+                    if let Some(real_id) = self.form_field_placeholder_map.get(parent_ref) {
+                        annot_dict.set("Parent", Object::Reference(*real_id));
+                    }
+                }
+            }
+
             self.write_object(annot_id, Object::Dictionary(annot_dict))?;
             annot_refs.push(Object::Reference(annot_id));
 
@@ -2528,6 +2633,8 @@ impl PdfWriter<BufWriter<std::fs::File>> {
             file_id: None,
             encryption_state: None,
             pending_encrypt_dict: None,
+            form_field_placeholder_map: HashMap::new(),
+            form_manager_field_refs: Vec::new(),
         })
     }
 }

--- a/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
+++ b/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
@@ -15,7 +15,7 @@
 //!     or carries /T + /FT inline (merged field/widget dict, per
 //!     ISO 32000-1 §12.7.3.1).
 
-use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::forms::{CheckBox, FormManager, TextField, Widget, WidgetAppearance};
 use oxidize_pdf::geometry::{Point, Rectangle};
 use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::PdfReader;
@@ -253,5 +253,154 @@ fn form_manager_multiple_fields_are_all_emitted_in_deterministic_order() {
         names,
         vec!["aaa_first".to_string(), "zzz_last".to_string()],
         "FormManager must emit fields in deterministic (alphabetical by name) order"
+    );
+}
+
+/// Regression test for the degenerate but legal case where a user attaches
+/// an empty FormManager to a document.
+///
+/// Behaviour under test: when `set_form_manager` is called with a manager
+/// that has no fields, the writer still emits `/AcroForm` on the catalog
+/// (matching `write_catalog`'s unconditional `AcroForm::new()` fallback)
+/// but its `/Fields` entry is the empty array. ISO 32000-1 §12.7.3 tolerates
+/// this — an AcroForm with no fields is syntactically well-formed — and it's
+/// the path the .NET wrapper takes when a user intends to populate fields
+/// after construction. If a future change decides to omit `/AcroForm` in
+/// this case, this test should be updated alongside that change.
+#[test]
+fn form_manager_empty_produces_empty_fields_array() {
+    let mut doc = Document::new();
+    let page = Page::a4();
+    doc.add_page(page);
+    doc.set_form_manager(FormManager::new());
+
+    let bytes = doc.to_bytes().expect("serialize document with empty FM");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    let catalog = reader.catalog().expect("catalog").clone();
+    // Current behaviour: `/AcroForm` is emitted even for an empty FormManager.
+    // Accept either "absent" or "present with empty Fields array" so this
+    // test remains stable if the writer later decides to suppress empty
+    // AcroForms. The core invariant we lock in is: no phantom fields.
+    match catalog.get("AcroForm") {
+        None => {
+            // Acceptable: empty FormManager → no AcroForm at all.
+        }
+        Some(acro_obj) => {
+            // Emitted: must then be indirect and carry an empty /Fields.
+            let (acro_n, acro_g) = acro_obj
+                .as_reference()
+                .expect("/AcroForm must be indirect when emitted");
+            let acro = reader
+                .get_object(acro_n, acro_g)
+                .expect("resolve AcroForm")
+                .clone();
+            let acro_dict = acro.as_dict().expect("/AcroForm must be a dictionary");
+            let fields_arr = acro_dict
+                .get("Fields")
+                .and_then(|o| o.as_array())
+                .expect("/AcroForm/Fields must exist as an array");
+            assert!(
+                fields_arr.is_empty(),
+                "empty FormManager must not produce phantom entries in /AcroForm/Fields; got {} entries",
+                fields_arr.len()
+            );
+        }
+    }
+}
+
+/// Regression test for the heterogeneous case: a text field + a checkbox
+/// in the same FormManager. Both must round-trip through the writer as
+/// indirect objects, both must appear in `/AcroForm/Fields`, and their
+/// `/FT` values must match the PDF type each field carries (Tx for text,
+/// Btn for checkbox — ISO 32000-1 Table 220).
+///
+/// This locks in the invariant that the dispatch-by-`add_*` method does
+/// not silently drop non-text field types, which was the original v2.5.6
+/// Task 2 bug class.
+#[test]
+fn form_manager_mixed_field_types_round_trip() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    // Text field — alphabetically "email" (sorts before "subscribe").
+    let text_rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let text_widget = Widget::new(text_rect).with_appearance(WidgetAppearance::default());
+    let text_ref = fm
+        .add_text_field(TextField::new("email"), text_widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(text_widget, text_ref)
+        .expect("attach text widget");
+
+    // Checkbox — alphabetically "subscribe" (sorts after "email").
+    let cb_rect = Rectangle::new(Point::new(100.0, 660.0), Point::new(115.0, 675.0));
+    let cb_widget = Widget::new(cb_rect).with_appearance(WidgetAppearance::default());
+    let cb_ref = fm
+        .add_checkbox(CheckBox::new("subscribe"), cb_widget.clone(), None)
+        .expect("add_checkbox");
+    page.add_form_widget_with_ref(cb_widget, cb_ref)
+        .expect("attach checkbox widget");
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // --- Resolve /AcroForm/Fields --------------------------------------
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve AcroForm")
+        .clone();
+    let fields_arr: Vec<PdfObject> = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields array")
+        .0
+        .clone();
+
+    assert_eq!(
+        fields_arr.len(),
+        2,
+        "/AcroForm/Fields must hold both the text field and the checkbox"
+    );
+
+    // --- Collect (name, type) pairs in emission order ------------------
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for entry in &fields_arr {
+        let (n, g) = entry
+            .as_reference()
+            .expect("each field entry must be a reference");
+        let obj = reader.get_object(n, g).expect("resolve field").clone();
+        let d = obj.as_dict().expect("field must be a dict");
+        let t = d
+            .get("T")
+            .and_then(|o| o.as_string())
+            .and_then(|s| s.as_str().ok())
+            .expect("field /T")
+            .to_owned();
+        let ft = d
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned())
+            .expect("field /FT");
+        pairs.push((t, ft));
+    }
+
+    // Deterministic (alphabetical) emission: "email" (Tx) then "subscribe" (Btn).
+    assert_eq!(
+        pairs,
+        vec![
+            ("email".to_string(), "Tx".to_string()),
+            ("subscribe".to_string(), "Btn".to_string()),
+        ],
+        "mixed field types must round-trip with correct /T and /FT values"
     );
 }

--- a/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
+++ b/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
@@ -1,0 +1,257 @@
+//! Integration tests for FormManager field serialization (Task 2 of v2.5.6 fix series).
+//!
+//! Regression suite for the bug where fields added via
+//! `FormManager::add_text_field` / `add_combo_box` / etc. were silently
+//! discarded at write time because `write_catalog` bound the form_manager
+//! to `_form_manager` without ever reading its `fields` map. As a result
+//! only fields appended manually to `document.acro_form.fields` ever
+//! reached the output PDF, and the .NET wrapper hit this limitation.
+//!
+//! These tests verify the real wire format of the written PDF via
+//! `PdfReader`:
+//!   * Each `FormField` in the manager becomes an indirect PDF object.
+//!   * Its `ObjectReference` lands in `/AcroForm/Fields`.
+//!   * The page widget annotation is either /Parent-linked to the field
+//!     or carries /T + /FT inline (merged field/widget dict, per
+//!     ISO 32000-1 §12.7.3.1).
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walks /Pages and returns the object reference of the first leaf page.
+/// All tests in this file use single-page documents.
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("catalog must carry /Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids must be an array");
+    kids.get(0)
+        .expect("/Pages/Kids[0] must exist")
+        .as_reference()
+        .expect("/Pages/Kids[0] must be a reference")
+}
+
+#[test]
+fn form_manager_fields_appear_as_indirect_objects_and_acroform_references_them() {
+    // Build a PDF with a single email field added through FormManager.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("email");
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("FormManager::add_text_field must succeed");
+
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref must succeed");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+
+    // Parse the written bytes and verify the wire format.
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // --- /Catalog/AcroForm must exist and be indirect -----------------
+    let (acro_obj_num, acro_gen_num) = {
+        let catalog = reader.catalog().expect("catalog").clone();
+        let acro_entry = catalog
+            .get("AcroForm")
+            .expect("/AcroForm must be present in catalog")
+            .clone();
+        acro_entry
+            .as_reference()
+            .expect("/AcroForm must be an indirect reference, not an inline dict")
+    };
+
+    // --- /AcroForm dict must contain exactly one Fields entry ---------
+    let (field_obj_num, field_gen_num) = {
+        let acro_obj = reader
+            .get_object(acro_obj_num, acro_gen_num)
+            .expect("resolve /AcroForm")
+            .clone();
+        let acro_dict = acro_obj.as_dict().expect("/AcroForm must be a dictionary");
+        let fields_obj = acro_dict
+            .get("Fields")
+            .expect("/AcroForm/Fields must exist");
+        let fields_arr = fields_obj
+            .as_array()
+            .expect("/AcroForm/Fields must be an array");
+        assert_eq!(
+            fields_arr.len(),
+            1,
+            "/AcroForm/Fields should hold exactly one entry (the email field)"
+        );
+        let field_ref_obj = fields_arr.get(0).expect("Fields[0] exists");
+        field_ref_obj
+            .as_reference()
+            .expect("/AcroForm/Fields[0] must be an indirect reference")
+    };
+
+    // --- Resolved field dict must carry /T = "email", /FT = /Tx -------
+    {
+        let field_obj = reader
+            .get_object(field_obj_num, field_gen_num)
+            .expect("resolve field")
+            .clone();
+        let field_dict = field_obj
+            .as_dict()
+            .expect("field must serialize as a dictionary");
+
+        let t_entry = field_dict
+            .get("T")
+            .and_then(|o| o.as_string())
+            .map(|s| s.as_str().expect("UTF-8").to_owned())
+            .expect("field /T must exist and be a PDF string");
+        assert_eq!(t_entry, "email", "field /T (partial field name)");
+
+        let ft_entry = field_dict
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned())
+            .expect("field /FT must exist and be a PDF name");
+        assert_eq!(ft_entry, "Tx", "field /FT (field type) must be Tx");
+    }
+
+    // --- Page must carry the widget as an indirect annotation ---------
+    let (page_obj_num, page_gen_num) = first_page_ref(&mut reader);
+    let page_dict = reader
+        .get_object(page_obj_num, page_gen_num)
+        .expect("resolve page")
+        .clone();
+    let page_dict = page_dict
+        .as_dict()
+        .expect("page object must be a dictionary");
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("page /Annots must exist as array");
+    assert_eq!(
+        annots.len(),
+        1,
+        "page should have exactly one widget annotation"
+    );
+    let (widget_obj_num, widget_gen_num) = annots
+        .get(0)
+        .expect("annots[0]")
+        .as_reference()
+        .expect("annotation must be indirect");
+
+    let widget_dict = {
+        let widget_obj = reader
+            .get_object(widget_obj_num, widget_gen_num)
+            .expect("resolve widget annotation")
+            .clone();
+        widget_obj
+            .as_dict()
+            .expect("widget annotation must be a dictionary")
+            .clone()
+    };
+
+    // Subtype must be Widget regardless of which link style we use.
+    let subtype = widget_dict
+        .get("Subtype")
+        .and_then(|o| o.as_name())
+        .map(|n| n.as_str().to_owned())
+        .expect("widget /Subtype must exist");
+    assert_eq!(subtype, "Widget", "widget /Subtype");
+
+    // Two acceptable shapes per ISO 32000-1 §12.7.3.1:
+    //   (a) separate objects: widget carries /Parent = field_ref
+    //   (b) merged: widget dict itself holds /T and /FT
+    let has_parent_to_field = widget_dict
+        .get("Parent")
+        .and_then(|o| o.as_reference())
+        .map(|(n, g)| n == field_obj_num && g == field_gen_num)
+        .unwrap_or(false);
+    let is_merged = widget_dict.get("T").is_some() && widget_dict.get("FT").is_some();
+
+    assert!(
+        has_parent_to_field || is_merged,
+        "widget annotation must either /Parent-link to the AcroForm field \
+         (expected ref {}/{}) or carry /T + /FT inline (merged field/widget dict)",
+        field_obj_num,
+        field_gen_num,
+    );
+}
+
+#[test]
+fn form_manager_multiple_fields_are_all_emitted_in_deterministic_order() {
+    // Two fields added out of alphabetical order; the serializer must emit
+    // both as indirect objects, and (per iter_fields_sorted) in a stable
+    // deterministic order so diffs are reproducible.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect_a = Rectangle::new(Point::new(50.0, 700.0), Point::new(250.0, 720.0));
+    let rect_b = Rectangle::new(Point::new(50.0, 650.0), Point::new(250.0, 670.0));
+
+    let widget_b = Widget::new(rect_b).with_appearance(WidgetAppearance::default());
+    let b_ref = fm
+        .add_text_field(TextField::new("zzz_last"), widget_b.clone(), None)
+        .unwrap();
+
+    let widget_a = Widget::new(rect_a).with_appearance(WidgetAppearance::default());
+    let a_ref = fm
+        .add_text_field(TextField::new("aaa_first"), widget_a.clone(), None)
+        .unwrap();
+
+    // Attach widgets to the page in the order they were created (reverse alpha).
+    page.add_form_widget_with_ref(widget_b, b_ref).unwrap();
+    page.add_form_widget_with_ref(widget_a, a_ref).unwrap();
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // Collect /AcroForm/Fields names in emission order.
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve AcroForm")
+        .clone();
+    let fields_arr: Vec<PdfObject> = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields array")
+        .0
+        .clone();
+
+    let mut names: Vec<String> = Vec::new();
+    for entry in &fields_arr {
+        let (n, g) = entry
+            .as_reference()
+            .expect("each field entry must be a reference");
+        let obj = reader.get_object(n, g).expect("resolve field").clone();
+        let t = obj
+            .as_dict()
+            .and_then(|d| d.get("T"))
+            .and_then(|o| o.as_string())
+            .and_then(|s| s.as_str().ok())
+            .expect("field /T")
+            .to_owned();
+        names.push(t);
+    }
+
+    assert_eq!(
+        names,
+        vec!["aaa_first".to_string(), "zzz_last".to_string()],
+        "FormManager must emit fields in deterministic (alphabetical by name) order"
+    );
+}

--- a/oxidize-pdf-core/tests/interactive_features_test.rs
+++ b/oxidize-pdf-core/tests/interactive_features_test.rs
@@ -157,11 +157,19 @@ fn test_forms_integration() {
 
                 if let Some(fields_obj) = acroform_dict.get("Fields") {
                     if let Some(fields_array) = fields_obj.as_array() {
-                        // Note: Due to current implementation, form fields are written
-                        // separately from widgets, so we just check that the array exists
-                        // The array might be empty or have different count than expected
-                        // This is a known limitation of the current implementation
-                        let _ = fields_array.len(); // Just verify it's a valid array
+                        // Both fields added via FormManager must reach the wire
+                        // (name_field + subscribe_checkbox). Before the v2.5.6
+                        // fix, `write_catalog` discarded manager fields entirely
+                        // and this array could be empty or reflect only legacy
+                        // widgets — that was the "known limitation" we just
+                        // closed.
+                        assert_eq!(
+                            fields_array.len(),
+                            2,
+                            "/AcroForm/Fields should hold the 2 fields added via FormManager \
+                             (name_field, subscribe_checkbox); got {}",
+                            fields_array.len()
+                        );
                     } else {
                         panic!("Fields should be an array");
                     }


### PR DESCRIPTION
## Summary

- Fixes the silent-drop bug where fields added via `FormManager::add_text_field` / `add_combo_box` / `add_checkbox` / etc. never reached the written PDF. `write_catalog` bound `document.form_manager` to `_form_manager` and threw it away, so only fields manually appended to `document.acro_form.fields` ever got serialized. This is the gap the .NET wrapper hit.
- Wires up the full serialization path per ISO 32000-1 §12.7.3: each FormField becomes an indirect object, its ref lands in `/AcroForm/Fields`, and page widget annotations link back via `/Parent` (ISO 32000-1 §12.7.3.1).
- Adds `Page::add_form_widget_with_ref(widget, field_ref)` for linking a page widget to an AcroForm field, plus `FormManager::iter_fields_sorted` for deterministic (alphabetical) emission order.

## Details

The writer now:
1. Pre-allocates an `ObjectId` for every FormManager field **before** `write_pages` (`preallocate_form_manager_fields`), building a placeholder → real-id map.
2. Writes each field-body dict into its reserved id in `write_catalog`, then appends the refs to `document.acro_form.fields` so `/AcroForm/Fields [N 0 R …]` is emitted.
3. Remaps `Annotation::field_parent` (a placeholder ref returned by `FormManager::add_*_field`) to the real id at widget-serialization time, so widget dicts carry `/Parent <N 0 R>`.

Field-manager internals gained a `field_refs: HashMap<String, ObjectReference>` so `iter_fields_sorted` can return `(name, field, placeholder)` triples, which is what lets the writer pair a sorted field with its caller-handed-out placeholder.

Hardened `test_forms_integration` — the `let _ = fields_array.len()` no-op + "known limitation" comment was replaced with a real assertion that both FormManager-added fields appear in `/AcroForm/Fields`.

## Test plan

- [x] New integration test `acroform_fields_serialize_test.rs` parses the written PDF through `PdfReader` and verifies:
  - `/AcroForm` is an indirect reference in the catalog.
  - `/AcroForm/Fields` holds the expected count.
  - Each entry is an indirect ref resolving to a dict with the correct `/T` and `/FT`.
  - Each page widget carries `/Parent` pointing at its field (or is merged with `/T + /FT` inline).
  - Multiple fields emit in alphabetical order regardless of insertion order.
- [x] `cargo test -p oxidize-pdf --test acroform_fields_serialize_test`: 2 passed.
- [x] `cargo test -p oxidize-pdf --test interactive_features_test`: 4 passed (hardened assertion green).
- [x] `cargo test --workspace --lib`: 6317 passed, 0 failed, 3 ignored.
- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --lib --all-features -- -D warnings`: clean.

## Notes / concerns

- `cargo clippy --all-targets --all-features -- -D warnings` fails on three pre-existing errors in unrelated test files (`encryption_cross_validation_test.rs` manual-strip, `parser_objects_coverage.rs` PI approximation, `forms_cross_module_integration_test.rs` PI approximation). Verified pre-existing on `origin/develop`; not touched per the "only code related to this task" rule. Raising separately is advised.
- No `.private/*` paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)