### PR TITLE
feat(document): Document::fill_field with appearance regen

### DIFF
--- a/oxidize-pdf-core/src/annotations/annotation.rs
+++ b/oxidize-pdf-core/src/annotations/annotation.rs
@@ -220,6 +220,13 @@ pub struct Annotation {
     pub color: Option<Color>,
     /// Page reference (set by manager)
     pub page: Option<ObjectReference>,
+    /// Parent form field reference for widget annotations that live as
+    /// children of an /AcroForm field (ISO 32000-1 §12.7.3.1).
+    ///
+    /// When set, serialization writes `/Parent <ref>` into the annotation
+    /// dictionary so that the widget is linked to the field it belongs to.
+    /// Only meaningful for `AnnotationType::Widget`; ignored otherwise.
+    pub field_parent: Option<ObjectReference>,
     /// Additional properties specific to annotation type
     pub properties: Dictionary,
 }
@@ -241,6 +248,7 @@ impl Annotation {
             border: None,
             color: None,
             page: None,
+            field_parent: None,
             properties: Dictionary::new(),
         }
     }
@@ -364,6 +372,13 @@ impl Annotation {
         // Page reference
         if let Some(page) = self.page {
             dict.set("P", Object::Reference(page));
+        }
+
+        // Parent form field (widget annotations only — ISO 32000-1 §12.7.3.1).
+        // Emitted before merging additional properties so any explicit
+        // `/Parent` already in `properties` takes precedence.
+        if let Some(parent_ref) = self.field_parent {
+            dict.set("Parent", Object::Reference(parent_ref));
         }
 
         // Merge additional properties

--- a/oxidize-pdf-core/src/annotations/annotation.rs
+++ b/oxidize-pdf-core/src/annotations/annotation.rs
@@ -226,7 +226,12 @@ pub struct Annotation {
     /// When set, serialization writes `/Parent <ref>` into the annotation
     /// dictionary so that the widget is linked to the field it belongs to.
     /// Only meaningful for `AnnotationType::Widget`; ignored otherwise.
-    pub field_parent: Option<ObjectReference>,
+    ///
+    /// Scoped to `pub(crate)` because setting a `/Parent` on a non-Widget
+    /// annotation is meaningless and (for encrypted / PDF/A output) risky.
+    /// External callers must go through [`Annotation::set_field_parent`],
+    /// which validates the annotation type.
+    pub(crate) field_parent: Option<ObjectReference>,
     /// Additional properties specific to annotation type
     pub properties: Dictionary,
 }
@@ -295,6 +300,29 @@ impl Annotation {
         for (key, value) in field_dict.iter() {
             self.properties.set(key, value.clone());
         }
+    }
+
+    /// Set the parent form-field reference for a Widget annotation.
+    ///
+    /// Widget annotations that live as children of an /AcroForm field
+    /// (ISO 32000-1 §12.7.3.1) must carry `/Parent` pointing at the
+    /// parent field dictionary. This setter records that relationship;
+    /// the writer remaps the placeholder to a real indirect-object id
+    /// at serialization time.
+    ///
+    /// Only meaningful for [`AnnotationType::Widget`]. In debug builds,
+    /// calling this on a non-Widget annotation is a programming error
+    /// and trips a `debug_assert!`. In release builds the setter still
+    /// stores the value, but `to_dict` will refuse to emit `/Parent`
+    /// for non-Widget annotations (defence in depth: the setter is the
+    /// primary gate; the emitter is the safety net).
+    pub fn set_field_parent(&mut self, parent: ObjectReference) {
+        debug_assert!(
+            matches!(self.annotation_type, AnnotationType::Widget),
+            "Annotation::set_field_parent should only be called on Widget annotations, got {:?}",
+            self.annotation_type
+        );
+        self.field_parent = Some(parent);
     }
 
     /// Convert to PDF dictionary
@@ -377,8 +405,17 @@ impl Annotation {
         // Parent form field (widget annotations only — ISO 32000-1 §12.7.3.1).
         // Emitted before merging additional properties so any explicit
         // `/Parent` already in `properties` takes precedence.
-        if let Some(parent_ref) = self.field_parent {
-            dict.set("Parent", Object::Reference(parent_ref));
+        //
+        // We gate on `annotation_type == Widget` as defence in depth even
+        // though `set_field_parent` already refuses non-Widget types: if
+        // someone flipped `annotation_type` after setting `field_parent`,
+        // emitting `/Parent` on, say, a Link would produce a malformed
+        // form hierarchy that most viewers silently tolerate but ISO
+        // 32000-1 §12.7.3.1 forbids.
+        if matches!(self.annotation_type, AnnotationType::Widget) {
+            if let Some(parent_ref) = self.field_parent {
+                dict.set("Parent", Object::Reference(parent_ref));
+            }
         }
 
         // Merge additional properties

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -497,6 +497,153 @@ impl Document {
         self.form_manager = None;
     }
 
+    /// Fill an AcroForm field by name, updating `/V` and regenerating the
+    /// widget appearance stream(s) so the value is both machine-readable
+    /// (via `/V` on the field dictionary) and visually present in the PDF
+    /// (via `/AP/N` on each widget annotation).
+    ///
+    /// This implements ISO 32000-1 §12.7.3.3 Table 228 (`/V` on form fields)
+    /// plus §12.5.5 / §12.7.3.3 interplay: a viewer that honours
+    /// `/NeedAppearances true` may regenerate appearance streams on open,
+    /// but a compliant writer should still emit them so the PDF renders
+    /// correctly in readers that do not.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` — the partial field name (`/T` on the field dictionary)
+    ///   assigned when the field was registered via `FormManager::add_*`.
+    /// * `value` — the new value. For text fields this becomes `/V` as a
+    ///   PDF string; it is also embedded verbatim into the regenerated
+    ///   appearance content stream (see `TextFieldAppearance`).
+    ///
+    /// # Errors
+    ///
+    /// * `PdfError::InvalidStructure` if the document has no `FormManager`
+    ///   attached (calling code must register fields before filling them).
+    /// * `PdfError::FieldNotFound` if no field with the given `name` exists
+    ///   in the `FormManager`.
+    ///
+    /// # Path chosen (v2.5.6 Task 3)
+    ///
+    /// This method operates on an in-memory `Document` that was BUILT in
+    /// the current process (via `FormManager` + `Page::add_form_widget_with_ref`).
+    /// It does not re-parse an existing PDF; hydration of a parsed PDF
+    /// back into a mutable `Document` is out of scope for v2.5.6 Task 3
+    /// and tracked separately. The writer accepts the mutated document
+    /// and emits /V + /AP/N so the typical round-trip
+    /// "build → fill → save → reader sees filled value" is covered.
+    pub fn fill_field(&mut self, name: &str, value: impl Into<String>) -> Result<()> {
+        use crate::error::PdfError;
+        use crate::forms::FieldType;
+        use crate::objects::Object;
+
+        let value: String = value.into();
+
+        let form_manager = self.form_manager.as_mut().ok_or_else(|| {
+            PdfError::InvalidStructure(
+                "Document has no FormManager; register fields via enable_forms() or \
+                 set_form_manager() before calling fill_field"
+                    .to_string(),
+            )
+        })?;
+
+        // Capture the placeholder ref BEFORE taking a mutable borrow on the
+        // field; it lets us locate matching widget annotations below without
+        // a second lookup through `form_manager`.
+        let placeholder_ref = form_manager.field_ref(name);
+
+        let form_field = form_manager
+            .get_field_mut(name)
+            .ok_or_else(|| PdfError::FieldNotFound(name.to_string()))?;
+
+        // Resolve the field type from the field dict's `/FT` entry so the
+        // regenerated appearance matches the field's declared type (Tx, Btn,
+        // Ch, Sig). Default to `FieldType::Text` if absent — the FormManager
+        // always sets `/FT`, but defensive default keeps us robust.
+        let field_type = match form_field.field_dict.get("FT") {
+            Some(Object::Name(n)) => match n.as_str() {
+                "Btn" => FieldType::Button,
+                "Ch" => FieldType::Choice,
+                "Sig" => FieldType::Signature,
+                _ => FieldType::Text,
+            },
+            _ => FieldType::Text,
+        };
+
+        // 1) Update /V on the field dict. For text and choice fields
+        //    /V is a PDF string; for button fields it's a name, but the
+        //    `fill_field` contract (set textual value) is targeted at text
+        //    fields. Callers who need to toggle checkboxes should reach
+        //    through `FormManager::get_field_mut` directly.
+        form_field
+            .field_dict
+            .set("V", Object::String(value.clone()));
+
+        // 2) Regenerate the appearance stream(s) on each widget belonging
+        //    to this field. The regenerated /AP dictionary lives on the
+        //    widget struct inside the FormManager — but the `Annotation`
+        //    on the page was built at `add_form_widget_with_ref` time from
+        //    a clone of the widget's annotation dict, and therefore carries
+        //    its own (stale) /AP. Step 3 below refreshes that.
+        for widget in &mut form_field.widgets {
+            widget.generate_appearance(field_type, Some(&value))?;
+        }
+
+        // 3) For each page annotation whose `/Parent` matches this field's
+        //    placeholder ref, rewrite `properties.AP` with the freshly
+        //    generated appearance dict. We iterate all pages because the
+        //    API permits (and the .NET wrapper sometimes exercises) the
+        //    same field being referenced by widgets on multiple pages.
+        if let Some(placeholder) = placeholder_ref {
+            // Re-borrow after the mutable borrow on `form_field` ends.
+            let form_field = self
+                .form_manager
+                .as_ref()
+                .and_then(|fm| fm.get_field(name))
+                .ok_or_else(|| PdfError::FieldNotFound(name.to_string()))?;
+
+            // Use the first widget's appearance as the representative dict
+            // for the field. All widgets of a text field share content in
+            // this implementation (they differ only in geometry), so this
+            // avoids rebuilding per-page — the Widget→Annotation mapping
+            // below re-associates each annotation with its own widget via
+            // `field_parent` matching.
+            for page in self.pages.iter_mut() {
+                for annot in page.annotations_mut().iter_mut() {
+                    if annot.field_parent != Some(placeholder) {
+                        continue;
+                    }
+                    // Find the widget whose rect matches this annotation's
+                    // rect. Widgets on a field are distinguished only by
+                    // geometry, so `Rect` is the natural key.
+                    let matching_widget = form_field.widgets.iter().find(|w| {
+                        (w.rect.lower_left.x - annot.rect.lower_left.x).abs() < f64::EPSILON
+                            && (w.rect.lower_left.y - annot.rect.lower_left.y).abs() < f64::EPSILON
+                            && (w.rect.upper_right.x - annot.rect.upper_right.x).abs()
+                                < f64::EPSILON
+                            && (w.rect.upper_right.y - annot.rect.upper_right.y).abs()
+                                < f64::EPSILON
+                    });
+                    let widget = match matching_widget {
+                        Some(w) => w,
+                        // If rects differ (e.g. the annotation was added via
+                        // the legacy `add_form_widget` path), fall back to
+                        // the first widget's appearance — still correct for
+                        // text content, may be geometrically approximate.
+                        None => &form_field.widgets[0],
+                    };
+                    if let Some(ref app_dict) = widget.appearance_streams {
+                        annot
+                            .properties
+                            .set("AP", Object::Dictionary(app_dict.to_dict()));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Saves the document to a file.
     ///
     /// # Errors

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -608,29 +608,43 @@ impl Document {
             // avoids rebuilding per-page — the Widget→Annotation mapping
             // below re-associates each annotation with its own widget via
             // `field_parent` matching.
+            // Tolerance for widget ↔ annotation rect matching. PDF
+            // coordinates are serialised as decimal strings and may drift
+            // by a few ULPs through a write → parse round-trip or through
+            // caller-side float arithmetic; `f64::EPSILON` (~2.22e-16) is
+            // far too tight to absorb that drift, so we allow up to 1e-3
+            // points (~0.00035 mm — well below any physically meaningful
+            // distance on paper, and 10× tighter than the smallest PDF
+            // rendering unit) before declaring two rects distinct.
+            const RECT_MATCH_TOLERANCE: f64 = 1e-3;
+
             for page in self.pages.iter_mut() {
                 for annot in page.annotations_mut().iter_mut() {
                     if annot.field_parent != Some(placeholder) {
                         continue;
                     }
-                    // Find the widget whose rect matches this annotation's
-                    // rect. Widgets on a field are distinguished only by
-                    // geometry, so `Rect` is the natural key.
+                    // Find the widget whose rect is within tolerance of
+                    // this annotation's rect. Widgets on a field are
+                    // distinguished only by geometry, so `Rect` is the
+                    // natural key.
                     let matching_widget = form_field.widgets.iter().find(|w| {
-                        (w.rect.lower_left.x - annot.rect.lower_left.x).abs() < f64::EPSILON
-                            && (w.rect.lower_left.y - annot.rect.lower_left.y).abs() < f64::EPSILON
+                        (w.rect.lower_left.x - annot.rect.lower_left.x).abs() < RECT_MATCH_TOLERANCE
+                            && (w.rect.lower_left.y - annot.rect.lower_left.y).abs()
+                                < RECT_MATCH_TOLERANCE
                             && (w.rect.upper_right.x - annot.rect.upper_right.x).abs()
-                                < f64::EPSILON
+                                < RECT_MATCH_TOLERANCE
                             && (w.rect.upper_right.y - annot.rect.upper_right.y).abs()
-                                < f64::EPSILON
+                                < RECT_MATCH_TOLERANCE
                     });
-                    let widget = match matching_widget {
-                        Some(w) => w,
-                        // If rects differ (e.g. the annotation was added via
-                        // the legacy `add_form_widget` path), fall back to
-                        // the first widget's appearance — still correct for
-                        // text content, may be geometrically approximate.
-                        None => &form_field.widgets[0],
+                    // Fallback to the first widget when no rect matches
+                    // (e.g. annotation added via legacy `add_form_widget`
+                    // with a different rect). If the field has no widgets
+                    // at all — a valid state, e.g.
+                    // `add_radio_button(..., None, None)` — skip /AP sync
+                    // entirely rather than indexing into an empty Vec.
+                    let Some(widget) = matching_widget.or_else(|| form_field.widgets.first())
+                    else {
+                        continue;
                     };
                     if let Some(ref app_dict) = widget.appearance_streams {
                         annot

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -130,6 +130,14 @@ impl Default for FormData {
 pub struct FormManager {
     /// Registered fields
     fields: HashMap<String, FormField>,
+    /// Placeholder `ObjectReference` returned to callers for each field,
+    /// keyed by field name. The reference is a *placeholder* — its object
+    /// number comes from the FormManager's local counter and is disjoint
+    /// from the writer's global object-id allocator. The writer builds a
+    /// placeholder → real-ObjectId map at serialization time so widget
+    /// annotations created via `Page::add_form_widget_with_ref` can
+    /// resolve their `/Parent` to the correct real id.
+    field_refs: HashMap<String, ObjectReference>,
     /// AcroForm dictionary
     acro_form: AcroForm,
     /// Next field ID
@@ -141,6 +149,7 @@ impl FormManager {
     pub fn new() -> Self {
         Self {
             fields: HashMap::new(),
+            field_refs: HashMap::new(),
             acro_form: AcroForm::new(),
             next_field_id: 1,
         }
@@ -172,11 +181,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -205,11 +214,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -238,11 +247,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -277,11 +286,11 @@ impl FormManager {
             }
         }
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -307,11 +316,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -337,11 +346,11 @@ impl FormManager {
         let mut form_field = FormField::new(field_dict);
         form_field.add_widget(widget);
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -371,11 +380,11 @@ impl FormManager {
             form_field.add_widget(widget);
         }
 
-        self.fields.insert(field_name, form_field);
-
         // Create object reference
         let obj_ref = ObjectReference::new(self.next_field_id, 0);
         self.next_field_id += 1;
+        self.field_refs.insert(field_name.clone(), obj_ref);
+        self.fields.insert(field_name, form_field);
         self.acro_form.add_field(obj_ref);
 
         Ok(obj_ref)
@@ -417,6 +426,31 @@ impl FormManager {
     /// Get the number of fields managed by this FormManager
     pub fn field_count(&self) -> usize {
         self.fields.len()
+    }
+
+    /// Iterate over fields in a deterministic (alphabetical by name) order,
+    /// paired with the placeholder `ObjectReference` that was returned to
+    /// the caller when the field was added.
+    ///
+    /// The underlying storage is a `HashMap`, which has non-deterministic
+    /// iteration. Serializers that need reproducible output (diff-stable
+    /// `/AcroForm/Fields` arrays, object-id allocations, etc.) MUST use
+    /// this method instead of `fields().iter()`. The placeholder ref is
+    /// the one the writer uses to build the placeholder → real-id map
+    /// consumed by widget-annotation `/Parent` resolution.
+    pub fn iter_fields_sorted(
+        &self,
+    ) -> impl Iterator<Item = (&String, &FormField, ObjectReference)> {
+        let mut keys: Vec<&String> = self.fields.keys().collect();
+        keys.sort();
+        keys.into_iter().map(move |k| {
+            let field = self.fields.get(k).expect("key came from map");
+            let placeholder = *self
+                .field_refs
+                .get(k)
+                .expect("every field must have a placeholder ref");
+            (k, field, placeholder)
+        })
     }
 }
 

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -405,6 +405,35 @@ impl FormManager {
         self.fields.get(name)
     }
 
+    /// Get a mutable reference to a field by name.
+    ///
+    /// This is the primary entry point for mutating an AcroForm field's
+    /// dictionary (for example, to set `/V` during form filling) and its
+    /// associated widgets' appearance streams. It returns `None` if the
+    /// field does not exist — callers are expected to surface that as an
+    /// error to the user (see `Document::fill_field`).
+    pub fn get_field_mut(&mut self, name: &str) -> Option<&mut FormField> {
+        self.fields.get_mut(name)
+    }
+
+    /// Get the placeholder `ObjectReference` recorded for a field by name.
+    ///
+    /// The reference is a *placeholder* produced by `FormManager`'s local
+    /// counter at `add_*_field` time. It is the same value that widget
+    /// annotations created via `Page::add_form_widget_with_ref` store as
+    /// their `/Parent`, so this accessor is the bridge used by
+    /// `Document::fill_field` to locate the matching widget annotations on
+    /// page dictionaries without relying on field-name matching (which
+    /// would be fragile for nested field hierarchies in the future).
+    ///
+    /// Returns `None` if the field does not exist. Scoped `pub(crate)`
+    /// because the placeholder id is a writer-internal concept — the
+    /// public surface is `Document::fill_field`, not direct manipulation
+    /// of placeholder refs.
+    pub(crate) fn field_ref(&self, name: &str) -> Option<ObjectReference> {
+        self.field_refs.get(name).copied()
+    }
+
     /// Set default appearance for all fields
     pub fn set_default_appearance(&mut self, da: impl Into<String>) {
         self.acro_form.da = Some(da.into());

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -438,18 +438,42 @@ impl FormManager {
     /// this method instead of `fields().iter()`. The placeholder ref is
     /// the one the writer uses to build the placeholder → real-id map
     /// consumed by widget-annotation `/Parent` resolution.
-    pub fn iter_fields_sorted(
+    ///
+    /// Scoped to `pub(crate)` because the placeholder `ObjectReference` is
+    /// a writer-internal concept — leaking it in the public API would
+    /// couple external callers to a serialization detail that is expected
+    /// to evolve. Public iteration can go through [`FormManager::fields`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a streaming iterator of `Result` items. The only way an
+    /// error is produced is if the internal `fields` / `field_refs` maps
+    /// desynchronize — a "can't happen" invariant that every `add_*_field`
+    /// method is responsible for upholding. A desync surfaces as
+    /// [`PdfError::Internal`] rather than a panic so the writer hot path
+    /// stays panic-free (ISO 32000-1 conformance errors must remain
+    /// recoverable).
+    pub(crate) fn iter_fields_sorted(
         &self,
-    ) -> impl Iterator<Item = (&String, &FormField, ObjectReference)> {
+    ) -> impl Iterator<Item = Result<(&String, &FormField, ObjectReference)>> {
         let mut keys: Vec<&String> = self.fields.keys().collect();
         keys.sort();
         keys.into_iter().map(move |k| {
-            let field = self.fields.get(k).expect("key came from map");
-            let placeholder = *self
-                .field_refs
-                .get(k)
-                .expect("every field must have a placeholder ref");
-            (k, field, placeholder)
+            // `k` was just produced by `self.fields.keys()`, so this lookup
+            // cannot fail within the same borrow. We still avoid `expect`
+            // on a hot path and surface an `Internal` error instead of
+            // panicking — callers already propagate `Result<()>`.
+            let field = self.fields.get(k).ok_or_else(|| {
+                crate::error::PdfError::Internal(format!(
+                    "FormManager internal invariant broken: field '{k}' missing from fields map during sorted iteration"
+                ))
+            })?;
+            let placeholder = *self.field_refs.get(k).ok_or_else(|| {
+                crate::error::PdfError::Internal(format!(
+                    "FormManager internal invariant broken: field '{k}' has no placeholder ref (add_*_field forgot to populate field_refs?)"
+                ))
+            })?;
+            Ok((k, field, placeholder))
         })
     }
 }

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -936,6 +936,49 @@ impl Page {
         widget_ref
     }
 
+    /// Add a form field widget to the page and link it to an existing AcroForm field.
+    ///
+    /// Unlike [`Page::add_form_widget`], which expects the writer to track the
+    /// relationship implicitly via shared field names, this variant records
+    /// the `field_ref` as the widget's `/Parent` so the resulting PDF carries
+    /// an explicit widget→field link per ISO 32000-1 §12.7.3.1.
+    ///
+    /// This is the recommended path when the field itself was created via
+    /// [`crate::forms::FormManager`] (whose `add_text_field`, `add_combo_box`,
+    /// etc. return the field's `ObjectReference`): the field object is
+    /// serialized as an indirect object, and every widget placed on a page
+    /// points back to it through `/Parent`.
+    ///
+    /// # Arguments
+    ///
+    /// * `widget` - The widget appearance/geometry to place on the page.
+    /// * `field_ref` - The `ObjectReference` of the AcroForm field this
+    ///   widget belongs to (as returned by `FormManager::add_*`).
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success. The method currently cannot fail; the `Result`
+    /// return type is reserved for future validation.
+    pub fn add_form_widget_with_ref(
+        &mut self,
+        widget: Widget,
+        field_ref: ObjectReference,
+    ) -> crate::error::Result<()> {
+        // Convert widget to annotation, same as add_form_widget.
+        let mut annot = Annotation::new(crate::annotations::AnnotationType::Widget, widget.rect);
+
+        for (key, value) in widget.to_annotation_dict().iter() {
+            annot.properties.set(key, value.clone());
+        }
+
+        // Record the parent field reference so the writer emits
+        // `/Parent <field_ref>` in the widget annotation dictionary.
+        annot.field_parent = Some(field_ref);
+
+        self.annotations.push(annot);
+        Ok(())
+    }
+
     /// Sets the header for this page.
     ///
     /// # Example

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -973,7 +973,10 @@ impl Page {
 
         // Record the parent field reference so the writer emits
         // `/Parent <field_ref>` in the widget annotation dictionary.
-        annot.field_parent = Some(field_ref);
+        // Goes through the setter so the Widget-annotation-type invariant
+        // is enforced (debug_assert! in debug builds) — `field_parent` is
+        // `pub(crate)` precisely to prevent external callers bypassing it.
+        annot.set_field_parent(field_ref);
 
         self.annotations.push(annot);
         Ok(())

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -184,7 +184,7 @@ impl<W: Write> PdfWriter<W> {
         // refs returned by `FormManager::add_text_field`. This is the piece
         // that bridges the FormManager's local id counter and the writer's
         // global id allocator. See `form_field_placeholder_map` for details.
-        self.preallocate_form_manager_fields(document);
+        self.preallocate_form_manager_fields(document)?;
 
         // Write pages (they contain widget annotations and font references)
         self.write_pages(document, &font_refs)?;
@@ -910,16 +910,22 @@ impl<W: Write> PdfWriter<W> {
             }
 
             // Write each field dict into its reserved id.
-            let sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = form_manager
-                .iter_fields_sorted()
-                .map(|(_name, form_field, placeholder)| {
-                    let real_id = *self
-                        .form_field_placeholder_map
-                        .get(&placeholder)
-                        .expect("every sorted field must have a pre-allocated real id");
-                    (form_field.field_dict.clone(), real_id)
-                })
-                .collect();
+            // Surface a clean `PdfError` if the placeholder-ref → real-id
+            // map is missing any entry — a "can't happen" breach of the
+            // invariant established by `preallocate_form_manager_fields`,
+            // which must run before this function.
+            let mut sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = Vec::new();
+            for item in form_manager.iter_fields_sorted() {
+                let (name, form_field, placeholder) = item?;
+                let real_id = *self.form_field_placeholder_map.get(&placeholder).ok_or_else(
+                    || {
+                        PdfError::Internal(format!(
+                            "AcroForm writer internal invariant broken: field '{name}' (placeholder {placeholder}) has no pre-allocated real object id — preallocate_form_manager_fields must run before write_catalog"
+                        ))
+                    },
+                )?;
+                sorted.push((form_field.field_dict.clone(), real_id));
+            }
             for (field_dict, real_id) in sorted {
                 self.write_object(real_id, Object::Dictionary(field_dict))?;
             }
@@ -1353,16 +1359,18 @@ impl<W: Write> PdfWriter<W> {
     /// Iteration order is deterministic (alphabetical by field name) via
     /// `FormManager::iter_fields_sorted` so object-ID allocation — and
     /// therefore the byte-for-byte output — is reproducible across builds.
-    fn preallocate_form_manager_fields(&mut self, document: &Document) {
+    fn preallocate_form_manager_fields(&mut self, document: &Document) -> Result<()> {
         let Some(form_manager) = &document.form_manager else {
-            return;
+            return Ok(());
         };
 
-        for (_name, _form_field, placeholder) in form_manager.iter_fields_sorted() {
+        for item in form_manager.iter_fields_sorted() {
+            let (_name, _form_field, placeholder) = item?;
             let real_id = self.allocate_object_id();
             self.form_field_placeholder_map.insert(placeholder, real_id);
             self.form_manager_field_refs.push(real_id);
         }
+        Ok(())
     }
 
     fn write_form_fields(&mut self, document: &mut Document) -> Result<()> {
@@ -2567,14 +2575,20 @@ impl<W: Write> PdfWriter<W> {
             // from the writer's allocator). At this point the writer has
             // already pre-allocated real ids for every FormManager field
             // via `preallocate_form_manager_fields`, so we translate.
+            //
+            // We read `field_parent` straight off the struct instead of
+            // round-tripping through `annot_dict.get("Parent")`: the
+            // dictionary representation is what we're producing, not a
+            // source of truth. The struct field is authoritative and
+            // avoids matching on a value we just computed.
+            //
             // Widgets whose parent placeholder is NOT in the map (e.g.
-            // the caller supplied a hand-built ref) are left unchanged —
-            // not every `/Parent` necessarily comes from the FormManager.
-            if annotation.field_parent.is_some() {
-                if let Some(Object::Reference(parent_ref)) = annot_dict.get("Parent") {
-                    if let Some(real_id) = self.form_field_placeholder_map.get(parent_ref) {
-                        annot_dict.set("Parent", Object::Reference(*real_id));
-                    }
+            // the caller supplied a hand-built ref, or `field_parent` was
+            // set from outside the FormManager) are left unchanged — not
+            // every `/Parent` necessarily comes from the FormManager.
+            if let Some(placeholder) = annotation.field_parent {
+                if let Some(real_id) = self.form_field_placeholder_map.get(&placeholder) {
+                    annot_dict.set("Parent", Object::Reference(*real_id));
                 }
             }
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2592,6 +2592,46 @@ impl<W: Write> PdfWriter<W> {
                 }
             }
 
+            // Externalize inline streams inside /AP.
+            //
+            // `Widget::generate_appearance` (and any user-supplied appearance
+            // dictionary) stores the /N, /R, /D entries as inline
+            // `Object::Stream` values inside the /AP sub-dictionary. Per
+            // ISO 32000-1 §7.3.8.1, "all streams shall be indirect objects" —
+            // inline streams as dictionary values are not permitted. We
+            // therefore externalize each inline stream to a freshly
+            // allocated indirect object and replace it with a /Reference.
+            //
+            // /AP itself has two legal shapes (§12.5.5):
+            //   * A single stream (direct or indirect) → the "default" state.
+            //   * A sub-dictionary mapping state names (/N, /R, /D) to
+            //     streams, where /D may further be a dict mapping values to
+            //     streams (radio buttons, checkboxes).
+            // We handle the sub-dict shape (which is what `fill_field`
+            // emits); the legacy single-stream shape falls through to the
+            // writer's default handling below.
+            if let Some(Object::Dictionary(ap_dict)) = annot_dict.get("AP") {
+                let mut updated_ap = crate::objects::Dictionary::new();
+                for (state_key, state_val) in ap_dict.iter() {
+                    match state_val {
+                        Object::Stream(sd, data) => {
+                            let stream_id = self.allocate_object_id();
+                            self.write_object(stream_id, Object::Stream(sd.clone(), data.clone()))?;
+                            updated_ap.set(state_key, Object::Reference(stream_id));
+                        }
+                        Object::Dictionary(down_dict) => {
+                            // /D sub-dict case: map value → stream.
+                            let externalized = self.externalize_streams_in_dict(down_dict)?;
+                            updated_ap.set(state_key, Object::Dictionary(externalized));
+                        }
+                        _ => {
+                            updated_ap.set(state_key, state_val.clone());
+                        }
+                    }
+                }
+                annot_dict.set("AP", Object::Dictionary(updated_ap));
+            }
+
             self.write_object(annot_id, Object::Dictionary(annot_dict))?;
             annot_refs.push(Object::Reference(annot_id));
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -102,6 +102,20 @@ pub struct PdfWriter<W: Write> {
     file_id: Option<Vec<u8>>,
     encryption_state: Option<WriterEncryptionState>,
     pending_encrypt_dict: Option<Dictionary>,
+    // FormManager field tracking:
+    //  * `form_field_placeholder_map` translates the placeholder
+    //    `ObjectReference` returned by `FormManager::add_text_field` et al.
+    //    (those use a local counter unaware of writer-side allocation) into
+    //    the real `ObjectId` chosen by `allocate_object_id`. Widgets created
+    //    via `Page::add_form_widget_with_ref` store the placeholder in
+    //    `Annotation::field_parent`; when the annotation dict is written we
+    //    remap it through this table so `/Parent` points at the real field.
+    //  * `form_manager_field_refs` is the ordered (alphabetical by field
+    //    name) list of real refs; it's appended to `document.acro_form.fields`
+    //    during `write_catalog` and is what ends up in
+    //    `/AcroForm/Fields`.
+    form_field_placeholder_map: HashMap<crate::objects::ObjectReference, ObjectId>,
+    form_manager_field_refs: Vec<crate::objects::ObjectReference>,
 }
 
 /// Holds the encryption key and encryptor for encrypting objects during write
@@ -137,6 +151,8 @@ impl<W: Write> PdfWriter<W> {
             file_id: None,
             encryption_state: None,
             pending_encrypt_dict: None,
+            form_field_placeholder_map: HashMap::new(),
+            form_manager_field_refs: Vec::new(),
         }
     }
 
@@ -161,6 +177,14 @@ impl<W: Write> PdfWriter<W> {
 
         // Write custom fonts first (so pages can reference them)
         let font_refs = self.write_fonts(document)?;
+
+        // Pre-allocate object IDs for every field owned by the FormManager
+        // BEFORE writing pages, so widget annotations on those pages can
+        // emit `/Parent <real_id>` instead of pointing at the placeholder
+        // refs returned by `FormManager::add_text_field`. This is the piece
+        // that bridges the FormManager's local id counter and the writer's
+        // global id allocator. See `form_field_placeholder_map` for details.
+        self.preallocate_form_manager_fields(document);
 
         // Write pages (they contain widget annotations and font references)
         self.write_pages(document, &font_refs)?;
@@ -861,12 +885,51 @@ impl<W: Write> PdfWriter<W> {
         catalog.set("Type", Object::Name("Catalog".to_string()));
         catalog.set("Pages", Object::Reference(pages_id));
 
-        // Process FormManager if present to update AcroForm
-        // We'll write the actual fields after pages are written
-        if let Some(_form_manager) = &document.form_manager {
-            // Ensure AcroForm exists
+        // Serialize fields owned by the FormManager (ISO 32000-1 §12.7.3).
+        //
+        // Before v2.5.6 this block did nothing: it bound `_form_manager`
+        // but never read its `fields` map, so only fields appended manually
+        // to `document.acro_form.fields` ever reached the output PDF. Any
+        // field created via `FormManager::add_text_field` / `add_combo_box`
+        // / etc. was silently dropped — exactly the gap the .NET wrapper
+        // hit.
+        //
+        // Object IDs for these fields were pre-allocated in
+        // `preallocate_form_manager_fields` (called before `write_pages`
+        // so widget `/Parent` refs could resolve). Here we only have to:
+        //   (a) write the field-body dict into each pre-allocated id, and
+        //   (b) append those ids to `document.acro_form.fields` so the
+        //       /AcroForm write block below emits
+        //       `/AcroForm/Fields [N 0 R ...]`.
+        //
+        // Iteration follows the same deterministic order used at
+        // pre-allocation time, so the order-vs-id pairing is stable.
+        if let Some(form_manager) = &document.form_manager {
             if document.acro_form.is_none() {
                 document.acro_form = Some(crate::forms::AcroForm::new());
+            }
+
+            // Write each field dict into its reserved id.
+            let sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = form_manager
+                .iter_fields_sorted()
+                .map(|(_name, form_field, placeholder)| {
+                    let real_id = *self
+                        .form_field_placeholder_map
+                        .get(&placeholder)
+                        .expect("every sorted field must have a pre-allocated real id");
+                    (form_field.field_dict.clone(), real_id)
+                })
+                .collect();
+            for (field_dict, real_id) in sorted {
+                self.write_object(real_id, Object::Dictionary(field_dict))?;
+            }
+
+            if let Some(acro) = document.acro_form.as_mut() {
+                for r in &self.form_manager_field_refs {
+                    if !acro.fields.contains(r) {
+                        acro.fields.push(*r);
+                    }
+                }
             }
         }
 
@@ -1276,6 +1339,30 @@ impl<W: Write> PdfWriter<W> {
 
         self.write_object(struct_tree_root_id, Object::Dictionary(struct_tree_root))?;
         Ok(struct_tree_root_id)
+    }
+
+    /// Reserve an `ObjectId` for every field owned by `document.form_manager`
+    /// and build the placeholder → real mapping used when widget annotations
+    /// are serialised (see `Annotation::field_parent`).
+    ///
+    /// Called once from `write_document` before `write_pages`, so widget
+    /// `/Parent` refs on pages resolve to real indirect objects. The field
+    /// bodies themselves are written later, in `write_catalog`, reusing
+    /// these pre-allocated IDs.
+    ///
+    /// Iteration order is deterministic (alphabetical by field name) via
+    /// `FormManager::iter_fields_sorted` so object-ID allocation — and
+    /// therefore the byte-for-byte output — is reproducible across builds.
+    fn preallocate_form_manager_fields(&mut self, document: &Document) {
+        let Some(form_manager) = &document.form_manager else {
+            return;
+        };
+
+        for (_name, _form_field, placeholder) in form_manager.iter_fields_sorted() {
+            let real_id = self.allocate_object_id();
+            self.form_field_placeholder_map.insert(placeholder, real_id);
+            self.form_manager_field_refs.push(real_id);
+        }
     }
 
     fn write_form_fields(&mut self, document: &mut Document) -> Result<()> {
@@ -2472,7 +2559,25 @@ impl<W: Write> PdfWriter<W> {
         //    page.add_annotation(). Each is written as an indirect object.
         for annotation in page.annotations() {
             let annot_id = self.allocate_object_id();
-            let annot_dict = annotation.to_dict();
+            let mut annot_dict = annotation.to_dict();
+
+            // Remap `/Parent` from FormManager placeholder → real ObjectId.
+            // `Annotation::field_parent` stores the placeholder ref returned
+            // by FormManager::add_*_field (which uses a counter disjoint
+            // from the writer's allocator). At this point the writer has
+            // already pre-allocated real ids for every FormManager field
+            // via `preallocate_form_manager_fields`, so we translate.
+            // Widgets whose parent placeholder is NOT in the map (e.g.
+            // the caller supplied a hand-built ref) are left unchanged —
+            // not every `/Parent` necessarily comes from the FormManager.
+            if annotation.field_parent.is_some() {
+                if let Some(Object::Reference(parent_ref)) = annot_dict.get("Parent") {
+                    if let Some(real_id) = self.form_field_placeholder_map.get(parent_ref) {
+                        annot_dict.set("Parent", Object::Reference(*real_id));
+                    }
+                }
+            }
+
             self.write_object(annot_id, Object::Dictionary(annot_dict))?;
             annot_refs.push(Object::Reference(annot_id));
 
@@ -2528,6 +2633,8 @@ impl PdfWriter<BufWriter<std::fs::File>> {
             file_id: None,
             encryption_state: None,
             pending_encrypt_dict: None,
+            form_field_placeholder_map: HashMap::new(),
+            form_manager_field_refs: Vec::new(),
         })
     }
 }

--- a/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
+++ b/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
@@ -15,7 +15,7 @@
 //!     or carries /T + /FT inline (merged field/widget dict, per
 //!     ISO 32000-1 §12.7.3.1).
 
-use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::forms::{CheckBox, FormManager, TextField, Widget, WidgetAppearance};
 use oxidize_pdf::geometry::{Point, Rectangle};
 use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::PdfReader;
@@ -253,5 +253,154 @@ fn form_manager_multiple_fields_are_all_emitted_in_deterministic_order() {
         names,
         vec!["aaa_first".to_string(), "zzz_last".to_string()],
         "FormManager must emit fields in deterministic (alphabetical by name) order"
+    );
+}
+
+/// Regression test for the degenerate but legal case where a user attaches
+/// an empty FormManager to a document.
+///
+/// Behaviour under test: when `set_form_manager` is called with a manager
+/// that has no fields, the writer still emits `/AcroForm` on the catalog
+/// (matching `write_catalog`'s unconditional `AcroForm::new()` fallback)
+/// but its `/Fields` entry is the empty array. ISO 32000-1 §12.7.3 tolerates
+/// this — an AcroForm with no fields is syntactically well-formed — and it's
+/// the path the .NET wrapper takes when a user intends to populate fields
+/// after construction. If a future change decides to omit `/AcroForm` in
+/// this case, this test should be updated alongside that change.
+#[test]
+fn form_manager_empty_produces_empty_fields_array() {
+    let mut doc = Document::new();
+    let page = Page::a4();
+    doc.add_page(page);
+    doc.set_form_manager(FormManager::new());
+
+    let bytes = doc.to_bytes().expect("serialize document with empty FM");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    let catalog = reader.catalog().expect("catalog").clone();
+    // Current behaviour: `/AcroForm` is emitted even for an empty FormManager.
+    // Accept either "absent" or "present with empty Fields array" so this
+    // test remains stable if the writer later decides to suppress empty
+    // AcroForms. The core invariant we lock in is: no phantom fields.
+    match catalog.get("AcroForm") {
+        None => {
+            // Acceptable: empty FormManager → no AcroForm at all.
+        }
+        Some(acro_obj) => {
+            // Emitted: must then be indirect and carry an empty /Fields.
+            let (acro_n, acro_g) = acro_obj
+                .as_reference()
+                .expect("/AcroForm must be indirect when emitted");
+            let acro = reader
+                .get_object(acro_n, acro_g)
+                .expect("resolve AcroForm")
+                .clone();
+            let acro_dict = acro.as_dict().expect("/AcroForm must be a dictionary");
+            let fields_arr = acro_dict
+                .get("Fields")
+                .and_then(|o| o.as_array())
+                .expect("/AcroForm/Fields must exist as an array");
+            assert!(
+                fields_arr.is_empty(),
+                "empty FormManager must not produce phantom entries in /AcroForm/Fields; got {} entries",
+                fields_arr.len()
+            );
+        }
+    }
+}
+
+/// Regression test for the heterogeneous case: a text field + a checkbox
+/// in the same FormManager. Both must round-trip through the writer as
+/// indirect objects, both must appear in `/AcroForm/Fields`, and their
+/// `/FT` values must match the PDF type each field carries (Tx for text,
+/// Btn for checkbox — ISO 32000-1 Table 220).
+///
+/// This locks in the invariant that the dispatch-by-`add_*` method does
+/// not silently drop non-text field types, which was the original v2.5.6
+/// Task 2 bug class.
+#[test]
+fn form_manager_mixed_field_types_round_trip() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    // Text field — alphabetically "email" (sorts before "subscribe").
+    let text_rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let text_widget = Widget::new(text_rect).with_appearance(WidgetAppearance::default());
+    let text_ref = fm
+        .add_text_field(TextField::new("email"), text_widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(text_widget, text_ref)
+        .expect("attach text widget");
+
+    // Checkbox — alphabetically "subscribe" (sorts after "email").
+    let cb_rect = Rectangle::new(Point::new(100.0, 660.0), Point::new(115.0, 675.0));
+    let cb_widget = Widget::new(cb_rect).with_appearance(WidgetAppearance::default());
+    let cb_ref = fm
+        .add_checkbox(CheckBox::new("subscribe"), cb_widget.clone(), None)
+        .expect("add_checkbox");
+    page.add_form_widget_with_ref(cb_widget, cb_ref)
+        .expect("attach checkbox widget");
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // --- Resolve /AcroForm/Fields --------------------------------------
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve AcroForm")
+        .clone();
+    let fields_arr: Vec<PdfObject> = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields array")
+        .0
+        .clone();
+
+    assert_eq!(
+        fields_arr.len(),
+        2,
+        "/AcroForm/Fields must hold both the text field and the checkbox"
+    );
+
+    // --- Collect (name, type) pairs in emission order ------------------
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for entry in &fields_arr {
+        let (n, g) = entry
+            .as_reference()
+            .expect("each field entry must be a reference");
+        let obj = reader.get_object(n, g).expect("resolve field").clone();
+        let d = obj.as_dict().expect("field must be a dict");
+        let t = d
+            .get("T")
+            .and_then(|o| o.as_string())
+            .and_then(|s| s.as_str().ok())
+            .expect("field /T")
+            .to_owned();
+        let ft = d
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned())
+            .expect("field /FT");
+        pairs.push((t, ft));
+    }
+
+    // Deterministic (alphabetical) emission: "email" (Tx) then "subscribe" (Btn).
+    assert_eq!(
+        pairs,
+        vec![
+            ("email".to_string(), "Tx".to_string()),
+            ("subscribe".to_string(), "Btn".to_string()),
+        ],
+        "mixed field types must round-trip with correct /T and /FT values"
     );
 }

--- a/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
+++ b/oxidize-pdf-core/tests/acroform_fields_serialize_test.rs
@@ -1,0 +1,257 @@
+//! Integration tests for FormManager field serialization (Task 2 of v2.5.6 fix series).
+//!
+//! Regression suite for the bug where fields added via
+//! `FormManager::add_text_field` / `add_combo_box` / etc. were silently
+//! discarded at write time because `write_catalog` bound the form_manager
+//! to `_form_manager` without ever reading its `fields` map. As a result
+//! only fields appended manually to `document.acro_form.fields` ever
+//! reached the output PDF, and the .NET wrapper hit this limitation.
+//!
+//! These tests verify the real wire format of the written PDF via
+//! `PdfReader`:
+//!   * Each `FormField` in the manager becomes an indirect PDF object.
+//!   * Its `ObjectReference` lands in `/AcroForm/Fields`.
+//!   * The page widget annotation is either /Parent-linked to the field
+//!     or carries /T + /FT inline (merged field/widget dict, per
+//!     ISO 32000-1 §12.7.3.1).
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walks /Pages and returns the object reference of the first leaf page.
+/// All tests in this file use single-page documents.
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("catalog must carry /Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids must be an array");
+    kids.get(0)
+        .expect("/Pages/Kids[0] must exist")
+        .as_reference()
+        .expect("/Pages/Kids[0] must be a reference")
+}
+
+#[test]
+fn form_manager_fields_appear_as_indirect_objects_and_acroform_references_them() {
+    // Build a PDF with a single email field added through FormManager.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("email");
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("FormManager::add_text_field must succeed");
+
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref must succeed");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+
+    // Parse the written bytes and verify the wire format.
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // --- /Catalog/AcroForm must exist and be indirect -----------------
+    let (acro_obj_num, acro_gen_num) = {
+        let catalog = reader.catalog().expect("catalog").clone();
+        let acro_entry = catalog
+            .get("AcroForm")
+            .expect("/AcroForm must be present in catalog")
+            .clone();
+        acro_entry
+            .as_reference()
+            .expect("/AcroForm must be an indirect reference, not an inline dict")
+    };
+
+    // --- /AcroForm dict must contain exactly one Fields entry ---------
+    let (field_obj_num, field_gen_num) = {
+        let acro_obj = reader
+            .get_object(acro_obj_num, acro_gen_num)
+            .expect("resolve /AcroForm")
+            .clone();
+        let acro_dict = acro_obj.as_dict().expect("/AcroForm must be a dictionary");
+        let fields_obj = acro_dict
+            .get("Fields")
+            .expect("/AcroForm/Fields must exist");
+        let fields_arr = fields_obj
+            .as_array()
+            .expect("/AcroForm/Fields must be an array");
+        assert_eq!(
+            fields_arr.len(),
+            1,
+            "/AcroForm/Fields should hold exactly one entry (the email field)"
+        );
+        let field_ref_obj = fields_arr.get(0).expect("Fields[0] exists");
+        field_ref_obj
+            .as_reference()
+            .expect("/AcroForm/Fields[0] must be an indirect reference")
+    };
+
+    // --- Resolved field dict must carry /T = "email", /FT = /Tx -------
+    {
+        let field_obj = reader
+            .get_object(field_obj_num, field_gen_num)
+            .expect("resolve field")
+            .clone();
+        let field_dict = field_obj
+            .as_dict()
+            .expect("field must serialize as a dictionary");
+
+        let t_entry = field_dict
+            .get("T")
+            .and_then(|o| o.as_string())
+            .map(|s| s.as_str().expect("UTF-8").to_owned())
+            .expect("field /T must exist and be a PDF string");
+        assert_eq!(t_entry, "email", "field /T (partial field name)");
+
+        let ft_entry = field_dict
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned())
+            .expect("field /FT must exist and be a PDF name");
+        assert_eq!(ft_entry, "Tx", "field /FT (field type) must be Tx");
+    }
+
+    // --- Page must carry the widget as an indirect annotation ---------
+    let (page_obj_num, page_gen_num) = first_page_ref(&mut reader);
+    let page_dict = reader
+        .get_object(page_obj_num, page_gen_num)
+        .expect("resolve page")
+        .clone();
+    let page_dict = page_dict
+        .as_dict()
+        .expect("page object must be a dictionary");
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("page /Annots must exist as array");
+    assert_eq!(
+        annots.len(),
+        1,
+        "page should have exactly one widget annotation"
+    );
+    let (widget_obj_num, widget_gen_num) = annots
+        .get(0)
+        .expect("annots[0]")
+        .as_reference()
+        .expect("annotation must be indirect");
+
+    let widget_dict = {
+        let widget_obj = reader
+            .get_object(widget_obj_num, widget_gen_num)
+            .expect("resolve widget annotation")
+            .clone();
+        widget_obj
+            .as_dict()
+            .expect("widget annotation must be a dictionary")
+            .clone()
+    };
+
+    // Subtype must be Widget regardless of which link style we use.
+    let subtype = widget_dict
+        .get("Subtype")
+        .and_then(|o| o.as_name())
+        .map(|n| n.as_str().to_owned())
+        .expect("widget /Subtype must exist");
+    assert_eq!(subtype, "Widget", "widget /Subtype");
+
+    // Two acceptable shapes per ISO 32000-1 §12.7.3.1:
+    //   (a) separate objects: widget carries /Parent = field_ref
+    //   (b) merged: widget dict itself holds /T and /FT
+    let has_parent_to_field = widget_dict
+        .get("Parent")
+        .and_then(|o| o.as_reference())
+        .map(|(n, g)| n == field_obj_num && g == field_gen_num)
+        .unwrap_or(false);
+    let is_merged = widget_dict.get("T").is_some() && widget_dict.get("FT").is_some();
+
+    assert!(
+        has_parent_to_field || is_merged,
+        "widget annotation must either /Parent-link to the AcroForm field \
+         (expected ref {}/{}) or carry /T + /FT inline (merged field/widget dict)",
+        field_obj_num,
+        field_gen_num,
+    );
+}
+
+#[test]
+fn form_manager_multiple_fields_are_all_emitted_in_deterministic_order() {
+    // Two fields added out of alphabetical order; the serializer must emit
+    // both as indirect objects, and (per iter_fields_sorted) in a stable
+    // deterministic order so diffs are reproducible.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect_a = Rectangle::new(Point::new(50.0, 700.0), Point::new(250.0, 720.0));
+    let rect_b = Rectangle::new(Point::new(50.0, 650.0), Point::new(250.0, 670.0));
+
+    let widget_b = Widget::new(rect_b).with_appearance(WidgetAppearance::default());
+    let b_ref = fm
+        .add_text_field(TextField::new("zzz_last"), widget_b.clone(), None)
+        .unwrap();
+
+    let widget_a = Widget::new(rect_a).with_appearance(WidgetAppearance::default());
+    let a_ref = fm
+        .add_text_field(TextField::new("aaa_first"), widget_a.clone(), None)
+        .unwrap();
+
+    // Attach widgets to the page in the order they were created (reverse alpha).
+    page.add_form_widget_with_ref(widget_b, b_ref).unwrap();
+    page.add_form_widget_with_ref(widget_a, a_ref).unwrap();
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let bytes = doc.to_bytes().expect("serialize document");
+
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // Collect /AcroForm/Fields names in emission order.
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve AcroForm")
+        .clone();
+    let fields_arr: Vec<PdfObject> = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields array")
+        .0
+        .clone();
+
+    let mut names: Vec<String> = Vec::new();
+    for entry in &fields_arr {
+        let (n, g) = entry
+            .as_reference()
+            .expect("each field entry must be a reference");
+        let obj = reader.get_object(n, g).expect("resolve field").clone();
+        let t = obj
+            .as_dict()
+            .and_then(|d| d.get("T"))
+            .and_then(|o| o.as_string())
+            .and_then(|s| s.as_str().ok())
+            .expect("field /T")
+            .to_owned();
+        names.push(t);
+    }
+
+    assert_eq!(
+        names,
+        vec!["aaa_first".to_string(), "zzz_last".to_string()],
+        "FormManager must emit fields in deterministic (alphabetical by name) order"
+    );
+}

--- a/oxidize-pdf-core/tests/fill_field_roundtrip_test.rs
+++ b/oxidize-pdf-core/tests/fill_field_roundtrip_test.rs
@@ -1,0 +1,218 @@
+//! Integration tests for `Document::fill_field` (Task 3 of v2.5.6 fix series).
+//!
+//! Verifies that `Document::fill_field(name, value)`:
+//!   1. Updates `/V` on the named AcroForm field (ISO 32000-1 §12.7.3.3 Table 228).
+//!   2. Regenerates the widget annotation's appearance stream(s) so the
+//!      value is visually present in the PDF (ISO 32000-1 §12.5.5 AP/N).
+//!
+//! Path chosen (per v2.5.6 plan, Task 3): Path A — narrow scope, no hydration.
+//! `fill_field` operates on an in-memory `Document` that was BUILT in the
+//! current process via `FormManager` + `Page::add_form_widget_with_ref`
+//! (the Task 2 path). The test then writes to bytes, parses those bytes
+//! through `PdfReader`, and asserts on the resolved wire format.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walks /Pages and returns the object reference of the first leaf page.
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("catalog must carry /Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids must be an array");
+    kids.get(0)
+        .expect("/Pages/Kids[0] must exist")
+        .as_reference()
+        .expect("/Pages/Kids[0] must be a reference")
+}
+
+/// Build a baseline single-page PDF that has one text field named `"email"`
+/// wired through `FormManager` + `Page::add_form_widget_with_ref` (Task 2).
+/// Returns the constructed `Document` (not yet serialized) so the caller can
+/// mutate it via `fill_field` before writing to bytes.
+fn build_baseline_document() -> Document {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("email");
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("FormManager::add_text_field must succeed");
+
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref must succeed");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    doc
+}
+
+#[test]
+fn fill_field_sets_v_and_regenerates_appearance_stream() {
+    // --- Arrange: build the baseline document -----------------------------
+    let mut doc = build_baseline_document();
+
+    // --- Act: fill the named field ---------------------------------------
+    doc.fill_field("email", "user@example.com")
+        .expect("fill_field must succeed on an existing field");
+
+    let bytes = doc.to_bytes().expect("serialize filled document to bytes");
+
+    // --- Assert: parse written bytes and verify wire format ---------------
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse written PDF");
+
+    // Resolve /AcroForm/Fields[0] -----------------------------------------
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm must be an indirect reference");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve /AcroForm")
+        .clone();
+    let (field_n, field_g) = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .and_then(|a| a.get(0))
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm/Fields[0] must be an indirect reference");
+
+    // --- Assertion 1: /V == "user@example.com" on the resolved field -----
+    {
+        let field_obj = reader
+            .get_object(field_n, field_g)
+            .expect("resolve field dict")
+            .clone();
+        let field_dict = field_obj.as_dict().expect("field must be a dictionary");
+        let v = field_dict
+            .get("V")
+            .and_then(|o| o.as_string())
+            .and_then(|s| s.as_str().ok())
+            .map(|s| s.to_owned())
+            .expect("field /V must be present after fill_field and decode as UTF-8");
+        assert_eq!(
+            v, "user@example.com",
+            "filled field /V must equal the value passed to fill_field"
+        );
+    }
+
+    // --- Assertion 2: Page 0 widget /AP/N is present and its stream -------
+    //                  content contains the filled value as ASCII bytes.
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_dict = reader
+        .get_object(page_n, page_g)
+        .expect("resolve page")
+        .clone();
+    let page_dict = page_dict.as_dict().expect("page must be a dictionary");
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("page /Annots must be an array");
+    assert_eq!(
+        annots.len(),
+        1,
+        "page must carry exactly one widget annotation"
+    );
+    let (widget_n, widget_g) = annots
+        .get(0)
+        .and_then(|o| o.as_reference())
+        .expect("annotation must be an indirect reference");
+
+    let widget_dict = reader
+        .get_object(widget_n, widget_g)
+        .expect("resolve widget annotation")
+        .clone();
+    let widget_dict = widget_dict
+        .as_dict()
+        .expect("widget annotation must be a dictionary")
+        .clone();
+
+    // /AP must exist as a dictionary with /N referring to a Form XObject.
+    let ap_dict = widget_dict
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("widget annotation must carry /AP after fill_field (appearance regenerated)")
+        .clone();
+
+    // /AP/N must be an indirect reference to a Form XObject stream
+    // (ISO 32000-1 §12.5.5: appearance streams are Form XObjects, which
+    //  per §7.3.8 MUST be indirect objects). Accept either a direct
+    //  Reference or — for defence in depth — an inline Stream.
+    let normal_entry = ap_dict
+        .get("N")
+        .expect("/AP must contain /N (normal appearance)")
+        .clone();
+
+    let (stream_dict_ref, stream_data): (oxidize_pdf::parser::objects::PdfDictionary, Vec<u8>) =
+        match normal_entry {
+            oxidize_pdf::parser::objects::PdfObject::Reference(n, g) => {
+                let form_xobj = reader
+                    .get_object(n, g)
+                    .expect("resolve /AP/N form xobject")
+                    .clone();
+                let stream = form_xobj
+                    .as_stream()
+                    .expect("/AP/N must resolve to a stream object");
+                let decoded = stream
+                    .decode(reader.options())
+                    .expect("decode /AP/N content stream");
+                (stream.dict.clone(), decoded)
+            }
+            oxidize_pdf::parser::objects::PdfObject::Stream(ref s) => {
+                let decoded = s
+                    .decode(reader.options())
+                    .expect("decode inline /AP/N content stream");
+                (s.dict.clone(), decoded)
+            }
+            other => panic!(
+                "/AP/N must be a stream (direct or indirect), got: {:?}",
+                other
+            ),
+        };
+
+    // Form XObject must declare Subtype /Form (ISO 32000-1 §8.10).
+    let subtype = stream_dict_ref
+        .get("Subtype")
+        .and_then(|o| o.as_name())
+        .map(|n| n.as_str().to_owned())
+        .expect("appearance stream must declare /Subtype");
+    assert_eq!(
+        subtype, "Form",
+        "/AP/N must be a Form XObject (Subtype /Form) per ISO 32000-1 §8.10"
+    );
+
+    // Finally: the decoded content stream must contain the filled value as
+    // ASCII bytes. The text-field appearance generator emits
+    // `(user@example.com) Tj` per `TextFieldAppearance::generate_appearance`
+    // (src/forms/appearance.rs), so the literal UTF-8 bytes of the filled
+    // value appear verbatim inside the content stream.
+    let needle = b"user@example.com";
+    assert!(
+        stream_data.windows(needle.len()).any(|w| w == needle),
+        "/AP/N content stream must contain the filled value as ASCII bytes; \
+         stream body is: {:?}",
+        String::from_utf8_lossy(&stream_data),
+    );
+}
+
+/// Regression test: `fill_field` must return an error for an unknown field
+/// name rather than silently succeeding (which would leave the caller
+/// believing the fill happened).
+#[test]
+fn fill_field_unknown_name_is_an_error() {
+    let mut doc = build_baseline_document();
+    let err = doc.fill_field("no_such_field", "whatever");
+    assert!(
+        err.is_err(),
+        "fill_field on an unknown field must return Err, got {:?}",
+        err
+    );
+}

--- a/oxidize-pdf-core/tests/fill_field_roundtrip_test.rs
+++ b/oxidize-pdf-core/tests/fill_field_roundtrip_test.rs
@@ -216,3 +216,238 @@ fn fill_field_unknown_name_is_an_error() {
         err
     );
 }
+
+/// Regression for I-1 (PR #203 code-review).
+///
+/// `fill_field` used to index into `form_field.widgets[0]` unconditionally
+/// as a fallback when no widget rect matched an annotation's rect. If the
+/// FormField was registered without any widgets (a valid state — e.g.
+/// `FormManager::add_radio_button(radio, None, None)` — or a field whose
+/// widgets vector was cleared after registration), that fallback would
+/// panic with an out-of-bounds index.
+///
+/// Contract: `fill_field` MUST NOT panic when a field has an empty widgets
+/// vector. It should still update `/V` on the field dict (step 1) and
+/// simply skip `/AP` synchronization on matching annotations (step 3),
+/// since there is no widget to draw an appearance from.
+#[test]
+fn fill_field_does_not_panic_when_field_has_no_widgets() {
+    // Build the scenario before handing ownership to Document:
+    //   - FormManager has field "email" with EMPTY widgets
+    //   - Page carries an annotation whose `field_parent` points at "email"
+    // This is the exact path that used to trip the `widgets[0]` panic.
+    let mut fm = FormManager::new();
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("email");
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("FormManager::add_text_field");
+
+    // Drop every widget from the FormField — the page still carries the
+    // widget annotation (wired via add_form_widget_with_ref below).
+    fm.get_field_mut("email")
+        .expect("field 'email' must exist")
+        .widgets
+        .clear();
+
+    let mut page = Page::a4();
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+
+    let mut doc = Document::new();
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    // Must not panic. Returns Ok because step 1 (update /V) is unaffected,
+    // and step 3 (sync /AP) becomes a no-op when the field has no widgets.
+    doc.fill_field("email", "irrelevant")
+        .expect("fill_field must succeed when widgets is empty");
+
+    // /V must still be set in the written PDF — step 1 of fill_field is
+    // widget-independent.
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve /AcroForm")
+        .clone();
+    let (field_n, field_g) = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .and_then(|a| a.get(0))
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm/Fields[0] indirect");
+    let field_obj = reader
+        .get_object(field_n, field_g)
+        .expect("resolve field")
+        .clone();
+    let v = field_obj
+        .as_dict()
+        .and_then(|d| d.get("V"))
+        .and_then(|o| o.as_string())
+        .and_then(|s| s.as_str().ok())
+        .map(|s| s.to_owned())
+        .expect("/V must be present after fill_field even with empty widgets");
+    assert_eq!(v, "irrelevant", "/V must equal the fill_field value");
+}
+
+/// Regression for I-3 (PR #203 code-review).
+///
+/// The widget ↔ annotation matching in `fill_field` compared rect
+/// coordinates with `f64::EPSILON` (~2.22e-16), a tolerance that's far
+/// tighter than any realistic PDF coordinate precision. Any sub-point
+/// numerical drift — from a `to_bytes() -> parse -> mutate` round-trip,
+/// from a user-computed rect that used floats differently, or from
+/// transformation math in downstream code — would cause every annotation
+/// to fall through to the `widgets[0]` fallback.
+///
+/// For a multi-widget field (e.g. the same "accept_terms" checkbox
+/// replicated on several pages, a radio-button group, or any custom layout
+/// with multiple appearance regions sharing one value), that fallback
+/// means every annotation gets widgets[0]'s appearance_streams — visually
+/// wrong for widgets 1..N.
+///
+/// Contract: rects that differ by less than 1e-3 points (0.00035 mm —
+/// far below any physically meaningful difference on paper) MUST match
+/// their corresponding widget, not fall back to widgets[0].
+#[test]
+fn fill_field_matches_widget_when_rect_differs_by_sub_millipoint() {
+    use oxidize_pdf::forms::{CheckBox, FormManager};
+    use oxidize_pdf::parser::objects::PdfObject;
+
+    // Two widgets on the SAME field at DIFFERENT rects — this is the
+    // scenario where selecting the correct widget matters visually.
+    // Checkbox is the simplest `FormManager::add_*` path that takes a
+    // single widget; we register the field once, then push the second
+    // widget manually into its `widgets` Vec so both belong to the same
+    // FormField (mirroring the multi-widget radio-button / duplicated-
+    // checkbox layouts that appear in real forms).
+    let rect_a = Rectangle::new(Point::new(100.0, 700.0), Point::new(200.0, 720.0));
+    let rect_b = Rectangle::new(Point::new(300.0, 400.0), Point::new(500.0, 460.0));
+
+    let w_a = Widget::new(rect_a).with_appearance(WidgetAppearance::default());
+    let w_b = Widget::new(rect_b).with_appearance(WidgetAppearance::default());
+
+    let mut fm = FormManager::new();
+    let field_ref = fm
+        .add_checkbox(CheckBox::new("choice"), w_a.clone(), None)
+        .expect("add_checkbox");
+    // Add the second widget so the FormField carries both.
+    fm.get_field_mut("choice")
+        .expect("field 'choice' exists")
+        .add_widget(w_b.clone());
+
+    // Build the page annotations with rects PERTURBED by a sub-millipoint
+    // delta (~5e-10 pts, ~2e6× above f64::EPSILON but 2e6× below 1e-3 pt).
+    // This is the regression setup: f64::EPSILON rejects both; 1e-3 pt
+    // accepts both and matches them to the correct widget.
+    const DELTA: f64 = 5e-10;
+    let perturbed_a = Rectangle::new(
+        Point::new(rect_a.lower_left.x + DELTA, rect_a.lower_left.y),
+        Point::new(rect_a.upper_right.x + DELTA, rect_a.upper_right.y),
+    );
+    let perturbed_b = Rectangle::new(
+        Point::new(rect_b.lower_left.x + DELTA, rect_b.lower_left.y),
+        Point::new(rect_b.upper_right.x + DELTA, rect_b.upper_right.y),
+    );
+
+    let mut page = Page::a4();
+    page.add_form_widget_with_ref(Widget::new(perturbed_a), field_ref)
+        .expect("add widget A annotation");
+    page.add_form_widget_with_ref(Widget::new(perturbed_b), field_ref)
+        .expect("add widget B annotation");
+
+    let mut doc = Document::new();
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("choice", "Yes")
+        .expect("fill_field must succeed");
+
+    // Assert on the serialized wire format: each annotation's /AP/N must
+    // resolve to a Form XObject with the /BBox of ITS OWN widget, not
+    // widgets[0]'s bbox. Widget A bbox is (0,0,100,20); widget B bbox is
+    // (0,0,200,60). Falling back to widgets[0] would make BOTH /BBoxes
+    // (0,0,100,20).
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_obj = reader
+        .get_object(page_n, page_g)
+        .expect("resolve page")
+        .clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("/Annots");
+    assert_eq!(annots.0.len(), 2, "expected 2 annotations");
+
+    let mut bboxes: Vec<(f64, f64, f64, f64)> = Vec::new();
+    for annot_entry in annots.0.iter() {
+        let (n, g) = annot_entry
+            .as_reference()
+            .expect("annotation must be an indirect reference");
+        let annot_obj = reader.get_object(n, g).expect("resolve annot").clone();
+        let annot_dict = annot_obj.as_dict().expect("annot dict").clone();
+        let ap = annot_dict
+            .get("AP")
+            .and_then(|o| o.as_dict())
+            .expect("/AP must be present after fill_field")
+            .clone();
+        let n_entry = ap.get("N").expect("/AP/N").clone();
+
+        let stream_dict = match n_entry {
+            PdfObject::Reference(rn, rg) => {
+                let resolved = reader.get_object(rn, rg).expect("resolve /AP/N").clone();
+                resolved
+                    .as_stream()
+                    .expect("/AP/N must be a stream")
+                    .dict
+                    .clone()
+            }
+            PdfObject::Stream(ref s) => s.dict.clone(),
+            other => panic!("/AP/N must be a stream, got {:?}", other),
+        };
+
+        let bbox_arr = stream_dict
+            .get("BBox")
+            .and_then(|o| o.as_array())
+            .expect("/AP/N must have /BBox");
+        let coords: Vec<f64> = bbox_arr
+            .0
+            .iter()
+            .filter_map(|o: &PdfObject| o.as_real().or_else(|| o.as_integer().map(|i| i as f64)))
+            .collect();
+        assert_eq!(coords.len(), 4, "/BBox must have 4 numbers");
+        bboxes.push((coords[0], coords[1], coords[2], coords[3]));
+    }
+
+    let expected_a = (0.0_f64, 0.0_f64, 100.0_f64, 20.0_f64);
+    let expected_b = (0.0_f64, 0.0_f64, 200.0_f64, 60.0_f64);
+    let near = |got: (f64, f64, f64, f64), want: (f64, f64, f64, f64)| -> bool {
+        (got.0 - want.0).abs() < 1e-6
+            && (got.1 - want.1).abs() < 1e-6
+            && (got.2 - want.2).abs() < 1e-6
+            && (got.3 - want.3).abs() < 1e-6
+    };
+
+    let has_a = bboxes.iter().any(|&b| near(b, expected_a));
+    let has_b = bboxes.iter().any(|&b| near(b, expected_b));
+    assert!(
+        has_a && has_b,
+        "each annotation must receive ITS OWN widget's /BBox \
+         (expected one of each: A={:?}, B={:?}), got: {:?}",
+        expected_a,
+        expected_b,
+        bboxes
+    );
+}

--- a/oxidize-pdf-core/tests/interactive_features_test.rs
+++ b/oxidize-pdf-core/tests/interactive_features_test.rs
@@ -157,11 +157,19 @@ fn test_forms_integration() {
 
                 if let Some(fields_obj) = acroform_dict.get("Fields") {
                     if let Some(fields_array) = fields_obj.as_array() {
-                        // Note: Due to current implementation, form fields are written
-                        // separately from widgets, so we just check that the array exists
-                        // The array might be empty or have different count than expected
-                        // This is a known limitation of the current implementation
-                        let _ = fields_array.len(); // Just verify it's a valid array
+                        // Both fields added via FormManager must reach the wire
+                        // (name_field + subscribe_checkbox). Before the v2.5.6
+                        // fix, `write_catalog` discarded manager fields entirely
+                        // and this array could be empty or reflect only legacy
+                        // widgets — that was the "known limitation" we just
+                        // closed.
+                        assert_eq!(
+                            fields_array.len(),
+                            2,
+                            "/AcroForm/Fields should hold the 2 fields added via FormManager \
+                             (name_field, subscribe_checkbox); got {}",
+                            fields_array.len()
+                        );
                     } else {
                         panic!("Fields should be an array");
                     }


### PR DESCRIPTION
## Summary

Task 3 of the v2.5.6 gap-closing series. Exposes a public `Document::fill_field(name, value)` API that:

1. Sets `/V` on the named AcroForm field per ISO 32000-1 §12.7.3.3 Table 228.
2. Regenerates each widget's appearance stream via `Widget::generate_appearance` so the value is visually present in the PDF (§12.5.5).

**Depends on PR #202 (FormManager field serialization) landing first** — the round-trip assertion relies on Task 2's `/Parent` linking. Branched from `fix/acroform-serialize-fields` (commit `339caea`), not from `develop`.

## Scope (Path A per v2.5.6 plan)

Operates on an in-memory `Document` built in the current process through `FormManager` + `Page::add_form_widget_with_ref` (the Task 2 path). Hydration of a parsed PDF back into a mutable `Document` is out of scope for v2.5.6 Task 3 — the .NET wrapper builds the PDF in-process, fills fields, and saves, so this covers the typical round-trip the gap audit surfaced.

## Changes

- `document.rs`: new `Document::fill_field` (public). Resolves `FieldType` from `/FT`, updates `/V` on the field dict, regenerates appearance on each widget, and syncs the regenerated `/AP` dict onto matching page annotations via `field_parent` placeholder-ref matching.
- `forms/form_data.rs`: expose `FormManager::get_field_mut` (pub) and `field_ref` (pub(crate)) — placeholder refs stay crate-scoped because they are a writer-internal concept.
- `writer/pdf_writer/mod.rs`: externalize inline `Object::Stream` values inside `/AP` to indirect objects before serializing annotations, per ISO 32000-1 §7.3.8.1 ("all streams shall be indirect objects"). Handles both the state-key shape (`/N`, `/R`, `/D` → stream) and the `/D` sub-dict shape (value → stream for radio/checkbox states).

## Test plan

- [x] New test file `tests/fill_field_roundtrip_test.rs` parses the written PDF through `PdfReader` and asserts on the resolved wire format:
  - [x] `/AcroForm/Fields[0]` resolved dict has `/V == "user@example.com"`.
  - [x] Page 0 widget `/AP/N` resolves to a Form XObject stream (Subtype `/Form`) whose decoded content stream contains the ASCII bytes of the filled value (emitted verbatim by `TextFieldAppearance` via `(…) Tj`).
  - [x] `fill_field` on an unknown field name returns `Err`.
- [x] Task 2 regression test `acroform_fields_serialize_test` still passes (4/4).
- [x] Full lib unit test suite: 6320/6320 passing.
- [x] Annotation + forms integration tests: annotation_write_test, annotations_integration_test, annotations_comprehensive_test, form_actions_tests, forms_comprehensive_test, forms_document_integration_test, source_highlighter_test — all passing.
- [x] `cargo clippy -p oxidize-pdf --lib --all-features -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.

Closes gap #3 from the .NET wrapper audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)