### PR TITLE
fix(text): propagate page-level font/size/fill_color into TextFlowContext (addresses #216)

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -826,7 +826,21 @@ impl Page {
     }
 
     pub fn text_flow(&self) -> TextFlowContext {
-        TextFlowContext::new(self.width, self.height, self.margins.clone())
+        // Issue #216: inherit the page-level text state (font, size, and
+        // fill colour) so callers that rely on `set_font` / `set_text_color`
+        // before invoking flow helpers (notably `text_flow_at` in the Python
+        // and .NET wrappers) get the formatting they configured. An explicit
+        // `ctx.set_font(...)` / `ctx.set_fill_color(...)` afterwards still
+        // overrides the inherited values.
+        let mut ctx = TextFlowContext::new(self.width, self.height, self.margins.clone());
+        ctx.set_font(
+            self.text_context.current_font().clone(),
+            self.text_context.font_size(),
+        );
+        if let Some(color) = self.text_context.fill_color() {
+            ctx.set_fill_color(color);
+        }
+        ctx
     }
 
     pub fn add_text_flow(&mut self, text_flow: &TextFlowContext) {

--- a/oxidize-pdf-core/src/text/flow.rs
+++ b/oxidize-pdf-core/src/text/flow.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::graphics::Color;
 use crate::page::Margins;
 use crate::text::{measure_text, split_into_words, Font};
 use std::collections::{HashMap, HashSet};
@@ -24,6 +25,12 @@ pub struct TextFlowContext {
     #[allow(dead_code)]
     page_height: f64,
     margins: Margins,
+    /// Optional fill color for text glyphs (issue #216). When `Some`,
+    /// `write_wrapped` emits the corresponding non-stroking color
+    /// operator (`rg`/`g`/`k`) inside each `BT … ET` block before the
+    /// `Tj`. `None` keeps the previous behaviour (whatever fill colour
+    /// the surrounding graphics state is already carrying).
+    fill_color: Option<Color>,
     /// Characters drawn so far, bucketed by active font name (issue
     /// #204). Consumed by `Page::add_text_flow` to merge into the
     /// page's graphics-context tracking so the writer can subset each
@@ -44,6 +51,7 @@ impl TextFlowContext {
             page_width,
             page_height,
             margins,
+            fill_color: None,
             used_characters_by_font: HashMap::new(),
         }
     }
@@ -70,6 +78,31 @@ impl TextFlowContext {
     pub fn set_alignment(&mut self, alignment: TextAlign) -> &mut Self {
         self.alignment = alignment;
         self
+    }
+
+    /// Sets the non-stroking (fill) color used for subsequent text emitted
+    /// by `write_wrapped` (issue #216). Mirrors `TextContext::set_fill_color`.
+    /// `None` keeps the surrounding graphics state untouched (previous
+    /// behaviour); `Some(color)` emits the matching PDF operator inside each
+    /// `BT … ET` block.
+    pub fn set_fill_color(&mut self, color: Color) -> &mut Self {
+        self.fill_color = Some(color);
+        self
+    }
+
+    /// Current font this context will use when emitting text.
+    pub fn current_font(&self) -> &Font {
+        &self.current_font
+    }
+
+    /// Current font size in points.
+    pub fn font_size(&self) -> f64 {
+        self.font_size
+    }
+
+    /// Current fill color, if one has been explicitly set (issue #216).
+    pub fn fill_color(&self) -> Option<Color> {
+        self.fill_color
     }
 
     pub fn at(&mut self, x: f64, y: f64) -> &mut Self {
@@ -147,6 +180,28 @@ impl TextFlowContext {
                 self.font_size
             )
             .expect("Writing to String should never fail");
+
+            // Apply non-stroking fill colour if one was inherited from the
+            // page-level text state (issue #216) or explicitly configured
+            // via `set_fill_color`. PDF spec ISO 32000-1 §8.6.8 allows
+            // colour-setting operators inside a text object; they take
+            // effect for the show-text operators that follow.
+            if let Some(color) = self.fill_color {
+                match color {
+                    Color::Rgb(r, g, b) => {
+                        writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} rg")
+                            .expect("Writing to String should never fail");
+                    }
+                    Color::Gray(gray) => {
+                        writeln!(&mut self.operations, "{gray:.3} g")
+                            .expect("Writing to String should never fail");
+                    }
+                    Color::Cmyk(c, m, y, k) => {
+                        writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} k")
+                            .expect("Writing to String should never fail");
+                    }
+                }
+            }
 
             // Set text position
             writeln!(&mut self.operations, "{:.2} {:.2} Td", x, self.cursor_y)

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -183,6 +183,13 @@ impl TextContext {
         &self.current_font
     }
 
+    /// Current non-stroking (fill) colour, if one has been explicitly set.
+    /// Used by `Page::text_flow` to propagate the page-level text colour
+    /// into derived `TextFlowContext`s (issue #216).
+    pub(crate) fn fill_color(&self) -> Option<Color> {
+        self.fill_color
+    }
+
     pub fn at(&mut self, x: f64, y: f64) -> &mut Self {
         // Update text_matrix immediately and store for write() operation
         self.text_matrix[4] = x;

--- a/oxidize-pdf-core/tests/text_flow_inherits_page_state_test.rs
+++ b/oxidize-pdf-core/tests/text_flow_inherits_page_state_test.rs
@@ -1,0 +1,231 @@
+//! Integration tests for issue #216:
+//!
+//! `Page::text_flow()` returns a `TextFlowContext` that should inherit the
+//! page's current text state (font, font size, fill color) so that
+//! `text_flow_at`-style helpers (Python wrapper, .NET wrapper) emit text
+//! using the font and color most recently set via `Page::text().set_font(...)`
+//! and `Page::text().set_fill_color(...)`.
+//!
+//! Before the fix the flow context was created with hardcoded defaults
+//! (Helvetica / 12pt / no fill colour) and silently ignored anything set on
+//! the page-level `TextContext`.
+
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::{Document, Font, Page};
+
+/// `Page::text_flow()` must return a context whose `current_font` and
+/// `font_size` match what was last set via `Page::text().set_font(...)`.
+#[test]
+fn text_flow_inherits_font_and_size_from_page_text_state() {
+    let mut page = Page::new(612.0, 792.0);
+
+    page.text().set_font(Font::TimesBold, 32.0);
+
+    let ctx = page.text_flow();
+
+    assert_eq!(
+        ctx.current_font(),
+        &Font::TimesBold,
+        "Page::text_flow() ignored the page-level font set via set_font()"
+    );
+    assert_eq!(
+        ctx.font_size(),
+        32.0,
+        "Page::text_flow() ignored the page-level font size set via set_font()"
+    );
+}
+
+/// `Page::text_flow()` must inherit the fill colour set on the page-level
+/// `TextContext` so that wrapped text honours `set_text_color`.
+#[test]
+fn text_flow_inherits_fill_color_from_page_text_state() {
+    let mut page = Page::new(612.0, 792.0);
+
+    page.text().set_fill_color(Color::rgb(0.8, 0.1, 0.1));
+
+    let ctx = page.text_flow();
+
+    assert_eq!(
+        ctx.fill_color(),
+        Some(Color::rgb(0.8, 0.1, 0.1)),
+        "Page::text_flow() ignored the page-level fill color set via set_fill_color()"
+    );
+}
+
+/// End-to-end check: setting Times-Bold/32 then writing wrapped text must
+/// produce a content stream whose `Tf` operator references Times-Bold at 32pt.
+/// This is the exact bug reported in #216.
+#[test]
+fn write_wrapped_emits_inherited_font_in_content_stream() {
+    let mut doc = Document::new();
+    let mut page = Page::new(612.0, 792.0);
+    page.set_margins(50.0, 50.0, 50.0, 50.0);
+
+    page.text().set_font(Font::TimesBold, 32.0);
+
+    let mut ctx = page.text_flow();
+    ctx.at(100.0, 700.0)
+        .write_wrapped("Heading in Times-Bold 32")
+        .expect("write_wrapped should not fail");
+
+    let ops = ctx.operations().to_owned();
+
+    assert!(
+        ops.contains("/Times-Bold 32 Tf"),
+        "Expected `/Times-Bold 32 Tf` operator in operations.\n\
+         Found instead:\n{ops}"
+    );
+    assert!(
+        !ops.contains("/Helvetica 12 Tf"),
+        "Found default `/Helvetica 12 Tf` — page-level font was NOT inherited.\n\
+         Operations:\n{ops}"
+    );
+
+    // Round-trip the document with compression disabled so we can assert the
+    // operator survives the writer pipeline, not just the in-memory ops buffer.
+    page.add_text_flow(&ctx);
+    doc.set_compress(false);
+    doc.add_page(page);
+    let bytes = doc.to_bytes().expect("to_bytes must succeed");
+    let needle = b"/Times-Bold 32 Tf";
+    assert!(
+        bytes.windows(needle.len()).any(|w| w == needle),
+        "Serialized PDF does not contain `/Times-Bold 32 Tf` — propagation \
+         was lost somewhere in the writer pipeline."
+    );
+}
+
+/// End-to-end check: setting a red fill colour then writing wrapped text
+/// must produce a content stream that emits `0.800 0.100 0.100 rg` inside
+/// the `BT … ET` block before the `Tj`. Without this propagation, the wrapped
+/// text inherits whatever fill colour the surrounding graphics state happens
+/// to carry (typically black) and silently drops the user's intent.
+#[test]
+fn write_wrapped_emits_inherited_fill_color_before_tj() {
+    let mut page = Page::new(612.0, 792.0);
+    page.set_margins(50.0, 50.0, 50.0, 50.0);
+
+    page.text().set_fill_color(Color::rgb(0.8, 0.1, 0.1));
+    page.text().set_font(Font::Helvetica, 14.0);
+
+    let mut ctx = page.text_flow();
+    ctx.at(100.0, 700.0)
+        .write_wrapped("Red wrapped text")
+        .expect("write_wrapped should not fail");
+
+    let ops = ctx.operations().to_owned();
+
+    let rg_pos = ops.find("0.800 0.100 0.100 rg").unwrap_or_else(|| {
+        panic!(
+            "Expected `0.800 0.100 0.100 rg` (non-stroking color) in operations.\n\
+             Found instead:\n{ops}"
+        )
+    });
+    let tj_pos = ops.find(" Tj").expect("Expected at least one Tj operator");
+
+    assert!(
+        rg_pos < tj_pos,
+        "Color operator `rg` must precede the first `Tj` so the show-text uses it.\n\
+         rg_pos={rg_pos} tj_pos={tj_pos}\nOperations:\n{ops}"
+    );
+}
+
+/// Regression guard: an explicit `set_font` on the flow context must override
+/// whatever was inherited from the page. This keeps existing call sites that
+/// configure the flow context directly working unchanged.
+#[test]
+fn flow_set_font_overrides_inherited_page_font() {
+    let mut page = Page::new(612.0, 792.0);
+    page.text().set_font(Font::TimesBold, 32.0);
+
+    let mut ctx = page.text_flow();
+    ctx.set_font(Font::Courier, 10.0);
+
+    assert_eq!(ctx.current_font(), &Font::Courier);
+    assert_eq!(ctx.font_size(), 10.0);
+}
+
+/// Symmetric regression guard for fill colour: an explicit `set_fill_color`
+/// on the flow context must override the colour inherited from the page-level
+/// `TextContext`, both at the field level and in the emitted content stream.
+#[test]
+fn flow_set_fill_color_overrides_inherited_page_color() {
+    let mut page = Page::new(612.0, 792.0);
+    page.text().set_fill_color(Color::rgb(0.8, 0.1, 0.1)); // red on the page
+
+    let mut ctx = page.text_flow();
+    ctx.set_fill_color(Color::rgb(0.1, 0.2, 0.9)); // blue overrides
+
+    assert_eq!(ctx.fill_color(), Some(Color::rgb(0.1, 0.2, 0.9)));
+
+    ctx.at(100.0, 700.0)
+        .write_wrapped("Should be blue, not red")
+        .expect("write_wrapped should not fail");
+
+    let ops = ctx.operations().to_owned();
+    assert!(
+        ops.contains("0.100 0.200 0.900 rg"),
+        "Override colour `0.100 0.200 0.900 rg` not found in operations:\n{ops}"
+    );
+    assert!(
+        !ops.contains("0.800 0.100 0.100 rg"),
+        "Inherited red `0.800 0.100 0.100 rg` should have been overridden:\n{ops}"
+    );
+}
+
+/// Coverage for the `Gray` arm of the colour emission match block. Without
+/// this test a regression in the operator/precision for `g` would slip past
+/// the existing `Rgb`-only test.
+#[test]
+fn write_wrapped_emits_gray_fill_color_operator() {
+    let mut page = Page::new(612.0, 792.0);
+    page.text().set_fill_color(Color::Gray(0.5));
+
+    let mut ctx = page.text_flow();
+    ctx.at(100.0, 700.0)
+        .write_wrapped("Mid-gray text")
+        .expect("write_wrapped should not fail");
+
+    let ops = ctx.operations().to_owned();
+
+    let g_pos = ops
+        .find("0.500 g")
+        .unwrap_or_else(|| panic!("Expected `0.500 g` in operations.\nOperations:\n{ops}"));
+    let tj_pos = ops.find(" Tj").expect("Expected at least one Tj operator");
+    assert!(
+        g_pos < tj_pos,
+        "Gray operator must precede the first Tj. g_pos={g_pos} tj_pos={tj_pos}\n{ops}"
+    );
+    // Negative-space check: no `rg` or `k` from the other arms.
+    assert!(
+        !ops.contains(" rg") && !ops.contains(" k"),
+        "Gray fill must emit only `g`, not `rg`/`k`:\n{ops}"
+    );
+}
+
+/// Coverage for the `Cmyk` arm of the colour emission match block.
+#[test]
+fn write_wrapped_emits_cmyk_fill_color_operator() {
+    let mut page = Page::new(612.0, 792.0);
+    page.text().set_fill_color(Color::Cmyk(0.0, 0.5, 0.5, 0.0));
+
+    let mut ctx = page.text_flow();
+    ctx.at(100.0, 700.0)
+        .write_wrapped("CMYK orange-ish")
+        .expect("write_wrapped should not fail");
+
+    let ops = ctx.operations().to_owned();
+
+    let k_pos = ops.find("0.000 0.500 0.500 0.000 k").unwrap_or_else(|| {
+        panic!("Expected `0.000 0.500 0.500 0.000 k` in operations.\nOperations:\n{ops}")
+    });
+    let tj_pos = ops.find(" Tj").expect("Expected at least one Tj operator");
+    assert!(
+        k_pos < tj_pos,
+        "CMYK operator must precede the first Tj. k_pos={k_pos} tj_pos={tj_pos}\n{ops}"
+    );
+    assert!(
+        !ops.contains(" rg") && !ops.contains(" g\n"),
+        "CMYK fill must emit only `k`, not `rg`/`g`:\n{ops}"
+    );
+}


### PR DESCRIPTION
## Summary

`Page::text_flow()` previously returned a `TextFlowContext` with hardcoded defaults (Helvetica / 12pt / no fill colour) and silently dropped whatever the caller had set on the page-level `TextContext` via `Page::text().set_font(...)` / `set_fill_color(...)`. The Python wrapper's `Page.text_flow_at` and the .NET `oxidize_text_flow_create` paths both inherit this bug — wrapped text always rendered in default Helvetica regardless of intent.

The fix propagates **font + font_size + fill_color** from the page-level `TextContext` into the new `TextFlowContext`, and `TextFlowContext::write_wrapped` now emits the matching non-stroking colour operator (`rg` / `g` / `k`) inside each `BT…ET` block when a fill colour is configured.

Explicit `ctx.set_font(...)` / `ctx.set_fill_color(...)` after `text_flow()` continues to override the inherited values — guarded by regression tests. The pre-fix Helvetica/12 defaults are preserved exactly when no page-level state has been set.

## Files changed

- `oxidize-pdf-core/src/page.rs` — `Page::text_flow()` propagates state from `self.text_context`.
- `oxidize-pdf-core/src/text/flow.rs` — adds `fill_color: Option<Color>` field, public getters (`current_font`, `font_size`, `fill_color`), setter (`set_fill_color`), and colour emission in `write_wrapped`.
- `oxidize-pdf-core/src/text/mod.rs` — adds `pub(crate) fn fill_color()` accessor on `TextContext`.
- `oxidize-pdf-core/tests/text_flow_inherits_page_state_test.rs` (new) — 8 content-verifying integration tests.

## Test plan

- [x] 8/8 integration tests in the new file (font inheritance, size inheritance, fill colour inheritance, `Tf` operator round-trip survives the writer pipeline, `rg` / `g` / `k` ordering before `Tj`, and override regression guards for both `set_font` and `set_fill_color`).
- [x] 50/50 unit tests in `text::flow` module pass (no regression in TextFlowContext behaviour).
- [x] Pre-existing #167 regression test (`tests/text_flow_at_x_test.rs`) still green.
- [x] Pre-commit hook: 6328/6328 lib unit tests pass.
- [x] Quality (`quality-rust`) and security (`security-expert-advisor`) reviews completed before commit; findings addressed in-commit (Gray + Cmyk coverage, `set_fill_color` override test, removal of byte-prefix smoke check).

## Out of scope (separate follow-up issues to be filed)

- Non-finite float sanitisation (`f64::NAN` / `inf` bypass `Color::*` clamp constructors via direct enum destructuring) across all content-stream colour writers — pre-existing across `graphics/mod.rs` and `patterns.rs`, not introduced here.
- Shared `write_fill_color` helper between `TextContext::apply_text_state_parameters` and `TextFlowContext::write_wrapped` to eliminate duplicated `match Color { Rgb / Gray / Cmyk }` arms.
- Parity propagation for the remaining `TextContext` state (`word_spacing`, `leading`, `stroke_color`, `character_spacing`, `horizontal_scaling`, `text_rise`, `rendering_mode`) — `TextFlowContext` doesn't yet support these as first-class fields.