### PR TITLE
fix(tables): TableStyle header typography overrides — addresses #217

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+- **`PageTables::add_styled_table` now correctly marks the header row as a header** (addresses #217). The convenience method appended the headers via `add_row`, which sets `is_header: false`. The `Table::render` path then skipped the configured `HeaderStyle` entirely (`use_header_style = row.is_header && …`) and the header was drawn with the default data-row font. Calling `add_header_row` instead applies the configured `HeaderStyle` as documented. Visible rendering change for `TableStyle::professional()` and `TableStyle::colorful()` callers: the header row now renders in `Helvetica-Bold` (the `HeaderStyle` default) rather than plain `Helvetica`.
+
+### Added
+- **`TableStyle::header_font: Option<Font>`** and **`TableStyle::header_bold: Option<bool>`** (addresses #217). Optional overrides for header typography; both default to `None`, in which case the legacy hardcoded `Font::Helvetica` + `bold: true` apply. The `add_styled_table` header-style gate now also fires on either of these so `TableStyle::minimal()` / `simple()` callers can override typography without having to also set a background colour.
+- **`TableStyle::with_header_font(font)`** and **`TableStyle::with_header_bold(bold)`** chainable setters for ergonomic preset overrides: `TableStyle::professional().with_header_font(Font::TimesRoman)`.
+- 11 content-verifying integration tests in `tests/issue_217_tablestyle_header_typography_test.rs` covering preset defaults, override behaviour (Times-Bold, non-bold Helvetica, Courier-Bold, Helvetica-Oblique pass-through), preset chaining, and the gate for typography-only overrides.
+
 ## [2.5.7] - 2026-04-23
 
 Single-fix patch release for the font subsetter, plus hardening of the internal content-stream API to prevent the same class of silent regression.

--- a/oxidize-pdf-core/src/page_tables.rs
+++ b/oxidize-pdf-core/src/page_tables.rs
@@ -44,6 +44,15 @@ pub struct TableStyle {
     pub header_text_color: Option<Color>,
     /// Default font size
     pub font_size: f64,
+    /// Header font override. `None` keeps the legacy default (`Font::Helvetica`).
+    /// See [issue #217](https://github.com/bzsanti/oxidizePdf/issues/217).
+    pub header_font: Option<Font>,
+    /// Header bold override. `None` keeps the legacy default (`true`).
+    /// Combined with `header_font`, the rendering layer maps non-oblique
+    /// builtin fonts to their `*Bold` variant (e.g. `TimesRoman` + `bold=true`
+    /// → `TimesBold`); oblique fonts and custom fonts are passed through
+    /// unchanged.
+    pub header_bold: Option<bool>,
 }
 
 impl TableStyle {
@@ -53,6 +62,8 @@ impl TableStyle {
             header_background: None,
             header_text_color: None,
             font_size: 10.0,
+            header_font: None,
+            header_bold: None,
         }
     }
 
@@ -62,6 +73,8 @@ impl TableStyle {
             header_background: None,
             header_text_color: None,
             font_size: 10.0,
+            header_font: None,
+            header_bold: None,
         }
     }
 
@@ -71,6 +84,8 @@ impl TableStyle {
             header_background: Some(Color::gray(0.1)),
             header_text_color: Some(Color::white()),
             font_size: 10.0,
+            header_font: None,
+            header_bold: None,
         }
     }
 
@@ -80,7 +95,34 @@ impl TableStyle {
             header_background: Some(Color::rgb(0.2, 0.4, 0.8)),
             header_text_color: Some(Color::white()),
             font_size: 10.0,
+            header_font: None,
+            header_bold: None,
         }
+    }
+
+    /// Override the header font. Chainable on presets.
+    ///
+    /// ```
+    /// use oxidize_pdf::page_tables::TableStyle;
+    /// use oxidize_pdf::text::Font;
+    /// let style = TableStyle::professional().with_header_font(Font::TimesRoman);
+    /// assert_eq!(style.header_font, Some(Font::TimesRoman));
+    /// ```
+    pub fn with_header_font(mut self, font: Font) -> Self {
+        self.header_font = Some(font);
+        self
+    }
+
+    /// Override the header bold flag. Chainable on presets.
+    ///
+    /// ```
+    /// use oxidize_pdf::page_tables::TableStyle;
+    /// let style = TableStyle::simple().with_header_bold(false);
+    /// assert_eq!(style.header_bold, Some(false));
+    /// ```
+    pub fn with_header_bold(mut self, bold: bool) -> Self {
+        self.header_bold = Some(bold);
+        self
     }
 }
 
@@ -135,14 +177,22 @@ impl PageTables for Page {
         // Create a simple table with the given style
         let mut table = Table::with_equal_columns(num_columns, width);
 
-        // Create table options based on style
-        let header_style = if style.header_background.is_some() || style.header_text_color.is_some()
+        // Create table options based on style.
+        //
+        // The header gate now also fires on `header_font` / `header_bold`
+        // overrides — without this, a caller picking `TableStyle::minimal()`
+        // (where both colour fields are `None`) and overriding only the font
+        // would have their request silently ignored.
+        let header_style = if style.header_background.is_some()
+            || style.header_text_color.is_some()
+            || style.header_font.is_some()
+            || style.header_bold.is_some()
         {
             Some(HeaderStyle {
                 background_color: style.header_background.unwrap_or(Color::white()),
                 text_color: style.header_text_color.unwrap_or(Color::black()),
-                font: Font::Helvetica,
-                bold: true,
+                font: style.header_font.clone().unwrap_or(Font::Helvetica),
+                bold: style.header_bold.unwrap_or(true),
             })
         } else {
             None
@@ -156,8 +206,12 @@ impl PageTables for Page {
 
         table.set_options(options);
 
-        // Add header row
-        table.add_row(headers)?;
+        // Add header row — `add_header_row` (not `add_row`) sets
+        // `is_header: true`. Without it the row is treated as data and the
+        // configured `HeaderStyle` is never applied at render time
+        // (see `Table::render`'s `use_header_style = row.is_header && …`
+        // guard). This was a pre-existing bug surfaced while fixing #217.
+        table.add_header_row(headers)?;
 
         // Add data rows
         for row_data in data {

--- a/oxidize-pdf-core/tests/issue_217_tablestyle_header_typography_test.rs
+++ b/oxidize-pdf-core/tests/issue_217_tablestyle_header_typography_test.rs
@@ -1,0 +1,191 @@
+//! Integration tests for `TableStyle` header-typography overrides — issue #217.
+//!
+//! Before this fix, `add_styled_table` hardcoded `Font::Helvetica` + `bold: true`
+//! at the call-site that builds `HeaderStyle`. None of the four presets
+//! (`minimal` / `simple` / `professional` / `colorful`) could override this.
+//!
+//! The tests verify content-stream output, never just absence of crash.
+
+use oxidize_pdf::page_tables::{PageTables, TableStyle};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::Page;
+
+// ---------- helpers ----------
+
+fn render_styled_table_and_get_ops(style: TableStyle) -> String {
+    let mut page = Page::a4();
+    page.add_styled_table(
+        vec!["Item".into(), "Qty".into()],
+        vec![vec!["Widget".into(), "2".into()]],
+        50.0,
+        700.0,
+        400.0,
+        style,
+    )
+    .expect("add_styled_table must succeed");
+    page.graphics().get_operations().to_string()
+}
+
+// ---------- spec-compliance defaults ----------
+//
+// Pre-fix, `add_styled_table` called `add_row(headers)` (not `add_header_row`),
+// so `HeaderStyle` was *never* applied — the header rendered in plain
+// `/Helvetica`. The two tests below lock in the fixed default (Helvetica-Bold
+// for the bundled presets that supply colour fields) so a future regression
+// to `add_row` is caught.
+
+#[test]
+fn default_professional_preset_emits_helvetica_bold_header() {
+    let ops = render_styled_table_and_get_ops(TableStyle::professional());
+    assert!(
+        ops.contains("/Helvetica-Bold"),
+        "professional preset must default to /Helvetica-Bold for the header; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn default_colorful_preset_emits_helvetica_bold_header() {
+    let ops = render_styled_table_and_get_ops(TableStyle::colorful());
+    assert!(
+        ops.contains("/Helvetica-Bold"),
+        "colorful preset must default to /Helvetica-Bold for the header; ops:\n{ops}"
+    );
+}
+
+// ---------- new fields directly settable ----------
+
+#[test]
+fn header_font_override_to_times_roman_with_bold_emits_times_bold() {
+    // Times-Roman + bold=true → Times-Bold (per existing HeaderStyle bold→variant
+    // mapping in table.rs:625-628).
+    let style = TableStyle {
+        header_font: Some(Font::TimesRoman),
+        header_bold: Some(true),
+        ..TableStyle::professional()
+    };
+    let ops = render_styled_table_and_get_ops(style);
+    assert!(
+        ops.contains("/Times-Bold"),
+        "header_font=TimesRoman + header_bold=true must emit /Times-Bold; ops:\n{ops}"
+    );
+    assert!(
+        !ops.contains("/Helvetica-Bold"),
+        "header_font override must replace default /Helvetica-Bold; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn header_bold_false_with_helvetica_emits_helvetica_not_helvetica_bold() {
+    // Helvetica + bold=false → Helvetica (no bold variant). The data row also
+    // renders Helvetica, so the assertion is "emits /Helvetica AND never
+    // /Helvetica-Bold". This is the regression for the hardcoded `bold: true`.
+    let style = TableStyle {
+        header_font: Some(Font::Helvetica),
+        header_bold: Some(false),
+        ..TableStyle::professional()
+    };
+    let ops = render_styled_table_and_get_ops(style);
+    assert!(
+        ops.contains("/Helvetica"),
+        "must emit /Helvetica; ops:\n{ops}"
+    );
+    assert!(
+        !ops.contains("/Helvetica-Bold"),
+        "header_bold=false must NOT emit /Helvetica-Bold; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn header_font_courier_with_bold_emits_courier_bold() {
+    let style = TableStyle {
+        header_font: Some(Font::Courier),
+        header_bold: Some(true),
+        ..TableStyle::professional()
+    };
+    let ops = render_styled_table_and_get_ops(style);
+    assert!(
+        ops.contains("/Courier-Bold"),
+        "Courier + bold=true must emit /Courier-Bold; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn header_font_oblique_with_bold_preserves_oblique_variant() {
+    // HelveticaOblique is not in the bold→variant mapping match arms (only
+    // Helvetica/TimesRoman/Courier are). The fallthrough `_ => style.font`
+    // means an oblique font stays oblique even with bold=true. This locks
+    // that behaviour: setting header_font=HelveticaOblique must NOT collapse
+    // back to Helvetica-Bold.
+    let style = TableStyle {
+        header_font: Some(Font::HelveticaOblique),
+        header_bold: Some(true),
+        ..TableStyle::professional()
+    };
+    let ops = render_styled_table_and_get_ops(style);
+    assert!(
+        ops.contains("/Helvetica-Oblique"),
+        "Oblique font must be preserved; ops:\n{ops}"
+    );
+}
+
+// ---------- presets default to None for typography overrides ----------
+
+#[test]
+fn all_presets_default_header_typography_overrides_to_none() {
+    for (name, style) in [
+        ("minimal", TableStyle::minimal()),
+        ("simple", TableStyle::simple()),
+        ("professional", TableStyle::professional()),
+        ("colorful", TableStyle::colorful()),
+    ] {
+        assert!(
+            style.header_font.is_none(),
+            "{name}: header_font must default to None so callers can override"
+        );
+        assert!(
+            style.header_bold.is_none(),
+            "{name}: header_bold must default to None so callers can override"
+        );
+    }
+}
+
+// ---------- builder methods (ergonomic chaining on presets) ----------
+
+#[test]
+fn with_header_font_sets_field_and_chains() {
+    let style = TableStyle::professional().with_header_font(Font::TimesRoman);
+    assert_eq!(style.header_font, Some(Font::TimesRoman));
+    // Chain preserves other preset fields:
+    assert!(style.header_background.is_some());
+    assert!(style.header_text_color.is_some());
+}
+
+#[test]
+fn with_header_bold_sets_field_and_chains() {
+    let style = TableStyle::simple().with_header_bold(false);
+    assert_eq!(style.header_bold, Some(false));
+}
+
+#[test]
+fn builder_chain_full_typography_override() {
+    let style = TableStyle::professional()
+        .with_header_font(Font::TimesRoman)
+        .with_header_bold(false);
+    assert_eq!(style.header_font, Some(Font::TimesRoman));
+    assert_eq!(style.header_bold, Some(false));
+}
+
+// ---------- preset chained override actually renders correctly ----------
+
+#[test]
+fn professional_preset_with_times_bold_override_renders_times_bold() {
+    // End-to-end: pick a preset, override only the typography, render, verify.
+    let style = TableStyle::professional()
+        .with_header_font(Font::TimesRoman)
+        .with_header_bold(true);
+    let ops = render_styled_table_and_get_ops(style);
+    assert!(
+        ops.contains("/Times-Bold"),
+        "professional + Times-Bold override must emit /Times-Bold; ops:\n{ops}"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses #217 (TableStyle has no `header_font` / `header_bold`; `add_styled_table` hardcodes Helvetica + bold). Two fixes in one commit:

### 1. API gap (the reported issue)

`TableStyle` gains two optional header-typography fields plus chainable setters:

```rust
pub struct TableStyle {
    // existing:
    pub header_background: Option<Color>,
    pub header_text_color: Option<Color>,
    pub font_size: f64,
    // new:
    pub header_font: Option<Font>,
    pub header_bold: Option<bool>,
}

impl TableStyle {
    pub fn with_header_font(mut self, font: Font) -> Self { … }
    pub fn with_header_bold(mut self, bold: bool) -> Self { … }
}
```

Both default to `None`, in which case the legacy hardcoded `Font::Helvetica` + `bold: true` apply. The header-style gate in `add_styled_table` now also fires on either of these so `TableStyle::minimal()` / `simple()` callers can override typography without having to also set a background colour.

Usage:
```rust
let style = TableStyle::professional()
    .with_header_font(Font::TimesRoman)
    .with_header_bold(true);
page.add_styled_table(headers, data, x, y, w, style)?;
// Header now renders in /Times-Bold.
```

### 2. Pre-existing rendering bug surfaced while fixing the gap

`add_styled_table` was calling `Table::add_row(headers)` instead of `add_header_row(headers)`. `add_row` sets `is_header: false`, and `Table::render`'s `use_header_style = row.is_header && …` guard then skipped the configured `HeaderStyle` entirely — so the header rendered in plain `/Helvetica` even with `TableStyle::professional()`, contrary to the method's documented contract.

**Visible behaviour change**: header now correctly renders in `/Helvetica-Bold` (the `HeaderStyle` default) for `TableStyle::professional()` and `TableStyle::colorful()` callers, as the API was always supposed to do. Documented in CHANGELOG under `### Fixed`.

### Why `header_italic` was dropped

The issue's "proposed fix" suggested `header_italic: Option<bool>` "consistent with HeaderStyle" — but `HeaderStyle` does not actually have an italic field. Italic is reachable today via `Font::HelveticaOblique` / `Font::TimesItalic` etc., and the existing fallthrough arm in `Table::render`'s bold→variant mapping preserves any non-plain font (test `header_font_oblique_with_bold_preserves_oblique_variant` locks this).

### TDD discipline

11 RED tests written first, watching-fail confirmed (14 compilation errors pointing exactly at the missing API). Implementation GREEN incremental. The pre-existing `add_row` bug was caught by the back-compat tests failing — they expected `/Helvetica-Bold` but the content stream emitted plain `/Helvetica`. Fixed at root cause (use `add_header_row`).

### Pre-commit reviews applied
- **quality-rust**: ship-with-followup. Pre-merge findings (doc-example `ignore` tag → real doc-test, CHANGELOG entry) applied. Non-blocking follow-ups: `with_header_background`/`with_header_text_color` for symmetry, extract bold→variant mapping helper, `PartialEq` derive on `TableStyle`.
- **security-expert-advisor**: ship. No new attack surface — typed enum + bool only, gate is O(1), `add_row` → `add_header_row` is strictly narrower (flips one bool, no parsing/validation widening). Pre-existing `Font::Custom(String)` ISO 32000-1 §7.3.5 escape concern noted but out of scope (pre-dates and outscopes this PR).

### Tests
- 11/11 GREEN in `tests/issue_217_tablestyle_header_typography_test.rs` (content-verifying — assert on `page.graphics().get_operations()` content for `/Helvetica-Bold`, `/Times-Bold`, `/Helvetica`, `/Helvetica-Oblique`, `/Courier-Bold`)
- 6328/6328 lib unit tests GREEN
- 2/2 new doc-tests GREEN
- `cargo clippy --all -- -D warnings` clean

## Test plan
- [x] 11/11 content-verifying tests in `tests/issue_217_tablestyle_header_typography_test.rs`
- [x] 6328/6328 lib unit tests
- [x] 2/2 doc-tests for chainable setters
- [x] `cargo clippy --all -- -D warnings`
- [ ] CI on PR: Ubuntu / Windows / macOS + T0+T1 corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)