### PR TITLE
refactor(api): typed PageColorSpace + iter_fields_sorted cleanup + rustdoc polish

### DIFF
--- a/oxidize-pdf-core/src/annotations/annotation.rs
+++ b/oxidize-pdf-core/src/annotations/annotation.rs
@@ -310,12 +310,20 @@ impl Annotation {
     /// the writer remaps the placeholder to a real indirect-object id
     /// at serialization time.
     ///
-    /// Only meaningful for [`AnnotationType::Widget`]. In debug builds,
-    /// calling this on a non-Widget annotation is a programming error
-    /// and trips a `debug_assert!`. In release builds the setter still
-    /// stores the value, but `to_dict` will refuse to emit `/Parent`
-    /// for non-Widget annotations (defence in depth: the setter is the
-    /// primary gate; the emitter is the safety net).
+    /// Only meaningful for [`AnnotationType::Widget`].
+    ///
+    /// # Panics
+    ///
+    /// In **debug builds**, calling this on a non-Widget annotation
+    /// trips a `debug_assert!` — using `/Parent` on a non-Widget
+    /// annotation is a spec violation and almost always a programmer
+    /// error. In **release builds** the setter still stores the value
+    /// (no panic), but the defence-in-depth check in [`to_dict`] will
+    /// refuse to emit `/Parent` for non-Widget annotations, so a
+    /// mis-targeted call is degraded to a silent no-op rather than an
+    /// invalid PDF.
+    ///
+    /// [`to_dict`]: Annotation::to_dict
     pub fn set_field_parent(&mut self, parent: ObjectReference) {
         debug_assert!(
             matches!(self.annotation_type, AnnotationType::Widget),

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -473,36 +473,35 @@ impl FormManager {
     /// couple external callers to a serialization detail that is expected
     /// to evolve. Public iteration can go through [`FormManager::fields`].
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns a streaming iterator of `Result` items. The only way an
-    /// error is produced is if the internal `fields` / `field_refs` maps
-    /// desynchronize — a "can't happen" invariant that every `add_*_field`
-    /// method is responsible for upholding. A desync surfaces as
-    /// [`PdfError::Internal`] rather than a panic so the writer hot path
-    /// stays panic-free (ISO 32000-1 conformance errors must remain
-    /// recoverable).
+    /// The iterator panics if the internal `fields` / `field_refs` maps
+    /// desynchronize — a "can't happen" invariant that every
+    /// `add_*_field` method is responsible for upholding. Panicking
+    /// here is acceptable because (a) the invariant is entirely under
+    /// this crate's control and (b) a broken invariant signals memory
+    /// corruption or a logic bug in `add_*_field`, not an ISO 32000-1
+    /// conformance issue — the writer has no meaningful recovery path.
+    /// The previous `Result` wrapper was removed (PR3 / QUAL-6) because
+    /// its error arm was observably unreachable and forced every call
+    /// site to thread `?` for no benefit.
     pub(crate) fn iter_fields_sorted(
         &self,
-    ) -> impl Iterator<Item = Result<(&String, &FormField, ObjectReference)>> {
+    ) -> impl Iterator<Item = (&String, &FormField, ObjectReference)> {
         let mut keys: Vec<&String> = self.fields.keys().collect();
         keys.sort();
         keys.into_iter().map(move |k| {
-            // `k` was just produced by `self.fields.keys()`, so this lookup
-            // cannot fail within the same borrow. We still avoid `expect`
-            // on a hot path and surface an `Internal` error instead of
-            // panicking — callers already propagate `Result<()>`.
-            let field = self.fields.get(k).ok_or_else(|| {
-                crate::error::PdfError::Internal(format!(
-                    "FormManager internal invariant broken: field '{k}' missing from fields map during sorted iteration"
-                ))
-            })?;
-            let placeholder = *self.field_refs.get(k).ok_or_else(|| {
-                crate::error::PdfError::Internal(format!(
-                    "FormManager internal invariant broken: field '{k}' has no placeholder ref (add_*_field forgot to populate field_refs?)"
-                ))
-            })?;
-            Ok((k, field, placeholder))
+            // `k` was just produced by `self.fields.keys()`, so this
+            // lookup is infallible under a single immutable borrow.
+            let field = self
+                .fields
+                .get(k)
+                .expect("FormManager invariant: key from fields.keys() must resolve in fields");
+            let placeholder = *self.field_refs.get(k).expect(
+                "FormManager invariant: every field in `fields` must have an entry in \
+                 `field_refs` — check add_*_field",
+            );
+            (k, field, placeholder)
         })
     }
 }
@@ -564,6 +563,41 @@ mod tests {
         let obj_ref = manager.add_checkbox(checkbox, widget, None).unwrap();
         assert_eq!(obj_ref.number(), 1);
         assert!(manager.get_field("agree").is_some());
+    }
+
+    /// PR3 / QUAL-6: `iter_fields_sorted` is non-fallible after cleanup.
+    /// Exercises two invariants at once:
+    ///   * The iterator yields the flat tuple `(&String, &FormField, ObjectReference)`
+    ///     — not a `Result<_>`, because the only previously-documented
+    ///     error path ("sister maps desynchronised") is a "can't happen"
+    ///     invariant upheld by every `add_*_field` call.
+    ///   * Fields are emitted in ASCII-lexicographic order of their
+    ///     partial names, regardless of insertion order. This is what
+    ///     keeps writer object-id allocation reproducible across runs.
+    #[test]
+    fn iter_fields_sorted_is_non_fallible_and_ordered() {
+        let mut manager = FormManager::new();
+        // Deliberately unsorted insertion: "zeta", "alpha", "mu".
+        let rect = Rectangle::new(Point::new(0.0, 0.0), Point::new(100.0, 20.0));
+        manager
+            .add_text_field(TextField::new("zeta"), Widget::new(rect), None)
+            .expect("add zeta");
+        manager
+            .add_text_field(TextField::new("alpha"), Widget::new(rect), None)
+            .expect("add alpha");
+        manager
+            .add_text_field(TextField::new("mu"), Widget::new(rect), None)
+            .expect("add mu");
+
+        let names: Vec<String> = manager
+            .iter_fields_sorted()
+            .map(|(name, _field, _placeholder)| name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["alpha".to_string(), "mu".to_string(), "zeta".to_string()],
+            "iter_fields_sorted must yield keys in ASCII-lexicographic order"
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -7,6 +7,7 @@ pub mod extraction;
 pub mod form_xobject;
 mod indexed_color;
 pub mod lab_color;
+pub mod page_color_space;
 mod path;
 mod patterns;
 mod pdf_image;
@@ -31,6 +32,7 @@ pub use form_xobject::{
 };
 pub use indexed_color::{BaseColorSpace, ColorLookupTable, IndexedColorManager, IndexedColorSpace};
 pub use lab_color::{LabColor, LabColorSpace};
+pub use page_color_space::{DeviceColorSpace, PageColorSpace, ParameterisedFamily};
 pub use path::{LineCap, LineJoin, PathBuilder, PathCommand, WindingRule};
 pub use patterns::{
     PaintType, PatternGraphicsContext, PatternManager, PatternMatrix, PatternType, TilingPattern,

--- a/oxidize-pdf-core/src/graphics/page_color_space.rs
+++ b/oxidize-pdf-core/src/graphics/page_color_space.rs
@@ -1,0 +1,172 @@
+//! Typed wrapper for page-level colour-space resource registration
+//! (ISO 32000-1 §8.6, Table 62).
+//!
+//! `Page::add_color_space` originally took a raw
+//! [`crate::objects::Object`], which leaked an internal serialization
+//! type across the public API and made the signature SemVer-fragile.
+//! This module introduces a small enum that models the two wire-format
+//! shapes a colour-space resource entry is allowed to take:
+//!
+//!   * A single `/Name` alias for a device space (ISO 32000-1 §8.6.4,
+//!     e.g. `/DeviceRGB`, `/DeviceCMYK`, `/Pattern`).
+//!   * A parameterised array `[/<family> <<params>>]` for calibrated
+//!     spaces (§8.6.5 `CalGray`, `CalRGB`, `Lab`, `ICCBased`).
+//!
+//! Indexed, Separation, and `DeviceN` spaces are intentionally out of
+//! scope for the v2.5.6 wrapper — those require longer tuple shapes
+//! (`[/Indexed base hival lookup]`, `[/Separation name alt tintFn]`,
+//! `[/DeviceN names alt tintFn attributes]`) that are better served by
+//! dedicated constructors added in a future SemVer-compatible superset
+//! (the enum is `#[non_exhaustive]` to preserve that option).
+
+use crate::objects::{Dictionary, Object};
+
+/// A colour space eligible for registration on a [`crate::Page`] under
+/// `/Resources/ColorSpace/<name>`.
+///
+/// See the module-level docs for the ISO 32000-1 clauses this models.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum PageColorSpace {
+    /// A named device-space alias — emitted as a single `/Name` at the
+    /// resource slot (ISO 32000-1 §8.6.4). Use when the caller wants
+    /// to reference a device space via a numeric or symbolic alias
+    /// (e.g. `/CS1 /DeviceRGB`).
+    DeviceAlias(DeviceColorSpace),
+    /// A calibrated colour space — emitted as `[/<family> <<params>>]`
+    /// (ISO 32000-1 §8.6.5). The parameter dictionary is written
+    /// verbatim; callers are responsible for its content.
+    Parameterised {
+        /// Which calibrated family this entry represents.
+        family: ParameterisedFamily,
+        /// Parameter dictionary — e.g. `WhitePoint`, `Gamma`, `Matrix`
+        /// for CalRGB; `N`, `Alternate`, `Metadata` for ICCBased.
+        params: Dictionary,
+    },
+}
+
+/// The four device colour spaces addressable through
+/// [`PageColorSpace::DeviceAlias`] (ISO 32000-1 §8.6.4 device spaces
+/// + §8.7.3.1 Pattern colour space).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DeviceColorSpace {
+    /// Single-channel grayscale (`/DeviceGray`).
+    Gray,
+    /// Three-channel RGB (`/DeviceRGB`).
+    Rgb,
+    /// Four-channel CMYK (`/DeviceCMYK`).
+    Cmyk,
+    /// Pattern colour space (`/Pattern`).
+    Pattern,
+}
+
+/// The calibrated colour-space families addressable through
+/// [`PageColorSpace::Parameterised`] (ISO 32000-1 §8.6.5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParameterisedFamily {
+    /// `CalGray` — CIE-based single-component (§8.6.5.1).
+    CalGray,
+    /// `CalRGB` — CIE-based three-component (§8.6.5.2).
+    CalRgb,
+    /// `Lab` — CIE 1976 L*a*b* (§8.6.5.4).
+    Lab,
+    /// `ICCBased` — ICC-profile-backed (§8.6.5.5).
+    IccBased,
+}
+
+impl DeviceColorSpace {
+    /// Returns the ISO 32000-1 §8.6 PDF name for this device space,
+    /// without the leading `/`.
+    pub const fn pdf_name(self) -> &'static str {
+        match self {
+            DeviceColorSpace::Gray => "DeviceGray",
+            DeviceColorSpace::Rgb => "DeviceRGB",
+            DeviceColorSpace::Cmyk => "DeviceCMYK",
+            DeviceColorSpace::Pattern => "Pattern",
+        }
+    }
+}
+
+impl ParameterisedFamily {
+    /// Returns the ISO 32000-1 §8.6.5 family name for this calibrated
+    /// colour space (the first element of the emitted array).
+    pub const fn pdf_name(self) -> &'static str {
+        match self {
+            ParameterisedFamily::CalGray => "CalGray",
+            ParameterisedFamily::CalRgb => "CalRGB",
+            ParameterisedFamily::Lab => "Lab",
+            ParameterisedFamily::IccBased => "ICCBased",
+        }
+    }
+}
+
+impl PageColorSpace {
+    /// Convert to the concrete [`Object`] shape the writer emits at
+    /// `/Resources/ColorSpace/<name>`.
+    ///
+    /// Device aliases become `Object::Name`; parameterised entries
+    /// become `Object::Array([Name, Dictionary])`. This keeps the
+    /// conversion in one place so wire-format decisions (e.g. whether
+    /// a future family needs a stream instead of a dict) live with the
+    /// enum they describe, not scattered across the writer.
+    pub(crate) fn to_object(&self) -> Object {
+        match self {
+            PageColorSpace::DeviceAlias(device) => Object::Name(device.pdf_name().to_string()),
+            PageColorSpace::Parameterised { family, params } => Object::Array(vec![
+                Object::Name(family.pdf_name().to_string()),
+                Object::Dictionary(params.clone()),
+            ]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_alias_to_object_is_name() {
+        let obj = PageColorSpace::DeviceAlias(DeviceColorSpace::Cmyk).to_object();
+        match obj {
+            Object::Name(n) => assert_eq!(n, "DeviceCMYK"),
+            other => panic!("expected Name(DeviceCMYK), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parameterised_to_object_is_two_element_array() {
+        let mut params = Dictionary::new();
+        params.set("Gamma", Object::Real(2.2));
+        let obj = PageColorSpace::Parameterised {
+            family: ParameterisedFamily::CalGray,
+            params,
+        }
+        .to_object();
+        match obj {
+            Object::Array(a) => {
+                assert_eq!(a.len(), 2);
+                assert!(matches!(&a[0], Object::Name(n) if n == "CalGray"));
+                assert!(matches!(&a[1], Object::Dictionary(_)));
+            }
+            other => panic!("expected two-element array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn device_pdf_name_covers_all_variants() {
+        assert_eq!(DeviceColorSpace::Gray.pdf_name(), "DeviceGray");
+        assert_eq!(DeviceColorSpace::Rgb.pdf_name(), "DeviceRGB");
+        assert_eq!(DeviceColorSpace::Cmyk.pdf_name(), "DeviceCMYK");
+        assert_eq!(DeviceColorSpace::Pattern.pdf_name(), "Pattern");
+    }
+
+    #[test]
+    fn parameterised_pdf_name_covers_all_variants() {
+        assert_eq!(ParameterisedFamily::CalGray.pdf_name(), "CalGray");
+        assert_eq!(ParameterisedFamily::CalRgb.pdf_name(), "CalRGB");
+        assert_eq!(ParameterisedFamily::Lab.pdf_name(), "Lab");
+        assert_eq!(ParameterisedFamily::IccBased.pdf_name(), "ICCBased");
+    }
+}

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -114,11 +114,11 @@ pub struct Page {
     images: HashMap<String, Image>,
     form_xobjects: HashMap<String, crate::graphics::FormXObject>,
     /// Registered colour spaces, emitted under `/Resources/ColorSpace`
-    /// per ISO 32000-1 §8.6, Table 62. Values preserve the caller-supplied
-    /// `Object` shape (typically `Array([Name, Dictionary])` for
-    /// parameterised spaces like CalRGB / ICCBased / Indexed, or a single
-    /// `Name` for aliasing a device space under a custom resource name).
-    color_spaces: HashMap<String, crate::objects::Object>,
+    /// per ISO 32000-1 §8.6, Table 62. Values are typed via
+    /// [`crate::graphics::PageColorSpace`] — see that enum for the two
+    /// supported wire-format shapes (device alias vs. parameterised
+    /// `[/<family> <<params>>]`).
+    color_spaces: HashMap<String, crate::graphics::PageColorSpace>,
     /// Registered tiling patterns, emitted as indirect stream objects
     /// referenced from `/Resources/Pattern` per ISO 32000-1 §8.7.3.
     patterns: HashMap<String, crate::graphics::TilingPattern>,
@@ -913,12 +913,22 @@ impl Page {
 
     /// Registers a colour space under `name` (ISO 32000-1 §8.6).
     ///
-    /// `cs` must be a legal PDF colour-space representation: either a
-    /// single name (e.g. `Object::Name("DeviceRGB")`) aliasing a device
-    /// space under a custom resource key, or an array like
-    /// `[/CalRGB <<dict>>]` / `[/ICCBased <<stream>>]` /
-    /// `[/Indexed /DeviceRGB N <hivals>]`. The writer serialises the
-    /// supplied object verbatim into `/Resources/ColorSpace/<name>`.
+    /// `cs` is a typed [`crate::graphics::PageColorSpace`] — either a
+    /// [`PageColorSpace::DeviceAlias`] wrapping one of the four device
+    /// spaces (`/DeviceGray`, `/DeviceRGB`, `/DeviceCMYK`, `/Pattern`),
+    /// or a [`PageColorSpace::Parameterised`] entry producing
+    /// `[/<family> <<params>>]` for the calibrated families (`CalGray`,
+    /// `CalRGB`, `Lab`, `ICCBased`). Indexed / Separation / DeviceN
+    /// shapes are out of scope for this wrapper at v2.5.6; see the
+    /// [`page_color_space`] module docs for the rationale.
+    ///
+    /// The writer emits the value under `/Resources/ColorSpace/<name>`,
+    /// converting the enum to its concrete wire format at serialization
+    /// time.
+    ///
+    /// [`page_color_space`]: crate::graphics::page_color_space
+    /// [`PageColorSpace::DeviceAlias`]: crate::graphics::PageColorSpace::DeviceAlias
+    /// [`PageColorSpace::Parameterised`]: crate::graphics::PageColorSpace::Parameterised
     ///
     /// # Errors
     ///
@@ -928,7 +938,7 @@ impl Page {
     pub fn add_color_space(
         &mut self,
         name: impl Into<String>,
-        cs: crate::objects::Object,
+        cs: crate::graphics::PageColorSpace,
     ) -> Result<()> {
         let name = name.into();
         validate_pdf_resource_name(&name)?;
@@ -937,7 +947,10 @@ impl Page {
     }
 
     /// Returns all colour spaces registered on this page.
-    pub fn color_spaces(&self) -> &HashMap<String, crate::objects::Object> {
+    ///
+    /// Map values are typed as [`crate::graphics::PageColorSpace`]; the
+    /// writer converts to the concrete PDF `Object` shape at emit time.
+    pub fn color_spaces(&self) -> &HashMap<String, crate::graphics::PageColorSpace> {
         &self.color_spaces
     }
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -941,8 +941,7 @@ impl<W: Write> PdfWriter<W> {
             // invariant established by `preallocate_form_manager_fields`,
             // which must run before this function.
             let mut sorted: Vec<(Dictionary, crate::objects::ObjectReference)> = Vec::new();
-            for item in form_manager.iter_fields_sorted() {
-                let (name, form_field, placeholder) = item?;
+            for (name, form_field, placeholder) in form_manager.iter_fields_sorted() {
                 let real_id = *self.form_field_placeholder_map.get(&placeholder).ok_or_else(
                     || {
                         PdfError::Internal(format!(
@@ -1390,8 +1389,7 @@ impl<W: Write> PdfWriter<W> {
             return Ok(());
         };
 
-        for item in form_manager.iter_fields_sorted() {
-            let (_name, _form_field, placeholder) = item?;
+        for (_name, _form_field, placeholder) in form_manager.iter_fields_sorted() {
             let real_id = self.allocate_object_id();
             self.form_field_placeholder_map.insert(placeholder, real_id);
             self.form_manager_field_refs.push(real_id);
@@ -2546,8 +2544,11 @@ impl<W: Write> PdfWriter<W> {
         // same sequence, producing byte-identical xref entries).
         if !page.color_spaces().is_empty() {
             let mut cs_dict = Dictionary::new();
-            for (name, obj) in page.color_spaces() {
-                cs_dict.set(name, obj.clone());
+            for (name, cs) in page.color_spaces() {
+                // Conversion lives on the enum (see `PageColorSpace::to_object`)
+                // so a future shape change (e.g. streams for ICCBased) is a
+                // single-file edit, not a writer-wide sweep.
+                cs_dict.set(name, cs.to_object());
             }
             resources.set("ColorSpace", Object::Dictionary(cs_dict));
         }

--- a/oxidize-pdf-core/tests/page_color_spaces_test.rs
+++ b/oxidize-pdf-core/tests/page_color_spaces_test.rs
@@ -1,22 +1,24 @@
-//! Task 4 of the v2.5.6 gap-closing series.
+//! Task 4 of the v2.5.6 gap-closing series — updated for PR3 / QUAL-5
+//! (typed [`PageColorSpace`] wrapper replacing the raw `Object` API).
 //!
 //! Callers that work with non-Device colour spaces (CalRGB, ICCBased, Lab,
 //! Indexed, DeviceN, Separation, Pattern) need a way to register those
 //! colour spaces against a `Page` so the writer emits them under
-//! `/Resources/ColorSpace` (ISO 32000-1 §8.6, Table 62). Before this
-//! change the `Page` struct had no such registry and the writer emitted
-//! no `/ColorSpace` entry — meaning the `cs` / `CS` content-stream
+//! `/Resources/ColorSpace` (ISO 32000-1 §8.6, Table 62). Before v2.5.6
+//! the `Page` struct had no such registry and the writer emitted no
+//! `/ColorSpace` entry — meaning the `cs` / `CS` content-stream
 //! operators had nothing to resolve by name.
 //!
 //! Contract being exercised:
-//!   * `Page::add_color_space(name, Object)` records a colour-space
-//!     resource under the given name.
+//!   * `Page::add_color_space(name, PageColorSpace)` records a
+//!     colour-space resource under the given name.
 //!   * `Page::color_spaces()` exposes the in-memory registry.
 //!   * The writer emits `/Resources/ColorSpace` as a direct dictionary
-//!     whose entries preserve the caller-supplied `Object` verbatim
-//!     (either `Object::Name("/CalRGB")` for simple names or
-//!     `Object::Array([Name, Dictionary])` for parameterised spaces).
+//!     whose entries are derived from the caller-supplied enum:
+//!     `DeviceAlias` → `Object::Name("<DeviceFoo>")`, `Parameterised`
+//!     → `Object::Array([Name, Dictionary])`.
 
+use oxidize_pdf::graphics::{DeviceColorSpace, PageColorSpace, ParameterisedFamily};
 use oxidize_pdf::objects::{Dictionary, Object};
 use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::PdfReader;
@@ -90,10 +92,10 @@ fn page_color_space_is_written_as_parameterised_array() {
     );
     page.add_color_space(
         "CS1",
-        Object::Array(vec![
-            Object::Name("CalRGB".to_string()),
-            Object::Dictionary(calrgb),
-        ]),
+        PageColorSpace::Parameterised {
+            family: ParameterisedFamily::CalRgb,
+            params: calrgb,
+        },
     )
     .expect("add_color_space");
     doc.add_page(page);
@@ -140,7 +142,7 @@ fn page_color_space_is_written_as_parameterised_array() {
 fn page_color_space_preserves_name_form() {
     let mut doc = Document::new();
     let mut page = Page::a4();
-    page.add_color_space("MyRGB", Object::Name("DeviceRGB".to_string()))
+    page.add_color_space("MyRGB", PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
         .expect("add_color_space");
     doc.add_page(page);
 
@@ -191,7 +193,7 @@ fn page_without_color_spaces_omits_colorspace_entry() {
 fn color_spaces_accessor_is_public_and_reflects_state() {
     let mut page = Page::a4();
     assert!(page.color_spaces().is_empty());
-    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()))
+    page.add_color_space("CS1", PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
         .expect("add_color_space");
     let map = page.color_spaces();
     assert_eq!(map.len(), 1);

--- a/oxidize-pdf-core/tests/page_color_spaces_typed_api_test.rs
+++ b/oxidize-pdf-core/tests/page_color_spaces_typed_api_test.rs
@@ -1,0 +1,241 @@
+//! PR3 / QUAL-5 — typed `PageColorSpace` public API.
+//!
+//! The prior `Page::add_color_space` signature took
+//! `crate::objects::Object` — an internal serialization type — which leaked
+//! a SemVer-fragile detail across the public API. This test locks in the
+//! replacement: a typed enum with two variants covering the two wire-format
+//! shapes allowed at `/Resources/ColorSpace/<name>` (ISO 32000-1 §8.6):
+//!
+//!   * `PageColorSpace::DeviceAlias(DeviceColorSpace::{Gray,Rgb,Cmyk,Pattern})`
+//!     → emitted as a single `/Name` (e.g. `/DeviceRGB`).
+//!   * `PageColorSpace::Parameterised { family, params }` → emitted as
+//!     `[/<family> <<params>>]` (Cal*, Lab, ICCBased — single-dict forms).
+//!
+//! The wrapper does NOT model Indexed/Separation/DeviceN N-tuple shapes at
+//! this stage; adding them in the future is a backwards-compatible
+//! superset (new enum variants guarded by `#[non_exhaustive]`).
+
+use oxidize_pdf::graphics::{DeviceColorSpace, PageColorSpace, ParameterisedFamily};
+use oxidize_pdf::objects::Dictionary;
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Walk the first page's `/Resources/ColorSpace` dict, resolving through
+/// indirect references if the writer chose to emit the map that way.
+fn resolve_page0_colorspace<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    let (page_n, page_g) = kids.0[0].as_reference().expect("/Pages/Kids[0] ref");
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Resources")
+            .clone()
+            .as_dict()
+            .expect("/Resources is dict")
+            .clone(),
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("ColorSpace").expect("/Resources/ColorSpace") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /ColorSpace")
+            .clone()
+            .as_dict()
+            .expect("/ColorSpace dict")
+            .clone(),
+        other => panic!("/ColorSpace: unexpected {:?}", other),
+    }
+}
+
+/// `DeviceAlias` variants serialise as single PDF names, not one-element
+/// arrays. Aliasing `/CS1` → `/DeviceRGB` is the wire-format shape expected
+/// by viewers (ISO 32000-1 §8.6.4).
+#[test]
+fn device_alias_emits_single_name_entry() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_color_space("CS1", PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
+        .expect("add_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let cs = resolve_page0_colorspace(&mut reader);
+    let entry = cs.get("CS1").expect("CS1 registered").clone();
+    let resolved = match entry {
+        PdfObject::Reference(n, g) => reader.get_object(n, g).expect("resolve").clone(),
+        other => other,
+    };
+    assert_eq!(
+        resolved.as_name().map(|n| n.as_str()),
+        Some("DeviceRGB"),
+        "DeviceAlias(Rgb) must serialise as /DeviceRGB, got {resolved:?}"
+    );
+}
+
+/// All four device-space aliases must round-trip through their correct PDF
+/// names per ISO 32000-1 §8.6.4 (DeviceGray/DeviceRGB/DeviceCMYK) and
+/// §8.6.6.1 (Pattern).
+#[test]
+fn device_alias_covers_all_four_device_spaces() {
+    let cases = [
+        (DeviceColorSpace::Gray, "DeviceGray"),
+        (DeviceColorSpace::Rgb, "DeviceRGB"),
+        (DeviceColorSpace::Cmyk, "DeviceCMYK"),
+        (DeviceColorSpace::Pattern, "Pattern"),
+    ];
+    for (device, expected_name) in cases {
+        let mut doc = Document::new();
+        let mut page = Page::a4();
+        page.add_color_space("CS", PageColorSpace::DeviceAlias(device))
+            .expect("add_color_space");
+        doc.add_page(page);
+        let bytes = doc.to_bytes().expect("serialize");
+        let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+        let cs = resolve_page0_colorspace(&mut reader);
+        let entry = cs.get("CS").expect("CS registered").clone();
+        let resolved = match entry {
+            PdfObject::Reference(n, g) => reader.get_object(n, g).expect("resolve").clone(),
+            other => other,
+        };
+        assert_eq!(
+            resolved.as_name().map(|n| n.as_str()),
+            Some(expected_name),
+            "DeviceAlias({device:?}) must serialise as /{expected_name}, got {resolved:?}"
+        );
+    }
+}
+
+/// `Parameterised` variants serialise as `[/<family> <<params>>]` —
+/// a two-element array. The parameter dictionary content must round-trip
+/// byte-for-byte-equivalent through the writer/reader path.
+#[test]
+fn parameterised_calrgb_emits_tuple_array() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut params = Dictionary::new();
+    params.set(
+        "WhitePoint",
+        oxidize_pdf::objects::Object::Array(vec![
+            oxidize_pdf::objects::Object::Real(0.9505),
+            oxidize_pdf::objects::Object::Real(1.0),
+            oxidize_pdf::objects::Object::Real(1.0890),
+        ]),
+    );
+    page.add_color_space(
+        "CS1",
+        PageColorSpace::Parameterised {
+            family: ParameterisedFamily::CalRgb,
+            params,
+        },
+    )
+    .expect("add_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let cs = resolve_page0_colorspace(&mut reader);
+    let entry = cs.get("CS1").expect("CS1 registered").clone();
+    let arr = match entry {
+        PdfObject::Array(a) => a,
+        PdfObject::Reference(n, g) => reader
+            .get_object(n, g)
+            .expect("resolve CS1")
+            .clone()
+            .as_array()
+            .expect("CS1 array")
+            .clone(),
+        other => panic!("CS1 must be array or ref, got {other:?}"),
+    };
+    assert_eq!(arr.0.len(), 2, "parameterised CS must be [Name, Dict]");
+    assert_eq!(
+        arr.0[0].as_name().map(|n| n.as_str()),
+        Some("CalRGB"),
+        "Parameterised family must serialise as the ISO name /CalRGB"
+    );
+    let params = arr.0[1].as_dict().expect("param dict at slot 1");
+    let wp = params
+        .get("WhitePoint")
+        .and_then(|o| o.as_array())
+        .expect("/WhitePoint");
+    assert_eq!(wp.0.len(), 3, "WhitePoint must be [X, Y, Z]");
+}
+
+/// Each `ParameterisedFamily` must map to its ISO-specified name when
+/// written (§8.6.5.1 CalGray, §8.6.5.2 CalRGB, §8.6.5.4 Lab, §8.6.5.5
+/// ICCBased). Locking these names in prevents accidental refactors from
+/// silently emitting non-conformant families.
+#[test]
+fn parameterised_family_maps_to_iso_name() {
+    let cases = [
+        (ParameterisedFamily::CalGray, "CalGray"),
+        (ParameterisedFamily::CalRgb, "CalRGB"),
+        (ParameterisedFamily::Lab, "Lab"),
+        (ParameterisedFamily::IccBased, "ICCBased"),
+    ];
+    for (family, expected) in cases {
+        let mut doc = Document::new();
+        let mut page = Page::a4();
+        let mut params = Dictionary::new();
+        params.set("Placeholder", oxidize_pdf::objects::Object::Integer(0));
+        page.add_color_space("CS", PageColorSpace::Parameterised { family, params })
+            .expect("add_color_space");
+        doc.add_page(page);
+        let bytes = doc.to_bytes().expect("serialize");
+        let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+        let cs = resolve_page0_colorspace(&mut reader);
+        let arr = cs.get("CS").and_then(|o| o.as_array()).expect("CS array");
+        assert_eq!(
+            arr.0[0].as_name().map(|n| n.as_str()),
+            Some(expected),
+            "Family {family:?} must serialise as /{expected}"
+        );
+    }
+}
+
+/// `Page::color_spaces()` returns a `&HashMap<String, PageColorSpace>` —
+/// not `&HashMap<String, Object>`. This test is a compile-time proof of
+/// the signature change (it would fail to compile if the accessor still
+/// returned `Object`).
+#[test]
+fn color_spaces_accessor_returns_typed_map() {
+    let mut page = Page::a4();
+    assert!(page.color_spaces().is_empty());
+    page.add_color_space("CS1", PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
+        .expect("add_color_space");
+    let map: &std::collections::HashMap<String, PageColorSpace> = page.color_spaces();
+    assert_eq!(map.len(), 1);
+    match map.get("CS1") {
+        Some(PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb)) => {}
+        other => panic!("expected DeviceAlias(Rgb), got {other:?}"),
+    }
+}
+
+/// Invalid PDF resource names (ISO 32000-1 §7.3.5) must still be rejected
+/// with `InvalidStructure` — the typed wrapper doesn't relax that check.
+#[test]
+fn typed_api_still_rejects_invalid_resource_names() {
+    let mut page = Page::a4();
+    let err = page
+        .add_color_space(
+            "bad name",
+            PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb),
+        )
+        .expect_err("whitespace in resource name must be rejected");
+    assert!(
+        matches!(err, oxidize_pdf::error::PdfError::InvalidStructure(_)),
+        "expected InvalidStructure, got {err:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/writer_hygiene_test.rs
+++ b/oxidize-pdf-core/tests/writer_hygiene_test.rs
@@ -29,8 +29,9 @@
 
 use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
 use oxidize_pdf::geometry::{Point, Rectangle};
-use oxidize_pdf::graphics::{FormXObject, PaintType, TilingPattern, TilingType};
-use oxidize_pdf::objects::Object;
+use oxidize_pdf::graphics::{
+    DeviceColorSpace, FormXObject, PageColorSpace, PaintType, TilingPattern, TilingType,
+};
 use oxidize_pdf::parser::PdfReader;
 use oxidize_pdf::{Document, Page};
 use std::io::Cursor;
@@ -161,7 +162,10 @@ fn object_string_escapes_backslash() {
 fn add_color_space_rejects_name_with_delimiters() {
     let mut page = Page::a4();
     // `>>` inside a Name would close the resource dict.
-    let result = page.add_color_space("Foo>>/Evil", Object::Name("DeviceRGB".to_string()));
+    let result = page.add_color_space(
+        "Foo>>/Evil",
+        PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb),
+    );
     assert!(
         result.is_err(),
         "add_color_space must reject names containing delimiters, got Ok"
@@ -222,13 +226,16 @@ fn add_form_xobject_rejects_name_with_hash_escape_introducer() {
 #[test]
 fn add_color_space_accepts_valid_names() {
     let mut page = Page::a4();
-    page.add_color_space("CS1", Object::Name("DeviceRGB".to_string()))
+    page.add_color_space("CS1", PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
         .expect("CS1 is a valid Name");
-    page.add_color_space("MyCustomSpace", Object::Name("DeviceCMYK".to_string()))
-        .expect("MyCustomSpace is a valid Name");
+    page.add_color_space(
+        "MyCustomSpace",
+        PageColorSpace::DeviceAlias(DeviceColorSpace::Cmyk),
+    )
+    .expect("MyCustomSpace is a valid Name");
     page.add_color_space(
         "CS_with_underscores-and-dashes",
-        Object::Name("DeviceGray".to_string()),
+        PageColorSpace::DeviceAlias(DeviceColorSpace::Gray),
     )
     .expect("underscores and dashes are valid in Names per §7.3.5");
 }
@@ -251,7 +258,7 @@ fn color_space_resource_entries_are_emitted_in_sorted_order() {
     let mut page = Page::a4();
     let insertion_order = ["CSE", "CSA", "CSC", "CSB", "CSD"];
     for name in &insertion_order {
-        page.add_color_space(*name, Object::Name("DeviceRGB".to_string()))
+        page.add_color_space(*name, PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb))
             .expect("add_color_space");
     }
     doc.add_page(page);


### PR DESCRIPTION
## Summary

PR3 of the post-v2.5.6 review sprint — closes the last five findings from the `quality-rust` audit (QUAL-4, QUAL-5, QUAL-6, QUAL-10, QUAL-11). With this merged, all 11 findings are addressed and v2.5.6 can be tagged.

- **QUAL-5 — typed `PageColorSpace`**: `Page::add_color_space` no longer takes `crate::objects::Object` (an internal serialization type). New enum in `graphics::page_color_space` models the two wire-format shapes ISO 32000-1 §8.6 allows at `/Resources/ColorSpace/<name>` — device alias (`DeviceColorSpace::{Gray, Rgb, Cmyk, Pattern}`) and parameterised (`ParameterisedFamily::{CalGray, CalRgb, Lab, IccBased}` + dict). Marked `#[non_exhaustive]` so Indexed/Separation/DeviceN can be added as a SemVer-compatible superset later. Writer emits via `to_object()` so any future wire-format change is a single-file edit.
- **QUAL-6 — `iter_fields_sorted` cleanup**: dropped the `Result` wrapper — both error arms were "can't happen" invariants upheld by `add_*_field`. Now panics with a descriptive message if the invariant is broken (writer has no recovery path for corrupted internal state). Both call sites in `pdf_writer::mod.rs` simplified to direct tuple destructuring.
- **QUAL-4/10/11 — rustdoc polish**: added `# Panics` section to `Annotation::set_field_parent` documenting the debug-build `debug_assert!` and the release-build defence-in-depth path through `to_dict`.

## SemVer note

Pre-release — v2.5.6 is NOT yet on crates.io, so the signature change is intentional and lands before the first published build.

## Test plan

- [x] 6 new content-verifying tests in `tests/page_color_spaces_typed_api_test.rs` (DeviceAlias round-trip, all 4 device spaces, CalRGB tuple shape, all 4 parameterised families, typed accessor, resource-name validation)
- [x] 4 existing `page_color_spaces_test.rs` tests migrated to typed API (still assert wire format)
- [x] 5 existing `writer_hygiene_test.rs` call sites migrated
- [x] 4 unit tests in `graphics::page_color_space::tests` (enum-to-Object conversion, family name mapping)
- [x] 1 unit test in `forms::form_data::tests::iter_fields_sorted_is_non_fallible_and_ordered` (RED first, then GREEN)
- [x] 6327 library unit tests pass
- [x] Integration test binaries pass (form, smask, shading, pattern, extgstate, formxobject, fill_field, acroform serialize)
- [x] `cargo clippy -p oxidize-pdf --lib` clean
- [x] `cargo doc -p oxidize-pdf --lib` clean for PR3-touched symbols

## Follow-up

With PR3 merged, the v2.5.6 release can proceed (3-step authorization — develop bump + CHANGELOG, develop→main merge, tag+publish — pending user greenlight per the 2026-04-10 error-log rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)