### PR TITLE
fix(tables): vertical-overflow handling for Table::render — addresses #218

### DIFF
--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -481,6 +481,16 @@ impl Document {
         self.pages.len()
     }
 
+    /// Gets a reference to the page at `index`, or `None` if out of bounds.
+    pub fn page(&self, index: usize) -> Option<&Page> {
+        self.pages.get(index)
+    }
+
+    /// Gets a mutable reference to the page at `index`, or `None` if out of bounds.
+    pub fn page_mut(&mut self, index: usize) -> Option<&mut Page> {
+        self.pages.get_mut(index)
+    }
+
     /// Gets a reference to the AcroForm (interactive form) if present.
     pub fn acro_form(&self) -> Option<&AcroForm> {
         self.acro_form.as_ref()

--- a/oxidize-pdf-core/src/error.rs
+++ b/oxidize-pdf-core/src/error.rs
@@ -70,9 +70,35 @@ pub enum PdfError {
 
     #[error("Object stream error: {0}")]
     ObjectStreamError(String),
+
+    #[error("Table overflow: {rendered} rows fit, {dropped} dropped below floor y={bottom_y}")]
+    TableOverflow {
+        /// Rows that would fit above `bottom_y`.
+        rendered: usize,
+        /// Rows that would not fit and were not drawn.
+        dropped: usize,
+        /// The vertical floor that triggered the overflow check.
+        bottom_y: f64,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, PdfError>;
+
+/// Reject NaN/±∞ values at API boundaries.
+///
+/// Used by features that compare floating-point coordinates against thresholds
+/// (e.g. table-pagination floors). NaN comparisons silently return `false`,
+/// so an unchecked NaN can bypass overflow guards entirely; ∞ does the
+/// opposite. Both are rejected as malformed input.
+pub(crate) fn ensure_finite(name: &str, v: f64) -> std::result::Result<(), PdfError> {
+    if v.is_finite() {
+        Ok(())
+    } else {
+        Err(PdfError::InvalidStructure(format!(
+            "{name} must be a finite f64, got {v}"
+        )))
+    }
+}
 
 // Convert AesError to PdfError
 impl From<crate::encryption::AesError> for PdfError {

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -554,6 +554,14 @@ impl Page {
         &mut self.graphics_context
     }
 
+    /// Returns the accumulated content-stream operators string for this page.
+    ///
+    /// Read-only counterpart to [`Page::graphics`]. Useful for inspecting what
+    /// has been drawn without taking a mutable borrow (eg. multi-page tests).
+    pub fn graphics_operations(&self) -> &str {
+        self.graphics_context.operations()
+    }
+
     /// Returns a mutable reference to the text context for adding text.
     pub fn text(&mut self) -> &mut TextContext {
         &mut self.text_context

--- a/oxidize-pdf-core/src/page_tables.rs
+++ b/oxidize-pdf-core/src/page_tables.rs
@@ -2,7 +2,8 @@
 //!
 //! This module provides traits and implementations to easily add tables to PDF pages.
 
-use crate::error::PdfError;
+use crate::document::Document;
+use crate::error::{ensure_finite, PdfError};
 use crate::graphics::Color;
 use crate::page::Page;
 use crate::text::{Font, HeaderStyle, Table, TableOptions};
@@ -164,6 +165,134 @@ impl PageTables for Page {
         }
 
         self.add_simple_table(&table, x, y)
+    }
+}
+
+/// Document-level extension for table rendering with automatic pagination.
+///
+/// Where [`PageTables`] writes a table on a single page, this trait will
+/// allocate continuation pages as needed when the table doesn't fit, and
+/// (by default) repeat header rows on each new page.
+///
+/// See [issue #218](https://github.com/bzsanti/oxidizePdf/issues/218) for the
+/// motivating use case.
+pub trait DocumentTables {
+    /// Render `table` starting at `(x, y)` on the page at `starting_page_index`.
+    /// If the table doesn't fit above `bottom_y`, allocate new pages of the
+    /// same dimensions and continue rendering each remaining slice at
+    /// `(x, next_page_y)`.
+    ///
+    /// All `y` values are absolute coordinates in the page's PDF coordinate
+    /// system (origin at the bottom-left). `bottom_y` is the floor below
+    /// which no row may be drawn; `next_page_y` is the top of the table on
+    /// every continuation page.
+    ///
+    /// When `table.options().repeat_header_on_split` is `true` (the default),
+    /// the leading header rows are repeated at the top of every continuation
+    /// page.
+    ///
+    /// # Returns
+    ///
+    /// `(final_page_index, final_y)` — where the layout cursor ended up after
+    /// the table was fully rendered. Callers can resume layout from there.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::TableOverflow`] when a single row is taller than
+    /// the available vertical space on a fresh page (the table cannot make
+    /// progress and would loop forever).
+    fn add_paginated_table(
+        &mut self,
+        starting_page_index: usize,
+        table: &Table,
+        x: f64,
+        y: f64,
+        bottom_y: f64,
+        next_page_y: f64,
+    ) -> Result<(usize, f64), PdfError>;
+}
+
+impl DocumentTables for Document {
+    fn add_paginated_table(
+        &mut self,
+        starting_page_index: usize,
+        table: &Table,
+        x: f64,
+        y: f64,
+        bottom_y: f64,
+        next_page_y: f64,
+    ) -> Result<(usize, f64), PdfError> {
+        // Reject non-finite floats at the API boundary. NaN comparisons silently
+        // return `false`, which would bypass `fit_count`'s overflow guard and
+        // silently render off-page — exactly the failure mode #218 prevents.
+        ensure_finite("x", x)?;
+        ensure_finite("y", y)?;
+        ensure_finite("bottom_y", bottom_y)?;
+        ensure_finite("next_page_y", next_page_y)?;
+
+        let repeat_headers = table.options().repeat_header_on_split;
+
+        let mut current_table = table.clone();
+        current_table.set_position(x, y);
+
+        let mut current_page_idx = starting_page_index;
+
+        loop {
+            // Capture the current page's dims (needed both for the floor check
+            // and for allocating a same-sized continuation page).
+            let (page_width, page_height) = match self.page(current_page_idx) {
+                Some(p) => (p.width(), p.height()),
+                None => {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "page index {current_page_idx} out of bounds (page_count={})",
+                        self.page_count()
+                    )))
+                }
+            };
+
+            // Snapshot the data-row count BEFORE rendering. The progress check
+            // must compare *data* rows, not raw row counts: a header-heavy
+            // table where the page only fits headers would render some rows
+            // but advance zero data rows, then re-prepend headers for the next
+            // page — unbounded memory growth (DoS).
+            let current_data_rows = current_table.row_count() - current_table.header_count();
+
+            let tail = {
+                let page = self.page_mut(current_page_idx).expect("checked above");
+                current_table.render_with_split(page.graphics(), bottom_y)?
+            };
+
+            match tail {
+                None => {
+                    let final_y = current_table.position().1 - current_table.get_height();
+                    return Ok((current_page_idx, final_y));
+                }
+                Some(mut tail) => {
+                    // Forward progress: at least one *data* row must have been
+                    // drawn on this page. Comparing raw `row_count()` is wrong
+                    // because headers prepended on the next iteration inflate
+                    // the count without making progress.
+                    let tail_data_rows = tail.row_count() - tail.header_count();
+                    let data_rows_drawn = current_data_rows.saturating_sub(tail_data_rows);
+                    if data_rows_drawn == 0 {
+                        return Err(PdfError::TableOverflow {
+                            rendered: current_table.row_count() - tail.row_count(),
+                            dropped: tail.row_count(),
+                            bottom_y,
+                        });
+                    }
+
+                    self.add_page(Page::new(page_width, page_height));
+                    current_page_idx = self.page_count() - 1;
+
+                    if repeat_headers {
+                        tail.prepend_headers_from(table);
+                    }
+                    tail.set_position(x, next_page_y);
+                    current_table = tail;
+                }
+            }
+        }
     }
 }
 

--- a/oxidize-pdf-core/src/text/table.rs
+++ b/oxidize-pdf-core/src/text/table.rs
@@ -3,7 +3,7 @@
 //! This module provides basic table functionality without CSS styling,
 //! suitable for structured data presentation in PDF documents.
 
-use crate::error::PdfError;
+use crate::error::{ensure_finite, PdfError};
 use crate::graphics::{Color, GraphicsContext, LineDashPattern};
 use crate::text::{measure_text, Font, TextAlign};
 
@@ -47,6 +47,9 @@ pub struct TableOptions {
     pub alternating_row_colors: Option<(Color, Color)>,
     /// Table background color
     pub background_color: Option<Color>,
+    /// When the table is split across pages by `Document::add_paginated_table`,
+    /// repeat header rows at the top of every continuation page. Defaults to `true`.
+    pub repeat_header_on_split: bool,
 }
 
 /// Header row styling options
@@ -141,6 +144,7 @@ impl Default for TableOptions {
             cell_border_style: CellBorderStyle::default(),
             alternating_row_colors: None,
             background_color: None,
+            repeat_header_on_split: true,
         }
     }
 }
@@ -173,6 +177,11 @@ impl Table {
     pub fn set_options(&mut self, options: TableOptions) -> &mut Self {
         self.options = options;
         self
+    }
+
+    /// Get a reference to the table's current options.
+    pub fn options(&self) -> &TableOptions {
+        &self.options
     }
 
     /// Add a header row
@@ -312,21 +321,161 @@ impl Table {
         self.column_widths.iter().sum()
     }
 
-    /// Render the table to a graphics context
+    /// Number of rows in this table (header + data).
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Number of leading header rows in this table.
+    pub fn header_count(&self) -> usize {
+        self.rows.iter().take_while(|r| r.is_header).count()
+    }
+
+    /// Current top-left position of the table, `(x, y)`.
+    pub fn position(&self) -> (f64, f64) {
+        self.position
+    }
+
+    /// Prepend a clone of the leading header rows from `source` to this table.
+    ///
+    /// Used by `Document::add_paginated_table` to repeat headers on continuation
+    /// pages when `TableOptions::repeat_header_on_split` is true. No-op when
+    /// `source` has zero header rows.
+    ///
+    /// Crate-private: callers outside this crate have no use case for this and
+    /// passing a `source` with mismatched `column_widths` would yield malformed
+    /// rendering.
+    pub(crate) fn prepend_headers_from(&mut self, source: &Table) {
+        let header_count = source.header_count();
+        if header_count == 0 {
+            return;
+        }
+        let mut new_rows: Vec<TableRow> = source.rows[..header_count].to_vec();
+        new_rows.extend(self.rows.drain(..));
+        self.rows = new_rows;
+    }
+
+    /// Render the table to a graphics context.
+    ///
+    /// Back-compat note: this method is **vertical-overflow-unaware** by design.
+    /// Rows past the page boundary are still drawn off-page (silent overflow).
+    /// Callers concerned with overflow should use [`Table::render_with_split`]
+    /// or [`Table::render_strict`], or [`crate::page_tables::DocumentTables::add_paginated_table`].
     pub fn render(&self, graphics: &mut GraphicsContext) -> Result<(), PdfError> {
+        // Direct call to the row-drawing helper with all rows — preserves the
+        // pre-#218 silent-overflow behaviour callers depend on, and skips the
+        // boundary `ensure_finite` check (which the safe APIs apply).
+        self.render_rows_slice(graphics, &self.rows, self.get_height())
+    }
+
+    /// Render as many leading rows as fully fit above `bottom_y`; return the
+    /// unrendered tail as a fresh [`Table`] (with the same `column_widths` and
+    /// `options`), or `None` when everything fit.
+    ///
+    /// **Tail position is a sentinel `(start_x, 0.0)`** — the caller MUST call
+    /// [`Table::set_position`] on the returned tail before using it for
+    /// rendering or fit checks. Calling `render_with_split` on a tail without
+    /// repositioning will report 0 rows fitting (since `start_y - row_height < bottom_y`
+    /// for any positive `bottom_y`) and yield a tail identical to the input.
+    /// For batteries-included pagination, see
+    /// [`crate::page_tables::DocumentTables::add_paginated_table`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] when `bottom_y` is not a finite
+    /// value (NaN or ±∞).
+    pub fn render_with_split(
+        &self,
+        graphics: &mut GraphicsContext,
+        bottom_y: f64,
+    ) -> Result<Option<Table>, PdfError> {
+        ensure_finite("bottom_y", bottom_y)?;
+        let (start_x, _start_y) = self.position;
+
+        // Pre-flight: how many leading rows fully fit above the floor?
+        let rendered_count = self.fit_count(bottom_y);
+        let rendered_height = self.rows[..rendered_count]
+            .iter()
+            .map(|r| self.calculate_row_height(r))
+            .sum::<f64>();
+
+        if rendered_count > 0 {
+            self.render_rows_slice(graphics, &self.rows[..rendered_count], rendered_height)?;
+        }
+
+        if rendered_count == self.rows.len() {
+            Ok(None)
+        } else {
+            let mut tail = self.clone();
+            tail.rows = self.rows[rendered_count..].to_vec();
+            tail.position = (start_x, 0.0);
+            Ok(Some(tail))
+        }
+    }
+
+    /// Strict variant: pre-flight check the table against `bottom_y`. If any
+    /// row would overflow, return [`PdfError::TableOverflow`] **without
+    /// drawing anything**; otherwise render normally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] when `bottom_y` is not finite.
+    pub fn render_strict(
+        &self,
+        graphics: &mut GraphicsContext,
+        bottom_y: f64,
+    ) -> Result<(), PdfError> {
+        ensure_finite("bottom_y", bottom_y)?;
+        let rendered = self.fit_count(bottom_y);
+        if rendered < self.rows.len() {
+            return Err(PdfError::TableOverflow {
+                rendered,
+                dropped: self.rows.len() - rendered,
+                bottom_y,
+            });
+        }
+        // Skip the redundant fit_count inside render() by going straight to
+        // the helper with the full row set.
+        self.render_rows_slice(graphics, &self.rows, self.get_height())
+    }
+
+    /// Count the number of leading rows that fully fit above `bottom_y`.
+    fn fit_count(&self, bottom_y: f64) -> usize {
+        let (_start_x, start_y) = self.position;
+        let mut current_y = start_y;
+        let mut count = 0usize;
+        for row in &self.rows {
+            let row_height = self.calculate_row_height(row);
+            let next_y = current_y - row_height;
+            if next_y < bottom_y {
+                break;
+            }
+            count += 1;
+            current_y = next_y;
+        }
+        count
+    }
+
+    /// Internal: draw a slice of rows starting at `self.position`. The
+    /// `rendered_height` parameter sizes the optional table-wide background.
+    fn render_rows_slice(
+        &self,
+        graphics: &mut GraphicsContext,
+        rows: &[TableRow],
+        rendered_height: f64,
+    ) -> Result<(), PdfError> {
         let (start_x, start_y) = self.position;
         let mut current_y = start_y;
 
-        // Draw table background if specified
-        // Table grows downward from start_y, so bottom-left is at start_y - height
+        // Draw table background if specified, sized to the rendered subset.
         if let Some(bg_color) = self.options.background_color {
             graphics.save_state();
             graphics.set_fill_color(bg_color);
             graphics.rectangle(
                 start_x,
-                start_y - self.get_height(),
+                start_y - rendered_height,
                 self.get_width(),
-                self.get_height(),
+                rendered_height,
             );
             graphics.fill();
             graphics.restore_state();
@@ -334,7 +483,7 @@ impl Table {
 
         // Draw each row
         let mut data_row_index: usize = 0; // Counts only non-header rows (for zebra stripes)
-        for (row_index, row) in self.rows.iter().enumerate() {
+        for (row_index, row) in rows.iter().enumerate() {
             let row_height = self.calculate_row_height(row);
             let mut current_x = start_x;
 
@@ -404,11 +553,13 @@ impl Table {
                         true
                     }
                     GridStyle::Outline => {
-                        // Only draw if it's an edge cell
+                        // Only draw if it's an edge cell.
+                        // For partial renders (page splits), the outline tracks the
+                        // boundary of the rendered slice, not the original full table.
                         col_index == 0
                             || col_index + cell.colspan >= self.column_widths.len()
                             || row_index == 0
-                            || row_index == self.rows.len() - 1
+                            || row_index == rows.len() - 1
                     }
                 };
 

--- a/oxidize-pdf-core/tests/table_pagination_test.rs
+++ b/oxidize-pdf-core/tests/table_pagination_test.rs
@@ -1,0 +1,446 @@
+//! Integration tests for `Table` vertical-overflow handling — issue #218.
+//!
+//! Three layers under test:
+//!   1. `Table::render_with_split(&mut GraphicsContext, bottom_y)` — primitive
+//!   2. `Table::render_strict(&mut GraphicsContext, bottom_y)` — pre-flight Err
+//!   3. `Document::add_paginated_table(...)` — batteries-included
+//!
+//! Tests verify content-stream output, never just absence of crash.
+
+use oxidize_pdf::error::PdfError;
+use oxidize_pdf::page_tables::{DocumentTables, PageTables};
+use oxidize_pdf::text::{Table, TableOptions};
+use oxidize_pdf::{Document, Page};
+
+// ---------- helpers ----------
+
+fn fixed_height_table(num_rows: usize, row_height: f64) -> Table {
+    let mut table = Table::with_equal_columns(2, 200.0);
+    let options = TableOptions {
+        row_height,
+        ..TableOptions::default()
+    };
+    table.set_options(options);
+    for i in 0..num_rows {
+        table
+            .add_row(vec![format!("r{i}c0"), format!("r{i}c1")])
+            .unwrap();
+    }
+    table
+}
+
+fn fixed_height_table_with_header(num_data_rows: usize, row_height: f64) -> Table {
+    let mut table = Table::with_equal_columns(2, 200.0);
+    let options = TableOptions {
+        row_height,
+        ..TableOptions::default()
+    };
+    table.set_options(options);
+    table
+        .add_header_row(vec!["H0".to_string(), "H1".to_string()])
+        .unwrap();
+    for i in 0..num_data_rows {
+        table
+            .add_row(vec![format!("r{i}c0"), format!("r{i}c1")])
+            .unwrap();
+    }
+    table
+}
+
+fn count_tj(content: &str) -> usize {
+    content.matches(") Tj\n").count() + content.matches("> Tj\n").count()
+}
+
+// ---------- tests ----------
+
+#[test]
+fn render_with_split_returns_tail_when_rows_overflow_bottom_y() {
+    // 10 rows × 30pt = 300pt total. position.y = 800, bottom_y = 650.
+    // Vertical room above floor = 150pt → exactly 5 rows fit, 5 are deferred.
+    let mut table = fixed_height_table(10, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    let result = table
+        .render_with_split(page.graphics(), 650.0)
+        .expect("render_with_split must succeed");
+
+    let tail = result.expect("tail must be Some when rows overflow");
+    assert_eq!(
+        tail.row_count(),
+        5,
+        "tail must contain exactly the 5 unrendered rows"
+    );
+
+    let ops = page.graphics().get_operations();
+    // Each row has 2 cells → 2 `Tj` per row × 5 rendered rows = 10
+    assert_eq!(
+        count_tj(ops),
+        10,
+        "exactly 10 Tj operators expected (5 rendered rows × 2 cells), got: {}",
+        count_tj(ops)
+    );
+
+    for i in 5..10 {
+        let needle = format!("r{i}c0");
+        assert!(
+            !ops.contains(&needle),
+            "row {i} must NOT be drawn but content stream contains '{needle}'"
+        );
+    }
+    for i in 0..5 {
+        let needle = format!("r{i}c0");
+        assert!(
+            ops.contains(&needle),
+            "row {i} must be drawn but content stream missing '{needle}'"
+        );
+    }
+}
+
+#[test]
+fn render_with_split_returns_none_when_everything_fits() {
+    let mut table = fixed_height_table(5, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    // bottom_y far below — everything fits.
+    let result = table
+        .render_with_split(page.graphics(), 0.0)
+        .expect("render_with_split must succeed");
+
+    assert!(
+        result.is_none(),
+        "tail must be None when everything fits, got Some(_)"
+    );
+
+    let ops = page.graphics().get_operations();
+    assert_eq!(
+        count_tj(ops),
+        10,
+        "all 5 rows × 2 cells = 10 Tj operators expected"
+    );
+    for i in 0..5 {
+        assert!(ops.contains(&format!("r{i}c0")));
+        assert!(ops.contains(&format!("r{i}c1")));
+    }
+}
+
+#[test]
+fn render_strict_returns_overflow_error_without_drawing_anything() {
+    let mut table = fixed_height_table(10, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    let err = table
+        .render_strict(page.graphics(), 650.0)
+        .expect_err("render_strict must Err on overflow");
+
+    match err {
+        PdfError::TableOverflow {
+            rendered,
+            dropped,
+            bottom_y,
+        } => {
+            assert_eq!(rendered, 5, "5 rows would have fit");
+            assert_eq!(dropped, 5, "5 rows would not have fit");
+            assert!(
+                (bottom_y - 650.0).abs() < f64::EPSILON,
+                "bottom_y must echo back the requested floor"
+            );
+        }
+        other => panic!("expected PdfError::TableOverflow, got {:?}", other),
+    }
+
+    // Critical invariant: pre-flight Err must NOT draw anything.
+    let ops = page.graphics().get_operations();
+    assert_eq!(
+        count_tj(ops),
+        0,
+        "render_strict must not emit any Tj before returning Err, got: {}",
+        ops
+    );
+}
+
+#[test]
+fn render_strict_succeeds_when_everything_fits() {
+    let mut table = fixed_height_table(5, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    table
+        .render_strict(page.graphics(), 0.0)
+        .expect("render_strict must succeed when everything fits");
+
+    let ops = page.graphics().get_operations();
+    assert_eq!(count_tj(ops), 10);
+}
+
+#[test]
+fn add_paginated_table_grows_pages_and_renders_every_row() {
+    // 100 data rows + 1 header. Row height 30. Page A4 (842 tall).
+    // Position y=800, bottom_margin=50 → ~25 rows per page; 100 rows → 4-5 pages.
+    let mut doc = Document::new();
+    let page = Page::a4();
+    doc.add_page(page);
+
+    let table = fixed_height_table_with_header(100, 30.0);
+    let (final_page_idx, final_y) = doc
+        .add_paginated_table(0, &table, 50.0, 800.0, 50.0, 800.0)
+        .expect("add_paginated_table must succeed");
+
+    assert!(
+        doc.page_count() > 1,
+        "should have allocated extra pages, got page_count={}",
+        doc.page_count()
+    );
+    assert_eq!(
+        final_page_idx,
+        doc.page_count() - 1,
+        "returned page index must point at the last page used"
+    );
+    assert!(
+        final_y > 0.0 && final_y < 800.0,
+        "final cursor y must be inside the last page below the start, got {final_y}"
+    );
+
+    // Sum data-row hits across all pages — each "rNcM" must appear exactly once.
+    for i in 0..100 {
+        let needle = format!("r{i}c0");
+        let total: usize = (0..doc.page_count())
+            .map(|p| {
+                doc.page(p)
+                    .unwrap()
+                    .graphics_operations()
+                    .matches(&needle)
+                    .count()
+            })
+            .sum();
+        assert_eq!(
+            total, 1,
+            "data row {i} must be drawn exactly once across all pages, got {total}"
+        );
+    }
+
+    // With repeat_header_on_split = true (default), header must appear on EVERY page used.
+    for p in 0..doc.page_count() {
+        let ops = doc.page(p).unwrap().graphics_operations();
+        assert!(
+            ops.contains("H0") && ops.contains("H1"),
+            "page {p} must contain repeated header (H0,H1)"
+        );
+    }
+}
+
+#[test]
+fn add_paginated_table_does_not_repeat_header_when_disabled() {
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+
+    let mut table = fixed_height_table_with_header(100, 30.0);
+    let mut options = TableOptions {
+        row_height: 30.0,
+        ..TableOptions::default()
+    };
+    options.repeat_header_on_split = false;
+    table.set_options(options);
+    // re-add header & rows since set_options after add_row keeps them; nothing to re-do here,
+    // but defensively rebuild to ensure options propagate to existing data isn't stale.
+    // (set_options only swaps the options struct, rows are untouched.)
+
+    let _ = doc
+        .add_paginated_table(0, &table, 50.0, 800.0, 50.0, 800.0)
+        .expect("add_paginated_table must succeed");
+
+    assert!(doc.page_count() > 1);
+
+    // Header must appear ONLY on page 0.
+    let page0 = doc.page(0).unwrap().graphics_operations().to_string();
+    assert!(
+        page0.contains("H0") && page0.contains("H1"),
+        "page 0 must have the header"
+    );
+    for p in 1..doc.page_count() {
+        let ops = doc.page(p).unwrap().graphics_operations();
+        assert!(
+            !ops.contains("H0") && !ops.contains("H1"),
+            "page {p} must NOT contain header when repeat_header_on_split=false; ops:\n{ops}"
+        );
+    }
+}
+
+#[test]
+fn add_paginated_table_errs_when_table_cannot_fit_on_a_blank_page() {
+    // Single row of height 1000pt on A4 (842) — even a fresh page can't hold it.
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+
+    let table = fixed_height_table(1, 1000.0);
+    let err = doc
+        .add_paginated_table(0, &table, 50.0, 800.0, 50.0, 800.0)
+        .expect_err("must Err when row is taller than any page");
+
+    match err {
+        PdfError::TableOverflow { .. } => {}
+        other => panic!("expected TableOverflow, got {:?}", other),
+    }
+}
+
+#[test]
+fn render_back_compat_silently_overflows_unchanged() {
+    // Lock the regression contract for issue #218: existing `render(...)` keeps its
+    // original behaviour (silent vertical overflow) so 2.x consumers don't break.
+    let mut table = fixed_height_table(50, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    table
+        .render(page.graphics())
+        .expect("legacy render must still return Ok");
+
+    let ops = page.graphics().get_operations();
+    // All 50 rows must be drawn regardless of the page boundary.
+    assert_eq!(
+        count_tj(ops),
+        100,
+        "legacy render must keep silently drawing past page bottom (50 rows × 2 cells)"
+    );
+    assert!(ops.contains("r49c0"), "even the last row must be emitted");
+}
+
+#[test]
+fn add_paginated_table_rejects_header_heavy_dos_input() {
+    // Regression for F1 (security review): a table whose leading headers
+    // consume an entire page must NOT trigger unbounded page allocation.
+    // If headers fit but no data row advances, the previous progress check
+    // (`tail.row_count() < current_table.row_count()`) was satisfied because
+    // re-prepending headers on the next iteration inflated the count without
+    // making real progress. A correct implementation compares *data* rows.
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+
+    // 30 header rows × 30pt = 900pt of headers, taller than A4 (842pt).
+    // So no header row even fits below a 50pt floor on a 842pt page either:
+    // even on a fresh page only some headers fit and zero data rows do.
+    let mut table = Table::with_equal_columns(2, 200.0);
+    let options = TableOptions {
+        row_height: 30.0,
+        ..TableOptions::default()
+    };
+    table.set_options(options);
+    for i in 0..30 {
+        table
+            .add_header_row(vec![format!("H{i}A"), format!("H{i}B")])
+            .unwrap();
+    }
+    table
+        .add_row(vec!["data".to_string(), "row".to_string()])
+        .unwrap();
+
+    let initial_page_count = doc.page_count();
+    let err = doc
+        .add_paginated_table(0, &table, 50.0, 800.0, 50.0, 800.0)
+        .expect_err("must Err — no data row can advance");
+
+    match err {
+        PdfError::TableOverflow { .. } => {}
+        other => panic!("expected TableOverflow, got {:?}", other),
+    }
+
+    // Critical bound: the implementation must not have allocated dozens of
+    // pages before returning. A small bounded growth (≤ 3 pages) is acceptable
+    // because the first page renders some headers; the failure must be
+    // detected on the next iteration.
+    let pages_added = doc.page_count() - initial_page_count;
+    assert!(
+        pages_added <= 3,
+        "DoS guard failed: {pages_added} pages allocated before TableOverflow returned (cap=3)"
+    );
+}
+
+#[test]
+fn render_with_split_rejects_non_finite_bottom_y() {
+    // Regression for F2 (security review): NaN/±∞ for `bottom_y` must NOT
+    // bypass overflow checks. NaN comparisons silently return `false`, so
+    // an unchecked NaN would make `fit_count` declare every row as fitting
+    // and silently render off-page — defeating the entire #218 control.
+    let mut table = fixed_height_table(5, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let result = table.render_with_split(page.graphics(), bad);
+        match result {
+            Err(PdfError::InvalidStructure(msg)) => {
+                assert!(
+                    msg.contains("bottom_y"),
+                    "error must name the bad parameter, got: {msg}"
+                );
+            }
+            other => panic!(
+                "expected InvalidStructure for bottom_y={bad}, got {:?}",
+                other
+            ),
+        }
+    }
+
+    // Critical: no Tj operators emitted for any of the rejected calls.
+    assert_eq!(
+        count_tj(page.graphics().get_operations()),
+        0,
+        "non-finite bottom_y must not draw anything"
+    );
+}
+
+#[test]
+fn render_strict_rejects_non_finite_bottom_y() {
+    let mut table = fixed_height_table(5, 30.0);
+    table.set_position(50.0, 800.0);
+
+    let mut page = Page::a4();
+    let err = table
+        .render_strict(page.graphics(), f64::NAN)
+        .expect_err("NaN bottom_y must be rejected");
+    assert!(matches!(err, PdfError::InvalidStructure(_)));
+    assert_eq!(count_tj(page.graphics().get_operations()), 0);
+}
+
+#[test]
+fn add_paginated_table_rejects_non_finite_floats() {
+    let mut doc = Document::new();
+    doc.add_page(Page::a4());
+    let table = fixed_height_table(5, 30.0);
+
+    let cases = [
+        (f64::NAN, 800.0, 50.0, 800.0, "x"),
+        (50.0, f64::NAN, 50.0, 800.0, "y"),
+        (50.0, 800.0, f64::INFINITY, 800.0, "bottom_y"),
+        (50.0, 800.0, 50.0, f64::NEG_INFINITY, "next_page_y"),
+    ];
+    for (x, y, bottom_y, next_y, name) in cases {
+        let err = doc
+            .add_paginated_table(0, &table, x, y, bottom_y, next_y)
+            .expect_err(&format!("{name} must be rejected"));
+        match err {
+            PdfError::InvalidStructure(msg) => assert!(
+                msg.contains(name),
+                "error message must name the bad parameter `{name}`, got: {msg}"
+            ),
+            other => panic!("expected InvalidStructure for bad {name}, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn page_tables_add_simple_table_unchanged() {
+    // Smoke regression on the unchanged trait method to ensure the new API
+    // additions don't break the existing `add_simple_table` integration.
+    let mut page = Page::a4();
+    let mut table = fixed_height_table(3, 30.0);
+    table.set_position(50.0, 800.0);
+
+    page.add_simple_table(&table, 50.0, 800.0)
+        .expect("add_simple_table must still succeed");
+
+    let ops = page.graphics().get_operations();
+    assert_eq!(count_tj(ops), 6, "3 rows × 2 cells");
+}


### PR DESCRIPTION
## Summary

Addresses #218 (Table::render silent vertical overflow / data loss). Adds 3 layers of API, all additive — zero breaking changes.

### New APIs

1. **Primitive** — `Table::render_with_split(graphics, bottom_y) -> Result<Option<Table>, PdfError>`
   Renders rows that fit above `bottom_y`; returns `Some(tail)` with the remainder (same `column_widths`/`options`) or `None` if everything fit.

2. **Strict** — `Table::render_strict(graphics, bottom_y) -> Result<(), PdfError>`
   Pre-flight check: if any row would overflow, returns `Err(PdfError::TableOverflow{rendered, dropped, bottom_y})` without drawing.

3. **Batteries-included** — `DocumentTables::add_paginated_table(starting_page_idx, table, x, y, bottom_y, next_page_y)` (new trait on `Document`).
   Allocates continuation pages and optionally repeats headers (`TableOptions::repeat_header_on_split`, default `true`).

### Auxiliary additive APIs
- `PdfError::TableOverflow { rendered, dropped, bottom_y }`
- `Table::row_count`, `header_count`, `position`, `options`
- `Page::graphics_operations(&self) -> &str` (read-only counterpart of `graphics()`)
- `Document::page(idx)`, `Document::page_mut(idx)`
- `error::ensure_finite()` helper (`pub(crate)`)

### Back-compat
`Table::render` unchanged. Refactor extracts a private `render_rows_slice` shared between the legacy render and the new APIs. Lock-in test `render_back_compat_silently_overflows_unchanged` guards the legacy behaviour.

### TDD discipline
7 RED tests written first, watching-fail confirmed (15 compilation errors pointing at the missing APIs). Implementation then GREEN incrementally.

### Pre-commit reviews applied (in same commit)
- **quality-rust** — 1 BLOCKER + 2 MAJOR.
- **security-expert-advisor** — 2 HIGH (F1 DoS via header-heavy input, F2 NaN/inf bypass), both with verified exploit paths.

Findings applied:
- **F1 (HIGH)**: progress check now compares *data-row counts* (`row_count - header_count`) instead of raw rows. Header-heavy input no longer grows tail without bound — `TableOverflow` returned immediately if no data row advances.
- **F2 (HIGH)**: `ensure_finite` applied in `render_with_split`/`render_strict`/`add_paginated_table` for `x`, `y`, `bottom_y`, `next_page_y`. Without it, `NaN < bottom_y` is always `false` → silent off-page render.
- **F4 (LOW)**: `prepend_headers_from` reduced to `pub(crate)`.
- **Quality NIT 7**: `render_strict` no longer calls `self.render()`. Calls `render_rows_slice` directly — drops the `NEG_INFINITY` sentinel entirely.
- **Quality MAJOR 2**: doc strengthening of `render_with_split` re: tail `position.y = 0.0` sentinel.

### Tests
- `tests/table_pagination_test.rs`: 13/13 GREEN (9 originals + 4 regression tests from reviews). All content-verifying.
- Lib suite: 6328/6328 GREEN.
- `cargo clippy --all -- -D warnings` clean.

## Test plan
- [x] 13/13 content-verifying tests in `tests/table_pagination_test.rs`
- [x] 6328/6328 lib unit tests
- [x] `cargo clippy --all -- -D warnings`
- [ ] CI on PR: Ubuntu / Windows / macOS + T0+T1 corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)