### PR TITLE
fix(forms,writer): fill_field /AP semantics + SoftMask /G indirect ref

### DIFF
--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -618,6 +618,12 @@ impl Document {
             // rendering unit) before declaring two rects distinct.
             const RECT_MATCH_TOLERANCE: f64 = 1e-3;
 
+            // Tracks whether we had to clear any stale /AP below. If so,
+            // flip `/AcroForm/NeedAppearances` true so viewers know to
+            // regenerate the appearance client-side — otherwise readers
+            // that trust /AP would render nothing where we removed it.
+            let mut needs_need_appearances = false;
+
             for page in self.pages.iter_mut() {
                 for annot in page.annotations_mut().iter_mut() {
                     if annot.field_parent != Some(placeholder) {
@@ -636,22 +642,41 @@ impl Document {
                             && (w.rect.upper_right.y - annot.rect.upper_right.y).abs()
                                 < RECT_MATCH_TOLERANCE
                     });
-                    // Fallback to the first widget when no rect matches
-                    // (e.g. annotation added via legacy `add_form_widget`
-                    // with a different rect). If the field has no widgets
-                    // at all — a valid state, e.g.
-                    // `add_radio_button(..., None, None)` — skip /AP sync
-                    // entirely rather than indexing into an empty Vec.
-                    let Some(widget) = matching_widget.or_else(|| form_field.widgets.first())
-                    else {
-                        continue;
-                    };
-                    if let Some(ref app_dict) = widget.appearance_streams {
-                        annot
-                            .properties
-                            .set("AP", Object::Dictionary(app_dict.to_dict()));
+
+                    match matching_widget.and_then(|w| w.appearance_streams.as_ref()) {
+                        Some(app_dict) => {
+                            annot
+                                .properties
+                                .set("AP", Object::Dictionary(app_dict.to_dict()));
+                        }
+                        None => {
+                            // Either (a) no widget rect matches this
+                            // annotation's rect, or (b) the matched
+                            // widget has no regenerated appearance
+                            // stream. In BOTH cases we must NOT guess a
+                            // substitute /AP (the previous fallback to
+                            // `widgets[0]` was a silent-wrong-widget bug
+                            // for multi-widget fields — see code-review
+                            // SEC-F3 2026-04-23). Instead clear any
+                            // stale /AP left from a prior fill and flip
+                            // /NeedAppearances so viewers regenerate.
+                            if annot.properties.get("AP").is_some() {
+                                annot.properties.remove("AP");
+                                needs_need_appearances = true;
+                            } else {
+                                // No stale /AP to clear; still flip
+                                // /NeedAppearances so the new /V gets
+                                // a fresh appearance at open time.
+                                needs_need_appearances = true;
+                            }
+                        }
                     }
                 }
+            }
+
+            if needs_need_appearances {
+                let acro_form = self.acro_form.get_or_insert_with(AcroForm::new);
+                acro_form.need_appearances = true;
             }
         }
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2372,6 +2372,14 @@ impl<W: Write> PdfWriter<W> {
         let has_images = !page.images().is_empty();
         let has_forms = !page.form_xobjects().is_empty();
 
+        // Tracks name→ObjectId for every FormXObject written below.
+        // Used downstream by the ExtGState SMask emission (ISO 32000-1
+        // §11.6.4.3 Table 144 requires /G to be an INDIRECT reference
+        // to a transparency-group Form XObject; the caller supplies the
+        // group by name in `SoftMask::alpha(name)` and we resolve that
+        // name to the ObjectId allocated here).
+        let mut form_xobject_ids: HashMap<String, ObjectId> = HashMap::new();
+
         if has_images || has_forms {
             let mut xobject_dict = Dictionary::new();
 
@@ -2423,6 +2431,9 @@ impl<W: Write> PdfWriter<W> {
                     Object::Stream(stream.dictionary().clone(), stream.data().to_vec());
                 self.write_object(form_id, stream_obj)?;
                 xobject_dict.set(name, Object::Reference(form_id));
+                // Record the mapping so a downstream SoftMask with
+                // `group_ref == name` can resolve to this indirect ref.
+                form_xobject_ids.insert(name.clone(), form_id);
             }
 
             resources.set("XObject", Object::Dictionary(xobject_dict));
@@ -2488,8 +2499,27 @@ impl<W: Write> PdfWriter<W> {
                 // form unconditionally so callers see a consistent
                 // shape (and because the builder already populated the
                 // dict variant for them).
+                //
+                // /G MUST be an indirect reference (Table 144). The
+                // `SoftMask` API models the group reference as a `String`
+                // name matching a FormXObject registered on this page
+                // via `Page::add_form_xobject(name, ...)`. Resolve the
+                // name here to the indirect ObjectId allocated above.
+                // If no matching FormXObject exists, surface a structured
+                // error rather than emit a spec-invalid /G /<Name> token.
                 if let Some(ref soft_mask) = state.soft_mask {
-                    let mask_dict = soft_mask.to_pdf_dictionary()?;
+                    let mut mask_dict = soft_mask.to_pdf_dictionary()?;
+                    if let Some(Object::Name(ref g_name)) = mask_dict.get("G").cloned() {
+                        let form_id = form_xobject_ids.get(g_name).ok_or_else(|| {
+                            crate::error::PdfError::InvalidStructure(format!(
+                                "SoftMask references transparency group {:?} but no matching \
+                                 FormXObject is registered on the page; call \
+                                 Page::add_form_xobject({:?}, ...) before saving",
+                                g_name, g_name
+                            ))
+                        })?;
+                        mask_dict.set("G", Object::Reference(*form_id));
+                    }
                     state_dict.set("SMask", Object::Dictionary(mask_dict));
                 }
 

--- a/oxidize-pdf-core/tests/extgstate_smask_bm_test.rs
+++ b/oxidize-pdf-core/tests/extgstate_smask_bm_test.rs
@@ -208,21 +208,36 @@ fn extgstate_emits_smask_none_when_set_soft_mask_none() {
 }
 
 /// Task 8 positive path: a real alpha soft mask must emit a dict with
-/// `/Type /Mask`, `/S /Alpha`, and a `/G` entry referencing the
-/// transparency group XObject name supplied by the caller (Table 144).
+/// `/Type /Mask`, `/S /Alpha`, and a `/G` entry that is an **indirect
+/// reference** to the transparency-group Form XObject registered on
+/// the page. ISO 32000-1 §11.6.4.3 Table 144 is explicit: `/G` is an
+/// indirect reference — a raw `/Name` is a spec violation and strict
+/// validators (Acrobat preflight, pdfcpu) reject it.
 ///
-/// We store the group ref as a Name for now (placeholder for a later
-/// indirect Object reference). That matches how `SoftMask::alpha(name)`
-/// models the reference today — when the writer upgrades to emitting
-/// `/G` as an indirect object reference, only the assertion on `/G`
-/// needs to adapt, not the public API.
+/// Previous iteration of this test accepted either form; that
+/// permissiveness masked a real bug. The PR2 code-quality audit
+/// tightened this assertion — the writer now resolves the
+/// `SoftMask::alpha(name)` string to the ObjectId allocated for the
+/// matching `Page::add_form_xobject(name, ...)` entry, and emits an
+/// indirect reference.
 #[test]
-fn extgstate_emits_smask_alpha_dict_with_group_reference() {
+fn extgstate_emits_smask_alpha_dict_with_indirect_g_reference() {
+    use oxidize_pdf::geometry::{Point, Rectangle};
+    use oxidize_pdf::graphics::FormXObject;
+
     let mut doc = Document::new();
     let mut page = Page::a4();
+
+    // The SoftMask references the transparency group by name — which
+    // means the caller MUST have registered a FormXObject under that
+    // name via `Page::add_form_xobject` so the writer can resolve it
+    // to an indirect reference.
+    let bbox = Rectangle::new(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
+    page.add_form_xobject("TransGroup", FormXObject::new(bbox))
+        .expect("add_form_xobject");
+
     let sm = SoftMask::alpha("TransGroup".to_string());
-    let gs = ExtGState::new().with_alpha_stroke(1.0);
-    let mut gs = gs;
+    let mut gs = ExtGState::new().with_alpha_stroke(1.0);
     gs.set_soft_mask(sm);
     let name = page
         .graphics()
@@ -252,14 +267,13 @@ fn extgstate_emits_smask_alpha_dict_with_group_reference() {
         Some("Alpha"),
         "/SMask/S must be /Alpha for SoftMask::alpha(...)"
     );
-    // /G is present as either a Name (current placeholder form) or a
-    // Reference. Either is acceptable for this regression check; the
-    // key invariant is that the group identifier survives round-trip.
+
+    // /G MUST be an indirect reference per §11.6.4.3 Table 144.
     let g = smask.get("G").expect("/SMask/G must be present");
-    let g_desc = format!("{:?}", g);
     assert!(
-        g_desc.contains("TransGroup"),
-        "/SMask/G must preserve the group reference 'TransGroup', got {:?}",
+        matches!(g, oxidize_pdf::parser::objects::PdfObject::Reference(_, _)),
+        "/SMask/G MUST be an indirect reference (ISO 32000-1 §11.6.4.3); \
+         got: {:?}",
         g
     );
 }

--- a/oxidize-pdf-core/tests/fill_field_and_smask_correctness_test.rs
+++ b/oxidize-pdf-core/tests/fill_field_and_smask_correctness_test.rs
@@ -1,0 +1,434 @@
+//! Regression tests for PR2 of the post-v2.5.6 code-quality + security
+//! review. Two findings, one semantic-correctness theme
+//! ("what the writer emits must actually be valid"):
+//!
+//!   * **SEC-F3** (combined with the defensive fix for **QUAL-2**) —
+//!     the rect-based widget↔annotation matcher fell back to
+//!     `widgets[0]` silently when no widget's rect matched the
+//!     annotation's rect. For multi-widget fields (same field drawn
+//!     on several pages, radio button groups) this meant every
+//!     unmatched annotation got widget-0's appearance regardless of
+//!     its actual geometry — a silent correctness failure. Contract:
+//!     on no-match OR on a widget whose `appearance_streams` is
+//!     unexpectedly `None`, `fill_field` MUST NOT write a guessed
+//!     `/AP`; instead it clears any stale `/AP` on the annotation
+//!     and marks `/AcroForm/NeedAppearances` true so viewers regenerate.
+//!
+//!     QUAL-2 (stale `/AP` when `appearance_streams` is `None`) is
+//!     not directly reachable through the current API because
+//!     `Widget::generate_appearance` always populates the field
+//!     before returning `Ok(())`. It is addressed *defensively* by
+//!     the same code path — no dedicated test, since constructing
+//!     the repro requires bypassing the builder API.
+//!
+//!   * **QUAL-1 / SEC-F2** — `SoftMask::to_pdf_dictionary()` emitted
+//!     `/G` as `Object::Name(group_ref)`. ISO 32000-1 §11.6.4.3
+//!     Table 144 REQUIRES `/G` to be an indirect reference to a
+//!     transparency-group Form XObject. Acrobat's preflight (and
+//!     pdfcpu's validator) rejects the Name form. Contract: the
+//!     writer must resolve the SoftMask's group name to the indirect
+//!     reference of the matching FormXObject registered on the page.
+//!     If no such FormXObject exists, emission must fail with a
+//!     structured error — emitting a bogus `/G` is worse than failing
+//!     loudly.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::{BlendMode, ExtGState, FormXObject, SoftMask};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+// -------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------
+
+fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages.get("Kids").and_then(|o| o.as_array()).expect("/Kids");
+    kids.0
+        .first()
+        .expect("/Kids[0]")
+        .as_reference()
+        .expect("ref")
+}
+
+fn resolve_field_dict<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm");
+    let acro = reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve /AcroForm")
+        .clone();
+    let (field_n, field_g) = acro
+        .as_dict()
+        .and_then(|d| d.get("Fields"))
+        .and_then(|o| o.as_array())
+        .and_then(|a| a.get(0))
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm/Fields[0]");
+    let field_obj = reader
+        .get_object(field_n, field_g)
+        .expect("resolve field")
+        .clone();
+    field_obj.as_dict().expect("field dict").clone()
+}
+
+fn page0_first_annotation<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page.as_dict().expect("page dict").clone();
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("/Annots");
+    let (annot_n, annot_g) = annots
+        .0
+        .first()
+        .expect("/Annots[0]")
+        .as_reference()
+        .expect("reference");
+    let annot_obj = reader
+        .get_object(annot_n, annot_g)
+        .expect("resolve annotation")
+        .clone();
+    annot_obj.as_dict().expect("annotation dict").clone()
+}
+
+fn acroform_dict<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let catalog = reader.catalog().expect("catalog").clone();
+    let (acro_n, acro_g) = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .expect("/AcroForm");
+    reader
+        .get_object(acro_n, acro_g)
+        .expect("resolve /AcroForm")
+        .clone()
+        .as_dict()
+        .expect("/AcroForm dict")
+        .clone()
+}
+
+// -------------------------------------------------------------------
+// QUAL-2 note: not directly testable through the public API because
+// `Widget::generate_appearance` always populates `appearance_streams`
+// (field.rs:157) before returning `Ok(())`. The implementation below
+// is defensive — if a future refactor lets `appearance_streams` stay
+// None after `generate_appearance`, fill_field will still clear stale
+// /AP rather than leave it intact — but exercising that path requires
+// bypassing the builder API, which no legitimate caller does.
+// -------------------------------------------------------------------
+
+#[test]
+#[ignore = "QUAL-2: defensive path not directly reachable without \
+            mutating private Widget state; covered by the F3 test \
+            instead (same /AP-clearing code path fires on rect \
+            mismatch, which IS reachable)"]
+fn fill_field_clears_stale_ap_when_widget_has_no_generated_appearance() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field_ref = fm
+        .add_text_field(TextField::new("email"), widget.clone(), None)
+        .expect("add_text_field");
+
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+
+    // Seed a stale /AP on the annotation — pretend the user filled this
+    // field previously with "OLDVALUE" and the appearance stream was
+    // baked in with that value.
+    {
+        use oxidize_pdf::objects::{Dictionary, Object};
+        let annot = page
+            .annotations_mut()
+            .get_mut(0)
+            .expect("annotation exists after add_form_widget_with_ref");
+        let mut ap = Dictionary::new();
+        let mut stale_n = Dictionary::new();
+        stale_n.set("Type", Object::Name("XObject".to_string()));
+        stale_n.set("Subtype", Object::Name("Form".to_string()));
+        ap.set("N", Object::Dictionary(stale_n));
+        annot.properties.set("AP", Object::Dictionary(ap));
+    }
+
+    // Clear widgets' appearance_streams to simulate the case where
+    // `Widget::generate_appearance` returned Ok without populating the
+    // stream (real push-button / radio widgets behave this way when
+    // constructed without an explicit appearance). We do this BEFORE
+    // `set_form_manager` because `Document` owns the FormManager by
+    // value after that call, so we mutate the local `fm` here.
+    for widget in &mut fm.get_field_mut("email").expect("email").widgets {
+        widget.appearance_streams = None;
+    }
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("email", "NEWVALUE")
+        .expect("fill_field must succeed");
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    // Assertion 1: /V on the field is the new value.
+    let field_dict = resolve_field_dict(&mut reader);
+    let v = field_dict
+        .get("V")
+        .and_then(|o| o.as_string())
+        .and_then(|s| s.as_str().ok())
+        .expect("/V present");
+    assert_eq!(v, "NEWVALUE", "/V must reflect the new value");
+
+    // Assertion 2: the stale /AP on the annotation MUST be cleared.
+    // Emitting NO /AP is correct behaviour — forces viewers to regenerate
+    // via /NeedAppearances rather than render the old baked-in value.
+    let annot_dict = page0_first_annotation(&mut reader);
+    assert!(
+        annot_dict.get("AP").is_none(),
+        "stale /AP must be cleared when the widget has no regenerated \
+         appearance stream; got: {:?}",
+        annot_dict.get("AP")
+    );
+
+    // Assertion 3: /AcroForm/NeedAppearances must be true so viewers
+    // know to compute the appearance themselves.
+    let acro = acroform_dict(&mut reader);
+    assert_eq!(
+        acro.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true),
+        "/AcroForm/NeedAppearances must be true after fill_field clears any /AP"
+    );
+}
+
+// -------------------------------------------------------------------
+// SEC-F3: clear /AP on rect mismatch instead of silently picking widgets[0]
+// -------------------------------------------------------------------
+
+/// Reproduces F3: two widgets on a single field with DIFFERENT rects,
+/// plus a page annotation whose rect matches neither (moved by multiple
+/// points — well beyond the 1e-3 tolerance). Pre-fill fix, the annotation
+/// would silently receive widgets[0]'s appearance, rendering the value
+/// at the wrong geometry. Post-fix the annotation's /AP is cleared and
+/// `NeedAppearances` is set.
+#[test]
+fn fill_field_clears_ap_on_rect_mismatch_instead_of_picking_widget_zero() {
+    use oxidize_pdf::forms::CheckBox;
+    use oxidize_pdf::graphics::FormXObject as _FormXObject;
+    let _ = _FormXObject::new(Rectangle::new(Point::new(0.0, 0.0), Point::new(1.0, 1.0))); // satisfies unused-import on some refactors
+
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    // Two widgets, visibly different rects.
+    let rect_a = Rectangle::new(Point::new(100.0, 700.0), Point::new(200.0, 720.0));
+    let rect_b = Rectangle::new(Point::new(300.0, 500.0), Point::new(450.0, 560.0));
+    let w_a = Widget::new(rect_a).with_appearance(WidgetAppearance::default());
+    let w_b = Widget::new(rect_b).with_appearance(WidgetAppearance::default());
+
+    let field_ref = fm
+        .add_checkbox(CheckBox::new("ch"), w_a.clone(), None)
+        .expect("add_checkbox");
+    fm.get_field_mut("ch").expect("ch exists").add_widget(w_b);
+
+    // Annotation on page with a rect that matches NEITHER widget (off by
+    // 10 pt — way above the 1e-3 tolerance).
+    let mismatched = Rectangle::new(Point::new(50.0, 50.0), Point::new(60.0, 60.0));
+    page.add_form_widget_with_ref(Widget::new(mismatched), field_ref)
+        .expect("add_form_widget_with_ref");
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("ch", "Yes")
+        .expect("fill_field must succeed");
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    // The lone annotation must NOT carry any /AP (would have been
+    // widgets[0]'s before the fix — wrong geometry). /NeedAppearances
+    // is set so viewers regenerate at the correct annotation rect.
+    let annot_dict = page0_first_annotation(&mut reader);
+    assert!(
+        annot_dict.get("AP").is_none(),
+        "annotation with rect matching no widget must have /AP cleared; got: {:?}",
+        annot_dict.get("AP")
+    );
+    let acro = acroform_dict(&mut reader);
+    assert_eq!(
+        acro.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true),
+        "/NeedAppearances must be true when fill_field cleared any /AP"
+    );
+}
+
+/// Regression guard for the happy path: when the annotation's rect
+/// matches a widget within tolerance, `/AP` MUST still be written
+/// (this is what the v2.5.6 fill_field roundtrip test covers — we
+/// restate it here to make sure the F3 fix didn't regress it).
+#[test]
+fn fill_field_still_writes_ap_on_rect_match() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field_ref = fm
+        .add_text_field(TextField::new("email"), widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("email", "user@example.com")
+        .expect("fill_field");
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    let annot_dict = page0_first_annotation(&mut reader);
+    let ap = annot_dict
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("/AP must be present on rect-matched happy path");
+    assert!(
+        ap.get("N").is_some(),
+        "/AP must carry /N (normal appearance)"
+    );
+}
+
+// -------------------------------------------------------------------
+// QUAL-1 / SEC-F2: SoftMask /G as indirect reference
+// -------------------------------------------------------------------
+
+/// Primary F2 assertion: a SoftMask with a group_ref name MUST surface
+/// as `/SMask/G <n 0 R>` (indirect reference) in the emitted PDF, not
+/// `/SMask/G /<name>` (direct name — spec violation per §11.6.4.3
+/// Table 144). The writer resolves the name to the indirect ID of the
+/// FormXObject the caller registered under that name on the page.
+#[test]
+fn softmask_g_is_emitted_as_indirect_reference_not_name() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    // Register a FormXObject to serve as the transparency group.
+    let bbox = Rectangle::from_position_and_size(0.0, 0.0, 100.0, 100.0);
+    page.add_form_xobject("TransGroup", FormXObject::new(bbox))
+        .expect("add_form_xobject");
+
+    // ExtGState with a SoftMask referencing the group by name.
+    let sm = SoftMask::alpha("TransGroup".to_string());
+    let mut gs = ExtGState::new().with_alpha_stroke(1.0);
+    gs.set_soft_mask(sm);
+    let name = page
+        .graphics()
+        .extgstate_manager_mut()
+        .add_state(gs)
+        .expect("add_state");
+
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    // Walk to /Resources/ExtGState/<name>.
+    let (page_n, page_g) = first_page_ref(&mut reader);
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = page_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    let extgstate = resources
+        .get("ExtGState")
+        .and_then(|o| o.as_dict())
+        .expect("/ExtGState");
+    let gs_dict = extgstate
+        .get(&name)
+        .and_then(|o| o.as_dict())
+        .expect("GS dict");
+
+    let smask = gs_dict
+        .get("SMask")
+        .and_then(|o| o.as_dict())
+        .expect("/SMask must be a dict");
+
+    // /G MUST be an indirect reference per §11.6.4.3 Table 144 —
+    // Object::Name is a spec violation and must not appear here.
+    let g = smask.get("G").expect("/SMask/G must be present");
+    assert!(
+        matches!(g, PdfObject::Reference(_, _)),
+        "/SMask/G MUST be an indirect reference per ISO 32000-1 §11.6.4.3; \
+         got: {:?}",
+        g
+    );
+
+    // And the referenced object must resolve to the Form XObject we
+    // registered (Type /XObject Subtype /Form).
+    let (g_n, g_g) = g.as_reference().expect("reference");
+    let target = reader.get_object(g_n, g_g).expect("resolve /G").clone();
+    let subtype = match &target {
+        PdfObject::Stream(s) => s
+            .dict
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned()),
+        PdfObject::Dictionary(d) => d
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str().to_owned()),
+        other => panic!("/SMask/G target must be stream or dict, got {:?}", other),
+    };
+    assert_eq!(
+        subtype.as_deref(),
+        Some("Form"),
+        "/SMask/G must resolve to a Form XObject"
+    );
+}
+
+/// F2 negative path: if the caller sets a SoftMask referencing a
+/// transparency group by name but never registers that FormXObject on
+/// the page, the writer MUST surface a structured error. Emitting the
+/// name as a raw /Name token (the pre-fix behaviour) is worse than
+/// failing loudly — it produces a PDF that looks valid to casual tools
+/// but is rejected by strict validators.
+#[test]
+fn softmask_emit_fails_when_group_xobject_not_registered() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    let sm = SoftMask::alpha("NotRegistered".to_string());
+    let mut gs = ExtGState::new().with_blend_mode(BlendMode::Multiply);
+    gs.set_soft_mask(sm);
+    page.graphics()
+        .extgstate_manager_mut()
+        .add_state(gs)
+        .expect("add_state");
+    doc.add_page(page);
+
+    let result = doc.to_bytes();
+    assert!(
+        result.is_err(),
+        "writer must reject a SoftMask whose group_ref names an \
+         unregistered FormXObject; got Ok PDF (likely contains a \
+         spec-invalid /G /<name> token)"
+    );
+}


### PR DESCRIPTION
PR 2 of 3 addressing post-v2.5.6 code-quality + security review. Covers 3 findings with one theme: **what the writer emits must be spec-valid**.

## SEC-F3 (Medium) + QUAL-2 (defensive) — fill_field /AP semantics

**Before**: when no widget rect matched an annotation's rect, `fill_field` silently fell back to `widgets[0]`, writing widget-0's appearance to the mismatched annotation. For a multi-widget field at different geometries, this is a silent correctness failure.

**Fix** (`document.rs` fill_field loop): rect-match failure OR None appearance_streams → clear stale /AP + set `/AcroForm/NeedAppearances = true`. Viewers ignoring NeedAppearances see a blank widget (safe); viewers honouring it regenerate correctly. **Worst case changed from "wrong content" to "temporarily blank".**

QUAL-2 (appearance_streams == None) is defensively handled by the same code path. Not directly reachable today (generate_appearance always populates) but the code was fragile.

## QUAL-1 / SEC-F2 (Medium) — SoftMask /G indirect reference

ISO 32000-1 §11.6.4.3 Table 144 REQUIRES /SMask/G to be an indirect reference to a transparency-group Form XObject. Before: `SoftMask::to_pdf_dictionary` emitted /G as `Object::Name(group_ref)` — spec-invalid. Acrobat Preflight + pdfcpu both reject.

**Bug was latent** — `to_pdf_dictionary` was never called from the writer until Task 8 of the v2.5.6 sprint (#207) wired it in. Surfaced now because we tested it.

**Fix** (`pdf_writer/mod.rs`):
- While writing Form XObjects, record `name → ObjectId` in a local `form_xobject_ids` map.
- When emitting /SMask, resolve /Name → /Reference using that map.
- If name not registered, return `PdfError::InvalidStructure` with a message pointing the caller at `Page::add_form_xobject`. Emitting spec-invalid /G was worse than failing loudly.

`SoftMask` public API unchanged — resolution happens entirely in the writer.

## Test plan (all wire-format, parse the emitted PDF)

New `tests/fill_field_and_smask_correctness_test.rs` with 5 tests:
- [x] `fill_field_clears_ap_on_rect_mismatch_instead_of_picking_widget_zero` — F3 primary repro.
- [x] `fill_field_still_writes_ap_on_rect_match` — happy-path regression guard.
- [x] `softmask_g_is_emitted_as_indirect_reference_not_name` — F2 primary.
- [x] `softmask_emit_fails_when_group_xobject_not_registered` — F2 negative path.
- [x] `fill_field_clears_stale_ap_when_widget_has_no_generated_appearance` (#[ignore]-d with explanation — QUAL-2 path not reachable without bypassing the builder API).

Existing `extgstate_emits_smask_alpha_dict_with_group_reference` renamed to `..._with_indirect_g_reference` and tightened — previously accepted either Name or Reference (masked the F2 bug). Now registers the FormXObject and asserts Reference strictly.

- [x] Lib: 6322 passing / 0 failed / 3 ignored.
- [x] Integration: 100% passing across 40+ binaries.
- [x] Clippy lib + new tests: clean. Fmt: clean.

---

**Lesson captured from this review**: the original test for F2 accepted either Name or Reference for /SMask/G — that permissiveness masked a real spec violation. The quality-rust reviewer caught it. Tests gating on concrete wire-format invariants beat tests that accept multiple shapes.

Next: PR3 (refactor/api-polish — QUAL-5 typed ColorSpace + QUAL-6 iter_fields_sorted + rustdoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)