### PR TITLE
fix(graphics): sanitize non-finite floats in colour emission via shared helper — addresses #220, #221

### DIFF
--- a/oxidize-pdf-core/src/annotations/annotation_type.rs
+++ b/oxidize-pdf-core/src/annotations/annotation_type.rs
@@ -38,11 +38,10 @@ impl FreeTextAnnotation {
 
     /// Set font and size
     pub fn with_font(mut self, font: Font, size: f64, color: Color) -> Self {
-        let color_str = match color {
-            Color::Gray(g) => format!("{g} g"),
-            Color::Rgb(r, g, b) => format!("{r} {g} {b} rg"),
-            Color::Cmyk(c, m, y, k) => format!("{c} {m} {y} {k} k"),
-        };
+        // Use the shared NaN-sanitising helper (issues #220, #221) — emits
+        // `.3`-precision tokens so the /DA string never carries
+        // `NaN`/`inf` that ISO 32000-1 §7.3.3 rejects.
+        let color_str = crate::graphics::color::fill_color_op(color);
 
         self.default_appearance = format!("/{} {size} Tf {color_str}", font.pdf_name());
         self

--- a/oxidize-pdf-core/src/annotations/geometric.rs
+++ b/oxidize-pdf-core/src/annotations/geometric.rs
@@ -360,23 +360,15 @@ impl GeometricAppearance {
         // Set border width
         stream.extend(format!("{} w\n", border_width).as_bytes());
 
-        // Set colors
+        // Set colors. Routed through the shared sanitising helpers
+        // (issues #220 + #221) so /AP appearance streams cannot emit
+        // NaN/inf tokens that ISO 32000-1 §7.3.3 rejects.
         if let Some(color) = interior_color {
-            let fill_op = match color {
-                Color::Gray(g) => format!("{} g\n", g),
-                Color::Rgb(r, g, b) => format!("{} {} {} rg\n", r, g, b),
-                Color::Cmyk(c, m, y, k) => format!("{} {} {} {} k\n", c, m, y, k),
-            };
-            stream.extend(fill_op.as_bytes());
+            crate::graphics::color::write_fill_color_bytes(&mut stream, *color);
         }
 
         if let Some(color) = border_color {
-            let stroke_op = match color {
-                Color::Gray(g) => format!("{} G\n", g),
-                Color::Rgb(r, g, b) => format!("{} {} {} RG\n", r, g, b),
-                Color::Cmyk(c, m, y, k) => format!("{} {} {} {} K\n", c, m, y, k),
-            };
-            stream.extend(stroke_op.as_bytes());
+            crate::graphics::color::write_stroke_color_bytes(&mut stream, *color);
         }
 
         // Draw circle using Bézier curves
@@ -467,23 +459,15 @@ impl GeometricAppearance {
         // Set border width
         stream.extend(format!("{} w\n", border_width).as_bytes());
 
-        // Set colors
+        // Set colors. Routed through the shared sanitising helpers
+        // (issues #220 + #221) so /AP appearance streams cannot emit
+        // NaN/inf tokens that ISO 32000-1 §7.3.3 rejects.
         if let Some(color) = interior_color {
-            let fill_op = match color {
-                Color::Gray(g) => format!("{} g\n", g),
-                Color::Rgb(r, g, b) => format!("{} {} {} rg\n", r, g, b),
-                Color::Cmyk(c, m, y, k) => format!("{} {} {} {} k\n", c, m, y, k),
-            };
-            stream.extend(fill_op.as_bytes());
+            crate::graphics::color::write_fill_color_bytes(&mut stream, *color);
         }
 
         if let Some(color) = border_color {
-            let stroke_op = match color {
-                Color::Gray(g) => format!("{} G\n", g),
-                Color::Rgb(r, g, b) => format!("{} {} {} RG\n", r, g, b),
-                Color::Cmyk(c, m, y, k) => format!("{} {} {} {} K\n", c, m, y, k),
-            };
-            stream.extend(stroke_op.as_bytes());
+            crate::graphics::color::write_stroke_color_bytes(&mut stream, *color);
         }
 
         // Draw rectangle

--- a/oxidize-pdf-core/src/forms/appearance.rs
+++ b/oxidize-pdf-core/src/forms/appearance.rs
@@ -339,21 +339,13 @@ impl TextFieldAppearance {
 
         // Draw background if specified
         if let Some(bg_color) = &widget.appearance.background_color {
-            match bg_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, *bg_color);
             content.push_str(&format!("0 0 {width} {height} re f\n"));
         }
 
         // Draw border
         if let Some(border_color) = &widget.appearance.border_color {
-            match border_color {
-                Color::Gray(g) => content.push_str(&format!("{g} G\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} RG\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} K\n")),
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
 
             match widget.appearance.border_style {
@@ -377,11 +369,7 @@ impl TextFieldAppearance {
         // Draw text if value is provided
         if let Some(text) = value {
             // Set text color
-            match self.text_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, self.text_color);
 
             // Begin text
             content.push_str("BT\n");
@@ -528,21 +516,13 @@ impl AppearanceGenerator for CheckBoxAppearance {
 
         // Draw background
         if let Some(bg_color) = &widget.appearance.background_color {
-            match bg_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, *bg_color);
             content.push_str(&format!("0 0 {width} {height} re f\n"));
         }
 
         // Draw border
         if let Some(border_color) = &widget.appearance.border_color {
-            match border_color {
-                Color::Gray(g) => content.push_str(&format!("{g} G\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} RG\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} K\n")),
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
             content.push_str(&format!("0 0 {width} {height} re S\n"));
         }
@@ -550,11 +530,7 @@ impl AppearanceGenerator for CheckBoxAppearance {
         // Draw check mark if checked
         if is_checked {
             // Set check color
-            match self.check_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, self.check_color);
 
             let inset = width * 0.2;
 
@@ -694,13 +670,9 @@ impl AppearanceGenerator for RadioButtonAppearance {
 
         // Draw background circle
         if let Some(bg_color) = &widget.appearance.background_color {
-            match bg_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, *bg_color);
         } else {
-            content.push_str("1 g\n"); // White background
+            crate::graphics::color::write_fill_color(&mut content, Color::Gray(1.0));
         }
 
         let cx = width / 2.0;
@@ -750,11 +722,7 @@ impl AppearanceGenerator for RadioButtonAppearance {
 
         // Draw border
         if let Some(border_color) = &widget.appearance.border_color {
-            match border_color {
-                Color::Gray(g) => content.push_str(&format!("{g} G\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} RG\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} K\n")),
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
 
             content.push_str(&format!("{} {} m\n", cx + r, cy));
@@ -799,11 +767,7 @@ impl AppearanceGenerator for RadioButtonAppearance {
 
         // Draw inner dot if selected
         if is_selected {
-            match self.selected_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, self.selected_color);
 
             let inner_r = r * 0.4;
             content.push_str(&format!("{} {} m\n", cx + inner_r, cy));
@@ -903,11 +867,7 @@ impl AppearanceGenerator for PushButtonAppearance {
                 .unwrap_or(Color::gray(0.9)),
         };
 
-        match bg_color {
-            Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-            Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-            Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-        }
+        crate::graphics::color::write_fill_color(&mut content, bg_color);
         content.push_str(&format!("0 0 {width} {height} re f\n"));
 
         // Draw beveled border for button appearance
@@ -925,11 +885,7 @@ impl AppearanceGenerator for PushButtonAppearance {
         } else {
             // Regular border
             if let Some(border_color) = &widget.appearance.border_color {
-                match border_color {
-                    Color::Gray(g) => content.push_str(&format!("{g} G\n")),
-                    Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} RG\n")),
-                    Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} K\n")),
-                }
+                crate::graphics::color::write_stroke_color(&mut content, *border_color);
                 content.push_str(&format!("{} w\n", widget.appearance.border_width));
                 content.push_str(&format!("0 0 {width} {height} re S\n"));
             }
@@ -937,11 +893,7 @@ impl AppearanceGenerator for PushButtonAppearance {
 
         // Draw label text
         if !self.label.is_empty() {
-            match self.text_color {
-                Color::Gray(g) => content.push_str(&format!("{g} g\n")),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{r} {g} {b} rg\n")),
-                Color::Cmyk(c, m, y, k) => content.push_str(&format!("{c} {m} {y} {k} k\n")),
-            }
+            crate::graphics::color::write_fill_color(&mut content, self.text_color);
 
             content.push_str("BT\n");
             content.push_str(&format!(
@@ -1047,19 +999,13 @@ impl ComboBoxAppearance {
         let mut used_chars_per_font: HashMap<String, HashSet<char>> = HashMap::new();
 
         // Draw background
-        content.push_str("1 1 1 rg\n"); // White background
+        crate::graphics::color::write_fill_color(&mut content, Color::white());
         content.push_str(&format!("0 0 {} {} re\n", width, height));
         content.push_str("f\n");
 
         // Draw border
         if let Some(ref border_color) = widget.appearance.border_color {
-            match border_color {
-                Color::Gray(g) => content.push_str(&format!("{} G\n", g)),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{} {} {} RG\n", r, g, b)),
-                Color::Cmyk(c, m, y, k) => {
-                    content.push_str(&format!("{} {} {} {} K\n", c, m, y, k))
-                }
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
             content.push_str(&format!("0 0 {} {} re\n", width, height));
             content.push_str("S\n");
@@ -1069,7 +1015,7 @@ impl ComboBoxAppearance {
         if self.show_arrow {
             let arrow_x = width - 15.0;
             let arrow_y = height / 2.0;
-            content.push_str("0.5 0.5 0.5 rg\n"); // Gray arrow
+            crate::graphics::color::write_fill_color(&mut content, Color::gray(0.5));
             content.push_str(&format!("{} {} m\n", arrow_x, arrow_y + 3.0));
             content.push_str(&format!("{} {} l\n", arrow_x + 8.0, arrow_y + 3.0));
             content.push_str(&format!("{} {} l\n", arrow_x + 4.0, arrow_y - 3.0));
@@ -1085,13 +1031,7 @@ impl ComboBoxAppearance {
                 self.font.pdf_name(),
                 self.font_size
             ));
-            match self.text_color {
-                Color::Gray(g) => content.push_str(&format!("{} g\n", g)),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{} {} {} rg\n", r, g, b)),
-                Color::Cmyk(c, m, y, k) => {
-                    content.push_str(&format!("{} {} {} {} k\n", c, m, y, k))
-                }
-            }
+            crate::graphics::color::write_fill_color(&mut content, self.text_color);
             content.push_str(&format!("5 {} Td\n", (height - self.font_size) / 2.0));
 
             // Same dispatch as `TextFieldAppearance::generate_appearance_with_font`
@@ -1192,19 +1132,13 @@ impl AppearanceGenerator for ListBoxAppearance {
         let mut content = String::new();
 
         // Draw background
-        content.push_str("1 1 1 rg\n"); // White background
+        crate::graphics::color::write_fill_color(&mut content, Color::white());
         content.push_str(&format!("0 0 {} {} re\n", width, height));
         content.push_str("f\n");
 
         // Draw border
         if let Some(ref border_color) = widget.appearance.border_color {
-            match border_color {
-                Color::Gray(g) => content.push_str(&format!("{} G\n", g)),
-                Color::Rgb(r, g, b) => content.push_str(&format!("{} {} {} RG\n", r, g, b)),
-                Color::Cmyk(c, m, y, k) => {
-                    content.push_str(&format!("{} {} {} {} K\n", c, m, y, k))
-                }
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
             content.push_str(&format!("0 0 {} {} re\n", width, height));
             content.push_str("S\n");
@@ -1219,13 +1153,7 @@ impl AppearanceGenerator for ListBoxAppearance {
 
             // Draw selection background if selected
             if self.selected.contains(&index) {
-                match self.selection_color {
-                    Color::Gray(g) => content.push_str(&format!("{} g\n", g)),
-                    Color::Rgb(r, g, b) => content.push_str(&format!("{} {} {} rg\n", r, g, b)),
-                    Color::Cmyk(c, m, y_val, k) => {
-                        content.push_str(&format!("{} {} {} {} k\n", c, m, y_val, k))
-                    }
-                }
+                crate::graphics::color::write_fill_color(&mut content, self.selection_color);
                 content.push_str(&format!("0 {} {} {} re\n", y, width, self.item_height));
                 content.push_str("f\n");
             }
@@ -1238,17 +1166,11 @@ impl AppearanceGenerator for ListBoxAppearance {
                 self.font_size
             ));
 
-            // Use white text for selected items, black for others
+            // Use white text for selected items, regular colour for others
             if self.selected.contains(&index) {
-                content.push_str("1 1 1 rg\n");
+                crate::graphics::color::write_fill_color(&mut content, Color::white());
             } else {
-                match self.text_color {
-                    Color::Gray(g) => content.push_str(&format!("{} g\n", g)),
-                    Color::Rgb(r, g, b) => content.push_str(&format!("{} {} {} rg\n", r, g, b)),
-                    Color::Cmyk(c, m, y_val, k) => {
-                        content.push_str(&format!("{} {} {} {} k\n", c, m, y_val, k))
-                    }
-                }
+                crate::graphics::color::write_fill_color(&mut content, self.text_color);
             }
 
             content.push_str(&format!("5 {} Td\n", y + 2.0));

--- a/oxidize-pdf-core/src/forms/button_widget.rs
+++ b/oxidize-pdf-core/src/forms/button_widget.rs
@@ -301,30 +301,18 @@ fn create_checkbox_appearance(widget: &ButtonWidget, checked: bool) -> Result<St
 
     // Draw background
     if let Some(bg) = &widget.background_color {
-        match bg {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} rg", r, g, b)?,
-            Color::Gray(g) => writeln!(&mut content, "{} g", g)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} k", c, m, y, k)?,
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut content, *bg);
         writeln!(&mut content, "0 0 {} {} re f", width, height)?;
     }
 
     // Draw border
-    match &widget.border_color {
-        Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} RG", r, g, b)?,
-        Color::Gray(gray) => writeln!(&mut content, "{} G", gray)?,
-        Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} K", c, m, y, k)?,
-    }
+    crate::graphics::color::write_stroke_color_bytes(&mut content, widget.border_color);
     writeln!(&mut content, "{} w", widget.border_width)?;
     writeln!(&mut content, "0 0 {} {} re S", width, height)?;
 
     // Draw check mark if checked
     if checked {
-        match &widget.text_color {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} RG", r, g, b)?,
-            Color::Gray(gray) => writeln!(&mut content, "{} G", gray)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} K", c, m, y, k)?,
-        }
+        crate::graphics::color::write_stroke_color_bytes(&mut content, widget.text_color);
         writeln!(&mut content, "2 w")?;
         writeln!(&mut content, "1 J")?; // Round line cap
 
@@ -364,11 +352,7 @@ fn create_radio_appearance(widget: &ButtonWidget, selected: bool) -> Result<Stre
 
     // Draw background circle
     if let Some(bg) = &widget.background_color {
-        match bg {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} rg", r, g, b)?,
-            Color::Gray(g) => writeln!(&mut content, "{} g", g)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} k", c, m, y, k)?,
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut content, *bg);
         draw_circle(
             &mut content,
             center_x,
@@ -379,11 +363,7 @@ fn create_radio_appearance(widget: &ButtonWidget, selected: bool) -> Result<Stre
     }
 
     // Draw border circle
-    match &widget.border_color {
-        Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} RG", r, g, b)?,
-        Color::Gray(gray) => writeln!(&mut content, "{} G", gray)?,
-        Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} K", c, m, y, k)?,
-    }
+    crate::graphics::color::write_stroke_color_bytes(&mut content, widget.border_color);
     writeln!(&mut content, "{} w", widget.border_width)?;
     draw_circle(
         &mut content,
@@ -395,11 +375,7 @@ fn create_radio_appearance(widget: &ButtonWidget, selected: bool) -> Result<Stre
 
     // Draw inner dot if selected
     if selected {
-        match &widget.text_color {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} rg", r, g, b)?,
-            Color::Gray(gray) => writeln!(&mut content, "{} g", gray)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} k", c, m, y, k)?,
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut content, widget.text_color);
         let dot_radius = radius * 0.4;
         draw_circle(&mut content, center_x, center_y, dot_radius)?;
         writeln!(&mut content, "f")?;
@@ -425,33 +401,25 @@ fn create_pushbutton_appearance(widget: &ButtonWidget, caption: Option<&str>) ->
     // Draw background with beveled effect
     if let Some(bg) = &widget.background_color {
         // Main background
-        match bg {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} rg", r, g, b)?,
-            Color::Gray(g) => writeln!(&mut content, "{} g", g)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} k", c, m, y, k)?,
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut content, *bg);
         writeln!(&mut content, "0 0 {} {} re f", width, height)?;
 
         // Top/left highlight (lighter)
-        writeln!(&mut content, "0.9 0.9 0.9 RG")?;
+        crate::graphics::color::write_stroke_color_bytes(&mut content, Color::gray(0.9));
         writeln!(&mut content, "2 w")?;
         writeln!(&mut content, "1 {} m", height - 1.0)?;
         writeln!(&mut content, "1 1 l")?;
         writeln!(&mut content, "{} 1 l S", width - 1.0)?;
 
         // Bottom/right shadow (darker)
-        writeln!(&mut content, "0.5 0.5 0.5 RG")?;
+        crate::graphics::color::write_stroke_color_bytes(&mut content, Color::gray(0.5));
         writeln!(&mut content, "{} 1 m", width - 1.0)?;
         writeln!(&mut content, "{} {} l", width - 1.0, height - 1.0)?;
         writeln!(&mut content, "1 {} l S", height - 1.0)?;
     }
 
     // Draw border
-    match &widget.border_color {
-        Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} RG", r, g, b)?,
-        Color::Gray(gray) => writeln!(&mut content, "{} G", gray)?,
-        Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} K", c, m, y, k)?,
-    }
+    crate::graphics::color::write_stroke_color_bytes(&mut content, widget.border_color);
     writeln!(&mut content, "{} w", widget.border_width)?;
     writeln!(&mut content, "0 0 {} {} re S", width, height)?;
 
@@ -459,11 +427,7 @@ fn create_pushbutton_appearance(widget: &ButtonWidget, caption: Option<&str>) ->
     if let Some(text) = caption {
         writeln!(&mut content, "BT")?;
         writeln!(&mut content, "/Helvetica {} Tf", widget.font_size)?;
-        match &widget.text_color {
-            Color::Rgb(r, g, b) => writeln!(&mut content, "{} {} {} rg", r, g, b)?,
-            Color::Gray(gray) => writeln!(&mut content, "{} g", gray)?,
-            Color::Cmyk(c, m, y, k) => writeln!(&mut content, "{} {} {} {} k", c, m, y, k)?,
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut content, widget.text_color);
 
         // Center text
         let text_width = text.len() as f64 * widget.font_size * 0.5;

--- a/oxidize-pdf-core/src/forms/choice_widget.rs
+++ b/oxidize-pdf-core/src/forms/choice_widget.rs
@@ -106,16 +106,13 @@ impl ChoiceWidget {
         // Save graphics state
         writeln!(&mut stream, "q").expect("Writing to string should never fail");
 
-        // Draw background if specified
+        // Draw background if specified — routed through the shared
+        // NaN-sanitising helpers (issues #220 + #221). The previous
+        // emitter forced RGB output via `.r()/.g()/.b()` regardless of
+        // the colour's native space; the helper now preserves the
+        // native space (`rg` / `g` / `k`) which is strictly more correct.
         if let Some(bg_color) = &self.background_color {
-            writeln!(
-                &mut stream,
-                "{:.3} {:.3} {:.3} rg",
-                bg_color.r(),
-                bg_color.g(),
-                bg_color.b()
-            )
-            .expect("Writing to string should never fail");
+            crate::graphics::color::write_fill_color(&mut stream, *bg_color);
             writeln!(
                 &mut stream,
                 "0 0 {} {} re",
@@ -127,14 +124,7 @@ impl ChoiceWidget {
         }
 
         // Draw border
-        writeln!(
-            &mut stream,
-            "{:.3} {:.3} {:.3} RG",
-            self.border_color.r(),
-            self.border_color.g(),
-            self.border_color.b()
-        )
-        .expect("Writing to string should never fail");
+        crate::graphics::color::write_stroke_color(&mut stream, self.border_color);
         writeln!(&mut stream, "{} w", self.border_width)
             .expect("Writing to string should never fail");
         writeln!(
@@ -149,8 +139,10 @@ impl ChoiceWidget {
         // Draw dropdown arrow on the right
         let arrow_x = self.rect.width() - 15.0;
         let arrow_y = self.rect.height() / 2.0;
-        writeln!(&mut stream, "{:.3} {:.3} {:.3} rg", 0.3, 0.3, 0.3)
-            .expect("Writing to string should never fail");
+        crate::graphics::color::write_fill_color(
+            &mut stream,
+            crate::graphics::Color::Rgb(0.3, 0.3, 0.3),
+        );
         writeln!(&mut stream, "{} {} m", arrow_x, arrow_y + 3.0)
             .expect("Writing to string should never fail");
         writeln!(&mut stream, "{} {} l", arrow_x + 8.0, arrow_y + 3.0)
@@ -170,14 +162,7 @@ impl ChoiceWidget {
                     self.font_size
                 )
                 .expect("Writing to string should never fail");
-                writeln!(
-                    &mut stream,
-                    "{:.3} {:.3} {:.3} rg",
-                    self.text_color.r(),
-                    self.text_color.g(),
-                    self.text_color.b()
-                )
-                .expect("Writing to string should never fail");
+                crate::graphics::color::write_fill_color(&mut stream, self.text_color);
                 writeln!(
                     &mut stream,
                     "2 {} Td",
@@ -203,16 +188,9 @@ impl ChoiceWidget {
         // Save graphics state
         writeln!(&mut stream, "q").expect("Writing to string should never fail");
 
-        // Draw background
+        // Draw background — sanitised via shared helper (issues #220 + #221).
         if let Some(bg_color) = &self.background_color {
-            writeln!(
-                &mut stream,
-                "{:.3} {:.3} {:.3} rg",
-                bg_color.r(),
-                bg_color.g(),
-                bg_color.b()
-            )
-            .expect("Writing to string should never fail");
+            crate::graphics::color::write_fill_color(&mut stream, *bg_color);
             writeln!(
                 &mut stream,
                 "0 0 {} {} re",
@@ -224,14 +202,7 @@ impl ChoiceWidget {
         }
 
         // Draw border
-        writeln!(
-            &mut stream,
-            "{:.3} {:.3} {:.3} RG",
-            self.border_color.r(),
-            self.border_color.g(),
-            self.border_color.b()
-        )
-        .expect("Writing to string should never fail");
+        crate::graphics::color::write_stroke_color(&mut stream, self.border_color);
         writeln!(&mut stream, "{} w", self.border_width)
             .expect("Writing to string should never fail");
         writeln!(
@@ -252,17 +223,10 @@ impl ChoiceWidget {
         for (idx, (_, display_text)) in listbox.options.iter().enumerate().take(visible_items) {
             let y_pos = self.rect.height() - ((idx + 1) as f64 * item_height);
 
-            // Draw highlight for selected items
+            // Draw highlight for selected items — sanitised via shared helper.
             if listbox.selected.contains(&idx) {
                 if let Some(highlight) = &self.highlight_color {
-                    writeln!(
-                        &mut stream,
-                        "{:.3} {:.3} {:.3} rg",
-                        highlight.r(),
-                        highlight.g(),
-                        highlight.b()
-                    )
-                    .expect("Writing to string should never fail");
+                    crate::graphics::color::write_fill_color(&mut stream, *highlight);
                     writeln!(
                         &mut stream,
                         "0 {} {} {} re",
@@ -284,14 +248,7 @@ impl ChoiceWidget {
                 self.font_size
             )
             .expect("Writing to string should never fail");
-            writeln!(
-                &mut stream,
-                "{:.3} {:.3} {:.3} rg",
-                self.text_color.r(),
-                self.text_color.g(),
-                self.text_color.b()
-            )
-            .expect("Writing to string should never fail");
+            crate::graphics::color::write_fill_color(&mut stream, self.text_color);
             writeln!(&mut stream, "2 {} Td", y_pos + 2.0)
                 .expect("Writing to string should never fail");
             writeln!(&mut stream, "({}) Tj", escape_pdf_string(display_text))
@@ -299,16 +256,16 @@ impl ChoiceWidget {
             writeln!(&mut stream, "ET").expect("Writing to string should never fail");
         }
 
-        // Draw scrollbar if needed
+        // Draw scrollbar if needed — sanitised via shared helper.
         if listbox.options.len() > visible_items {
-            writeln!(&mut stream, "0.7 0.7 0.7 rg").expect("Writing to string should never fail");
+            crate::graphics::color::write_fill_color(&mut stream, Color::gray(0.7));
             let scrollbar_x = self.rect.width() - 10.0;
             writeln!(&mut stream, "{} 0 8 {} re", scrollbar_x, self.rect.height())
                 .expect("Writing to string should never fail");
             writeln!(&mut stream, "f").expect("Writing to string should never fail");
 
             // Draw scroll thumb
-            writeln!(&mut stream, "0.4 0.4 0.4 rg").expect("Writing to string should never fail");
+            crate::graphics::color::write_fill_color(&mut stream, Color::gray(0.4));
             let thumb_height =
                 (visible_items as f64 / listbox.options.len() as f64) * self.rect.height();
             writeln!(
@@ -368,14 +325,13 @@ pub fn create_combobox_widget(combo: &ComboBox, widget: &ChoiceWidget) -> Result
     ap_dict.set("N", Object::Dictionary(n_dict));
     field_dict.set("AP", Object::Dictionary(ap_dict));
 
-    // Set default appearance string
+    // Set default appearance string — sanitised via shared helper
+    // (issues #220 + #221). Emits the colour's native space, not always RGB.
     let da = format!(
-        "/{} {} Tf {} {} {} rg",
+        "/{} {} Tf {}",
         widget.font.pdf_name(),
         widget.font_size,
-        widget.text_color.r(),
-        widget.text_color.g(),
-        widget.text_color.b(),
+        crate::graphics::color::fill_color_op(widget.text_color),
     );
     field_dict.set("DA", Object::String(da));
 
@@ -424,14 +380,13 @@ pub fn create_listbox_widget(listbox: &ListBox, widget: &ChoiceWidget) -> Result
     ap_dict.set("N", Object::Dictionary(n_dict));
     field_dict.set("AP", Object::Dictionary(ap_dict));
 
-    // Set default appearance string
+    // Set default appearance string — sanitised via shared helper
+    // (issues #220 + #221). Emits the colour's native space, not always RGB.
     let da = format!(
-        "/{} {} Tf {} {} {} rg",
+        "/{} {} Tf {}",
         widget.font.pdf_name(),
         widget.font_size,
-        widget.text_color.r(),
-        widget.text_color.g(),
-        widget.text_color.b(),
+        crate::graphics::color::fill_color_op(widget.text_color),
     );
     field_dict.set("DA", Object::String(da));
 

--- a/oxidize-pdf-core/src/forms/field_appearance.rs
+++ b/oxidize-pdf-core/src/forms/field_appearance.rs
@@ -257,12 +257,7 @@ impl FieldAppearanceGenerator {
 
         // Draw background if specified
         if let Some(bg_color) = &self.background_color {
-            ops.push(format!(
-                "{} {} {} rg",
-                bg_color.r(),
-                bg_color.g(),
-                bg_color.b()
-            ));
+            ops.push(crate::graphics::color::fill_color_op(*bg_color));
             ops.push(format!("0 0 {} {} re", width, height));
             ops.push("f".to_string());
         }
@@ -271,12 +266,7 @@ impl FieldAppearanceGenerator {
         if let Some(border_color) = &self.border_color {
             if self.border_width > 0.0 {
                 ops.push(format!("{} w", self.border_width));
-                ops.push(format!(
-                    "{} {} {} RG",
-                    border_color.r(),
-                    border_color.g(),
-                    border_color.b()
-                ));
+                ops.push(crate::graphics::color::stroke_color_op(*border_color));
                 ops.push(format!(
                     "{} {} {} {} re",
                     self.border_width / 2.0,
@@ -295,12 +285,7 @@ impl FieldAppearanceGenerator {
         ops.push(format!("/{} {} Tf", self.font, self.font_size));
 
         // Set text color
-        ops.push(format!(
-            "{} {} {} rg",
-            self.text_color.r(),
-            self.text_color.g(),
-            self.text_color.b()
-        ));
+        ops.push(crate::graphics::color::fill_color_op(self.text_color));
 
         // Calculate text position
         let padding = 2.0;
@@ -426,12 +411,7 @@ impl ButtonAppearanceGenerator {
         ops.push("q".to_string());
 
         // Draw background
-        ops.push(format!(
-            "{} {} {} rg",
-            self.background_color.r(),
-            self.background_color.g(),
-            self.background_color.b()
-        ));
+        ops.push(crate::graphics::color::fill_color_op(self.background_color));
 
         match self.style {
             ButtonStyle::Radio => {
@@ -442,23 +422,13 @@ impl ButtonAppearanceGenerator {
                 // Draw border
                 if self.border_width > 0.0 {
                     ops.push(format!("{} w", self.border_width));
-                    ops.push(format!(
-                        "{} {} {} RG",
-                        self.border_color.r(),
-                        self.border_color.g(),
-                        self.border_color.b()
-                    ));
+                    ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                     ops.push("s".to_string());
                 }
 
                 // Draw dot
                 let dot_size = self.size * 0.3;
-                ops.push(format!(
-                    "{} {} {} rg",
-                    self.check_color.r(),
-                    self.check_color.g(),
-                    self.check_color.b()
-                ));
+                ops.push(crate::graphics::color::fill_color_op(self.check_color));
                 self.draw_circle(&mut ops, self.size / 2.0, self.size / 2.0, dot_size);
                 ops.push("f".to_string());
             }
@@ -470,12 +440,7 @@ impl ButtonAppearanceGenerator {
                 // Draw border
                 if self.border_width > 0.0 {
                     ops.push(format!("{} w", self.border_width));
-                    ops.push(format!(
-                        "{} {} {} RG",
-                        self.border_color.r(),
-                        self.border_color.g(),
-                        self.border_color.b()
-                    ));
+                    ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                     ops.push(format!(
                         "{} {} {} {} re",
                         self.border_width / 2.0,
@@ -487,12 +452,7 @@ impl ButtonAppearanceGenerator {
                 }
 
                 // Draw check mark based on style
-                ops.push(format!(
-                    "{} {} {} rg",
-                    self.check_color.r(),
-                    self.check_color.g(),
-                    self.check_color.b()
-                ));
+                ops.push(crate::graphics::color::fill_color_op(self.check_color));
 
                 self.draw_check_style(&mut ops);
             }
@@ -531,12 +491,7 @@ impl ButtonAppearanceGenerator {
         ops.push("q".to_string());
 
         // Draw background
-        ops.push(format!(
-            "{} {} {} rg",
-            self.background_color.r(),
-            self.background_color.g(),
-            self.background_color.b()
-        ));
+        ops.push(crate::graphics::color::fill_color_op(self.background_color));
 
         if self.style == ButtonStyle::Radio {
             // Circle background
@@ -546,12 +501,7 @@ impl ButtonAppearanceGenerator {
             // Draw border
             if self.border_width > 0.0 {
                 ops.push(format!("{} w", self.border_width));
-                ops.push(format!(
-                    "{} {} {} RG",
-                    self.border_color.r(),
-                    self.border_color.g(),
-                    self.border_color.b()
-                ));
+                ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                 ops.push("s".to_string());
             }
         } else {
@@ -562,12 +512,7 @@ impl ButtonAppearanceGenerator {
             // Draw border
             if self.border_width > 0.0 {
                 ops.push(format!("{} w", self.border_width));
-                ops.push(format!(
-                    "{} {} {} RG",
-                    self.border_color.r(),
-                    self.border_color.g(),
-                    self.border_color.b()
-                ));
+                ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                 ops.push(format!(
                     "{} {} {} {} re",
                     self.border_width / 2.0,
@@ -797,12 +742,7 @@ impl PushButtonAppearanceGenerator {
             self.background_color
         };
 
-        ops.push(format!(
-            "{} {} {} rg",
-            bg_color.r(),
-            bg_color.g(),
-            bg_color.b()
-        ));
+        ops.push(crate::graphics::color::fill_color_op(bg_color));
         ops.push(format!("0 0 {} {} re", width, height));
         ops.push("f".to_string());
 
@@ -813,12 +753,7 @@ impl PushButtonAppearanceGenerator {
         if !self.caption.is_empty() {
             ops.push("BT".to_string());
             ops.push(format!("/{} {} Tf", self.font, self.font_size));
-            ops.push(format!(
-                "{} {} {} rg",
-                self.text_color.r(),
-                self.text_color.g(),
-                self.text_color.b()
-            ));
+            ops.push(crate::graphics::color::fill_color_op(self.text_color));
 
             // Center text
             let text_x = width / 2.0;
@@ -859,12 +794,7 @@ impl PushButtonAppearanceGenerator {
             ButtonBorderStyle::Solid => {
                 if self.border_width > 0.0 {
                     ops.push(format!("{} w", self.border_width));
-                    ops.push(format!(
-                        "{} {} {} RG",
-                        self.border_color.r(),
-                        self.border_color.g(),
-                        self.border_color.b()
-                    ));
+                    ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                     ops.push(format!(
                         "{} {} {} {} re",
                         self.border_width / 2.0,
@@ -879,12 +809,7 @@ impl PushButtonAppearanceGenerator {
                 if self.border_width > 0.0 {
                     ops.push(format!("{} w", self.border_width));
                     ops.push("[3 3] 0 d".to_string()); // Dash pattern
-                    ops.push(format!(
-                        "{} {} {} RG",
-                        self.border_color.r(),
-                        self.border_color.g(),
-                        self.border_color.b()
-                    ));
+                    ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                     ops.push(format!(
                         "{} {} {} {} re",
                         self.border_width / 2.0,
@@ -910,24 +835,14 @@ impl PushButtonAppearanceGenerator {
 
                 // Top and left edges (light)
                 ops.push(format!("{} w", self.border_width));
-                ops.push(format!(
-                    "{} {} {} RG",
-                    light_color.r(),
-                    light_color.g(),
-                    light_color.b()
-                ));
+                ops.push(crate::graphics::color::stroke_color_op(light_color));
                 ops.push(format!("{} {} m", 0.0, 0.0));
                 ops.push(format!("{} {} l", 0.0, height));
                 ops.push(format!("{} {} l", width, height));
                 ops.push("S".to_string());
 
                 // Bottom and right edges (dark)
-                ops.push(format!(
-                    "{} {} {} RG",
-                    dark_color.r(),
-                    dark_color.g(),
-                    dark_color.b()
-                ));
+                ops.push(crate::graphics::color::stroke_color_op(dark_color));
                 ops.push(format!("{} {} m", width, height));
                 ops.push(format!("{} {} l", width, 0.0));
                 ops.push(format!("{} {} l", 0.0, 0.0));
@@ -936,12 +851,7 @@ impl PushButtonAppearanceGenerator {
             ButtonBorderStyle::Underline => {
                 if self.border_width > 0.0 {
                     ops.push(format!("{} w", self.border_width));
-                    ops.push(format!(
-                        "{} {} {} RG",
-                        self.border_color.r(),
-                        self.border_color.g(),
-                        self.border_color.b()
-                    ));
+                    ops.push(crate::graphics::color::stroke_color_op(self.border_color));
                     ops.push(format!("{} {} m", 0.0, self.border_width / 2.0));
                     ops.push(format!("{} {} l", width, self.border_width / 2.0));
                     ops.push("S".to_string());

--- a/oxidize-pdf-core/src/forms/field_type.rs
+++ b/oxidize-pdf-core/src/forms/field_type.rs
@@ -43,11 +43,7 @@ impl DefaultAppearance {
     /// - `Font::Custom("CJK")`, 14.0, `Color::rgb(0.0, 0.0, 0.0)` →
     ///   `/CJK 14 Tf 0 0 0 rg`
     pub fn to_da_string(&self) -> String {
-        let color_op = match self.color {
-            Color::Gray(g) => format!("{} g", g),
-            Color::Rgb(r, g, b) => format!("{} {} {} rg", r, g, b),
-            Color::Cmyk(c, m, y, k) => format!("{} {} {} {} k", c, m, y, k),
-        };
+        let color_op = crate::graphics::color::fill_color_op(self.color);
         format!(
             "/{} {} Tf {}",
             self.font.pdf_name(),

--- a/oxidize-pdf-core/src/forms/signature_field.rs
+++ b/oxidize-pdf-core/src/forms/signature_field.rs
@@ -250,34 +250,15 @@ impl SignatureField {
     pub fn generate_appearance(&self, width: f64, height: f64) -> Result<Vec<u8>, PdfError> {
         let mut stream = Vec::new();
 
-        // Background
+        // Background — routed through the shared NaN-sanitising helper
+        // (issues #220 + #221).
         if let Some(bg_color) = self.appearance.background_color {
-            match bg_color {
-                Color::Rgb(r, g, b) => {
-                    stream.extend(format!("{} {} {} rg\n", r, g, b).as_bytes());
-                }
-                Color::Gray(v) => {
-                    stream.extend(format!("{} g\n", v).as_bytes());
-                }
-                Color::Cmyk(c, m, y, k) => {
-                    stream.extend(format!("{} {} {} {} k\n", c, m, y, k).as_bytes());
-                }
-            }
+            crate::graphics::color::write_fill_color_bytes(&mut stream, bg_color);
             stream.extend(format!("0 0 {} {} re f\n", width, height).as_bytes());
         }
 
         // Border
-        match self.appearance.border_color {
-            Color::Rgb(r, g, b) => {
-                stream.extend(format!("{} {} {} RG\n", r, g, b).as_bytes());
-            }
-            Color::Gray(v) => {
-                stream.extend(format!("{} G\n", v).as_bytes());
-            }
-            Color::Cmyk(c, m, y, k) => {
-                stream.extend(format!("{} {} {} {} K\n", c, m, y, k).as_bytes());
-            }
-        }
+        crate::graphics::color::write_stroke_color_bytes(&mut stream, self.appearance.border_color);
         stream.extend(format!("{} w\n", self.appearance.border_width).as_bytes());
         stream.extend(format!("0 0 {} {} re S\n", width, height).as_bytes());
 
@@ -291,17 +272,7 @@ impl SignatureField {
             )
             .as_bytes(),
         );
-        match self.appearance.text_color {
-            Color::Rgb(r, g, b) => {
-                stream.extend(format!("{} {} {} rg\n", r, g, b).as_bytes());
-            }
-            Color::Gray(v) => {
-                stream.extend(format!("{} g\n", v).as_bytes());
-            }
-            Color::Cmyk(c, m, y, k) => {
-                stream.extend(format!("{} {} {} {} k\n", c, m, y, k).as_bytes());
-            }
-        }
+        crate::graphics::color::write_fill_color_bytes(&mut stream, self.appearance.text_color);
 
         let mut y_pos = height - self.appearance.font_size - 5.0;
         let x_pos = 5.0;

--- a/oxidize-pdf-core/src/forms/signature_widget.rs
+++ b/oxidize-pdf-core/src/forms/signature_widget.rs
@@ -453,34 +453,15 @@ impl SignatureWidget {
         Ok(())
     }
 
-    /// Helper to set fill color
+    /// Helper to set fill color — routed through the shared NaN-sanitising
+    /// helper (issues #220 + #221).
     fn set_fill_color(stream: &mut Vec<u8>, color: &Color) {
-        match color {
-            Color::Rgb(r, g, b) => {
-                stream.extend(format!("{} {} {} rg\n", r, g, b).as_bytes());
-            }
-            Color::Gray(v) => {
-                stream.extend(format!("{} g\n", v).as_bytes());
-            }
-            Color::Cmyk(c, m, y, k) => {
-                stream.extend(format!("{} {} {} {} k\n", c, m, y, k).as_bytes());
-            }
-        }
+        crate::graphics::color::write_fill_color_bytes(stream, *color);
     }
 
-    /// Helper to set stroke color
+    /// Helper to set stroke color — routed through the shared sanitising helper.
     fn set_stroke_color(stream: &mut Vec<u8>, color: &Color) {
-        match color {
-            Color::Rgb(r, g, b) => {
-                stream.extend(format!("{} {} {} RG\n", r, g, b).as_bytes());
-            }
-            Color::Gray(v) => {
-                stream.extend(format!("{} G\n", v).as_bytes());
-            }
-            Color::Cmyk(c, m, y, k) => {
-                stream.extend(format!("{} {} {} {} K\n", c, m, y, k).as_bytes());
-            }
-        }
+        crate::graphics::color::write_stroke_color_bytes(stream, *color);
     }
 
     /// Convert to PDF widget annotation dictionary
@@ -821,50 +802,52 @@ mod tests {
     fn test_set_fill_color() {
         let mut stream = Vec::new();
 
-        // Test RGB fill
+        // After the issue #220/#221 helper migration these emitters now
+        // share the `.3`-precision format used elsewhere in the pipeline,
+        // so the wire form is `1.000 0.500 0.000 rg`, not `1 0.5 0 rg`.
         let rgb = Color::rgb(1.0, 0.5, 0.0);
         SignatureWidget::set_fill_color(&mut stream, &rgb);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("1 0.5 0 rg"));
+        assert!(result.contains("1.000 0.500 0.000 rg"));
 
         // Test gray fill
         stream.clear();
         let gray = Color::gray(0.7);
         SignatureWidget::set_fill_color(&mut stream, &gray);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("0.7 g"));
+        assert!(result.contains("0.700 g"));
 
         // Test CMYK fill
         stream.clear();
         let cmyk = Color::cmyk(0.2, 0.3, 0.4, 0.1);
         SignatureWidget::set_fill_color(&mut stream, &cmyk);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("0.2 0.3 0.4 0.1 k"));
+        assert!(result.contains("0.200 0.300 0.400 0.100 k"));
     }
 
     #[test]
     fn test_set_stroke_color() {
         let mut stream = Vec::new();
 
-        // Test RGB stroke
+        // `.3`-precision format (issue #220/#221 helper migration).
         let rgb = Color::rgb(0.0, 0.0, 1.0);
         SignatureWidget::set_stroke_color(&mut stream, &rgb);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("0 0 1 RG"));
+        assert!(result.contains("0.000 0.000 1.000 RG"));
 
         // Test gray stroke
         stream.clear();
         let gray = Color::gray(0.3);
         SignatureWidget::set_stroke_color(&mut stream, &gray);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("0.3 G"));
+        assert!(result.contains("0.300 G"));
 
         // Test CMYK stroke
         stream.clear();
         let cmyk = Color::cmyk(1.0, 0.0, 0.0, 0.0);
         SignatureWidget::set_stroke_color(&mut stream, &cmyk);
         let result = String::from_utf8_lossy(&stream);
-        assert!(result.contains("1 0 0 0 K"));
+        assert!(result.contains("1.000 0.000 0.000 0.000 K"));
     }
 
     #[test]

--- a/oxidize-pdf-core/src/graphics/color.rs
+++ b/oxidize-pdf-core/src/graphics/color.rs
@@ -222,6 +222,199 @@ impl Color {
     }
 }
 
+/// Substitute non-finite floats with `0.0` for safe content-stream emission
+/// (issue #220). Direct enum construction such as `Color::Rgb(f64::NAN, …)`
+/// bypasses the `Color::rgb`/`gray`/`cmyk` clamps; emitting the raw value with
+/// `{:.3}` would produce `NaN`/`inf`/`-inf` tokens, which ISO 32000-1 §7.3.3
+/// rejects as numeric values and conformant viewers reject the entire content
+/// stream.
+///
+/// This is a finite-only check — finite values pass through unchanged
+/// (including values outside `[0.0, 1.0]`, which the renderer is responsible
+/// for clamping). The aim is strictly to keep the wire format syntactically
+/// valid, not to enforce colour-value semantics here.
+#[inline]
+pub(crate) fn finite_or_zero(val: f64) -> f64 {
+    if val.is_finite() {
+        val
+    } else {
+        0.0
+    }
+}
+
+/// Single source of truth for non-stroking colour-operator emission (issue
+/// #221). Returns the operator as a `String` *without* trailing newline,
+/// with NaN/inf sanitisation (issue #220) and `.3`-precision formatting.
+///
+/// Operators emitted (ISO 32000-1 §8.6.8):
+/// - `Color::Rgb(r, g, b)`     → `"r g b rg"`
+/// - `Color::Gray(g)`          → `"g g"`
+/// - `Color::Cmyk(c, m, y, k)` → `"c m y k k"`
+///
+/// Use this when embedding the operator inside a larger PDF expression —
+/// e.g. an annotation `/DA` default-appearance string `/Helv 12 Tf 0 0 0 rg`.
+/// For content-stream emission with trailing newline, prefer
+/// [`write_fill_color`] (writes to `&mut String`) or
+/// [`write_fill_color_bytes`] (writes to `&mut Vec<u8>`).
+pub(crate) fn fill_color_op(color: Color) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    match color {
+        Color::Rgb(r, g, b) => write!(
+            &mut s,
+            "{:.3} {:.3} {:.3} rg",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => write!(&mut s, "{:.3} g", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => write!(
+            &mut s,
+            "{:.3} {:.3} {:.3} {:.3} k",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a String never fails");
+    s
+}
+
+/// Single source of truth for stroking colour-operator emission. Companion
+/// to [`fill_color_op`] (uppercase `RG` / `G` / `K`). No trailing newline,
+/// NaN/inf sanitised.
+pub(crate) fn stroke_color_op(color: Color) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    match color {
+        Color::Rgb(r, g, b) => write!(
+            &mut s,
+            "{:.3} {:.3} {:.3} RG",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => write!(&mut s, "{:.3} G", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => write!(
+            &mut s,
+            "{:.3} {:.3} {:.3} {:.3} K",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a String never fails");
+    s
+}
+
+/// Append the non-stroking colour operator for `color` to a `String`
+/// content-stream buffer, followed by a `\n`. Direct emission via
+/// `std::fmt::Write` — no intermediate `String` allocation.
+pub(crate) fn write_fill_color(ops: &mut String, color: Color) {
+    use std::fmt::Write;
+    match color {
+        Color::Rgb(r, g, b) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} rg",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => writeln!(ops, "{:.3} g", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} {:.3} k",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a String never fails");
+}
+
+/// Append the stroking colour operator for `color` to a `String`
+/// content-stream buffer, followed by a `\n`. Companion to
+/// [`write_fill_color`] (uppercase `RG` / `G` / `K`).
+pub(crate) fn write_stroke_color(ops: &mut String, color: Color) {
+    use std::fmt::Write;
+    match color {
+        Color::Rgb(r, g, b) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} RG",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => writeln!(ops, "{:.3} G", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} {:.3} K",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a String never fails");
+}
+
+/// Append the non-stroking colour operator for `color` to a `Vec<u8>`
+/// content-stream buffer, followed by `\n`. Direct emission via
+/// `std::io::Write` — no intermediate allocation. For form-widget streams
+/// in `forms/button_widget.rs`, `forms/appearance.rs`, etc., which use
+/// `Vec<u8>` as their accumulator.
+pub(crate) fn write_fill_color_bytes(ops: &mut Vec<u8>, color: Color) {
+    use std::io::Write;
+    match color {
+        Color::Rgb(r, g, b) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} rg",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => writeln!(ops, "{:.3} g", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} {:.3} k",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a Vec<u8> never fails");
+}
+
+/// Append the stroking colour operator for `color` to a `Vec<u8>`
+/// content-stream buffer, followed by `\n`. Companion to
+/// [`write_fill_color_bytes`].
+pub(crate) fn write_stroke_color_bytes(ops: &mut Vec<u8>, color: Color) {
+    use std::io::Write;
+    match color {
+        Color::Rgb(r, g, b) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} RG",
+            finite_or_zero(r),
+            finite_or_zero(g),
+            finite_or_zero(b)
+        ),
+        Color::Gray(gray) => writeln!(ops, "{:.3} G", finite_or_zero(gray)),
+        Color::Cmyk(c, m, y, k) => writeln!(
+            ops,
+            "{:.3} {:.3} {:.3} {:.3} K",
+            finite_or_zero(c),
+            finite_or_zero(m),
+            finite_or_zero(y),
+            finite_or_zero(k)
+        ),
+    }
+    .expect("writing to a Vec<u8> never fails");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -870,5 +1063,121 @@ mod tests {
         assert_eq!(m, 0.0, "Magenta should be 0 for pure black");
         assert_eq!(y, 0.0, "Yellow should be 0 for pure black");
         assert_eq!(k, 1.0, "K should be 1.0 for pure black");
+    }
+
+    // ---------- write_fill_color / write_stroke_color helpers (issues #220, #221) ----------
+
+    #[test]
+    fn finite_or_zero_passes_finite_values_unchanged() {
+        assert_eq!(finite_or_zero(0.0), 0.0);
+        assert_eq!(finite_or_zero(0.5), 0.5);
+        assert_eq!(finite_or_zero(1.0), 1.0);
+        assert_eq!(finite_or_zero(-0.5), -0.5); // out-of-range but finite — caller's problem
+        assert_eq!(finite_or_zero(2.0), 2.0);
+    }
+
+    #[test]
+    fn finite_or_zero_replaces_nan_with_zero() {
+        assert_eq!(finite_or_zero(f64::NAN), 0.0);
+    }
+
+    #[test]
+    fn finite_or_zero_replaces_pos_inf_with_zero() {
+        assert_eq!(finite_or_zero(f64::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn finite_or_zero_replaces_neg_inf_with_zero() {
+        assert_eq!(finite_or_zero(f64::NEG_INFINITY), 0.0);
+    }
+
+    #[test]
+    fn write_fill_color_rgb_emits_lowercase_rg_with_three_decimals() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Rgb(0.25, 0.5, 0.75));
+        assert_eq!(ops, "0.250 0.500 0.750 rg\n");
+    }
+
+    #[test]
+    fn write_fill_color_gray_emits_lowercase_g() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Gray(0.5));
+        assert_eq!(ops, "0.500 g\n");
+    }
+
+    #[test]
+    fn write_fill_color_cmyk_emits_lowercase_k() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Cmyk(0.1, 0.2, 0.3, 0.4));
+        assert_eq!(ops, "0.100 0.200 0.300 0.400 k\n");
+    }
+
+    #[test]
+    fn write_stroke_color_rgb_emits_uppercase_rg() {
+        let mut ops = String::new();
+        write_stroke_color(&mut ops, Color::Rgb(0.25, 0.5, 0.75));
+        assert_eq!(ops, "0.250 0.500 0.750 RG\n");
+    }
+
+    #[test]
+    fn write_stroke_color_gray_emits_uppercase_g() {
+        let mut ops = String::new();
+        write_stroke_color(&mut ops, Color::Gray(0.5));
+        assert_eq!(ops, "0.500 G\n");
+    }
+
+    #[test]
+    fn write_stroke_color_cmyk_emits_uppercase_k() {
+        let mut ops = String::new();
+        write_stroke_color(&mut ops, Color::Cmyk(0.1, 0.2, 0.3, 0.4));
+        assert_eq!(ops, "0.100 0.200 0.300 0.400 K\n");
+    }
+
+    #[test]
+    fn write_fill_color_sanitises_nan_red_only() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Rgb(f64::NAN, 0.5, 0.75));
+        assert_eq!(ops, "0.000 0.500 0.750 rg\n");
+    }
+
+    #[test]
+    fn write_fill_color_sanitises_pos_inf() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Gray(f64::INFINITY));
+        assert_eq!(ops, "0.000 g\n");
+    }
+
+    #[test]
+    fn write_fill_color_sanitises_neg_inf() {
+        let mut ops = String::new();
+        write_fill_color(&mut ops, Color::Cmyk(f64::NEG_INFINITY, 0.0, 0.0, 0.0));
+        assert_eq!(ops, "0.000 0.000 0.000 0.000 k\n");
+    }
+
+    #[test]
+    fn write_stroke_color_sanitises_nan_in_cmyk() {
+        let mut ops = String::new();
+        write_stroke_color(&mut ops, Color::Cmyk(0.1, f64::NAN, 0.3, f64::INFINITY));
+        assert_eq!(ops, "0.100 0.000 0.300 0.000 K\n");
+    }
+
+    #[test]
+    fn write_fill_color_appends_to_existing_ops_buffer() {
+        let mut ops = String::from("BT\n");
+        write_fill_color(&mut ops, Color::Rgb(0.0, 0.0, 0.0));
+        assert_eq!(ops, "BT\n0.000 0.000 0.000 rg\n");
+    }
+
+    #[test]
+    fn fill_and_stroke_operators_differ_only_in_case() {
+        // Lock the case-difference contract: the same colour goes through both
+        // helpers and emits operators that match in everything except the
+        // case of the operator-name suffix.
+        let mut fill_ops = String::new();
+        let mut stroke_ops = String::new();
+        write_fill_color(&mut fill_ops, Color::Rgb(0.1, 0.2, 0.3));
+        write_stroke_color(&mut stroke_ops, Color::Rgb(0.1, 0.2, 0.3));
+        assert_eq!(fill_ops, "0.100 0.200 0.300 rg\n");
+        assert_eq!(stroke_ops, "0.100 0.200 0.300 RG\n");
     }
 }

--- a/oxidize-pdf-core/src/graphics/form_xobject.rs
+++ b/oxidize-pdf-core/src/graphics/form_xobject.rs
@@ -224,15 +224,22 @@ impl FormXObjectBuilder {
         self
     }
 
-    /// Set fill color (RGB)
+    /// Set fill color (RGB) — routed through the shared NaN-sanitising
+    /// helper (issues #220 + #221) so non-finite inputs cannot produce
+    /// `NaN`/`inf` tokens that ISO 32000-1 §7.3.3 rejects.
     pub fn fill_color(mut self, r: f64, g: f64, b: f64) -> Self {
-        self.operations.push(format!("{} {} {} rg", r, g, b));
+        self.operations.push(crate::graphics::color::fill_color_op(
+            crate::graphics::Color::Rgb(r, g, b),
+        ));
         self
     }
 
-    /// Set stroke color (RGB)
+    /// Set stroke color (RGB) — sanitised via shared helper.
     pub fn stroke_color(mut self, r: f64, g: f64, b: f64) -> Self {
-        self.operations.push(format!("{} {} {} RG", r, g, b));
+        self.operations
+            .push(crate::graphics::color::stroke_color_op(
+                crate::graphics::Color::Rgb(r, g, b),
+            ));
         self
     }
 
@@ -575,7 +582,9 @@ mod tests {
             .build();
 
         let content = String::from_utf8(form.content).unwrap();
-        assert!(content.contains("1 0 0 rg"));
+        // After issue #220/#221 helper migration, fill_color/stroke_color
+        // emit `.3`-precision tokens — `1.000 0.000 0.000 rg`, not `1 0 0 rg`.
+        assert!(content.contains("1.000 0.000 0.000 rg"));
         assert!(content.contains("10 10 80 80 re"));
         assert!(content.contains("f"));
     }
@@ -597,7 +606,7 @@ mod tests {
         let content = String::from_utf8(form.content.clone()).unwrap();
         assert!(content.contains("q"));
         assert!(content.contains("Q"));
-        assert!(content.contains("0 0 1 RG"));
+        assert!(content.contains("0.000 0.000 1.000 RG"));
         assert!(form.has_transparency());
     }
 
@@ -609,7 +618,7 @@ mod tests {
         assert_eq!(form.bbox.height(), 20.0);
 
         let content = String::from_utf8(form.content).unwrap();
-        assert!(content.contains("0 0.5 0 RG")); // Green color
+        assert!(content.contains("0.000 0.500 0.000 RG")); // Green color
     }
 
     #[test]
@@ -619,7 +628,7 @@ mod tests {
         assert_eq!(form.bbox.width(), 30.0);
 
         let content = String::from_utf8(form.content).unwrap();
-        assert!(content.contains("0.8 0 0 RG")); // Red color
+        assert!(content.contains("0.800 0.000 0.000 RG")); // Red color
     }
 
     #[test]
@@ -644,7 +653,7 @@ mod tests {
         assert_eq!(star.bbox.width(), 100.0);
 
         let content = String::from_utf8(star.content).unwrap();
-        assert!(content.contains("1 0.8 0 rg")); // Gold color
+        assert!(content.contains("1.000 0.800 0.000 rg")); // Gold color
     }
 
     #[test]

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -1,6 +1,6 @@
 pub mod calibrated_color;
 pub mod clipping;
-mod color;
+pub(crate) mod color;
 mod color_profiles;
 pub mod devicen_color;
 pub mod extraction;
@@ -604,37 +604,16 @@ impl GraphicsContext {
     }
 
     fn apply_stroke_color(&mut self) {
-        match self.stroke_color {
-            Color::Rgb(r, g, b) => {
-                writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} RG")
-                    .expect("Writing to string should never fail");
-            }
-            Color::Gray(g) => {
-                writeln!(&mut self.operations, "{g:.3} G")
-                    .expect("Writing to string should never fail");
-            }
-            Color::Cmyk(c, m, y, k) => {
-                writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} K")
-                    .expect("Writing to string should never fail");
-            }
-        }
+        // Single source of truth for stroke-colour emission across
+        // `TextContext`, `TextFlowContext`, and `GraphicsContext` — see
+        // `graphics::color::write_stroke_color` (issues #220 + #221).
+        color::write_stroke_color(&mut self.operations, self.stroke_color);
     }
 
     fn apply_fill_color(&mut self) {
-        match self.current_color {
-            Color::Rgb(r, g, b) => {
-                writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} rg")
-                    .expect("Writing to string should never fail");
-            }
-            Color::Gray(g) => {
-                writeln!(&mut self.operations, "{g:.3} g")
-                    .expect("Writing to string should never fail");
-            }
-            Color::Cmyk(c, m, y, k) => {
-                writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} k")
-                    .expect("Writing to string should never fail");
-            }
-        }
+        // Single source of truth for fill-colour emission. See sibling
+        // `apply_stroke_color` and `graphics::color::write_fill_color`.
+        color::write_fill_color(&mut self.operations, self.current_color);
     }
 
     pub(crate) fn generate_operations(&self) -> Result<Vec<u8>> {

--- a/oxidize-pdf-core/src/graphics/patterns.rs
+++ b/oxidize-pdf-core/src/graphics/patterns.rs
@@ -7,7 +7,7 @@
 //! - Pattern resources
 
 use crate::error::{PdfError, Result};
-use crate::graphics::GraphicsContext;
+use crate::graphics::{Color, GraphicsContext};
 use crate::objects::{Dictionary, Object};
 use std::collections::HashMap;
 
@@ -418,8 +418,13 @@ impl PatternManager {
             cell_size * 2.0,
         );
 
-        // Add first color rectangle
-        pattern.add_command(&format!("{} {} {} rg", color1[0], color1[1], color1[2]));
+        // Add first color rectangle. The public APIs accept raw `[f64; 3]`,
+        // so we wrap them in `Color::Rgb` and route through the shared
+        // sanitising helper (issues #220 + #221) — single emission site for
+        // every colour operator in the codebase.
+        let c1 = Color::Rgb(color1[0], color1[1], color1[2]);
+        let c2 = Color::Rgb(color2[0], color2[1], color2[2]);
+        pattern.add_command(crate::graphics::color::fill_color_op(c1).as_str());
         pattern.add_rectangle(0.0, 0.0, cell_size, cell_size);
         pattern.fill();
 
@@ -427,7 +432,7 @@ impl PatternManager {
         pattern.fill();
 
         // Add second color rectangles
-        pattern.add_command(&format!("{} {} {} rg", color2[0], color2[1], color2[2]));
+        pattern.add_command(crate::graphics::color::fill_color_op(c2).as_str());
         pattern.add_rectangle(cell_size, 0.0, cell_size, cell_size);
         pattern.fill();
 
@@ -461,13 +466,15 @@ impl PatternManager {
             pattern = pattern.with_matrix(rotation_matrix);
         }
 
-        // Add first color stripe
-        pattern.add_command(&format!("{} {} {} rg", color1[0], color1[1], color1[2]));
+        // Add first color stripe (sanitised via shared helper).
+        let c1 = Color::Rgb(color1[0], color1[1], color1[2]);
+        let c2 = Color::Rgb(color2[0], color2[1], color2[2]);
+        pattern.add_command(crate::graphics::color::fill_color_op(c1).as_str());
         pattern.add_rectangle(0.0, 0.0, stripe_width, pattern_size);
         pattern.fill();
 
         // Add second color stripe
-        pattern.add_command(&format!("{} {} {} rg", color2[0], color2[1], color2[2]));
+        pattern.add_command(crate::graphics::color::fill_color_op(c2).as_str());
         pattern.add_rectangle(stripe_width, 0.0, stripe_width, pattern_size);
         pattern.fill();
 
@@ -492,19 +499,19 @@ impl PatternManager {
             pattern_size,
         );
 
-        // Background
-        pattern.add_command(&format!(
-            "{} {} {} rg",
-            background_color[0], background_color[1], background_color[2]
-        ));
+        // Background (sanitised via shared helper).
+        let bg = Color::Rgb(
+            background_color[0],
+            background_color[1],
+            background_color[2],
+        );
+        let dot = Color::Rgb(dot_color[0], dot_color[1], dot_color[2]);
+        pattern.add_command(crate::graphics::color::fill_color_op(bg).as_str());
         pattern.add_rectangle(0.0, 0.0, pattern_size, pattern_size);
         pattern.fill();
 
         // Dot
-        pattern.add_command(&format!(
-            "{} {} {} rg",
-            dot_color[0], dot_color[1], dot_color[2]
-        ));
+        pattern.add_command(crate::graphics::color::fill_color_op(dot).as_str());
         pattern.add_circle(pattern_size / 2.0, pattern_size / 2.0, dot_radius);
         pattern.fill();
 
@@ -1073,10 +1080,13 @@ mod tests {
         let pattern = manager.get_pattern(&name).unwrap();
         let content = String::from_utf8(pattern.content_stream.clone()).unwrap();
 
-        // Should contain color commands
-        assert!(content.contains("1 1 1 rg")); // White
-        assert!(content.contains("0 0 0 rg")); // Black
-                                               // Should contain rectangles
+        // Should contain color commands. Pattern emitters now share the
+        // `.3`-precision format used elsewhere in the pipeline (issue #220
+        // sanitisation pass), so the wire form is `1.000 1.000 1.000 rg`,
+        // not the unformatted `1 1 1 rg` the previous emitter produced.
+        assert!(content.contains("1.000 1.000 1.000 rg")); // White
+        assert!(content.contains("0.000 0.000 0.000 rg")); // Black
+                                                           // Should contain rectangles
         assert!(content.contains("re"));
         assert!(content.contains("f"));
     }
@@ -1113,12 +1123,14 @@ mod tests {
         let pattern = manager.get_pattern(&name).unwrap();
         let content = String::from_utf8(pattern.content_stream.clone()).unwrap();
 
-        // Should draw background rectangle
-        assert!(content.contains("1 1 1 rg")); // White background
+        // Should draw background rectangle. Pattern emitters now use
+        // `.3`-precision (issue #220 sanitisation pass), so the wire form
+        // is `1.000 1.000 1.000 rg`, not unformatted `1 1 1 rg`.
+        assert!(content.contains("1.000 1.000 1.000 rg")); // White background
         assert!(content.contains("0 0 10 10 re")); // Background rectangle
 
         // Should draw circle
-        assert!(content.contains("0 0 0 rg")); // Black dot
+        assert!(content.contains("0.000 0.000 0.000 rg")); // Black dot
         assert!(content.contains("m")); // Move to
         assert!(content.contains("c")); // Curve (for circle)
     }

--- a/oxidize-pdf-core/src/layout/rich_text.rs
+++ b/oxidize-pdf-core/src/layout/rich_text.rs
@@ -105,18 +105,8 @@ impl RichText {
         writeln!(&mut ops, "{x:.2} {y:.2} Td").expect("write to String");
 
         for span in &self.spans {
-            // Set color
-            match span.color {
-                Color::Rgb(r, g, b) => {
-                    writeln!(&mut ops, "{r:.3} {g:.3} {b:.3} rg").expect("write to String");
-                }
-                Color::Gray(gray) => {
-                    writeln!(&mut ops, "{gray:.3} g").expect("write to String");
-                }
-                Color::Cmyk(c, m, y, k) => {
-                    writeln!(&mut ops, "{c:.3} {m:.3} {y:.3} {k:.3} k").expect("write to String");
-                }
-            }
+            // Set color via the shared NaN-sanitising helper (issues #220, #221).
+            crate::graphics::color::write_fill_color(&mut ops, span.color);
 
             // Set font
             let font_name = span.font.pdf_name();

--- a/oxidize-pdf-core/src/text/flow.rs
+++ b/oxidize-pdf-core/src/text/flow.rs
@@ -186,21 +186,12 @@ impl TextFlowContext {
             // via `set_fill_color`. PDF spec ISO 32000-1 §8.6.8 allows
             // colour-setting operators inside a text object; they take
             // effect for the show-text operators that follow.
+            //
+            // Routed through the shared NaN-sanitising helper (issues
+            // #220 + #221) so this site cannot diverge from `TextContext`
+            // / `GraphicsContext`.
             if let Some(color) = self.fill_color {
-                match color {
-                    Color::Rgb(r, g, b) => {
-                        writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} rg")
-                            .expect("Writing to String should never fail");
-                    }
-                    Color::Gray(gray) => {
-                        writeln!(&mut self.operations, "{gray:.3} g")
-                            .expect("Writing to String should never fail");
-                    }
-                    Color::Cmyk(c, m, y, k) => {
-                        writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} k")
-                            .expect("Writing to String should never fail");
-                    }
-                }
+                crate::graphics::color::write_fill_color(&mut self.operations, color);
             }
 
             // Set text position

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -369,40 +369,14 @@ impl TextContext {
                 .expect("Writing to String should never fail");
         }
 
-        // Fill color
+        // Fill / stroke colour: routed through the shared NaN-sanitising
+        // helpers (issues #220 + #221) so every emission site treats
+        // non-finite floats identically and emits .3-precision operators.
         if let Some(color) = self.fill_color {
-            match color {
-                Color::Rgb(r, g, b) => {
-                    writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} rg")
-                        .expect("Writing to String should never fail");
-                }
-                Color::Gray(gray) => {
-                    writeln!(&mut self.operations, "{gray:.3} g")
-                        .expect("Writing to String should never fail");
-                }
-                Color::Cmyk(c, m, y, k) => {
-                    writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} k")
-                        .expect("Writing to String should never fail");
-                }
-            }
+            crate::graphics::color::write_fill_color(&mut self.operations, color);
         }
-
-        // Stroke color
         if let Some(color) = self.stroke_color {
-            match color {
-                Color::Rgb(r, g, b) => {
-                    writeln!(&mut self.operations, "{r:.3} {g:.3} {b:.3} RG")
-                        .expect("Writing to String should never fail");
-                }
-                Color::Gray(gray) => {
-                    writeln!(&mut self.operations, "{gray:.3} G")
-                        .expect("Writing to String should never fail");
-                }
-                Color::Cmyk(c, m, y, k) => {
-                    writeln!(&mut self.operations, "{c:.3} {m:.3} {y:.3} {k:.3} K")
-                        .expect("Writing to String should never fail");
-                }
-            }
+            crate::graphics::color::write_stroke_color(&mut self.operations, color);
         }
     }
 

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -3710,8 +3710,8 @@ impl<W: Write> PdfWriter<W> {
         // Set graphics state
         content.push_str("q\n");
 
-        // Draw border (black)
-        content.push_str("0 0 0 RG\n"); // Black stroke color
+        // Draw border (black) — single source of truth for color emission.
+        crate::graphics::color::write_stroke_color(&mut content, crate::graphics::Color::black());
         content.push_str("1 w\n"); // 1pt line width
 
         // Draw rectangle border
@@ -3719,7 +3719,7 @@ impl<W: Write> PdfWriter<W> {
         content.push_str("S\n"); // Stroke
 
         // Fill with white background
-        content.push_str("1 1 1 rg\n"); // White fill color
+        crate::graphics::color::write_fill_color(&mut content, crate::graphics::Color::white());
         content.push_str(&format!("0.5 0.5 {} {} re\n", width - 1.0, height - 1.0));
         content.push_str("f\n"); // Fill
 
@@ -3764,36 +3764,17 @@ impl<W: Write> PdfWriter<W> {
         // Set graphics state
         content.push_str("q\n");
 
-        // Draw background if specified
+        // Draw background if specified — routed through the shared
+        // NaN-sanitising helpers (issues #220, #221).
         if let Some(bg_color) = &widget.appearance.background_color {
-            match bg_color {
-                crate::graphics::Color::Gray(g) => {
-                    content.push_str(&format!("{g} g\n"));
-                }
-                crate::graphics::Color::Rgb(r, g, b) => {
-                    content.push_str(&format!("{r} {g} {b} rg\n"));
-                }
-                crate::graphics::Color::Cmyk(c, m, y, k) => {
-                    content.push_str(&format!("{c} {m} {y} {k} k\n"));
-                }
-            }
+            crate::graphics::color::write_fill_color(&mut content, *bg_color);
             content.push_str(&format!("0 0 {width} {height} re\n"));
             content.push_str("f\n");
         }
 
         // Draw border
         if let Some(border_color) = &widget.appearance.border_color {
-            match border_color {
-                crate::graphics::Color::Gray(g) => {
-                    content.push_str(&format!("{g} G\n"));
-                }
-                crate::graphics::Color::Rgb(r, g, b) => {
-                    content.push_str(&format!("{r} {g} {b} RG\n"));
-                }
-                crate::graphics::Color::Cmyk(c, m, y, k) => {
-                    content.push_str(&format!("{c} {m} {y} {k} K\n"));
-                }
-            }
+            crate::graphics::color::write_stroke_color(&mut content, *border_color);
             content.push_str(&format!("{} w\n", widget.appearance.border_width));
             content.push_str(&format!("0 0 {width} {height} re\n"));
             content.push_str("S\n");
@@ -3805,7 +3786,10 @@ impl<W: Write> PdfWriter<W> {
                 if let Some(Object::Name(v)) = field_dict.get("V") {
                     if v == "Yes" {
                         // Draw checkmark
-                        content.push_str("0 0 0 RG\n"); // Black
+                        crate::graphics::color::write_stroke_color(
+                            &mut content,
+                            crate::graphics::Color::black(),
+                        );
                         content.push_str("2 w\n");
                         let margin = width * 0.2;
                         content.push_str(&format!("{} {} m\n", margin, height / 2.0));

--- a/oxidize-pdf-core/tests/field_appearance_tests.rs
+++ b/oxidize-pdf-core/tests/field_appearance_tests.rs
@@ -434,14 +434,15 @@ fn test_field_with_background_and_border() {
     let stream = generator.generate_text_field().unwrap();
     let content = String::from_utf8_lossy(stream.data());
 
-    // Should contain background fill
-    assert!(content.contains("0.95 0.95 1 rg"));
+    // Should contain background fill — `.3`-precision after the issue
+    // #220/#221 helper migration (single source of truth for colour ops).
+    assert!(content.contains("0.950 0.950 1.000 rg"));
     assert!(content.contains("re"));
     assert!(content.contains("f"));
 
     // Should contain border stroke
     assert!(content.contains("2 w"));
-    assert!(content.contains("0 0 0.5 RG"));
+    assert!(content.contains("0.000 0.000 0.500 RG"));
     assert!(content.contains("S"));
 }
 

--- a/oxidize-pdf-core/tests/issue_220_color_emission_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/issue_220_color_emission_sanitization_test.rs
@@ -1,0 +1,392 @@
+//! Integration tests for non-finite-float sanitisation in colour emission —
+//! issue #220, coordinated with the shared `write_fill_color`/`write_stroke_color`
+//! helper from issue #221.
+//!
+//! Direct enum construction (`Color::Rgb(f64::NAN, 0.0, 0.0)`) bypasses the
+//! `Color::rgb`/`gray`/`cmyk` clamps. Without sanitisation at emission, the
+//! `{:.3}` formatter emits `NaN`, `inf`, or `-inf` tokens — ISO 32000-1 §7.3.3
+//! rejects those as numeric values and conformant viewers reject the entire
+//! content stream.
+//!
+//! These tests verify the full pipeline: every emission site now refuses
+//! to put a non-finite float on the wire and substitutes `0.000` instead.
+
+use oxidize_pdf::graphics::{Color, GraphicsContext, PatternManager};
+use oxidize_pdf::text::{Font, TextContext};
+use oxidize_pdf::Margins;
+
+// We need the `text::flow::TextFlowContext` for the TextFlowContext tests.
+// It's accessible through `oxidize_pdf::text::TextFlowContext`.
+use oxidize_pdf::text::TextFlowContext;
+
+// ---------- helper ----------
+
+fn assert_no_non_finite_tokens(ops: &str, context: &str) {
+    for forbidden in ["NaN", "inf", "Inf", "INF", "-inf", "-Inf"] {
+        assert!(
+            !ops.contains(forbidden),
+            "{context}: forbidden token '{forbidden}' appears in content stream:\n{ops}"
+        );
+    }
+}
+
+// ---------- TextContext: fill colour ----------
+
+#[test]
+fn text_context_fill_color_nan_red_emits_zero_and_keeps_other_components() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_fill_color(Color::Rgb(f64::NAN, 0.5, 0.75));
+    ctx.write("hello").expect("write must succeed");
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext fill NaN red");
+    assert!(
+        ops.contains("0.000 0.500 0.750 rg"),
+        "NaN red must be substituted with 0.000 while green/blue pass through; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn text_context_fill_color_pos_inf_emits_zero() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_fill_color(Color::Rgb(f64::INFINITY, 0.0, 0.0));
+    ctx.write("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext fill +inf red");
+    assert!(
+        ops.contains("0.000 0.000 0.000 rg"),
+        "+inf red must be sanitised to 0.000; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn text_context_fill_color_neg_inf_gray_emits_zero() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_fill_color(Color::Gray(f64::NEG_INFINITY));
+    ctx.write("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext fill -inf gray");
+    assert!(
+        ops.contains("0.000 g"),
+        "-inf gray must emit 0.000 g; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn text_context_fill_color_cmyk_with_nan_yellow() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_fill_color(Color::Cmyk(0.1, 0.2, f64::NAN, 0.4));
+    ctx.write("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext fill cmyk NaN yellow");
+    assert!(
+        ops.contains("0.100 0.200 0.000 0.400 k"),
+        "NaN yellow must be 0.000, others pass through; ops:\n{ops}"
+    );
+}
+
+// ---------- TextContext: stroke colour ----------
+
+#[test]
+fn text_context_stroke_color_nan_emits_zero() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_stroke_color(Color::Rgb(f64::NAN, 0.5, 0.5));
+    ctx.write("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext stroke NaN");
+    assert!(
+        ops.contains("0.000 0.500 0.500 RG"),
+        "stroke RG with NaN red must sanitise; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn text_context_stroke_color_inf_cmyk_emits_zero() {
+    let mut ctx = TextContext::new();
+    ctx.set_font(Font::Helvetica, 12.0);
+    ctx.set_stroke_color(Color::Cmyk(f64::INFINITY, 0.2, 0.3, 0.4));
+    ctx.write("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextContext stroke +inf cyan");
+    assert!(
+        ops.contains("0.000 0.200 0.300 0.400 K"),
+        "stroke K with inf cyan must sanitise; ops:\n{ops}"
+    );
+}
+
+// ---------- TextFlowContext: fill colour ----------
+
+#[test]
+fn text_flow_context_fill_color_nan_emits_zero() {
+    let mut ctx = TextFlowContext::new(595.0, 842.0, Margins::default());
+    ctx.set_fill_color(Color::Rgb(0.5, f64::NAN, 0.5));
+    ctx.write_wrapped("hello world").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextFlowContext fill NaN green");
+    assert!(
+        ops.contains("0.500 0.000 0.500 rg"),
+        "NaN green must be 0.000; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn text_flow_context_fill_color_inf_gray_emits_zero() {
+    let mut ctx = TextFlowContext::new(595.0, 842.0, Margins::default());
+    ctx.set_fill_color(Color::Gray(f64::INFINITY));
+    ctx.write_wrapped("x").unwrap();
+
+    let ops = ctx.operations();
+    assert_no_non_finite_tokens(ops, "TextFlowContext fill +inf gray");
+    assert!(
+        ops.contains("0.000 g"),
+        "+inf gray must emit 0.000 g; ops:\n{ops}"
+    );
+}
+
+// ---------- GraphicsContext: fill + stroke ----------
+
+#[test]
+fn graphics_context_fill_color_nan_emits_zero() {
+    let mut g = GraphicsContext::new();
+    g.set_fill_color(Color::Rgb(f64::NAN, 0.4, 0.6));
+    g.fill();
+
+    let ops = g.get_operations();
+    assert_no_non_finite_tokens(ops, "GraphicsContext fill NaN");
+    assert!(
+        ops.contains("0.000 0.400 0.600 rg"),
+        "GraphicsContext fill must sanitise NaN; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn graphics_context_stroke_color_neg_inf_emits_zero() {
+    let mut g = GraphicsContext::new();
+    g.set_stroke_color(Color::Cmyk(f64::NEG_INFINITY, 0.0, 0.0, 0.0));
+    g.stroke();
+
+    let ops = g.get_operations();
+    assert_no_non_finite_tokens(ops, "GraphicsContext stroke -inf");
+    assert!(
+        ops.contains("0.000 0.000 0.000 0.000 K"),
+        "GraphicsContext stroke must sanitise -inf; ops:\n{ops}"
+    );
+}
+
+#[test]
+fn graphics_context_finite_value_passes_through_unchanged() {
+    // Regression guard: sanitisation must NOT alter finite values.
+    let mut g = GraphicsContext::new();
+    g.set_fill_color(Color::Rgb(0.123, 0.456, 0.789));
+    g.fill();
+
+    let ops = g.get_operations();
+    assert!(
+        ops.contains("0.123 0.456 0.789 rg"),
+        "finite RGB must pass through with .3 precision unchanged; ops:\n{ops}"
+    );
+}
+
+// ---------- Pattern: raw [f64; 3] arrays ----------
+
+#[test]
+fn pattern_checkerboard_with_nan_color_does_not_emit_nan() {
+    // patterns.rs sites use raw [f64; 3], not Color enum. They are listed
+    // in #220's "Affected sites (verified)" so they must also be sanitised.
+    let mut mgr = PatternManager::new();
+    let pattern_name = mgr
+        .create_checkerboard_pattern(10.0, [f64::NAN, 0.0, 0.0], [0.5, 0.5, 0.5])
+        .expect("checkerboard creation must succeed");
+    let pattern = mgr
+        .get_pattern(&pattern_name)
+        .expect("registered pattern lookup must succeed");
+    let stream = String::from_utf8(pattern.content_stream.clone())
+        .expect("pattern content stream must be UTF-8");
+
+    assert_no_non_finite_tokens(&stream, "pattern checkerboard NaN red");
+}
+
+#[test]
+fn pattern_stripe_with_inf_color_does_not_emit_inf() {
+    let mut mgr = PatternManager::new();
+    let name = mgr
+        .create_stripe_pattern(5.0, 0.0, [0.0, f64::INFINITY, 0.0], [0.2, 0.2, 0.2])
+        .expect("stripe creation must succeed");
+    let pattern = mgr.get_pattern(&name).unwrap();
+    let stream = String::from_utf8(pattern.content_stream.clone()).unwrap();
+
+    assert_no_non_finite_tokens(&stream, "pattern stripe +inf green");
+}
+
+// ---------- Parity (issue #221) ----------
+
+#[test]
+fn text_context_and_text_flow_context_emit_identical_rgb_fill() {
+    // Both call sites collapse to the same helper; emitted byte-for-byte
+    // identical operators is the contract.
+    let mut tc = TextContext::new();
+    tc.set_font(Font::Helvetica, 12.0);
+    tc.set_fill_color(Color::Rgb(0.25, 0.5, 0.75));
+    tc.write("x").unwrap();
+
+    let mut tfc = TextFlowContext::new(595.0, 842.0, Margins::default());
+    tfc.set_fill_color(Color::Rgb(0.25, 0.5, 0.75));
+    tfc.write_wrapped("x").unwrap();
+
+    let needle = "0.250 0.500 0.750 rg";
+    assert!(
+        tc.operations().contains(needle),
+        "TextContext: missing '{needle}'; ops:\n{}",
+        tc.operations()
+    );
+    assert!(
+        tfc.operations().contains(needle),
+        "TextFlowContext: missing '{needle}'; ops:\n{}",
+        tfc.operations()
+    );
+}
+
+#[test]
+fn graphics_context_and_text_context_emit_identical_rgb_fill() {
+    // GraphicsContext::apply_fill_color and TextContext::apply_text_state_parameters
+    // must converge on the same helper output.
+    let mut g = GraphicsContext::new();
+    g.set_fill_color(Color::Rgb(0.25, 0.5, 0.75));
+    g.fill();
+
+    let mut tc = TextContext::new();
+    tc.set_font(Font::Helvetica, 12.0);
+    tc.set_fill_color(Color::Rgb(0.25, 0.5, 0.75));
+    tc.write("x").unwrap();
+
+    let needle = "0.250 0.500 0.750 rg";
+    assert!(g.get_operations().contains(needle));
+    assert!(tc.operations().contains(needle));
+}
+
+// ---------- Graphics: FormXObject ----------
+
+#[test]
+fn form_xobject_fill_color_with_nan_emits_zero() {
+    use oxidize_pdf::geometry::{Point, Rectangle};
+    use oxidize_pdf::graphics::{FormTemplates, FormXObjectBuilder};
+
+    let bbox = Rectangle::new(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
+    let form = FormXObjectBuilder::new(bbox)
+        .fill_color(f64::NAN, 0.5, 0.75)
+        .rectangle(0.0, 0.0, 100.0, 100.0)
+        .fill()
+        .build();
+
+    let content = String::from_utf8(form.content).expect("content must be UTF-8");
+    assert_no_non_finite_tokens(&content, "FormXObject fill NaN");
+    assert!(
+        content.contains("0.000 0.500 0.750 rg"),
+        "FormXObject fill must sanitise; content:\n{content}"
+    );
+
+    // Regression: existing FormTemplates still produce sanitised output for
+    // their hard-coded finite values.
+    let star = FormTemplates::star(100.0, 5);
+    let star_content = String::from_utf8(star.content).expect("content must be UTF-8");
+    assert!(
+        star_content.contains("1.000 0.800 0.000 rg"),
+        "FormTemplates::star gold colour must round-trip through helper; content:\n{star_content}"
+    );
+}
+
+#[test]
+fn form_xobject_stroke_color_with_inf_emits_zero() {
+    use oxidize_pdf::geometry::{Point, Rectangle};
+    use oxidize_pdf::graphics::FormXObjectBuilder;
+
+    let bbox = Rectangle::new(Point::new(0.0, 0.0), Point::new(50.0, 50.0));
+    let form = FormXObjectBuilder::new(bbox)
+        .stroke_color(0.5, f64::INFINITY, 0.5)
+        .move_to(0.0, 0.0)
+        .line_to(50.0, 50.0)
+        .stroke()
+        .build();
+
+    let content = String::from_utf8(form.content).expect("content must be UTF-8");
+    assert_no_non_finite_tokens(&content, "FormXObject stroke +inf");
+    assert!(
+        content.contains("0.500 0.000 0.500 RG"),
+        "FormXObject stroke must sanitise; content:\n{content}"
+    );
+}
+
+// ---------- Forms: field_appearance.rs ----------
+
+#[test]
+fn field_appearance_text_field_with_nan_background_emits_zero() {
+    use oxidize_pdf::forms::field_appearance::{FieldAppearanceGenerator, TextAlignment};
+
+    let generator = FieldAppearanceGenerator {
+        font: "Helv".to_string(),
+        font_size: 12.0,
+        text_color: Color::black(),
+        value: "x".to_string(),
+        background_color: Some(Color::Rgb(f64::NAN, 0.5, 0.5)),
+        border_color: Some(Color::Cmyk(f64::INFINITY, 0.2, 0.3, 0.4)),
+        border_width: 1.0,
+        rect: [0.0, 0.0, 100.0, 25.0],
+        alignment: TextAlignment::Left,
+        multiline: false,
+        max_length: None,
+        comb: false,
+    };
+
+    let stream = generator
+        .generate_text_field()
+        .expect("text field generation must succeed");
+    let content = String::from_utf8_lossy(stream.data());
+    assert_no_non_finite_tokens(&content, "field_appearance text-field");
+    assert!(
+        content.contains("0.000 0.500 0.500 rg"),
+        "background NaN red must sanitise; content:\n{content}"
+    );
+    assert!(
+        content.contains("0.000 0.200 0.300 0.400 K"),
+        "border CMYK +inf cyan must sanitise; content:\n{content}"
+    );
+}
+
+// ---------- Annotations: free-text /DA string ----------
+
+#[test]
+fn free_text_annotation_da_with_nan_emits_zero() {
+    use oxidize_pdf::annotations::FreeTextAnnotation;
+    use oxidize_pdf::geometry::{Point, Rectangle};
+
+    let rect = Rectangle::new(Point::new(0.0, 0.0), Point::new(100.0, 50.0));
+    let ann = FreeTextAnnotation::new(rect, "hello")
+        .with_font(Font::Helvetica, 12.0, Color::Rgb(f64::NAN, 0.5, 0.5))
+        .to_annotation();
+
+    // The /DA entry on the annotation properties must not contain NaN.
+    let da = ann
+        .properties
+        .get("DA")
+        .expect("annotation must have /DA entry");
+    let da_str = match da {
+        oxidize_pdf::objects::Object::String(s) => s.clone(),
+        other => panic!("/DA must be a String, got {:?}", other),
+    };
+    assert_no_non_finite_tokens(&da_str, "FreeText /DA");
+    assert!(
+        da_str.contains("0.000 0.500 0.500 rg"),
+        "/DA must sanitise NaN red; /DA:\n{da_str}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the colour-emission DoS attack surface described in issue #220 and the duplication footgun in #221 by introducing a single source of truth for every colour-operator emission across the codebase.

**Threat model**: direct construction of `Color::Rgb(f64::NAN, ...)` (and the other variants — they are `pub`) bypasses the clamping in `Color::rgb`/`gray`/`cmyk` constructors. Without sanitisation at the emission boundary, the `{:.3}` formatter writes literal `NaN` / `inf` / `-inf` tokens to the content stream. ISO 32000-1 §7.3.3 rejects those as numeric values, so conformant viewers reject the entire content stream — availability DoS via crafted input.

## What changed

1. **New helpers in `graphics/color.rs`**:
   - `finite_or_zero(f64) -> f64` — substitutes NaN/inf with 0.0.
   - `fill_color_op(Color)` / `stroke_color_op(Color)` — single source of truth, returns String without trailing newline (used in /DA strings, pattern commands, etc.).
   - `write_fill_color` / `write_stroke_color` — direct emission to `&mut String` with `\n` (uses `std::fmt::Write`, no intermediate alloc).
   - `write_fill_color_bytes` / `write_stroke_color_bytes` — direct emission to `&mut Vec<u8>` with `\n` (uses `std::io::Write`, no intermediate alloc).

2. **Migrated 17 source files**, ~50 emitter sites:
   - `text/mod.rs`, `text/flow.rs`
   - `graphics/mod.rs`, `graphics/patterns.rs`, `graphics/form_xobject.rs`
   - `forms/appearance.rs`, `forms/button_widget.rs`, `forms/choice_widget.rs`, `forms/field_appearance.rs`, `forms/field_type.rs`, `forms/signature_field.rs`, `forms/signature_widget.rs`
   - `annotations/annotation_type.rs`, `annotations/geometric.rs`
   - `layout/rich_text.rs`
   - `writer/pdf_writer/mod.rs`

   This includes the 4 sites listed explicitly in #220 plus all sibling emitters that were vulnerable to the same CWE-20 (Improper Input Validation).

3. **Wire-format consolidation**: every emitter now uses `.3`-precision uniformly (some sites previously used unformatted `{}`). Wire form is more consistent and slightly more verbose (~5 chars per operator) but ISO-conformant in every case.

## Behaviour change worth flagging

`forms/choice_widget.rs` previously forced RGB output via `.r()/.g()/.b()` lossy conversion regardless of the colour's native space. The helper now emits the native space (`rg` / `g` / `k`) which is strictly more correct. PDF/A consumers that relied on the implicit RGB normalisation should verify their output intent now references DeviceCMYK if needed.

## Tests

- **19 new content-verifying integration tests** in `tests/issue_220_color_emission_sanitization_test.rs` covering TextContext, TextFlowContext, GraphicsContext, patterns, FormXObject, FreeText `/DA`, and field_appearance text fields. No smoke tests — every assertion checks actual content.
- **13 new unit tests** in `graphics/color.rs` for the helper itself.
- **7 pre-existing unit tests + 1 integration test updated** to reflect the new `.3`-precision wire format (deliberate consolidation, not a regression).
- **Suite**: 6344 lib + 8258 integration tests pass, 0 regressions.
- `cargo clippy --lib -p oxidize-pdf -- -D warnings` clean.

## Reviews applied pre-commit (parallel agents)

- **quality-rust** verdict: APPROVE-WITH-FOLLOWUPS. Findings actioned in same commit:
  - 15 hardcoded literal emitters (e.g. `"1 1 1 rg"`, `"0 0 0 RG"`) migrated to use `Color::white()`, `Color::black()`, `Color::gray(...)` + helper.
  - Redundant `String` allocations in `_bytes` variants eliminated by direct `std::io::Write` emission.
  - Pattern emitters now route via `Color::Rgb(...)` wrapper instead of intermediate `format!`.
- **security-expert-advisor** verdict: APPROVE. Colour attack surface fully closed. HIGH finding on non-colour numeric emitters (line widths, transform matrices, dash patterns, `Td`, `m`, `l`, `c`, `re`, etc.) — same CWE class but **out of scope for #220**. Tracked as a separate follow-up issue for v2.7.0.

## Net impact

`+514 / -579 LOC` — single source of truth, less duplication.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --lib -p oxidize-pdf` (6344 passed)
- [x] `cargo test --tests -p oxidize-pdf` (8258 passed)
- [x] `cargo clippy --lib -p oxidize-pdf -- -D warnings` clean
- [x] `cargo fmt --all` applied (pre-commit hook enforced)
- [x] No `.private/` or sensitive paths in diff (`git status --porcelain | grep -iE '\.private/|private\.'` returns empty)

## Related work for v2.7.0 (not in this PR)

- Apply the same finite-or-zero discipline to non-colour numeric content-stream emitters (line widths, `cm`, `Td`, dash patterns, etc.) — separate issue to be opened post-release.
- Issue #222 — complete `TextContext → TextFlowContext` state propagation for the remaining 7 fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)