### PR TITLE
feat(page): register ColorSpace/Pattern/Shading + writer emission (Tasks 4-6)

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -66,6 +66,18 @@ pub struct Page {
     text_context: TextContext,
     images: HashMap<String, Image>,
     form_xobjects: HashMap<String, crate::graphics::FormXObject>,
+    /// Registered colour spaces, emitted under `/Resources/ColorSpace`
+    /// per ISO 32000-1 §8.6, Table 62. Values preserve the caller-supplied
+    /// `Object` shape (typically `Array([Name, Dictionary])` for
+    /// parameterised spaces like CalRGB / ICCBased / Indexed, or a single
+    /// `Name` for aliasing a device space under a custom resource name).
+    color_spaces: HashMap<String, crate::objects::Object>,
+    /// Registered tiling patterns, emitted as indirect stream objects
+    /// referenced from `/Resources/Pattern` per ISO 32000-1 §8.7.3.
+    patterns: HashMap<String, crate::graphics::TilingPattern>,
+    /// Registered shadings, emitted as indirect dictionary objects
+    /// referenced from `/Resources/Shading` per ISO 32000-1 §8.7.4.
+    shadings: HashMap<String, crate::graphics::ShadingDefinition>,
     header: Option<HeaderFooter>,
     footer: Option<HeaderFooter>,
     annotations: Vec<Annotation>,
@@ -94,6 +106,9 @@ impl Page {
             text_context: TextContext::new(),
             images: HashMap::new(),
             form_xobjects: HashMap::new(),
+            color_spaces: HashMap::new(),
+            patterns: HashMap::new(),
+            shadings: HashMap::new(),
             header: None,
             footer: None,
             annotations: Vec::new(),
@@ -836,6 +851,61 @@ impl Page {
     /// [`Page::add_form_xobject`].
     pub fn form_xobjects(&self) -> &HashMap<String, crate::graphics::FormXObject> {
         &self.form_xobjects
+    }
+
+    /// Registers a colour space under `name` (ISO 32000-1 §8.6).
+    ///
+    /// `cs` must be a legal PDF colour-space representation: either a
+    /// single name (e.g. `Object::Name("DeviceRGB")`) aliasing a device
+    /// space under a custom resource key, or an array like
+    /// `[/CalRGB <<dict>>]` / `[/ICCBased <<stream>>]` /
+    /// `[/Indexed /DeviceRGB N <hivals>]`. The writer serialises the
+    /// supplied object verbatim into `/Resources/ColorSpace/<name>`.
+    pub fn add_color_space(&mut self, name: impl Into<String>, cs: crate::objects::Object) {
+        self.color_spaces.insert(name.into(), cs);
+    }
+
+    /// Returns all colour spaces registered on this page.
+    pub fn color_spaces(&self) -> &HashMap<String, crate::objects::Object> {
+        &self.color_spaces
+    }
+
+    /// Registers a tiling pattern under `name` (ISO 32000-1 §8.7.3).
+    ///
+    /// The writer emits each pattern as an indirect stream object (patterns
+    /// are streams per §7.3.8.1) and references it from
+    /// `/Resources/Pattern/<name>`. Inside the content stream, paint the
+    /// pattern with `/<name> scn` / `/<name> SCN` after selecting the
+    /// /Pattern colour space.
+    pub fn add_pattern(
+        &mut self,
+        name: impl Into<String>,
+        pattern: crate::graphics::TilingPattern,
+    ) {
+        self.patterns.insert(name.into(), pattern);
+    }
+
+    /// Returns all tiling patterns registered on this page.
+    pub fn patterns(&self) -> &HashMap<String, crate::graphics::TilingPattern> {
+        &self.patterns
+    }
+
+    /// Registers a shading under `name` (ISO 32000-1 §8.7.4).
+    ///
+    /// The writer emits the shading as an indirect dictionary object and
+    /// references it from `/Resources/Shading/<name>`. Paint with the
+    /// `sh` operator (`/<name> sh`) or via a type-2 Pattern.
+    pub fn add_shading(
+        &mut self,
+        name: impl Into<String>,
+        shading: crate::graphics::ShadingDefinition,
+    ) {
+        self.shadings.insert(name.into(), shading);
+    }
+
+    /// Returns all shadings registered on this page.
+    pub fn shadings(&self) -> &HashMap<String, crate::graphics::ShadingDefinition> {
+        &self.shadings
     }
 
     /// Appends raw PDF operators to the content stream.

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2440,6 +2440,54 @@ impl<W: Write> PdfWriter<W> {
             }
         }
 
+        // ColorSpace resources (ISO 32000-1 §8.6, Table 62). Emitted as a
+        // direct sub-dictionary — colour-space *parameters* (the dict
+        // inside `[/CalRGB <<..>>]`) are generally small and inlining them
+        // keeps the cross-reference table lean. Callers that need
+        // larger / shared colour spaces can register them once and reuse
+        // the same key across pages.
+        if !page.color_spaces().is_empty() {
+            let mut cs_dict = Dictionary::new();
+            for (name, obj) in page.color_spaces() {
+                cs_dict.set(name, obj.clone());
+            }
+            resources.set("ColorSpace", Object::Dictionary(cs_dict));
+        }
+
+        // Pattern resources (ISO 32000-1 §8.7.3). Patterns are streams
+        // (§7.3.8.1 requires streams to be indirect objects), so each
+        // pattern is allocated an object id, written as an indirect
+        // stream, and referenced by /Resources/Pattern/<name>.
+        if !page.patterns().is_empty() {
+            let mut pat_dict = Dictionary::new();
+            for (name, pattern) in page.patterns() {
+                let pattern_id = self.allocate_object_id();
+                let pattern_dict = pattern.to_pdf_dictionary()?;
+                self.write_object(
+                    pattern_id,
+                    Object::Stream(pattern_dict, pattern.content_stream.clone()),
+                )?;
+                pat_dict.set(name, Object::Reference(pattern_id));
+            }
+            resources.set("Pattern", Object::Dictionary(pat_dict));
+        }
+
+        // Shading resources (ISO 32000-1 §8.7.4). Shadings are dicts
+        // (not streams for ShadingType 1–3; types 4–7 are streams but we
+        // currently only serialise 1–3 via `ShadingDefinition`). Written
+        // as indirect dicts so the same shading can be referenced from
+        // multiple pages / pattern cells in future iterations.
+        if !page.shadings().is_empty() {
+            let mut sh_dict = Dictionary::new();
+            for (name, shading) in page.shadings() {
+                let shading_id = self.allocate_object_id();
+                let shading_dict = shading.to_pdf_dictionary()?;
+                self.write_object(shading_id, Object::Dictionary(shading_dict))?;
+                sh_dict.set(name, Object::Reference(shading_id));
+            }
+            resources.set("Shading", Object::Dictionary(sh_dict));
+        }
+
         // Merge preserved resources from original PDF (if any)
         // Phase 2.3: Rename preserved fonts to avoid conflicts with overlay fonts
         if let Some(preserved_res) = page.get_preserved_resources() {

--- a/oxidize-pdf-core/tests/page_color_spaces_test.rs
+++ b/oxidize-pdf-core/tests/page_color_spaces_test.rs
@@ -1,0 +1,196 @@
+//! Task 4 of the v2.5.6 gap-closing series.
+//!
+//! Callers that work with non-Device colour spaces (CalRGB, ICCBased, Lab,
+//! Indexed, DeviceN, Separation, Pattern) need a way to register those
+//! colour spaces against a `Page` so the writer emits them under
+//! `/Resources/ColorSpace` (ISO 32000-1 §8.6, Table 62). Before this
+//! change the `Page` struct had no such registry and the writer emitted
+//! no `/ColorSpace` entry — meaning the `cs` / `CS` content-stream
+//! operators had nothing to resolve by name.
+//!
+//! Contract being exercised:
+//!   * `Page::add_color_space(name, Object)` records a colour-space
+//!     resource under the given name.
+//!   * `Page::color_spaces()` exposes the in-memory registry.
+//!   * The writer emits `/Resources/ColorSpace` as a direct dictionary
+//!     whose entries preserve the caller-supplied `Object` verbatim
+//!     (either `Object::Name("/CalRGB")` for simple names or
+//!     `Object::Array([Name, Dictionary])` for parameterised spaces).
+
+use oxidize_pdf::objects::{Dictionary, Object};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walks /Pages → first leaf page and returns its object reference.
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    kids.0
+        .first()
+        .expect("/Pages/Kids[0]")
+        .as_reference()
+        .expect("/Pages/Kids[0] reference")
+}
+
+/// Resolve the /Resources/ColorSpace dict for page 0.
+fn resolve_page0_colorspace<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => {
+            let r = reader
+                .get_object(*n, *g)
+                .expect("resolve /Resources")
+                .clone();
+            r.as_dict().expect("/Resources is dict").clone()
+        }
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("ColorSpace").expect("/Resources/ColorSpace") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /ColorSpace")
+            .clone()
+            .as_dict()
+            .expect("/ColorSpace dict")
+            .clone(),
+        other => panic!("/ColorSpace: unexpected {:?}", other),
+    }
+}
+
+/// Primary Task 4 assertion: a registered parameterised colour space
+/// surfaces in `/Resources/ColorSpace` with its caller-supplied structure
+/// preserved (name in slot 0, dict in slot 1 per ISO 32000-1 §8.6.5).
+#[test]
+fn page_color_space_is_written_as_parameterised_array() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    // CalRGB with a sRGB-ish white point; exact values don't matter
+    // beyond round-trip. What matters is the wire-format shape:
+    // /CS1 [/CalRGB <</WhitePoint [..]>>]
+    let mut calrgb = Dictionary::new();
+    calrgb.set(
+        "WhitePoint",
+        Object::Array(vec![
+            Object::Real(0.9505),
+            Object::Real(1.0),
+            Object::Real(1.0890),
+        ]),
+    );
+    page.add_color_space(
+        "CS1",
+        Object::Array(vec![
+            Object::Name("CalRGB".to_string()),
+            Object::Dictionary(calrgb),
+        ]),
+    );
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let cs = resolve_page0_colorspace(&mut reader);
+    let entry = cs.get("CS1").expect("CS1 must be registered").clone();
+
+    // Accept either a direct array (what we emit today) or an indirect
+    // reference (valid per spec; `resolve` handles both).
+    let arr = match entry {
+        PdfObject::Array(a) => a,
+        PdfObject::Reference(n, g) => {
+            let r = reader.get_object(n, g).expect("resolve CS1").clone();
+            r.as_array().expect("CS1 array").clone()
+        }
+        other => panic!("CS1 must be array or ref, got {:?}", other),
+    };
+
+    assert_eq!(arr.0.len(), 2, "parameterised CS must have [Name, Dict]");
+    assert_eq!(
+        arr.0[0].as_name().map(|n| n.as_str()),
+        Some("CalRGB"),
+        "CS1 slot 0 must be /CalRGB"
+    );
+    let params = arr.0[1]
+        .as_dict()
+        .expect("CS1 slot 1 must be the parameters dict");
+    let wp = params
+        .get("WhitePoint")
+        .and_then(|o| o.as_array())
+        .expect("/WhitePoint");
+    assert_eq!(wp.0.len(), 3, "WhitePoint must be [X, Y, Z]");
+}
+
+/// Task 4 edge case: a colour space registered as a single Name (e.g.
+/// `/DeviceRGB`) must round-trip as a Name, not be coerced into an array.
+/// This is legal per ISO 32000-1 §8.6 and saves ~20 bytes per registry
+/// entry when the caller wants to alias a device space under a custom
+/// resource name.
+#[test]
+fn page_color_space_preserves_name_form() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_color_space("MyRGB", Object::Name("DeviceRGB".to_string()));
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let cs = resolve_page0_colorspace(&mut reader);
+    let entry = cs.get("MyRGB").expect("MyRGB must be registered").clone();
+    let resolved = match entry {
+        PdfObject::Reference(n, g) => reader.get_object(n, g).expect("resolve").clone(),
+        other => other,
+    };
+    assert_eq!(
+        resolved.as_name().map(|n| n.as_str()),
+        Some("DeviceRGB"),
+        "MyRGB must round-trip as /DeviceRGB"
+    );
+}
+
+/// Task 4 negative case: a page with no registered colour spaces must NOT
+/// emit an empty `/ColorSpace` dict. The entry is optional and emitting
+/// an empty dict confuses downstream tools that treat its presence as a
+/// signal of custom spaces.
+#[test]
+fn page_without_color_spaces_omits_colorspace_entry() {
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = page_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    assert!(
+        resources.get("ColorSpace").is_none(),
+        "/ColorSpace must be absent when no colour space was registered, got: {:?}",
+        resources.get("ColorSpace")
+    );
+}
+
+/// Task 4 public-API regression: `Page::color_spaces()` must be callable
+/// from outside the crate and reflect in-memory state before
+/// serialisation.
+#[test]
+fn color_spaces_accessor_is_public_and_reflects_state() {
+    let mut page = Page::a4();
+    assert!(page.color_spaces().is_empty());
+    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()));
+    let map = page.color_spaces();
+    assert_eq!(map.len(), 1);
+    assert!(map.contains_key("CS1"));
+}

--- a/oxidize-pdf-core/tests/page_patterns_test.rs
+++ b/oxidize-pdf-core/tests/page_patterns_test.rs
@@ -1,0 +1,184 @@
+//! Task 5 of the v2.5.6 gap-closing series.
+//!
+//! `TilingPattern` is a first-class graphics resource in this crate
+//! (`graphics::patterns::TilingPattern`) with a full
+//! `to_pdf_dictionary` serialiser. It was never reachable from the page
+//! resource dictionary though: the `Page` struct had no registry for
+//! patterns and the writer emitted no `/Resources/Pattern`. Content-
+//! stream operators like `/P1 cs /P1 scn` were therefore unresolved,
+//! and callers could not fill with a tiling pattern.
+//!
+//! Contract being exercised:
+//!   * `Page::add_pattern(name, TilingPattern)` registers a pattern
+//!     resource.
+//!   * `Page::patterns()` exposes the registry.
+//!   * The writer emits each pattern as an INDIRECT stream object
+//!     (ISO 32000-1 §8.7 "Patterns shall be stream objects") and
+//!     references it from `/Resources/Pattern/<Name>`.
+
+use oxidize_pdf::graphics::{PaintType, TilingPattern, TilingType};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    kids.0
+        .first()
+        .expect("/Pages/Kids[0]")
+        .as_reference()
+        .expect("/Pages/Kids[0] reference")
+}
+
+fn resolve_page0_pattern_dict<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Resources")
+            .clone()
+            .as_dict()
+            .expect("/Resources dict")
+            .clone(),
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("Pattern").expect("/Resources/Pattern") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Pattern")
+            .clone()
+            .as_dict()
+            .expect("/Pattern dict")
+            .clone(),
+        other => panic!("/Pattern: unexpected {:?}", other),
+    }
+}
+
+/// Build a minimal-but-valid tiling pattern: a 20×20 red fill cell.
+fn make_red_tile(name: &str) -> TilingPattern {
+    let mut pattern = TilingPattern::new(
+        name.to_string(),
+        PaintType::Colored,
+        TilingType::ConstantSpacing,
+        [0.0, 0.0, 20.0, 20.0],
+        20.0,
+        20.0,
+    );
+    pattern.add_command("1 0 0 rg");
+    pattern.add_command("0 0 20 20 re");
+    pattern.add_command("f");
+    pattern
+}
+
+/// Primary Task 5 assertion: a registered TilingPattern surfaces as an
+/// INDIRECT stream object under `/Resources/Pattern/<Name>`, and the
+/// stream dict carries the required ISO 32000-1 §8.7.3 Table 75 entries
+/// (`/Type /Pattern`, `/PatternType 1`, `/BBox`, `/XStep`, `/YStep`).
+#[test]
+fn page_pattern_is_written_as_indirect_stream_with_required_entries() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_pattern("P1", make_red_tile("P1"));
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let pat = resolve_page0_pattern_dict(&mut reader);
+
+    // /Resources/Pattern/P1 MUST be an indirect reference (patterns are
+    // streams; per §7.3.8.1 streams MUST be indirect objects).
+    let (n, g) = pat
+        .get("P1")
+        .and_then(|o| o.as_reference())
+        .expect("/P1 must be an indirect reference to a pattern stream");
+
+    let stream_obj = reader.get_object(n, g).expect("resolve P1").clone();
+    let stream = stream_obj.as_stream().expect("P1 must resolve to a stream");
+    let dict = &stream.dict;
+
+    assert_eq!(
+        dict.get("Type")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("Pattern"),
+        "/Type must be /Pattern"
+    );
+    assert_eq!(
+        dict.get("PatternType").and_then(|o| o.as_integer()),
+        Some(1),
+        "/PatternType must be 1 (tiling) per ISO 32000-1 §8.7.3.1"
+    );
+    let bbox = dict
+        .get("BBox")
+        .and_then(|o| o.as_array())
+        .expect("/BBox required");
+    assert_eq!(bbox.0.len(), 4, "/BBox must have 4 numbers");
+    assert!(
+        dict.get("XStep")
+            .and_then(|o| o.as_real().or_else(|| o.as_integer().map(|i| i as f64)))
+            .is_some(),
+        "/XStep required"
+    );
+    assert!(
+        dict.get("YStep")
+            .and_then(|o| o.as_real().or_else(|| o.as_integer().map(|i| i as f64)))
+            .is_some(),
+        "/YStep required"
+    );
+
+    // Content stream must carry the caller-supplied drawing operators.
+    let decoded = stream
+        .decode(reader.options())
+        .expect("decode pattern content stream");
+    let text = String::from_utf8_lossy(&decoded);
+    assert!(
+        text.contains("1 0 0 rg") && text.contains("re") && text.contains('f'),
+        "content stream must carry the red-fill commands, got: {:?}",
+        text
+    );
+}
+
+/// Task 5 negative case: a page without patterns must omit
+/// `/Resources/Pattern` entirely.
+#[test]
+fn page_without_patterns_omits_pattern_entry() {
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = page_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    assert!(
+        resources.get("Pattern").is_none(),
+        "/Pattern must be absent when no pattern was registered"
+    );
+}
+
+/// Task 5 public-API regression: `Page::patterns()` must be callable from
+/// outside the crate.
+#[test]
+fn patterns_accessor_is_public_and_reflects_state() {
+    let mut page = Page::a4();
+    assert!(page.patterns().is_empty());
+    page.add_pattern("P1", make_red_tile("P1"));
+    let map = page.patterns();
+    assert_eq!(map.len(), 1);
+    assert!(map.contains_key("P1"));
+}

--- a/oxidize-pdf-core/tests/page_shadings_test.rs
+++ b/oxidize-pdf-core/tests/page_shadings_test.rs
@@ -1,0 +1,152 @@
+//! Task 6 of the v2.5.6 gap-closing series.
+//!
+//! `ShadingDefinition` (Axial / Radial / FunctionBased, under
+//! `graphics::shadings`) already has a `to_pdf_dictionary` serialiser
+//! per ISO 32000-1 §8.7.4, but Page had no way to register a shading
+//! resource and the writer emitted no `/Resources/Shading`. So any
+//! attempt to paint a gradient with the `sh` operator or a type-2
+//! `ShadingPattern` failed to resolve the shading name.
+//!
+//! Contract being exercised:
+//!   * `Page::add_shading(name, ShadingDefinition)` registers a shading
+//!     resource.
+//!   * `Page::shadings()` exposes the registry.
+//!   * The writer emits each shading as an indirect dictionary object
+//!     (per §8.7.4 shadings are dicts, not streams) and references it
+//!     from `/Resources/Shading/<Name>`.
+
+use oxidize_pdf::graphics::{
+    AxialShading, Color, ColorStop, Point as ShadingPoint, ShadingDefinition,
+};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    kids.0
+        .first()
+        .expect("/Pages/Kids[0]")
+        .as_reference()
+        .expect("/Pages/Kids[0] reference")
+}
+
+fn resolve_page0_shading_dict<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Resources")
+            .clone()
+            .as_dict()
+            .expect("/Resources dict")
+            .clone(),
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("Shading").expect("/Resources/Shading") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Shading")
+            .clone()
+            .as_dict()
+            .expect("/Shading dict")
+            .clone(),
+        other => panic!("/Shading: unexpected {:?}", other),
+    }
+}
+
+fn make_axial(name: &str) -> ShadingDefinition {
+    let stops = vec![
+        ColorStop::new(0.0, Color::Rgb(1.0, 0.0, 0.0)),
+        ColorStop::new(1.0, Color::Rgb(0.0, 0.0, 1.0)),
+    ];
+    let axial = AxialShading::new(
+        name.to_string(),
+        ShadingPoint::new(0.0, 0.0),
+        ShadingPoint::new(100.0, 0.0),
+        stops,
+    );
+    ShadingDefinition::Axial(axial)
+}
+
+/// Primary Task 6 assertion: a registered axial shading surfaces as an
+/// INDIRECT dictionary under `/Resources/Shading/<Name>`, and the dict
+/// carries `/ShadingType 2` (axial, ISO 32000-1 §8.7.4.5.2).
+#[test]
+fn page_shading_is_written_as_indirect_dict_with_shadingtype() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_shading("Sh1", make_axial("Sh1"));
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+
+    let (n, g) = sh
+        .get("Sh1")
+        .and_then(|o| o.as_reference())
+        .expect("/Sh1 must be an indirect reference");
+
+    let obj = reader.get_object(n, g).expect("resolve Sh1").clone();
+    let dict = obj.as_dict().expect("Sh1 must resolve to a dictionary");
+
+    assert_eq!(
+        dict.get("ShadingType").and_then(|o| o.as_integer()),
+        Some(2),
+        "/ShadingType must be 2 (axial) per ISO 32000-1 §8.7.4.5.2"
+    );
+    let coords = dict
+        .get("Coords")
+        .and_then(|o| o.as_array())
+        .expect("/Coords required for axial shading");
+    assert_eq!(
+        coords.0.len(),
+        4,
+        "/Coords must be [x0 y0 x1 y1] per Table 80"
+    );
+}
+
+/// Task 6 negative case: a page without shadings must omit `/Shading`
+/// entirely rather than emit an empty dict.
+#[test]
+fn page_without_shadings_omits_shading_entry() {
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = page_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    assert!(
+        resources.get("Shading").is_none(),
+        "/Shading must be absent when no shading was registered"
+    );
+}
+
+/// Task 6 public-API regression.
+#[test]
+fn shadings_accessor_is_public_and_reflects_state() {
+    let mut page = Page::a4();
+    assert!(page.shadings().is_empty());
+    page.add_shading("Sh1", make_axial("Sh1"));
+    let map = page.shadings();
+    assert_eq!(map.len(), 1);
+    assert!(map.contains_key("Sh1"));
+}


### PR DESCRIPTION
## Summary

Closes **Tasks 4, 5 and 6** of the v2.5.6 gap-closing series. All three gaps are structurally identical (a \`HashMap<String, Resource>\` registry on \`Page\` + public \`add_*\`/accessor methods + a writer block that emits the resources under \`/Resources/<Key>\`), so they ship together to avoid triplicated CI rounds.

### Motivation (from the .NET wrapper audit)

The graphics layer already modelled \`CalRGB\`/\`ICCBased\` colour spaces, \`TilingPattern\`, \`AxialShading\` and \`RadialShading\` — with full \`to_pdf_dictionary\` serialisers — but \`Page\` had no registry for any of them and the writer emitted no \`/Resources/ColorSpace\`, \`/Resources/Pattern\` or \`/Resources/Shading\`. Content-stream operators like \`/CS1 cs\` / \`/P1 scn\` / \`/Sh1 sh\` were therefore unresolved from external code, even though the machinery to serialise the resources existed.

### Changes

| Task | Resource | Registry | Writer form | Spec |
|---|---|---|---|---|
| 4 | Colour spaces | \`HashMap<String, Object>\` (Name or \`[Name, Dict]\`) | Direct sub-dict | §8.6 Table 62 |
| 5 | Tiling patterns | \`HashMap<String, TilingPattern>\` | **Indirect** streams (§7.3.8.1) | §8.7.3 Table 75 |
| 6 | Shadings | \`HashMap<String, ShadingDefinition>\` | **Indirect** dicts | §8.7.4 Tables 79-80 |

Writer blocks are inserted *before* the \"Merge preserved resources\" step so overlay-preserved resources still win on key collision — matches the existing precedence rule for \`/Font\` and \`/XObject\`.

### Test plan (10 tests, all wire-format)

Each test serialises a \`Document\`, re-parses the bytes, and walks \`/Pages → /Resources → /<Key>\` to assert spec-mandated invariants:

- [x] **ColorSpace** (4 tests): parameterised array \`[/CalRGB <<..>>]\` round-trip, single-Name round-trip, negative case (entry absent when empty), \`color_spaces()\` accessor.
- [x] **Pattern** (3 tests): indirect stream with \`/Type /Pattern\` / \`/PatternType 1\` / \`/BBox\` / \`/XStep\` / \`/YStep\` + content stream carries drawing operators, negative case, \`patterns()\` accessor.
- [x] **Shading** (3 tests): indirect dict with \`/ShadingType 2\` + \`/Coords [x0 y0 x1 y1]\` (axial), negative case, \`shadings()\` accessor.
- [x] RED confirmed: 9× E0599 method-not-found across the three test files before the Page changes.
- [x] Lib suite: 6322 passing / 0 failed / 3 ignored.
- [x] \`cargo clippy -p oxidize-pdf --lib --all-features -- -D warnings\`: clean.
- [x] \`cargo clippy -p oxidize-pdf --test page_color_spaces_test --test page_patterns_test --test page_shadings_test -- -D warnings\`: clean.
- [x] \`cargo fmt --check\`: clean.

### Note

No smoke tests — every assertion reads the emitted PDF and checks ISO-mandated keys / values. Negative cases explicitly confirm no empty dict is emitted when the registry is empty (which would otherwise mislead downstream tools into thinking custom resources exist).

Closes 3 more of the 9 gaps; **2 remaining** (Task 8 ExtGState /SMask+/BM, Task 10 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)