### PR TITLE
fix(writer): PDF-string escape + resource-name validation + deterministic dict emission

### DIFF
--- a/oxidize-pdf-core/src/operations/overlay.rs
+++ b/oxidize-pdf-core/src/operations/overlay.rs
@@ -310,7 +310,10 @@ impl<R: Read + Seek> PdfOverlay<R> {
         }
 
         let xobj_name = format!("Overlay{}", overlay_page_idx);
-        page.add_form_xobject(&xobj_name, form);
+        // Overlay-generated names are under our control (`Overlay{n}`)
+        // and always valid per ISO 32000-1 §7.3.5, so `?` is defensive
+        // here rather than a practical failure mode.
+        page.add_form_xobject(&xobj_name, form)?;
 
         // Calculate CTM for positioning and scaling
         let base_w = parsed_base.width();

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -56,6 +56,53 @@ impl Default for Margins {
 ///     .fill();
 /// # Ok::<(), oxidize_pdf::PdfError>(())
 /// ```
+/// Validates that `name` is a well-formed PDF resource name per
+/// ISO 32000-1 §7.3.5 (Name Objects).
+///
+/// A resource name is a `Name` token written as `/<name>` inside a
+/// dictionary. The spec forbids:
+///   * empty names (must have at least one regular character);
+///   * whitespace characters (NUL, HT, LF, FF, CR, SP);
+///   * delimiter characters `( ) < > [ ] { } / %`;
+///   * the `#` character, which is reserved for the 2-digit hex escape
+///     form (`#NN`) — accepting raw `#` would require callers to think
+///     about hex escaping, which we decline to do at this layer.
+///
+/// We reject at the public API boundary so a caller cannot — even
+/// unintentionally — smuggle a dict-closing token into a resource name
+/// and produce a PDF where the emitted `/<name>` splits the resource
+/// dict into pieces.
+fn validate_pdf_resource_name(name: &str) -> Result<()> {
+    use crate::error::PdfError;
+
+    if name.is_empty() {
+        return Err(PdfError::InvalidStructure(
+            "PDF resource name must not be empty (ISO 32000-1 §7.3.5)".to_string(),
+        ));
+    }
+
+    for (idx, byte) in name.as_bytes().iter().enumerate() {
+        // Whitespace per Table 1 (§7.2.3).
+        let is_whitespace = matches!(*byte, 0x00 | 0x09 | 0x0A | 0x0C | 0x0D | 0x20);
+        // Delimiters per Table 2 (§7.2.3).
+        let is_delimiter = matches!(
+            *byte,
+            b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'
+        );
+        // Hex-escape introducer (§7.3.5): legal only as `#NN`, but we
+        // reject outright rather than trust callers to escape correctly.
+        let is_hash = *byte == b'#';
+
+        if is_whitespace || is_delimiter || is_hash {
+            return Err(PdfError::InvalidStructure(format!(
+                "invalid PDF resource name {name:?}: byte 0x{byte:02X} at position {idx} \
+                 is not allowed per ISO 32000-1 §7.3.5 (whitespace, delimiter, or `#`)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[derive(Clone)]
 pub struct Page {
     width: f64,
@@ -826,6 +873,14 @@ impl Page {
     /// into the underlying map); if you need idempotent registration,
     /// inspect [`Page::form_xobjects`] before calling.
     ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is empty or
+    /// contains any character forbidden by ISO 32000-1 §7.3.5 (delimiter
+    /// characters `( ) < > [ ] { } / %`, whitespace, or the `#` escape
+    /// introducer). Emitting such a name verbatim would close the
+    /// resource dict early and allow dict-level injection.
+    ///
     /// ```rust
     /// use oxidize_pdf::geometry::Rectangle;
     /// use oxidize_pdf::graphics::FormXObject;
@@ -833,15 +888,18 @@ impl Page {
     ///
     /// let mut page = Page::a4();
     /// let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
-    /// page.add_form_xobject("F1", FormXObject::new(bbox));
+    /// page.add_form_xobject("F1", FormXObject::new(bbox)).unwrap();
     /// assert!(page.form_xobjects().contains_key("F1"));
     /// ```
     pub fn add_form_xobject(
         &mut self,
         name: impl Into<String>,
         form: crate::graphics::FormXObject,
-    ) {
-        self.form_xobjects.insert(name.into(), form);
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        self.form_xobjects.insert(name, form);
+        Ok(())
     }
 
     /// Returns all Form XObjects registered on this page (public as of v2.5.6).
@@ -861,8 +919,21 @@ impl Page {
     /// `[/CalRGB <<dict>>]` / `[/ICCBased <<stream>>]` /
     /// `[/Indexed /DeviceRGB N <hivals>]`. The writer serialises the
     /// supplied object verbatim into `/Resources/ColorSpace/<name>`.
-    pub fn add_color_space(&mut self, name: impl Into<String>, cs: crate::objects::Object) {
-        self.color_spaces.insert(name.into(), cs);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid
+    /// PDF resource name per ISO 32000-1 §7.3.5 (see
+    /// [`Page::add_form_xobject`] for the full rule).
+    pub fn add_color_space(
+        &mut self,
+        name: impl Into<String>,
+        cs: crate::objects::Object,
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        self.color_spaces.insert(name, cs);
+        Ok(())
     }
 
     /// Returns all colour spaces registered on this page.
@@ -877,12 +948,20 @@ impl Page {
     /// `/Resources/Pattern/<name>`. Inside the content stream, paint the
     /// pattern with `/<name> scn` / `/<name> SCN` after selecting the
     /// /Pattern colour space.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid
+    /// PDF resource name per ISO 32000-1 §7.3.5.
     pub fn add_pattern(
         &mut self,
         name: impl Into<String>,
         pattern: crate::graphics::TilingPattern,
-    ) {
-        self.patterns.insert(name.into(), pattern);
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        self.patterns.insert(name, pattern);
+        Ok(())
     }
 
     /// Returns all tiling patterns registered on this page.
@@ -895,12 +974,20 @@ impl Page {
     /// The writer emits the shading as an indirect dictionary object and
     /// references it from `/Resources/Shading/<name>`. Paint with the
     /// `sh` operator (`/<name> sh`) or via a type-2 Pattern.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid
+    /// PDF resource name per ISO 32000-1 §7.3.5.
     pub fn add_shading(
         &mut self,
         name: impl Into<String>,
         shading: crate::graphics::ShadingDefinition,
-    ) {
-        self.shadings.insert(name.into(), shading);
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        self.shadings.insert(name, shading);
+        Ok(())
     }
 
     /// Returns all shadings registered on this page.

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -71,6 +71,32 @@ impl WriterConfig {
     }
 }
 
+/// Escape the three characters that are meaningful inside a PDF literal
+/// string (ISO 32000-1 §7.3.4.2): backslash introduces escape sequences
+/// and MUST be doubled; parentheses delimit the string and MUST be
+/// prefixed with a backslash when they appear in the payload.
+///
+/// Other control characters (CR, LF, HT, BS, FF) are legal inside a
+/// literal string *unescaped*, so we leave them alone — the parser is
+/// required to accept them verbatim per §7.3.4.2 Table 3. Octal
+/// escapes are a valid alternative encoding but not required here.
+///
+/// Correct ordering is essential: `\` MUST be escaped first (otherwise
+/// the `\` we insert to escape a `(` would itself get doubled). This
+/// helper walks the input exactly once and emits the escaped form.
+fn escape_pdf_string_bytes(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    for &byte in input {
+        match byte {
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'(' => out.extend_from_slice(b"\\("),
+            b')' => out.extend_from_slice(b"\\)"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 pub struct PdfWriter<W: Write> {
     writer: W,
     xref_positions: HashMap<ObjectId, u64>,
@@ -2349,7 +2375,13 @@ impl<W: Write> PdfWriter<W> {
         if has_images || has_forms {
             let mut xobject_dict = Dictionary::new();
 
-            for (name, image) in page.images() {
+            // Sort by name for reproducible output (images first, then
+            // form xobjects — both sorted within their group). Sharing
+            // the sort key produces the same layout across builds.
+            let mut image_entries: Vec<(&String, &crate::graphics::Image)> =
+                page.images().iter().collect();
+            image_entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, image) in image_entries {
                 // Use sequential ObjectId allocation to avoid conflicts
                 let image_id = self.allocate_object_id();
 
@@ -2381,7 +2413,10 @@ impl<W: Write> PdfWriter<W> {
             }
 
             // Write Form XObjects (used for overlay/watermark operations)
-            for (name, form) in page.form_xobjects() {
+            let mut form_entries: Vec<(&String, &crate::graphics::FormXObject)> =
+                page.form_xobjects().iter().collect();
+            form_entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, form) in form_entries {
                 let form_id = self.allocate_object_id();
                 let stream = form.to_stream()?;
                 let stream_obj =
@@ -2396,7 +2431,11 @@ impl<W: Write> PdfWriter<W> {
         // Add ExtGState resources for transparency
         if let Some(extgstate_states) = page.get_extgstate_resources() {
             let mut extgstate_dict = Dictionary::new();
-            for (name, state) in extgstate_states {
+            // Sort ExtGState entries by name for reproducible output.
+            let mut extgstate_entries: Vec<(&String, &crate::graphics::ExtGState)> =
+                extgstate_states.iter().collect();
+            extgstate_entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, state) in extgstate_entries {
                 let mut state_dict = Dictionary::new();
                 state_dict.set("Type", Object::Name("ExtGState".to_string()));
 
@@ -2467,6 +2506,14 @@ impl<W: Write> PdfWriter<W> {
         // keeps the cross-reference table lean. Callers that need
         // larger / shared colour spaces can register them once and reuse
         // the same key across pages.
+        // Deterministic emission of all three resource sub-dicts is
+        // enforced at Dictionary write time (see QUAL-9 sort below in
+        // `write_object_value`). We therefore iterate the source
+        // HashMaps in any order here — the serializer reorders.
+        // However we DO sort Pattern / Shading entries before
+        // `allocate_object_id()` so object-id allocation is also
+        // reproducible (two identical documents allocate ids in the
+        // same sequence, producing byte-identical xref entries).
         if !page.color_spaces().is_empty() {
             let mut cs_dict = Dictionary::new();
             for (name, obj) in page.color_spaces() {
@@ -2475,13 +2522,12 @@ impl<W: Write> PdfWriter<W> {
             resources.set("ColorSpace", Object::Dictionary(cs_dict));
         }
 
-        // Pattern resources (ISO 32000-1 §8.7.3). Patterns are streams
-        // (§7.3.8.1 requires streams to be indirect objects), so each
-        // pattern is allocated an object id, written as an indirect
-        // stream, and referenced by /Resources/Pattern/<name>.
         if !page.patterns().is_empty() {
             let mut pat_dict = Dictionary::new();
-            for (name, pattern) in page.patterns() {
+            let mut entries: Vec<(&String, &crate::graphics::TilingPattern)> =
+                page.patterns().iter().collect();
+            entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, pattern) in entries {
                 let pattern_id = self.allocate_object_id();
                 let pattern_dict = pattern.to_pdf_dictionary()?;
                 self.write_object(
@@ -2493,14 +2539,12 @@ impl<W: Write> PdfWriter<W> {
             resources.set("Pattern", Object::Dictionary(pat_dict));
         }
 
-        // Shading resources (ISO 32000-1 §8.7.4). Shadings are dicts
-        // (not streams for ShadingType 1–3; types 4–7 are streams but we
-        // currently only serialise 1–3 via `ShadingDefinition`). Written
-        // as indirect dicts so the same shading can be referenced from
-        // multiple pages / pattern cells in future iterations.
         if !page.shadings().is_empty() {
             let mut sh_dict = Dictionary::new();
-            for (name, shading) in page.shadings() {
+            let mut entries: Vec<(&String, &crate::graphics::ShadingDefinition)> =
+                page.shadings().iter().collect();
+            entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, shading) in entries {
                 let shading_id = self.allocate_object_id();
                 let shading_dict = shading.to_pdf_dictionary()?;
                 self.write_object(shading_id, Object::Dictionary(shading_dict))?;
@@ -3000,8 +3044,16 @@ impl<W: Write> PdfWriter<W> {
                     .as_bytes(),
             )?,
             Object::String(s) => {
+                // ISO 32000-1 §7.3.4.2: inside a literal string, the
+                // characters `\`, `(` and `)` MUST be escaped (as `\\`,
+                // `\(`, `\)` respectively) so the parser does not
+                // terminate the string early or treat `\` as an escape
+                // introducer for the following byte. Without this, a
+                // caller-supplied value containing `)` (e.g. through
+                // `Document::fill_field`) would close the literal and
+                // allow dict-level injection into the enclosing object.
                 self.write_bytes(b"(")?;
-                self.write_bytes(s.as_bytes())?;
+                self.write_bytes(&escape_pdf_string_bytes(s.as_bytes()))?;
                 self.write_bytes(b")")?;
             }
             Object::ByteString(bytes) => {
@@ -3027,8 +3079,17 @@ impl<W: Write> PdfWriter<W> {
                 self.write_bytes(b"]")?;
             }
             Object::Dictionary(dict) => {
+                // Sort entries lexicographically by key for reproducible
+                // output. `Dictionary` is backed by `HashMap` (with
+                // per-instance randomised iteration order), so two
+                // identical logical documents would otherwise emit
+                // byte-different PDFs. PDF dict entries are unordered
+                // by spec (ISO 32000-1 §7.3.7 Table 5: "the order of
+                // entries ... is not significant"), so sorting is safe.
                 self.write_bytes(b"<<")?;
-                for (key, value) in dict.entries() {
+                let mut entries: Vec<(&String, &Object)> = dict.entries().collect();
+                entries.sort_by_key(|(k, _)| k.as_str());
+                for (key, value) in entries {
                     self.write_bytes(b"\n/")?;
                     self.write_bytes(key.as_bytes())?;
                     self.write_bytes(b" ")?;
@@ -3068,8 +3129,10 @@ impl<W: Write> PdfWriter<W> {
                     .as_bytes(),
             ),
             Object::String(s) => {
+                // Same escape rules as the streaming `write_object_value`
+                // path — see ISO 32000-1 §7.3.4.2.
                 buffer.push(b'(');
-                buffer.extend_from_slice(s.as_bytes());
+                buffer.extend_from_slice(&escape_pdf_string_bytes(s.as_bytes()));
                 buffer.push(b')');
             }
             Object::ByteString(bytes) => {
@@ -3094,8 +3157,13 @@ impl<W: Write> PdfWriter<W> {
                 buffer.push(b']');
             }
             Object::Dictionary(dict) => {
+                // Same deterministic-order rule as the streaming writer
+                // (see `write_object_value`): sort entries by key for
+                // reproducible output across builds.
                 buffer.extend_from_slice(b"<<");
-                for (key, value) in dict.entries() {
+                let mut entries: Vec<(&String, &Object)> = dict.entries().collect();
+                entries.sort_by_key(|(k, _)| k.as_str());
+                for (key, value) in entries {
                     buffer.extend_from_slice(b"\n/");
                     buffer.extend_from_slice(key.as_bytes());
                     buffer.push(b' ');

--- a/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/tests.rs
@@ -1508,9 +1508,22 @@ mod comprehensive_tests {
 
         let content = String::from_utf8_lossy(&buffer);
 
-        // Should properly handle special characters
-        assert!(content.contains("(Text with ) and ( parentheses)"));
-        assert!(content.contains("(Text with \\ backslash)"));
+        // Should properly escape special characters per ISO 32000-1
+        // §7.3.4.2 (post-F1 fix). Raw `)` and `(` inside the string
+        // payload close / open new groups; a raw `\` introduces an
+        // escape sequence. All three MUST be backslash-escaped so the
+        // parser round-trips the original bytes. Accepting the
+        // pre-F1-fix unescaped form would re-introduce the dict-level
+        // injection vector documented in
+        // tests/writer_hygiene_test.rs::object_string_escapes_delimiters_in_dict_injection_payload.
+        assert!(
+            content.contains(r"(Text with \) and \( parentheses)"),
+            "parens inside Object::String must be escaped as \\) and \\("
+        );
+        assert!(
+            content.contains(r"(Text with \\ backslash)"),
+            "backslash inside Object::String must be escaped as \\\\"
+        );
     }
 
     // Test 30: Resource dictionary structure

--- a/oxidize-pdf-core/tests/formxobject_group_test.rs
+++ b/oxidize-pdf-core/tests/formxobject_group_test.rs
@@ -113,7 +113,7 @@ fn formxobject_with_transparency_group_emits_group_dict() {
 
     // Public API as of v2.5.6 (Task 7). If this call fails to compile,
     // the visibility regressed to pub(crate).
-    page.add_form_xobject("F1", form);
+    page.add_form_xobject("F1", form).expect("add_form_xobject");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -191,7 +191,7 @@ fn formxobject_transparency_group_emits_isolated_and_knockout_booleans() {
         isolated: true,
         knockout: true,
     });
-    page.add_form_xobject("F1", form);
+    page.add_form_xobject("F1", form).expect("add_form_xobject");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -232,7 +232,8 @@ fn formxobject_without_transparency_group_omits_group_dict() {
     let mut page = Page::a4();
 
     let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
-    page.add_form_xobject("F1", FormXObject::new(bbox));
+    page.add_form_xobject("F1", FormXObject::new(bbox))
+        .expect("add_form_xobject");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -258,7 +259,8 @@ fn form_xobjects_accessor_is_public_and_reflects_state() {
     );
 
     let bbox = Rectangle::from_position_and_size(0.0, 0.0, 10.0, 10.0);
-    page.add_form_xobject("Stamp", FormXObject::new(bbox));
+    page.add_form_xobject("Stamp", FormXObject::new(bbox))
+        .expect("add_form_xobject");
 
     let map = page.form_xobjects();
     assert_eq!(map.len(), 1, "exactly one form xobject expected");

--- a/oxidize-pdf-core/tests/page_color_spaces_test.rs
+++ b/oxidize-pdf-core/tests/page_color_spaces_test.rs
@@ -94,7 +94,8 @@ fn page_color_space_is_written_as_parameterised_array() {
             Object::Name("CalRGB".to_string()),
             Object::Dictionary(calrgb),
         ]),
-    );
+    )
+    .expect("add_color_space");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -139,7 +140,8 @@ fn page_color_space_is_written_as_parameterised_array() {
 fn page_color_space_preserves_name_form() {
     let mut doc = Document::new();
     let mut page = Page::a4();
-    page.add_color_space("MyRGB", Object::Name("DeviceRGB".to_string()));
+    page.add_color_space("MyRGB", Object::Name("DeviceRGB".to_string()))
+        .expect("add_color_space");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -189,7 +191,8 @@ fn page_without_color_spaces_omits_colorspace_entry() {
 fn color_spaces_accessor_is_public_and_reflects_state() {
     let mut page = Page::a4();
     assert!(page.color_spaces().is_empty());
-    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()));
+    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()))
+        .expect("add_color_space");
     let map = page.color_spaces();
     assert_eq!(map.len(), 1);
     assert!(map.contains_key("CS1"));

--- a/oxidize-pdf-core/tests/page_patterns_test.rs
+++ b/oxidize-pdf-core/tests/page_patterns_test.rs
@@ -89,7 +89,8 @@ fn make_red_tile(name: &str) -> TilingPattern {
 fn page_pattern_is_written_as_indirect_stream_with_required_entries() {
     let mut doc = Document::new();
     let mut page = Page::a4();
-    page.add_pattern("P1", make_red_tile("P1"));
+    page.add_pattern("P1", make_red_tile("P1"))
+        .expect("add_pattern");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -177,7 +178,8 @@ fn page_without_patterns_omits_pattern_entry() {
 fn patterns_accessor_is_public_and_reflects_state() {
     let mut page = Page::a4();
     assert!(page.patterns().is_empty());
-    page.add_pattern("P1", make_red_tile("P1"));
+    page.add_pattern("P1", make_red_tile("P1"))
+        .expect("add_pattern");
     let map = page.patterns();
     assert_eq!(map.len(), 1);
     assert!(map.contains_key("P1"));

--- a/oxidize-pdf-core/tests/page_shadings_test.rs
+++ b/oxidize-pdf-core/tests/page_shadings_test.rs
@@ -87,7 +87,8 @@ fn make_axial(name: &str) -> ShadingDefinition {
 fn page_shading_is_written_as_indirect_dict_with_shadingtype() {
     let mut doc = Document::new();
     let mut page = Page::a4();
-    page.add_shading("Sh1", make_axial("Sh1"));
+    page.add_shading("Sh1", make_axial("Sh1"))
+        .expect("add_shading");
     doc.add_page(page);
 
     let bytes = doc.to_bytes().expect("serialize");
@@ -145,7 +146,8 @@ fn page_without_shadings_omits_shading_entry() {
 fn shadings_accessor_is_public_and_reflects_state() {
     let mut page = Page::a4();
     assert!(page.shadings().is_empty());
-    page.add_shading("Sh1", make_axial("Sh1"));
+    page.add_shading("Sh1", make_axial("Sh1"))
+        .expect("add_shading");
     let map = page.shadings();
     assert_eq!(map.len(), 1);
     assert!(map.contains_key("Sh1"));

--- a/oxidize-pdf-core/tests/writer_hygiene_test.rs
+++ b/oxidize-pdf-core/tests/writer_hygiene_test.rs
@@ -1,0 +1,325 @@
+//! Regression tests for the v2.5.6 post-release code-quality audit:
+//!
+//!   * **SEC-F1** — PDF string literals (`Object::String`) must escape
+//!     `\`, `(`, `)` before writing (ISO 32000-1 §7.3.4.2). Prior to
+//!     this fix the writer emitted raw bytes inside `(...)` so a
+//!     caller-supplied value containing `)` could close the string
+//!     early and inject arbitrary dict keys into the enclosing object
+//!     (reachable from `Document::fill_field` and from every
+//!     `/Info`-metadata setter).
+//!
+//!   * **SEC-F5** — `Page::add_color_space` / `add_pattern` /
+//!     `add_shading` / `add_form_xobject` must validate the supplied
+//!     resource name against ISO 32000-1 §7.3.5 (no whitespace, no
+//!     delimiter characters `( ) < > [ ] { } / %`, no `#` escape
+//!     introducer). A caller-controlled name containing delimiters
+//!     produces a /Name token that prematurely closes the resource
+//!     dict, opening a dict-level injection parallel to F1.
+//!
+//!   * **QUAL-9** — Resource-dictionary entries (`/Font`, `/XObject`,
+//!     `/ColorSpace`, `/Pattern`, `/Shading`, `/ExtGState`) must be
+//!     emitted in deterministic order so two logically-identical
+//!     documents serialise to byte-identical PDFs. Previously the
+//!     writer iterated `HashMap`s whose iteration order is randomised
+//!     per-instance, making reproducible builds and PDF diffs
+//!     impossible.
+//!
+//! All assertions are wire-format: parse the emitted PDF and inspect
+//! resolved objects. No smoke tests.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::{FormXObject, PaintType, TilingPattern, TilingType};
+use oxidize_pdf::objects::Object;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn build_document_with_filled_field(value: &str) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("email");
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("add_text_field");
+
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("email", value).expect("fill_field");
+    doc.to_bytes().expect("serialize")
+}
+
+/// SEC-F1 primary assertion. A value containing the delimiters that
+/// close a PDF string literal (`)`), plus a backslash (`\`), MUST
+/// round-trip through write→parse as the exact same bytes — no dict
+/// injection, no byte mangling.
+///
+/// The attack payload mimics a real injection: `foo) /Evil (true` in
+/// the raw byte stream would close the `(foo)` string, inject an
+/// `/Evil true` dict key, and leave `/true` dangling. After the fix,
+/// the payload is written as `(foo\) /Evil \(true)` and the parser
+/// returns the original bytes verbatim.
+#[test]
+fn object_string_escapes_delimiters_in_dict_injection_payload() {
+    let payload = "foo) /Evil (true";
+    let bytes = build_document_with_filled_field(payload);
+
+    // Parse the PDF and resolve /AcroForm/Fields[0]/V.
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm indirect");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve /AcroForm")
+        .clone();
+    let (field_n, field_g) = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .and_then(|a| a.get(0))
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm/Fields[0]");
+    let field_obj = reader
+        .get_object(field_n, field_g)
+        .expect("resolve field")
+        .clone();
+    let field_dict = field_obj.as_dict().expect("field dict").clone();
+
+    // Assertion 1: /V must resolve to the EXACT original bytes.
+    // If the writer didn't escape, the parser would see either
+    //   - a string "foo" followed by a rogue /Evil key (breaking the
+    //     dict), or
+    //   - a truncated string "foo" with trailing garbage.
+    // Either way, /V would NOT equal the original payload.
+    let v = field_dict
+        .get("V")
+        .and_then(|o| o.as_string())
+        .and_then(|s| s.as_str().ok())
+        .expect("/V must be a parseable PDF string");
+    assert_eq!(
+        v, payload,
+        "fill_field value must round-trip byte-identically; got {:?}",
+        v
+    );
+
+    // Assertion 2: /Evil must NOT appear as a key in the field dict.
+    // (Belt-and-braces: if escaping failed silently in a way that
+    // still parses as a string, this wouldn't fire, but it's cheap
+    // and catches the obvious injection.)
+    assert!(
+        field_dict.get("Evil").is_none(),
+        "injected /Evil key must not appear in the field dict"
+    );
+}
+
+/// SEC-F1 extended: a `\`-containing payload must survive round-trip.
+/// The PDF escape grammar treats `\` as the escape introducer, so a
+/// naive double-escape (only escaping `(` and `)`) would flip `\`
+/// to garbage.
+#[test]
+fn object_string_escapes_backslash() {
+    let payload = r"C:\Users\admin\secrets.txt";
+    let bytes = build_document_with_filled_field(payload);
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm");
+    let acro = reader.get_object(acro_n, acro_g).expect("acro").clone();
+    let (field_n, field_g) = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .and_then(|a| a.get(0))
+        .and_then(|o| o.as_reference())
+        .expect("fields[0]");
+    let field = reader.get_object(field_n, field_g).expect("field").clone();
+    let v = field
+        .as_dict()
+        .and_then(|d| d.get("V"))
+        .and_then(|o| o.as_string())
+        .and_then(|s| s.as_str().ok())
+        .expect("/V");
+    assert_eq!(v, payload, "backslash payload must round-trip");
+}
+
+/// SEC-F5: delimiter-containing resource name must be rejected at the
+/// public `add_*` boundary (returns `Err`), not silently accepted and
+/// written as a malformed /Name token that closes the resource dict.
+#[test]
+fn add_color_space_rejects_name_with_delimiters() {
+    let mut page = Page::a4();
+    // `>>` inside a Name would close the resource dict.
+    let result = page.add_color_space("Foo>>/Evil", Object::Name("DeviceRGB".to_string()));
+    assert!(
+        result.is_err(),
+        "add_color_space must reject names containing delimiters, got Ok"
+    );
+}
+
+#[test]
+fn add_pattern_rejects_name_with_whitespace() {
+    let mut page = Page::a4();
+    let pattern = TilingPattern::new(
+        "P1".to_string(),
+        PaintType::Colored,
+        TilingType::ConstantSpacing,
+        [0.0, 0.0, 10.0, 10.0],
+        10.0,
+        10.0,
+    );
+    let result = page.add_pattern("Pat tern", pattern);
+    assert!(
+        result.is_err(),
+        "add_pattern must reject names containing whitespace"
+    );
+}
+
+#[test]
+fn add_shading_rejects_empty_name() {
+    use oxidize_pdf::graphics::{
+        AxialShading, Color, ColorStop, Point as ShadingPoint, ShadingDefinition,
+    };
+    let mut page = Page::a4();
+    let axial = AxialShading::new(
+        "Sh1".to_string(),
+        ShadingPoint::new(0.0, 0.0),
+        ShadingPoint::new(10.0, 0.0),
+        vec![ColorStop::new(0.0, Color::Rgb(1.0, 0.0, 0.0))],
+    );
+    let result = page.add_shading("", ShadingDefinition::Axial(axial));
+    assert!(
+        result.is_err(),
+        "add_shading must reject empty names (§7.3.5 requires at least one regular character)"
+    );
+}
+
+#[test]
+fn add_form_xobject_rejects_name_with_hash_escape_introducer() {
+    let mut page = Page::a4();
+    let bbox = Rectangle::new(Point::new(0.0, 0.0), Point::new(10.0, 10.0));
+    // `#` is the /Name hex-escape introducer (§7.3.5). A raw `#` in a
+    // Name without two following hex digits is illegal.
+    let result = page.add_form_xobject("F#XX", FormXObject::new(bbox));
+    assert!(
+        result.is_err(),
+        "add_form_xobject must reject names containing the `#` escape introducer"
+    );
+}
+
+/// SEC-F5 positive: valid, spec-compliant names keep working.
+#[test]
+fn add_color_space_accepts_valid_names() {
+    let mut page = Page::a4();
+    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()))
+        .expect("CS1 is a valid Name");
+    page.add_color_space("MyCustomSpace", Object::Name("DeviceCMYK".to_string()))
+        .expect("MyCustomSpace is a valid Name");
+    page.add_color_space(
+        "CS_with_underscores-and-dashes",
+        Object::Name("DeviceGray".to_string()),
+    )
+    .expect("underscores and dashes are valid in Names per §7.3.5");
+}
+
+/// QUAL-9: resource-dictionary entries MUST be emitted in a
+/// deterministic (sorted) order so the PDF is reproducible and
+/// diffable. We can't rely on the parser preserving dict key order
+/// (the internal `PdfDictionary` uses a `HashMap`), so we inspect the
+/// raw serialised bytes for the order of `/CSX` tokens within the
+/// `/ColorSpace << ... >>` block.
+///
+/// Strategy: register 5 colour spaces in a deliberately unsorted
+/// insertion order (CSE, CSA, CSC, CSB, CSD). In the emitted bytes
+/// the keys of `/ColorSpace` must appear in ASCII-lexicographic order
+/// — that's the invariant sorted emission guarantees, and it does NOT
+/// depend on `HashMap` iteration happening to match insertion order.
+#[test]
+fn color_space_resource_entries_are_emitted_in_sorted_order() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let insertion_order = ["CSE", "CSA", "CSC", "CSB", "CSD"];
+    for name in &insertion_order {
+        page.add_color_space(*name, Object::Name("DeviceRGB".to_string()))
+            .expect("add_color_space");
+    }
+    doc.add_page(page);
+    let bytes = doc.to_bytes().expect("serialize");
+
+    // Work in raw bytes throughout — the PDF is ASCII for resource
+    // names and delimiters, but can contain arbitrary bytes elsewhere
+    // (object streams, content streams). Using String::from_utf8_lossy
+    // rewrites non-UTF8 bytes as U+FFFD (3 bytes), desynchronising
+    // char-offsets from byte-offsets downstream.
+    fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+
+    let cs_marker = b"/ColorSpace";
+    let cs_start = find_bytes(&bytes, cs_marker).expect("/ColorSpace in bytes");
+    // Skip the marker, then find the `<<` that opens the ColorSpace
+    // sub-dict.
+    let after_marker = cs_start + cs_marker.len();
+    let open_rel = find_bytes(&bytes[after_marker..], b"<<").expect("<< after /ColorSpace");
+    let absolute_open = after_marker + open_rel;
+
+    // Find the matching `>>` by walking with a depth counter starting
+    // at 1 (we're already inside the opened dict). Note: the outer
+    // /CalRGB parameter dicts would add nesting, but in this test we
+    // only register Name-form entries (`/DeviceRGB`) so there are no
+    // nested dicts — the first `>>` is the close. We still use the
+    // balanced walker for robustness.
+    let mut depth: usize = 1;
+    let mut i = absolute_open + 2;
+    let mut close: Option<usize> = None;
+    while i + 1 < bytes.len() {
+        match &bytes[i..i + 2] {
+            b"<<" => {
+                depth += 1;
+                i += 2;
+            }
+            b">>" => {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(i);
+                    break;
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    let close = close.expect("matching >> for /ColorSpace <<");
+    let cs_block = &bytes[absolute_open..close];
+
+    // Scan the block for each /CSX token; the positions must be in
+    // lexicographic order of the names (what sorted emission guarantees).
+    let mut observed: Vec<(usize, &str)> = Vec::new();
+    for name in &insertion_order {
+        let needle: Vec<u8> = [b"/", name.as_bytes()].concat();
+        let pos = find_bytes(cs_block, &needle)
+            .unwrap_or_else(|| panic!("/{} missing from /ColorSpace block", name));
+        observed.push((pos, *name));
+    }
+    observed.sort_by_key(|(pos, _)| *pos);
+    let observed_names: Vec<&str> = observed.iter().map(|(_, n)| *n).collect();
+    let mut expected = observed_names.clone();
+    expected.sort();
+    assert_eq!(
+        observed_names, expected,
+        "/ColorSpace entries must be emitted in ASCII-sorted order \
+         regardless of insertion order; got {:?}",
+        observed_names
+    );
+}


### PR DESCRIPTION
## Summary

PR 1 of 3 addressing the post-v2.5.6-sprint code-quality + security review. Covers **3 findings** on the writer layer:

| Finding | Severity | What | Where |
|---|---|---|---|
| **SEC-F1** | High | PDF string literals emitted without escaping `\`, `(`, `)` — dict-level injection via `fill_field` / Info metadata | \`pdf_writer/mod.rs\` \`Object::String\` arms |
| **SEC-F5** | Medium | Resource-name validation missing on \`Page::add_*\` — Name-level injection parallel to F1 | \`page.rs\` |
| **QUAL-9** | Non-blocking | \`Dictionary\` HashMap iteration order randomised → non-reproducible PDFs | \`pdf_writer/mod.rs\` \`Object::Dictionary\` arm |

## F1 — PDF string-literal escape

The writer previously emitted \`Object::String(s)\` as \`(<raw bytes>)\` with no escaping. ISO 32000-1 §7.3.4.2 REQUIRES \`\\\`, \`(\`, \`)\` inside a literal string to be backslash-escaped.

Exploit: \`doc.fill_field(\"email\", \"foo) /Evil (true\")\` emitted \`/V (foo) /Evil (true)\` — injecting \`/Evil\` as a new dict key. Same code path powers every \`/Info\` metadata setter.

**Fix**: new \`escape_pdf_string_bytes\` helper at module scope applied to both streaming and object-stream buffer writers. Order-correct (\`\\\` first, then \`(\`, \`)\`).

**Note**: the text-field *appearance-stream* escape at \`forms/appearance.rs:275-279\` was already correct — this fix is purely at the object-serialisation level.

## F5 — Resource-name validation

\`Page::add_color_space\` / \`add_pattern\` / \`add_shading\` / \`add_form_xobject\` accepted any string without validation. A caller supplying \`\"Foo>>/Evil\"\` produced \`/Foo>>/Evil\` in the emitted dict — the \`>>\` closed the sub-dict and injected \`/Evil\` at parent scope.

**Fix**: new \`validate_pdf_resource_name\` helper rejecting (a) empty, (b) whitespace, (c) delimiters \`( ) < > [ ] { } / %\`, (d) \`#\` hex-escape introducer. All four \`add_*\` methods now return \`Result<(), PdfError>\` instead of \`()\`.

**SemVer note**: these methods shipped in v2.5.6 (commit \`f01fe65\`) but have NOT been published to crates.io. The signature change is pre-release and breaks no external consumer.

## QUAL-9 — Deterministic dict emission

\`Dictionary\` is backed by \`HashMap\` with per-instance randomised iteration order. Two logically-identical documents serialised to byte-different PDFs.

**Fix**: sort \`dict.entries()\` by key inside both \`Object::Dictionary\` serialization arms. PDF dict entries are explicitly unordered per §7.3.7 Table 5 — sorting is semantically neutral. Pattern and Shading indirect-object allocation also sorts by name before \`allocate_object_id\`, so xref entries are reproducible too.

## Test plan

New file \`tests/writer_hygiene_test.rs\` with **8 tests** (all wire-format, parse the emitted PDF):
- [x] \`object_string_escapes_delimiters_in_dict_injection_payload\` — builds a filled-field PDF with the injection payload \`\"foo) /Evil (true\"\`, asserts /V round-trips byte-identically AND /Evil did NOT leak into the field dict.
- [x] \`object_string_escapes_backslash\` — Windows-path payload \`r\"C:\\\\Users\\\\admin\\\\secrets.txt\"\`.
- [x] \`add_color_space_rejects_name_with_delimiters\` / \`_with_whitespace\` / \`_with_hash_escape_introducer\` / \`_empty_name\`.
- [x] \`add_color_space_accepts_valid_names\` — happy path (ASCII, \`_\`, \`-\`).
- [x] \`color_space_resource_entries_are_emitted_in_sorted_order\` — byte-level inspection of emission order.

Pre-existing test \`test_write_pdf_special_characters\` updated to reflect the correct escape output (the old assertion encoded the F1 bug as expected behaviour).

Existing integration tests (\`formxobject_group_test\`, \`page_color_spaces_test\`, \`page_patterns_test\`, \`page_shadings_test\`) updated to handle the new \`Result<()>\` return from the \`add_*\` methods.

- [x] Lib: 6322 passing / 0 failed / 3 ignored.
- [x] Integration: 100% across 40+ test binaries.
- [x] \`cargo clippy -p oxidize-pdf --lib --all-features -- -D warnings\`: clean.
- [x] \`cargo clippy -p oxidize-pdf --test writer_hygiene_test -- -D warnings\`: clean.
- [x] \`cargo fmt --check\`: clean.

---

**Next in the review-driven series**: PR2 (\`fix/correctness-fill-field-and-smask\` — QUAL-2 + SEC-F3 + QUAL-1/F2) and PR3 (\`refactor/api-polish\` — QUAL-5 + QUAL-6 + rustdoc). Merge of this PR before the others is fine; they don't touch the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)