### PR TITLE
feat(page): expose FormXObject public API + /Group regression tests (Tasks 7+9)

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -799,9 +799,29 @@ impl Page {
         &self.images
     }
 
-    /// Adds a Form XObject resource to this page.
-    /// Used by overlay operations to embed external page content.
-    pub(crate) fn add_form_xobject(
+    /// Adds a Form XObject resource to this page (public as of v2.5.6).
+    ///
+    /// `name` is the key under which the Form XObject is exposed in the
+    /// page's `/Resources/XObject` dictionary — typically `F1`, `Fm0`, etc.
+    /// Use this when embedding reusable graphical content, overlays, stamps
+    /// or template page fragments composed with the `FormXObject` /
+    /// `FormXObjectBuilder` APIs.
+    ///
+    /// Duplicate names overwrite silently (the same behaviour as inserting
+    /// into the underlying map); if you need idempotent registration,
+    /// inspect [`Page::form_xobjects`] before calling.
+    ///
+    /// ```rust
+    /// use oxidize_pdf::geometry::Rectangle;
+    /// use oxidize_pdf::graphics::FormXObject;
+    /// use oxidize_pdf::Page;
+    ///
+    /// let mut page = Page::a4();
+    /// let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
+    /// page.add_form_xobject("F1", FormXObject::new(bbox));
+    /// assert!(page.form_xobjects().contains_key("F1"));
+    /// ```
+    pub fn add_form_xobject(
         &mut self,
         name: impl Into<String>,
         form: crate::graphics::FormXObject,
@@ -809,8 +829,12 @@ impl Page {
         self.form_xobjects.insert(name.into(), form);
     }
 
-    /// Returns all Form XObjects registered on this page.
-    pub(crate) fn form_xobjects(&self) -> &HashMap<String, crate::graphics::FormXObject> {
+    /// Returns all Form XObjects registered on this page (public as of v2.5.6).
+    ///
+    /// Keys correspond to `/Resources/XObject` entries emitted by the
+    /// writer. The returned map is read-only; to mutate, use
+    /// [`Page::add_form_xobject`].
+    pub fn form_xobjects(&self) -> &HashMap<String, crate::graphics::FormXObject> {
         &self.form_xobjects
     }
 

--- a/oxidize-pdf-core/tests/formxobject_group_test.rs
+++ b/oxidize-pdf-core/tests/formxobject_group_test.rs
@@ -1,0 +1,269 @@
+//! Regression tests for Task 7 + Task 9 of the v2.5.6 gap series.
+//!
+//! Two concerns, one PR:
+//!
+//! - **Task 7 (public API surface):** `Page::add_form_xobject` and
+//!   `Page::form_xobjects` are declared `pub` as part of v2.5.6 so external
+//!   users can attach Form XObject resources (overlays, stamps, reusable
+//!   shapes) without reaching through internal machinery. The mere fact
+//!   that this integration-test file — which lives outside the crate —
+//!   compiles and calls `page.add_form_xobject(...)` proves the visibility
+//!   contract. If either method regresses back to `pub(crate)`, this file
+//!   stops compiling, which is the regression guard.
+//!
+//! - **Task 9 (wire-format invariant):** A `FormXObject` constructed with a
+//!   `TransparencyGroup` MUST serialise with a `/Group` sub-dictionary
+//!   carrying `/Type /Group`, `/S /Transparency`, `/CS <color space>`, and
+//!   optional `/I`/`/K` booleans (ISO 32000-1 §11.6.6, Table 147). A
+//!   FormXObject without a transparency group MUST NOT emit `/Group`.
+//!   Both invariants are already implemented in
+//!   `graphics::form_xobject::FormXObject::to_stream`; these tests lock
+//!   the behaviour so a future refactor cannot silently drop it.
+
+use oxidize_pdf::geometry::Rectangle;
+// `graphics::TransparencyGroup` is the general-purpose struct from
+// `graphics::transparency`; `FormXObject::with_transparency_group` takes
+// the FormXObject-local variant re-exported under the alias
+// `FormTransparencyGroup` (see `graphics/mod.rs:28`). Using the alias
+// keeps the intent explicit and avoids ambiguity with the general struct.
+use oxidize_pdf::graphics::{FormTransparencyGroup, FormXObject};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walks /Pages down to the first leaf page and returns its object ref.
+/// Matches the helper already used by `fill_field_roundtrip_test`.
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("catalog must carry /Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids must be an array");
+    kids.0
+        .first()
+        .expect("/Pages/Kids[0] must exist")
+        .as_reference()
+        .expect("/Pages/Kids[0] must be a reference")
+}
+
+/// Resolve the first Form XObject registered under `/Resources/XObject`
+/// on the first leaf page. Returns the resolved stream dict.
+fn resolve_first_page_xobject<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+    name: &str,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page_obj = reader
+        .get_object(page_n, page_g)
+        .expect("resolve page")
+        .clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+
+    // /Resources may be a direct dict or an indirect reference.
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => {
+            let r = reader
+                .get_object(*n, *g)
+                .expect("resolve /Resources")
+                .clone();
+            r.as_dict().expect("/Resources is dict").clone()
+        }
+        other => panic!("/Resources must be dict or ref, got {:?}", other),
+    };
+
+    let xobjects = match resources.get("XObject").expect("/XObject must be present") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => {
+            let r = reader.get_object(*n, *g).expect("resolve /XObject").clone();
+            r.as_dict().expect("/XObject is dict").clone()
+        }
+        other => panic!("/XObject must be dict or ref, got {:?}", other),
+    };
+
+    let (stream_n, stream_g) = xobjects
+        .get(name)
+        .and_then(|o| o.as_reference())
+        .unwrap_or_else(|| panic!("/XObject/{} must be indirect", name));
+    let stream_obj = reader
+        .get_object(stream_n, stream_g)
+        .expect("resolve xobject stream")
+        .clone();
+    stream_obj
+        .as_stream()
+        .expect("xobject must be a stream")
+        .dict
+        .clone()
+}
+
+/// Task 9 primary assertion: a FormXObject with a TransparencyGroup
+/// serialises with a `/Group` dict carrying the ISO 32000-1 §11.6.6 entries.
+#[test]
+fn formxobject_with_transparency_group_emits_group_dict() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
+    let form = FormXObject::new(bbox).with_transparency_group(FormTransparencyGroup {
+        color_space: "DeviceRGB".to_string(),
+        isolated: false,
+        knockout: false,
+    });
+
+    // Public API as of v2.5.6 (Task 7). If this call fails to compile,
+    // the visibility regressed to pub(crate).
+    page.add_form_xobject("F1", form);
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let stream_dict = resolve_first_page_xobject(&mut reader, "F1");
+
+    // /Subtype /Form (ISO 32000-1 §8.10) — sanity check: proves we resolved
+    // the right object.
+    assert_eq!(
+        stream_dict
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("Form"),
+        "/F1 must be a Form XObject"
+    );
+
+    // /Group must be a direct dict with the required ISO 32000-1 §11.6.6
+    // entries.
+    let group = stream_dict
+        .get("Group")
+        .and_then(|o| o.as_dict())
+        .expect("/Group dict must be present for a FormXObject with transparency");
+
+    assert_eq!(
+        group
+            .get("Type")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("Group"),
+        "/Group/Type must be /Group"
+    );
+    assert_eq!(
+        group.get("S").and_then(|o| o.as_name()).map(|n| n.as_str()),
+        Some("Transparency"),
+        "/Group/S must be /Transparency"
+    );
+    assert_eq!(
+        group
+            .get("CS")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceRGB"),
+        "/Group/CS must reflect the color_space requested"
+    );
+
+    // /I and /K are optional; when constructed with isolated=false and
+    // knockout=false, `to_stream` omits them (ISO 32000-1 §11.6.6 default).
+    // If they are emitted anyway, they MUST be false to preserve semantics.
+    if let Some(i) = group.get("I").and_then(|o| o.as_bool()) {
+        assert!(
+            !i,
+            "/Group/I must be false when isolated=false was requested"
+        );
+    }
+    if let Some(k) = group.get("K").and_then(|o| o.as_bool()) {
+        assert!(
+            !k,
+            "/Group/K must be false when knockout=false was requested"
+        );
+    }
+}
+
+/// Task 9 edge case: flipping `isolated` / `knockout` on the TransparencyGroup
+/// must surface as `/I true` / `/K true` entries in the emitted /Group dict.
+#[test]
+fn formxobject_transparency_group_emits_isolated_and_knockout_booleans() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    let bbox = Rectangle::from_position_and_size(0.0, 0.0, 50.0, 50.0);
+    let form = FormXObject::new(bbox).with_transparency_group(FormTransparencyGroup {
+        color_space: "DeviceCMYK".to_string(),
+        isolated: true,
+        knockout: true,
+    });
+    page.add_form_xobject("F1", form);
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let stream_dict = resolve_first_page_xobject(&mut reader, "F1");
+
+    let group = stream_dict
+        .get("Group")
+        .and_then(|o| o.as_dict())
+        .expect("/Group must be present");
+    assert_eq!(
+        group.get("I").and_then(|o| o.as_bool()),
+        Some(true),
+        "/Group/I must be true when isolated=true"
+    );
+    assert_eq!(
+        group.get("K").and_then(|o| o.as_bool()),
+        Some(true),
+        "/Group/K must be true when knockout=true"
+    );
+    assert_eq!(
+        group
+            .get("CS")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceCMYK"),
+        "/Group/CS must reflect the color_space requested"
+    );
+}
+
+/// Task 9 negative case: a FormXObject constructed WITHOUT a
+/// TransparencyGroup must omit `/Group` entirely. Emitting an empty or
+/// defaulted `/Group` would be an ISO violation (the dict is optional per
+/// Table 147 and its presence signals transparency semantics).
+#[test]
+fn formxobject_without_transparency_group_omits_group_dict() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
+    page.add_form_xobject("F1", FormXObject::new(bbox));
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let stream_dict = resolve_first_page_xobject(&mut reader, "F1");
+
+    assert!(
+        stream_dict.get("Group").is_none(),
+        "/Group must be absent when no TransparencyGroup was set, got: {:?}",
+        stream_dict.get("Group")
+    );
+}
+
+/// Task 7 public-accessor regression: `Page::form_xobjects()` must be
+/// callable from outside the crate and reflect in-memory state before
+/// serialisation.
+#[test]
+fn form_xobjects_accessor_is_public_and_reflects_state() {
+    let mut page = Page::a4();
+    assert!(
+        page.form_xobjects().is_empty(),
+        "new page must carry no form xobjects"
+    );
+
+    let bbox = Rectangle::from_position_and_size(0.0, 0.0, 10.0, 10.0);
+    page.add_form_xobject("Stamp", FormXObject::new(bbox));
+
+    let map = page.form_xobjects();
+    assert_eq!(map.len(), 1, "exactly one form xobject expected");
+    assert!(
+        map.contains_key("Stamp"),
+        "the inserted resource name must survive the accessor"
+    );
+}


### PR DESCRIPTION
## Summary

Closes **Tasks 7 and 9** of the v2.5.6 gap-closing series (per the .NET wrapper audit). Combined into a single PR because Task 9 is literally the regression test suite for the API surface that Task 7 exposes — splitting them would leave a window where `add_form_xobject` is public but untested.

### Task 7 — visibility
- `Page::add_form_xobject`  \`pub(crate)\` → \`pub\`
- `Page::form_xobjects`     \`pub(crate)\` → \`pub\`
- Both gained full rustdoc; a doctest on `add_form_xobject` covers the happy path.
- No behaviour change; the overlay code paths that already used these methods continue unchanged.

### Task 9 — `/Group` wire format regression guard
New file `oxidize-pdf-core/tests/formxobject_group_test.rs` with 4 tests that serialise a `Document`, re-parse the bytes, and walk `/Pages → /Resources → /XObject → /F1` stream dict → `/Group` to verify **ISO 32000-1 §11.6.6 (Table 147)** invariants:

1. `/Group` present with `/Type /Group`, `/S /Transparency`, `/CS` set to requested color space when `FormTransparencyGroup` attached.
2. `/I true` / `/K true` surface when `isolated` / `knockout` are set.
3. `/Group` absent when no `FormTransparencyGroup` was attached.
4. `page.form_xobjects()` accessor returns inserted resources (in-memory state check).

All assertions are wire-format — no smoke tests.

### Implementation note
`FormXObject::with_transparency_group` takes the struct from `graphics::form_xobject` (re-exported as `FormTransparencyGroup` in `graphics/mod.rs:28`), NOT the general-purpose `TransparencyGroup` from `graphics::transparency` (which carries extra `blend_mode`/`opacity` fields and `color_space: Option<String>`). Tests import `FormTransparencyGroup` explicitly to avoid the name collision.

## Test plan

- [x] RED confirmed: without the visibility change the test file fails to compile with 6× E0624 (private method).
- [x] GREEN: `cargo test -p oxidize-pdf --test formxobject_group_test` → 4/4 passing.
- [x] Lib suite: `cargo test -p oxidize-pdf --lib` → 6322 passing / 0 failed / 3 ignored.
- [x] Doctests including the new one: 42/42 passing.
- [x] `cargo clippy -p oxidize-pdf --lib --all-features -- -D warnings`: clean.
- [x] `cargo clippy -p oxidize-pdf --test formxobject_group_test -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.

Closes 2 of the 9 gaps; 5 remaining (Tasks 4, 5, 6, 8, 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)