### PR TITLE
fix(fonts): per-font character tracking for subsetting

### DIFF
--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -10,7 +10,7 @@ use crate::text::metrics::{register_custom_font_metrics, FontMetrics as TextMeas
 use crate::text::FontEncoding;
 use crate::writer::PdfWriter;
 use chrono::{DateTime, Local, Utc};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 mod encryption;
@@ -52,7 +52,11 @@ pub struct Document {
     /// Cache for custom fonts
     pub(crate) custom_fonts: FontCache,
     /// Characters used in the document (for font subsetting)
-    pub(crate) used_characters: HashSet<char>,
+    /// Characters drawn in this document, bucketed by font name
+    /// (ISO 32000-1 §9.7.4 — only custom Type0/CID fonts need
+    /// subsetting; see issue #204). Populated by `add_page` from the
+    /// page's per-font accumulators.
+    pub(crate) used_characters_by_font: HashMap<String, HashSet<char>>,
     /// Action to execute when the document is opened
     pub(crate) open_action: Option<crate::actions::Action>,
     /// Viewer preferences for controlling document display
@@ -123,7 +127,7 @@ impl Document {
             compress: true,          // Enable compression by default
             use_xref_streams: false, // Disabled by default for compatibility
             custom_fonts: FontCache::new(),
-            used_characters: HashSet::new(),
+            used_characters_by_font: HashMap::new(),
             open_action: None,
             viewer_preferences: None,
             semantic_entities: Vec::new(),
@@ -133,9 +137,14 @@ impl Document {
 
     /// Adds a page to the document.
     pub fn add_page(&mut self, page: Page) {
-        // Collect used characters from the page
-        if let Some(used_chars) = page.get_used_characters() {
-            self.used_characters.extend(used_chars);
+        // Merge the page's per-font character accumulators into the
+        // document-wide map (issue #204 — each font gets subsetted with
+        // only its own characters later at write time).
+        for (font_name, chars) in page.get_used_characters_by_font() {
+            self.used_characters_by_font
+                .entry(font_name)
+                .or_default()
+                .extend(chars);
         }
         self.pages.push(page);
     }

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -99,8 +99,12 @@ pub struct GraphicsContext {
     current_font_size: f64,
     // Whether the current font is a custom (Type0/CID) font requiring Unicode encoding
     is_custom_font: bool,
-    // Character tracking for font subsetting
-    used_characters: HashSet<char>,
+    // Character tracking for font subsetting, bucketed by custom-font name
+    // (issue #204 — builtin fonts are not tracked because they don't need
+    // subsetting; a single global set across all fonts caused every font's
+    // subset to include chars drawn with a different font, doubling emitted
+    // size when two fonts in the same family were registered).
+    used_characters_by_font: HashMap<String, HashSet<char>>,
     // Glyph mapping for Unicode fonts (Unicode code point -> Glyph ID)
     glyph_mapping: Option<HashMap<u32, u16>>,
     // Transparency group stack for nested groups
@@ -156,7 +160,7 @@ impl GraphicsContext {
             current_font_name: None,
             current_font_size: 12.0,
             is_custom_font: false,
-            used_characters: HashSet::new(),
+            used_characters_by_font: HashMap::new(),
             glyph_mapping: None,
             transparency_stack: Vec::new(),
         }
@@ -752,8 +756,10 @@ impl GraphicsContext {
     /// Supplementary plane characters (U+10000..U+10FFFF) use UTF-16BE surrogate pairs.
     /// For standard fonts, text is encoded as literal PDF strings.
     pub fn show_text(&mut self, text: &str) -> Result<&mut Self> {
-        // Track used characters for font subsetting
-        self.used_characters.extend(text.chars());
+        // Track used characters for font subsetting, bucketed by font name
+        // (issue #204). Builtin fonts skip tracking — subsetting only
+        // applies to custom Type0/CID fonts.
+        self.record_used_chars(text);
 
         if self.is_custom_font {
             // For custom fonts (CJK/Type0), encode as hex string with Unicode code points as CIDs
@@ -1157,8 +1163,9 @@ impl GraphicsContext {
 
     /// Draw text at the specified position with automatic encoding detection
     pub fn draw_text(&mut self, text: &str, x: f64, y: f64) -> Result<&mut Self> {
-        // Track used characters for font subsetting
-        self.used_characters.extend(text.chars());
+        // Track used characters for font subsetting, bucketed by font name
+        // (issue #204).
+        self.record_used_chars(text);
 
         // Detect if text needs Unicode encoding: custom fonts always use hex,
         // and text with non-Latin-1 characters also needs Unicode encoding
@@ -1452,12 +1459,65 @@ impl GraphicsContext {
         Ok(self)
     }
 
-    /// Get the characters used in this graphics context
+    /// Record `text` as drawn with the currently-active font.
+    ///
+    /// Chars are bucketed under the font name (builtin or custom) so
+    /// that the writer can subset each custom font with only its own
+    /// characters (issue #204). When no font has been set yet the
+    /// chars are bucketed under an empty-string sentinel — the writer
+    /// iterates `custom_font_names()` when subsetting and that list
+    /// never contains an empty name, so the sentinel is ignored by
+    /// the writer but keeps the merged [`Self::get_used_characters`]
+    /// accessor lossless for diagnostic callers.
+    fn record_used_chars(&mut self, text: &str) {
+        let bucket = self.current_font_name.as_deref().unwrap_or("").to_string();
+        self.used_characters_by_font
+            .entry(bucket)
+            .or_default()
+            .extend(text.chars());
+    }
+
+    /// Get the characters used in this graphics context, merged across
+    /// fonts. Test-only back-compat accessor; production callers go
+    /// through [`GraphicsContext::get_used_characters_by_font`] so the
+    /// writer can subset each custom font with only its own characters
+    /// (issue #204).
+    #[cfg(test)]
     pub(crate) fn get_used_characters(&self) -> Option<HashSet<char>> {
-        if self.used_characters.is_empty() {
+        let merged: HashSet<char> = self
+            .used_characters_by_font
+            .values()
+            .flat_map(|s| s.iter().copied())
+            .collect();
+        if merged.is_empty() {
             None
         } else {
-            Some(self.used_characters.clone())
+            Some(merged)
+        }
+    }
+
+    /// Get the per-font character map for font subsetting (issue #204).
+    ///
+    /// Keys are the registered custom-font names exactly as passed to
+    /// `Document::add_font_from_bytes`. Builtin fonts never appear as
+    /// keys because they don't need subsetting. A font name missing
+    /// from the map means no content stream in this context drew any
+    /// character with that font.
+    pub(crate) fn get_used_characters_by_font(&self) -> &HashMap<String, HashSet<char>> {
+        &self.used_characters_by_font
+    }
+
+    /// Merge a per-font char map produced by an external content-stream
+    /// builder (e.g. [`crate::layout::RichText::render_operations`])
+    /// into this graphics context's accumulator. Issue #204 — callers
+    /// of [`crate::Page::append_raw_content`] MUST report what they
+    /// drew so the writer can subset each custom font correctly.
+    pub(crate) fn merge_font_usage(&mut self, usage: &HashMap<String, HashSet<char>>) {
+        for (name, chars) in usage {
+            self.used_characters_by_font
+                .entry(name.clone())
+                .or_default()
+                .extend(chars);
         }
     }
 }
@@ -2885,9 +2945,12 @@ mod tests {
         ctx.show_text("你好A").unwrap();
         ctx.end_text();
 
-        assert!(ctx.used_characters.contains(&'你'));
-        assert!(ctx.used_characters.contains(&'好'));
-        assert!(ctx.used_characters.contains(&'A'));
+        let chars = ctx
+            .get_used_characters()
+            .expect("show_text with a custom font must record characters");
+        assert!(chars.contains(&'你'));
+        assert!(chars.contains(&'好'));
+        assert!(chars.contains(&'A'));
     }
 
     #[test]

--- a/oxidize-pdf-core/src/layout/flow.rs
+++ b/oxidize-pdf-core/src/layout/flow.rs
@@ -333,11 +333,11 @@ impl FlowLayout {
                     )?;
                 }
                 FlowElement::RichText { rich, line_height } => {
-                    let ops = rich.render_operations(
+                    let (ops, font_usage) = rich.render_operations(
                         self.config.margin_left,
                         cursor_y - rich.max_font_size() * line_height,
                     );
-                    current_page.append_raw_content(ops.as_bytes());
+                    current_page.append_raw_content(ops.as_bytes(), &font_usage);
                 }
                 FlowElement::Image {
                     name,

--- a/oxidize-pdf-core/src/layout/rich_text.rs
+++ b/oxidize-pdf-core/src/layout/rich_text.rs
@@ -1,5 +1,6 @@
 use crate::text::{measure_text, Font};
 use crate::Color;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 /// A styled text segment with its own font, size, and color.
@@ -78,9 +79,25 @@ impl RichText {
     /// Generate PDF operators to render this rich text at position (x, y).
     ///
     /// Produces a single BT/ET block with per-span font/color/text changes.
-    pub(crate) fn render_operations(&self, x: f64, y: f64) -> String {
+    /// Render this rich-text block to a content-stream fragment plus a
+    /// per-font character usage map (issue #204).
+    ///
+    /// The caller is responsible for splicing `ops` into the target
+    /// page's content stream and reporting `font_usage` via
+    /// [`crate::Page::append_raw_content`] — both go together so the
+    /// writer knows which fonts this fragment referenced and what
+    /// characters it drew with each. Returning the usage map is the
+    /// type-gated replacement for scattering `record_used_chars` calls
+    /// through every content builder; future builders cannot forget
+    /// tracking because `append_raw_content` won't compile without it.
+    pub(crate) fn render_operations(
+        &self,
+        x: f64,
+        y: f64,
+    ) -> (String, HashMap<String, HashSet<char>>) {
+        let mut font_usage: HashMap<String, HashSet<char>> = HashMap::new();
         if self.spans.is_empty() {
-            return String::new();
+            return (String::new(), font_usage);
         }
 
         let mut ops = String::new();
@@ -102,13 +119,8 @@ impl RichText {
             }
 
             // Set font
-            writeln!(
-                &mut ops,
-                "/{} {:.2} Tf",
-                span.font.pdf_name(),
-                span.font_size
-            )
-            .expect("write to String");
+            let font_name = span.font.pdf_name();
+            writeln!(&mut ops, "/{} {:.2} Tf", font_name, span.font_size).expect("write to String");
 
             // Show text with escaping
             ops.push('(');
@@ -124,10 +136,17 @@ impl RichText {
                 }
             }
             ops.push_str(") Tj\n");
+
+            // Report the characters drawn with this span's font so the
+            // writer can subset the font accurately (issue #204).
+            font_usage
+                .entry(font_name)
+                .or_default()
+                .extend(span.text.chars());
         }
 
         ops.push_str("ET\n");
-        ops
+        (ops, font_usage)
     }
 }
 
@@ -140,7 +159,9 @@ mod tests {
         let rt = RichText::new(vec![]);
         assert_eq!(rt.total_width(), 0.0);
         assert_eq!(rt.max_font_size(), 0.0);
-        assert!(rt.render_operations(0.0, 0.0).is_empty());
+        let (ops, font_usage) = rt.render_operations(0.0, 0.0);
+        assert!(ops.is_empty());
+        assert!(font_usage.is_empty(), "no spans → no font usage reported");
     }
 
     #[test]
@@ -151,10 +172,21 @@ mod tests {
             12.0,
             Color::black(),
         )]);
-        let ops = rt.render_operations(50.0, 700.0);
+        let (ops, font_usage) = rt.render_operations(50.0, 700.0);
         assert!(ops.starts_with("BT\n"));
         assert!(ops.ends_with("ET\n"));
         assert!(ops.contains("(Hello) Tj"));
         assert!(ops.contains("/Helvetica 12.00 Tf"));
+
+        // PR for issue #204: render_operations must also report per-font
+        // char usage so the caller can feed it into the page tracker
+        // via `Page::append_raw_content`.
+        let chars = font_usage
+            .get("Helvetica")
+            .expect("Helvetica span must produce a bucket");
+        assert!(chars.contains(&'H'));
+        assert!(chars.contains(&'e'));
+        assert!(chars.contains(&'l'));
+        assert!(chars.contains(&'o'));
     }
 }

--- a/oxidize-pdf-core/src/operations/overlay.rs
+++ b/oxidize-pdf-core/src/operations/overlay.rs
@@ -14,6 +14,7 @@ use crate::geometry::{Point, Rectangle};
 use crate::graphics::{ExtGState, FormXObject};
 use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Seek};
 use std::path::Path;
 
@@ -349,8 +350,20 @@ impl<R: Read + Seek> PdfOverlay<R> {
         ops.push_str(&format!("/{} Do\n", xobj_name));
         ops.push_str("Q\n");
 
-        // Append overlay operators to page content (renders on top of existing content)
-        page.append_raw_content(ops.as_bytes());
+        // Append overlay operators to page content (renders on top of
+        // existing content).
+        //
+        // The overlay path composes a `cm` matrix + `/<xobj> Do` — it
+        // does NOT emit `Tj` operators directly. The XObject invoked
+        // carries its own font references and character data (those
+        // live in the source PDF's resources, independent of this
+        // Document's `custom_fonts` registry). Consequently there are
+        // no fonts OF THE TARGET DOCUMENT referenced inside `ops`, and
+        // the issue-#204 font-usage map is correctly empty here. If a
+        // future overlay variant starts embedding inline `Tj` against
+        // target-document fonts, it must populate this map.
+        let font_usage: HashMap<String, HashSet<char>> = HashMap::new();
+        page.append_raw_content(ops.as_bytes(), &font_usage);
 
         Ok(())
     }

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -832,6 +832,16 @@ impl Page {
     pub fn add_text_flow(&mut self, text_flow: &TextFlowContext) {
         let operations = text_flow.generate_operations();
         self.content.extend_from_slice(&operations);
+        // Absorb the text flow's per-font character tracking into the
+        // page's graphics-context accumulator so the writer can subset
+        // each custom font referenced by the flow (issue #204). Pre-fix
+        // this merge did not happen, so a `TextFlowContext` with a
+        // `Font::Custom` produced a content stream that referenced a
+        // font whose subset was driven by whatever other page drew
+        // with the global `used_characters` — and after the fix, the
+        // unused-font skip would remove the font entirely.
+        self.graphics_context
+            .merge_font_usage(text_flow.get_used_characters_by_font());
     }
 
     pub fn add_image(&mut self, name: impl Into<String>, image: Image) {
@@ -1008,10 +1018,28 @@ impl Page {
         &self.shadings
     }
 
-    /// Appends raw PDF operators to the content stream.
-    /// Content appended here renders AFTER the existing page content (on top).
-    pub(crate) fn append_raw_content(&mut self, data: &[u8]) {
+    /// Append raw PDF operators to the content stream and record which
+    /// fonts each character was drawn with (issue #204).
+    ///
+    /// `font_usage` MUST account for every `Tj`/`TJ` emitted inside
+    /// `data` — the caller is the only actor that has ground truth
+    /// about which font was active when the operator was generated.
+    /// Pre-fix this method took just `data`; the resulting silent
+    /// failure mode (unused fonts being subsetted with someone else's
+    /// characters, or — post-fix — missing entirely from the emitted
+    /// PDF because no per-font bucket existed) is exactly what the
+    /// type-gate here prevents. Future content builders must return
+    /// their usage map alongside their bytes.
+    ///
+    /// Content appended here renders AFTER the existing page content
+    /// (on top).
+    pub(crate) fn append_raw_content(
+        &mut self,
+        data: &[u8],
+        font_usage: &HashMap<String, HashSet<char>>,
+    ) {
         self.content.extend_from_slice(data);
+        self.graphics_context.merge_font_usage(font_usage);
     }
 
     /// Add a table to the page.
@@ -1187,6 +1215,7 @@ impl Page {
     /// page.set_header(HeaderFooter::new_header("Company Report 2024"));
     /// ```
     pub fn set_header(&mut self, header: HeaderFooter) {
+        self.register_header_footer_font_usage(&header);
         self.header = Some(header);
     }
 
@@ -1201,7 +1230,53 @@ impl Page {
     /// page.set_footer(HeaderFooter::new_footer("Page {{page_number}} of {{total_pages}}"));
     /// ```
     pub fn set_footer(&mut self, footer: HeaderFooter) {
+        self.register_header_footer_font_usage(&footer);
         self.footer = Some(footer);
+    }
+
+    /// Eagerly record the font + estimated character set of a header or
+    /// footer on the page's graphics-context accumulator (gap R5 of
+    /// issue #204).
+    ///
+    /// Header/footer content is rendered at serialization time — inside
+    /// `generate_content_with_page_info` — which runs AFTER the writer
+    /// has snapshotted the document's per-font map into its own
+    /// `document_used_chars_by_font`. Any characters drawn at render
+    /// time therefore arrive too late to be included in the font
+    /// subset. We compensate here by expanding the template with
+    /// canonical sample values (the numeric placeholders become the
+    /// digit set; `{{date}}`, `{{time}}`, `{{month}}`, etc. expand to
+    /// the current locale's rendering) and registering those chars
+    /// plus the template's literal text up front.
+    ///
+    /// **Known limitation**: user-supplied `custom_values` passed later
+    /// to the writer may introduce characters not in the template
+    /// literal. Those chars will NOT appear in the embedded subset and
+    /// will render as `.notdef`. Callers who need runtime-defined
+    /// custom strings in a custom-font header should also draw a
+    /// `page.text()` with the same font somewhere (even invisibly)
+    /// so the chars reach the per-font bucket through the standard
+    /// path.
+    fn register_header_footer_font_usage(&mut self, hf: &HeaderFooter) {
+        let font_name = hf.options().font.pdf_name();
+
+        // Render the template with canonical sample values to capture
+        // both the literal text and whatever the locale-dependent
+        // placeholders expand to (month name, date format, etc.).
+        // page_number=1 / total_pages=999 covers the digit 9 which is
+        // the upper boundary of common PDFs; a further safety net adds
+        // the full digit set below.
+        let sampled = hf.render(1, 999, None);
+
+        let mut chars: HashSet<char> = sampled.chars().collect();
+        // Digits 0-9 are guaranteed to appear once the template is
+        // rendered with real page numbers (the sample above only
+        // covered {1, 9} digits). Include the rest so page 2..8 don't
+        // render as .notdef on the last page of a >10-page document.
+        chars.extend('0'..='9');
+
+        self.graphics_context
+            .merge_font_usage(&std::iter::once((font_name, chars)).collect());
     }
 
     /// Gets a reference to the header if set.
@@ -1370,21 +1445,42 @@ impl Page {
         dict
     }
 
-    /// Gets all characters used in this page.
+    /// Gets all characters used in this page, bucketed by font name
+    /// (issue #204).
     ///
-    /// Combines characters from both graphics_context and text_context
-    /// to ensure proper font subsetting for custom fonts (fixes issue #97).
-    pub(crate) fn get_used_characters(&self) -> Option<HashSet<char>> {
-        let graphics_chars = self.graphics_context.get_used_characters();
-        let text_chars = self.text_context.get_used_characters();
+    /// Merges the per-font maps from `graphics_context` and
+    /// `text_context` — either or both may contain entries for the
+    /// same font (e.g. a caller mixed `page.text()` with direct
+    /// graphics-context `draw_text`). Both builtin and custom fonts
+    /// appear as keys; the writer filters to the registered custom
+    /// fonts at subsetting time (builtin fonts don't need subsetting).
+    pub(crate) fn get_used_characters_by_font(&self) -> HashMap<String, HashSet<char>> {
+        let mut merged: HashMap<String, HashSet<char>> = HashMap::new();
+        for (name, chars) in self.graphics_context.get_used_characters_by_font() {
+            merged.entry(name.clone()).or_default().extend(chars);
+        }
+        for (name, chars) in self.text_context.get_used_characters_by_font() {
+            merged.entry(name.clone()).or_default().extend(chars);
+        }
+        merged
+    }
 
-        match (graphics_chars, text_chars) {
-            (None, None) => None,
-            (Some(chars), None) | (None, Some(chars)) => Some(chars),
-            (Some(mut g_chars), Some(t_chars)) => {
-                g_chars.extend(t_chars);
-                Some(g_chars)
-            }
+    /// Back-compat accessor used by the legacy issue-#97 tests: returns
+    /// all characters drawn on this page merged across fonts. Prefer
+    /// [`Page::get_used_characters_by_font`] for new callers — the
+    /// writer depends on per-font accuracy to avoid bundling the
+    /// active font's coverage into unused fonts (issue #204).
+    #[cfg(test)]
+    pub(crate) fn get_used_characters(&self) -> Option<HashSet<char>> {
+        let merged: HashSet<char> = self
+            .get_used_characters_by_font()
+            .into_values()
+            .flatten()
+            .collect();
+        if merged.is_empty() {
+            None
+        } else {
+            Some(merged)
         }
     }
 

--- a/oxidize-pdf-core/src/text/flow.rs
+++ b/oxidize-pdf-core/src/text/flow.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use crate::page::Margins;
 use crate::text::{measure_text, split_into_words, Font};
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -23,6 +24,11 @@ pub struct TextFlowContext {
     #[allow(dead_code)]
     page_height: f64,
     margins: Margins,
+    /// Characters drawn so far, bucketed by active font name (issue
+    /// #204). Consumed by `Page::add_text_flow` to merge into the
+    /// page's graphics-context tracking so the writer can subset each
+    /// custom font with only its own characters.
+    used_characters_by_font: HashMap<String, HashSet<char>>,
 }
 
 impl TextFlowContext {
@@ -38,7 +44,16 @@ impl TextFlowContext {
             page_width,
             page_height,
             margins,
+            used_characters_by_font: HashMap::new(),
         }
+    }
+
+    /// Get the per-font character usage accumulated by `write_wrapped`
+    /// (issue #204). `Page::add_text_flow` merges this into the page's
+    /// graphics context so the writer knows which custom fonts were
+    /// referenced and what characters each drew.
+    pub(crate) fn get_used_characters_by_font(&self) -> &HashMap<String, HashSet<char>> {
+        &self.used_characters_by_font
     }
 
     pub fn set_font(&mut self, font: Font, size: f64) -> &mut Self {
@@ -165,6 +180,16 @@ impl TextFlowContext {
                 }
             }
             self.operations.push_str(") Tj\n");
+
+            // Record per-font char usage so the consuming page can
+            // report it to the writer (issue #204). Bucketed under the
+            // current font's PDF name so both custom and builtin fonts
+            // are visible — the writer filters to registered custom
+            // fonts when subsetting.
+            self.used_characters_by_font
+                .entry(self.current_font.pdf_name())
+                .or_default()
+                .extend(line_text.chars());
 
             // Reset word spacing if it was set
             if self.alignment == TextAlign::Justified && i < lines.len() - 1 {

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -56,7 +56,7 @@ pub use tesseract_provider::{RustyTesseractConfig, RustyTesseractProvider};
 
 use crate::error::Result;
 use crate::Color;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 /// Text rendering mode for PDF text operations
@@ -98,8 +98,13 @@ pub struct TextContext {
     // Color parameters
     fill_color: Option<Color>,
     stroke_color: Option<Color>,
-    // Track used characters for font subsetting (fixes issue #97)
-    used_characters: HashSet<char>,
+    // Track used characters per custom-font name (issue #204 — a single
+    // global set caused every registered font to be subsetted with the
+    // same characters, so two fonts of the same family ended up with
+    // duplicated subsets). Builtin fonts are not tracked because they
+    // don't need subsetting. Extended by `write` whenever the active
+    // font is `Font::Custom`.
+    used_characters_by_font: HashMap<String, HashSet<char>>,
 }
 
 impl Default for TextContext {
@@ -124,20 +129,46 @@ impl TextContext {
             rendering_mode: None,
             fill_color: None,
             stroke_color: None,
-            used_characters: HashSet::new(),
+            used_characters_by_font: HashMap::new(),
         }
     }
 
-    /// Get the characters used in this text context for font subsetting.
-    ///
-    /// This is used to determine which glyphs need to be embedded when using
-    /// custom fonts (especially CJK fonts).
+    /// Record `text` as drawn with the currently-active font, bucketed
+    /// under the font's PDF name (issue #204). Builtin and custom fonts
+    /// are both tracked; the writer later filters to the set of
+    /// registered custom fonts when subsetting.
+    fn record_used_chars(&mut self, text: &str) {
+        let name = match &self.current_font {
+            Font::Custom(name) => name.clone(),
+            builtin => builtin.pdf_name(),
+        };
+        self.used_characters_by_font
+            .entry(name)
+            .or_default()
+            .extend(text.chars());
+    }
+
+    /// Get the characters used in this text context (merged across all
+    /// fonts). Test-only compatibility accessor; callers that need
+    /// per-font accuracy for subsetting should use
+    /// [`TextContext::get_used_characters_by_font`] (issue #204).
+    #[cfg(test)]
     pub(crate) fn get_used_characters(&self) -> Option<HashSet<char>> {
-        if self.used_characters.is_empty() {
+        let merged: HashSet<char> = self
+            .used_characters_by_font
+            .values()
+            .flat_map(|s| s.iter().copied())
+            .collect();
+        if merged.is_empty() {
             None
         } else {
-            Some(self.used_characters.clone())
+            Some(merged)
         }
+    }
+
+    /// Get the per-font character map for font subsetting (issue #204).
+    pub(crate) fn get_used_characters_by_font(&self) -> &HashMap<String, HashSet<char>> {
+        &self.used_characters_by_font
     }
 
     pub fn set_font(&mut self, font: Font, size: f64) -> &mut Self {
@@ -234,8 +265,9 @@ impl TextContext {
             }
         }
 
-        // Track used characters for font subsetting (fixes issue #97)
-        self.used_characters.extend(text.chars());
+        // Track used characters for font subsetting bucketed by the
+        // active custom font (issue #204).
+        self.record_used_chars(text);
 
         // End text object
         self.operations.push_str("ET\n");

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -115,8 +115,12 @@ pub struct PdfWriter<W: Write> {
     page_ids: Vec<ObjectId>,       // page IDs for form field references
     // Configuration
     config: WriterConfig,
-    // Characters used in document (for font subsetting)
-    document_used_chars: Option<std::collections::HashSet<char>>,
+    // Characters used in document, bucketed by font name (issue #204).
+    // The writer uses this to subset each custom font with only its
+    // own characters — a single global set caused unused fonts to be
+    // embedded with the active fonts' character coverage, doubling
+    // emitted size when two fonts shared a family.
+    document_used_chars_by_font: std::collections::HashMap<String, std::collections::HashSet<char>>,
     // Object stream buffering (when use_object_streams is enabled)
     buffered_objects: HashMap<ObjectId, Vec<u8>>,
     compressed_object_map: HashMap<ObjectId, (ObjectId, u32)>, // obj_id -> (stream_id, index)
@@ -168,7 +172,7 @@ impl<W: Write> PdfWriter<W> {
             form_field_ids: Vec::new(),
             page_ids: Vec::new(),
             config,
-            document_used_chars: None,
+            document_used_chars_by_font: std::collections::HashMap::new(),
             buffered_objects: HashMap::new(),
             compressed_object_map: HashMap::new(),
             prev_xref_offset: None,
@@ -184,8 +188,8 @@ impl<W: Write> PdfWriter<W> {
 
     pub fn write_document(&mut self, document: &mut Document) -> Result<()> {
         // Store used characters for font subsetting
-        if !document.used_characters.is_empty() {
-            self.document_used_chars = Some(document.used_characters.clone());
+        if !document.used_characters_by_font.is_empty() {
+            self.document_used_chars_by_font = document.used_characters_by_font.clone();
         }
 
         self.write_header()?;
@@ -393,8 +397,8 @@ impl<W: Write> PdfWriter<W> {
         self.current_position = base_size;
 
         // Step 3: Write new/modified objects only
-        if !document.used_characters.is_empty() {
-            self.document_used_chars = Some(document.used_characters.clone());
+        if !document.used_characters_by_font.is_empty() {
+            self.document_used_chars_by_font = document.used_characters_by_font.clone();
         }
 
         // Allocate IDs for new objects
@@ -619,8 +623,8 @@ impl<W: Write> PdfWriter<W> {
         self.current_position = base_size;
 
         // Step 3: Write replacement pages
-        if !document.used_characters.is_empty() {
-            self.document_used_chars = Some(document.used_characters.clone());
+        if !document.used_characters_by_font.is_empty() {
+            self.document_used_chars_by_font = document.used_characters_by_font.clone();
         }
 
         self.catalog_id = Some(self.allocate_object_id());
@@ -794,8 +798,8 @@ impl<W: Write> PdfWriter<W> {
 
         // Step 7: Write document with standard writer methods
         // This ensures consistent object numbering
-        if !temp_doc.used_characters.is_empty() {
-            self.document_used_chars = Some(temp_doc.used_characters.clone());
+        if !temp_doc.used_characters_by_font.is_empty() {
+            self.document_used_chars_by_font = temp_doc.used_characters_by_font.clone();
         }
 
         self.catalog_id = Some(self.allocate_object_id());
@@ -1466,8 +1470,24 @@ impl<W: Write> PdfWriter<W> {
     fn write_fonts(&mut self, document: &Document) -> Result<HashMap<String, ObjectId>> {
         let mut font_refs = HashMap::new();
 
-        // Write custom fonts from the document
+        // Write custom fonts from the document. Fonts registered via
+        // `add_font_from_bytes` but never referenced from any content
+        // stream (i.e. never `set_font`'d on any page) are skipped —
+        // embedding them waste space and was the direct cause of
+        // issue #204 (two fonts in the same family both getting
+        // subsetted with the active font's character set). The
+        // per-font map is built during tracking by
+        // `GraphicsContext::record_used_chars` / its `TextContext`
+        // counterpart.
         for font_name in document.custom_font_names() {
+            let has_usage = self
+                .document_used_chars_by_font
+                .get(&font_name)
+                .map(|chars| !chars.is_empty())
+                .unwrap_or(false);
+            if !has_usage {
+                continue;
+            }
             if let Some(font) = document.get_custom_font(&font_name) {
                 // For now, write all custom fonts as TrueType with Identity-H for Unicode support
                 // The font from document is Arc<fonts::Font>, not text::font_manager::CustomFont
@@ -1496,16 +1516,25 @@ impl<W: Write> PdfWriter<W> {
         font_name: &str,
         font: &crate::fonts::Font,
     ) -> Result<ObjectId> {
-        // Get used characters from document for subsetting
-        let used_chars = self.document_used_chars.clone().unwrap_or_else(|| {
-            // If no tracking, include common characters as fallback
-            let mut chars = std::collections::HashSet::new();
-            for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 .,!?".chars()
-            {
-                chars.insert(ch);
-            }
-            chars
-        });
+        // Per-font character set for subsetting (issue #204). Falls
+        // back to a small ASCII/digit set only when the document
+        // tracked no characters at all for this font — the ancient
+        // code path pre-dating char tracking. Post-fix this fallback
+        // shouldn't fire for any font reached through `write_fonts`
+        // because that path already filters unused fonts out.
+        let used_chars = self
+            .document_used_chars_by_font
+            .get(font_name)
+            .cloned()
+            .unwrap_or_else(|| {
+                let mut chars = std::collections::HashSet::new();
+                for ch in
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 .,!?".chars()
+                {
+                    chars.insert(ch);
+                }
+                chars
+            });
         // Allocate IDs for all font objects
         let font_id = self.allocate_object_id();
         let descendant_font_id = self.allocate_object_id();
@@ -1660,7 +1689,7 @@ impl<W: Write> PdfWriter<W> {
         if cid_font_subtype == "CIDFontType2" {
             // TrueType fonts need CIDToGIDMap to map CIDs (Unicode code points) to Glyph IDs
             let cid_to_gid_map =
-                self.generate_cid_to_gid_map(font, subset_glyph_mapping.as_ref())?;
+                self.generate_cid_to_gid_map(font_name, font, subset_glyph_mapping.as_ref())?;
             if !cid_to_gid_map.is_empty() {
                 // Write the CIDToGIDMap as a stream, FlateDecode-compressed
                 // when possible. The raw map is dimensioned to the highest
@@ -1703,7 +1732,7 @@ impl<W: Write> PdfWriter<W> {
         // stream is FlateDecode-compressed when the `compression` feature and
         // writer config allow it. The unfiltered, uncompressed version used to
         // dominate PDF output (~14 KB for a 2-char Latin document).
-        let cmap_data = self.generate_tounicode_cmap_from_font(font);
+        let cmap_data = self.generate_tounicode_cmap_from_font(font_name, font);
         let cmap_dict = Dictionary::new();
         #[cfg(feature = "compression")]
         let cmap_stream = if self.config.compress_streams {
@@ -1921,6 +1950,7 @@ impl<W: Write> PdfWriter<W> {
     /// Generate CIDToGIDMap for Type0 font
     fn generate_cid_to_gid_map(
         &mut self,
+        font_name: &str,
         font: &crate::fonts::Font,
         subset_mapping: Option<&HashMap<u32, u16>>,
     ) -> Result<Vec<u8>> {
@@ -1950,7 +1980,11 @@ impl<W: Write> PdfWriter<W> {
 
         // OPTIMIZATION: Only create map for characters actually used in the document
         // Get used characters from document tracking
-        let used_chars = self.document_used_chars.clone().unwrap_or_default();
+        let used_chars = self
+            .document_used_chars_by_font
+            .get(font_name)
+            .cloned()
+            .unwrap_or_default();
 
         // Find the maximum Unicode value from used characters or full font
         let max_unicode = if !used_chars.is_empty() {
@@ -1995,7 +2029,11 @@ impl<W: Write> PdfWriter<W> {
     }
 
     /// Generate ToUnicode CMap for Type0 font from fonts::Font
-    fn generate_tounicode_cmap_from_font(&self, font: &crate::fonts::Font) -> Vec<u8> {
+    fn generate_tounicode_cmap_from_font(
+        &self,
+        font_name: &str,
+        font: &crate::fonts::Font,
+    ) -> Vec<u8> {
         use crate::text::fonts::truetype::TrueTypeFont;
 
         let mut cmap = String::new();
@@ -2020,8 +2058,10 @@ impl<W: Write> PdfWriter<W> {
         // produces a single `<CID> <unicode>` entry. If the document tracked
         // no used characters (legacy path), fall back to the font's full cmap
         // filtered to the BMP — but that path is a backstop, not the norm.
-        let used_codepoints: Option<std::collections::HashSet<u32>> =
-            self.document_used_chars.as_ref().map(|chars| {
+        let used_codepoints: Option<std::collections::HashSet<u32>> = self
+            .document_used_chars_by_font
+            .get(font_name)
+            .map(|chars| {
                 chars
                     .iter()
                     .map(|c| *c as u32)
@@ -2822,7 +2862,7 @@ impl PdfWriter<BufWriter<std::fs::File>> {
             form_field_ids: Vec::new(),
             page_ids: Vec::new(),
             config: WriterConfig::default(),
-            document_used_chars: None,
+            document_used_chars_by_font: std::collections::HashMap::new(),
             buffered_objects: HashMap::new(),
             compressed_object_map: HashMap::new(),
             prev_xref_offset: None,

--- a/oxidize-pdf-core/tests/per_font_char_tracking_test.rs
+++ b/oxidize-pdf-core/tests/per_font_char_tracking_test.rs
@@ -1,0 +1,358 @@
+//! Issue #204 — per-font character tracking.
+//!
+//! When multiple custom fonts are registered on a `Document` but only a
+//! subset are actually referenced from content streams, the output PDF
+//! must NOT embed the unused fonts with the character set accumulated by
+//! the used fonts.
+//!
+//! Prior to this fix (<2.5.7) `Document.used_characters` was a single
+//! `HashSet<char>` shared across all fonts. The writer subsetted every
+//! registered font with the same global set, so two CJK fonts in the
+//! same family (e.g. `SourceHanSansTC-Regular` + `SourceHanSansTC-Bold`)
+//! — where the second one was registered but never called via
+//! `set_font` — both ended up with ~200-glyph subsets, doubling the
+//! emitted size. Reported by @sparkyandrew in
+//! https://github.com/bzsanti/oxidizePdf/issues/204
+//!
+//! The fix is in two parts:
+//!   1. Track characters per-font (`HashMap<String, HashSet<char>>`) so
+//!      each font's subset reflects only the characters actually drawn
+//!      with that font.
+//!   2. Skip emitting fonts whose per-font character set is empty (no
+//!      content stream can reference them anyway, so embedding is waste).
+//!
+//! Assertions below target **wire format**: parse the emitted PDF and
+//! inspect `/Resources/Font` + referenced font dictionaries. No file-size
+//! smoke tests.
+
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Font, Page};
+use std::io::Cursor;
+
+const CJK_PATH: &str = "../test-pdfs/SourceHanSansSC-Regular.otf";
+const LATIN_PATH: &str = "../test-pdfs/SourceSans3-Regular.otf";
+
+fn load_fixture(path: &str) -> Option<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|_| eprintln!("SKIPPED: {} not found", path))
+        .ok()
+}
+
+/// Walk the first page's `/Resources/Font` dict.
+fn resolve_page0_fonts<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    let (page_n, page_g) = kids.0[0].as_reference().expect("/Pages/Kids[0] ref");
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Resources")
+            .clone()
+            .as_dict()
+            .expect("/Resources is dict")
+            .clone(),
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("Font").expect("/Resources/Font") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Font")
+            .clone()
+            .as_dict()
+            .expect("/Font dict")
+            .clone(),
+        other => panic!("/Font: unexpected {:?}", other),
+    }
+}
+
+/// Primary regression for #204. Two large CJK fonts are registered under
+/// different names (simulating Regular + Bold of the same family, which
+/// is the user's exact scenario), but only one is referenced via
+/// `set_font`. The unused font must NOT appear in any page's
+/// `/Resources/Font` — it's unreferenced by any content stream and
+/// embedding it wastes 5-20KB per font.
+#[test]
+fn unused_font_is_absent_from_resources() {
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    // Two logical fonts, same bytes — simulates Regular + Bold of the
+    // same family. Both are 16.5 MB on disk.
+    doc.add_font_from_bytes("CJK-Regular", cjk_data.clone())
+        .expect("add CJK-Regular");
+    doc.add_font_from_bytes("CJK-Bold", cjk_data)
+        .expect("add CJK-Bold");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("CJK-Regular".to_string()), 14.0)
+        .at(30.0, 800.0)
+        .write("高效能")
+        .expect("write CJK text with Regular");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(
+        fonts.get("CJK-Regular").is_some(),
+        "/Resources/Font must contain CJK-Regular (it was used); keys = {:?}",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+    assert!(
+        fonts.get("CJK-Bold").is_none(),
+        "/Resources/Font must NOT contain CJK-Bold (no content stream references it); \
+         keys = {:?}. Embedding unused fonts wastes space — see issue #204.",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}
+
+/// Mixed scenario: one CJK font used, one Latin font registered but
+/// unused. Same assertion as the CJK+CJK case — the unused Latin font
+/// must not surface in `/Resources/Font` even though its character
+/// coverage partially overlaps with the accumulated global set (ASCII
+/// characters that may appear in CJK text are present in both fonts).
+#[test]
+fn unused_latin_font_absent_when_cjk_used() {
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+    let latin_data = match load_fixture(LATIN_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("CJK", cjk_data).expect("add CJK");
+    doc.add_font_from_bytes("Latin", latin_data)
+        .expect("add Latin");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("CJK".to_string()), 14.0)
+        .at(30.0, 800.0)
+        .write("可靠性")
+        .expect("write CJK text");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(fonts.get("CJK").is_some(), "CJK must be present (used)");
+    assert!(
+        fonts.get("Latin").is_none(),
+        "Latin must be absent (registered but never referenced via set_font); \
+         keys = {:?}",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}
+
+/// Gap R1 from the post-fix analysis: `layout::rich_text::RichText` used
+/// inside `FlowLayout` emits its content stream via `append_raw_content`
+/// which historically bypassed char tracking. Under the issue #204 fix,
+/// any custom font only referenced from RichText would silently disappear
+/// from the output (no bucket → writer skips → widget references a
+/// missing font).
+///
+/// This test enforces the fixed contract: the RichText-referenced font
+/// MUST appear in `/Resources/Font` when the document is serialised.
+/// The `pub(crate)` method `Page::append_raw_content` now requires a
+/// `font_usage` map as a typed gate, so every future caller is
+/// compile-errored into reporting what they draw.
+#[test]
+fn rich_text_with_custom_font_embeds_font() {
+    use oxidize_pdf::layout::{FlowLayout, PageConfig, RichText, TextSpan};
+    use oxidize_pdf::Color;
+
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("MyCJK", cjk_data)
+        .expect("register CJK");
+
+    let rich = RichText::new(vec![TextSpan::new(
+        "高效能",
+        Font::Custom("MyCJK".to_string()),
+        14.0,
+        Color::black(),
+    )]);
+
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut layout = FlowLayout::new(config);
+    layout.add_rich_text(rich);
+    layout.build_into(&mut doc).expect("build flow");
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(
+        fonts.get("MyCJK").is_some(),
+        "/Resources/Font must contain MyCJK because RichText referenced it; \
+         keys = {:?}. If this fires, `RichText::render_operations` or \
+         its caller in `FlowLayout::build_into` is not reporting font \
+         usage to the page (gap R1 from issue #204 analysis).",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}
+
+/// Gap R4: `DocumentBuilder::add_text(text, Font::Custom(...), size)`
+/// (and more broadly any caller of `Page::add_text_flow` whose
+/// `TextFlowContext` uses a custom font) emits `Tj` operators into the
+/// page content stream without going through `GraphicsContext::show_text`
+/// or `TextContext::write`. The pre-fix global `used_characters` was
+/// also not updated, but the writer embedded every registered font
+/// anyway. Post-fix, the unused font is skipped → PDF has `/CJK 14 Tf`
+/// but no `/CJK` resource.
+///
+/// The typed-gate plumbing now extends to `TextFlowContext` so the
+/// page tracks chars drawn via `write_wrapped`.
+#[test]
+fn text_flow_with_custom_font_embeds_font() {
+    use oxidize_pdf::layout::{FlowLayout, PageConfig};
+
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    // DocumentBuilder::build() creates a new Document, so we use
+    // build_into on a Document that has the custom font pre-registered.
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("MyCJK", cjk_data)
+        .expect("register CJK");
+
+    let config = PageConfig::a4_with_margins(50.0, 50.0, 50.0, 50.0);
+    let mut layout = FlowLayout::new(config);
+    layout.add_text("高效能", Font::Custom("MyCJK".to_string()), 14.0);
+    layout.build_into(&mut doc).expect("build flow");
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(
+        fonts.get("MyCJK").is_some(),
+        "/Resources/Font must contain MyCJK: `DocumentBuilder::add_text` \
+         with a Custom font goes through `TextFlowContext` + \
+         `page.add_text_flow` which, gap R4, did not track chars. keys = {:?}",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}
+
+/// Gap R5: a page whose ONLY reference to a custom font is inside a
+/// header (or footer) must still embed that font. Pre-fix the header's
+/// chars were never tracked anywhere — the writer fell back to an
+/// ASCII character set and subsetted the font with digits + letters
+/// by accident, so `"Page 1 of 10"` rendered. Post-issue-#204, the
+/// per-font bucket for that font is empty → writer skips it → header
+/// references a missing font resource.
+///
+/// Fix: eagerly register header/footer font + sampled template chars
+/// at `Page::set_header` / `set_footer` time, so the page's
+/// graphics-context accumulator contains enough characters for the
+/// writer to embed a usable subset.
+#[test]
+fn header_only_custom_font_embeds_font() {
+    use oxidize_pdf::text::{HeaderFooter, HeaderFooterOptions};
+
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("MyCJK", cjk_data)
+        .expect("register CJK");
+
+    let mut page = Page::a4();
+    // No text drawn on the page body. Only the header references MyCJK.
+    let options = HeaderFooterOptions {
+        font: Font::Custom("MyCJK".to_string()),
+        font_size: 10.0,
+        ..Default::default()
+    };
+    let header =
+        HeaderFooter::new_header("Page {{page_number}} of {{total_pages}}").with_options(options);
+    page.set_header(header);
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(
+        fonts.get("MyCJK").is_some(),
+        "/Resources/Font must contain MyCJK even when only a header \
+         references it; keys = {:?}. See gap R5 in issue #204 analysis.",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}
+
+/// Regression: when both fonts ARE used, each must remain independently
+/// registered. Guards against an over-aggressive fix that skips fonts
+/// incorrectly.
+#[test]
+fn both_fonts_present_when_both_used() {
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+    let latin_data = match load_fixture(LATIN_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("CJK", cjk_data).expect("add CJK");
+    doc.add_font_from_bytes("Latin", latin_data)
+        .expect("add Latin");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("CJK".to_string()), 14.0)
+        .at(30.0, 800.0)
+        .write("高效能")
+        .expect("CJK text");
+    page.text()
+        .set_font(Font::Custom("Latin".to_string()), 12.0)
+        .at(30.0, 780.0)
+        .write("Hello world")
+        .expect("Latin text");
+    doc.add_page(page);
+
+    let pdf_bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse");
+    let fonts = resolve_page0_fonts(&mut reader);
+
+    assert!(
+        fonts.get("CJK").is_some(),
+        "CJK must be present when used; keys = {:?}",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+    assert!(
+        fonts.get("Latin").is_some(),
+        "Latin must be present when used; keys = {:?}",
+        fonts.0.keys().map(|k| &k.0).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Addresses the font subsetter issue reported by @sparkyandrew (see #204). The issue stays open for the user to verify and close manually.

**Root cause**: `Document.used_characters` was a single `HashSet<char>` shared across every registered custom font. The writer then subsetted EVERY font with the same global set, so two fonts from the same family (user reported SourceHanSansTC-Regular + SourceHanSansTC-Bold) — even when only one was referenced from `set_font` — both ended up with ~200-glyph subsets. User's report: output size doubled.

**Fix**: replace the single set with `HashMap<String, HashSet<char>>` keyed by font name at every layer. Each font now gets subsetted with only its own characters. Fonts registered via `add_font_from_bytes` but never referenced from any content stream are skipped entirely.

## Scope of the change

After drafting the minimal fix I ran a deep audit of every code path that emits text into a content stream to find bypasses. Five gaps surfaced; three are addressed here, one is documented in code, and the last is tracked separately:

| Gap | Description | Status |
|---|---|---|
| — | Primary bug: per-font char tracking | fixed |
| R1 | `RichText::render_operations` via `FlowLayout` bypassed tracking | fixed — returns `(ops, font_usage)` tuple, caller feeds into `Page::append_raw_content` |
| R2 | Form-field `/AP` streams hard-code `Type1 BaseFont` — incompatible with custom Type0 fonts regardless of tracking | tracked in #212 (format-level issue, separate refactor) |
| R3 | `overlay.rs` | documented in code (overlay invokes `/<xobj> Do`, never inline `Tj` against target-document fonts) |
| R4 | `TextFlowContext` via `Page::add_text_flow` bypassed tracking | fixed — per-font tracking added; `add_text_flow` absorbs via `merge_font_usage` |
| R5 | Header/footer custom font never reached the writer's snapshot | fixed — `Page::set_header`/`set_footer` eagerly register font + sampled template chars |

### Type-gated API

`Page::append_raw_content(data)` → `Page::append_raw_content(data, font_usage)`. The method is `pub(crate)` so there is no SemVer impact — but now every future content-stream builder inside the crate **fails to compile** unless it reports which fonts it referenced and which characters it drew with each. This is the mechanism that makes R1/R4-style silent bypasses impossible to reintroduce.

## Test plan

New file `tests/per_font_char_tracking_test.rs` (all content-verifying — parse the emitted PDF, walk `/Resources/Font`, no smoke tests):

- [x] `unused_font_is_absent_from_resources` — the exact user scenario (two CJK fonts registered under different names, only one used)
- [x] `unused_latin_font_absent_when_cjk_used` — mixed CJK + Latin
- [x] `both_fonts_present_when_both_used` — over-aggressive-skip regression guard
- [x] `rich_text_with_custom_font_embeds_font` — R1
- [x] `text_flow_with_custom_font_embeds_font` — R4
- [x] `header_only_custom_font_embeds_font` — R5

Plus an updated `RichText` unit test to lock the `(ops, font_usage)` contract.

- [x] 6327 library unit tests pass
- [x] Integration test binaries pass (form filling, smask, shading, pattern, extgstate, formxobject, round-trip, cjk)
- [x] `cargo clippy -p oxidize-pdf --lib -- -D warnings` clean
- [x] Pre-commit hook (fmt + clippy + build + tests) green on the commit

## Out of scope — tracked separately

**#212 — form field /AP streams incompatible with custom Type0/CID fonts**: `forms/appearance.rs:280-304` hard-codes `{/Type /Font, /Subtype /Type1, /BaseFont <name>}` in the self-contained `/Resources/Font` of every widget appearance. Works for builtin base-14 fonts (where viewers resolve names natively); produces invalid PDFs for custom CIDFontType0 fonts. Fixing requires architectural work on the appearance generator; deferred to #212.

🤖 Generated with Claude Code