### PR TITLE
Form field appearance Type0/CID — addresses #212

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Added
+
+- **`ComboBox::with_default_appearance(font, size, color)`** — typed `/DA` builder mirroring `TextField::with_default_appearance`. `FormManager::add_combo_box` now propagates the typed `DefaultAppearance` to `FormField.default_appearance`, so `Document::fill_field` on a `Choice` field can dispatch to the Type0/CID custom-font path. Without this, fill_field on a ComboBox fell through to the Helvetica + WinAnsi path and returned `PdfError::EncodingError` for any non-WinAnsi value (addresses #212).
+- **`ListBoxAppearance::generate_appearance_with_font(widget, value, state, custom_font)`** — Type0/CID-aware appearance generator, matching the existing pattern on `TextFieldAppearance` and `ComboBoxAppearance`. Dispatches on `(font.is_custom(), custom_font)` to emit hex-CID Tj operators and a Type0 placeholder resource entry for custom fonts; the legacy `AppearanceGenerator::generate_appearance` now delegates to it with `custom_font = None` (addresses #212).
+
+### Fixed
+
+- **`PushButtonAppearance` with `Font::Custom(_)`** unconditionally emitted `/Subtype /Type1` in the AP `/Resources/Font` dict and called `emit_tj_for_builtin` on the label (which rejects custom fonts with `PdfError::EncodingError`), so push buttons with CJK / non-WinAnsi fonts could not be generated at all. The resource dict now emits a `/Subtype /Type0` placeholder for custom fonts (rewritten to an indirect Reference at write time by `rewrite_ap_stream_font_resources`), and the label-render block is skipped when the font is custom — the hex-CID Tj path for push button labels remains a follow-up because the generator does not yet take a `custom_font` parameter (addresses #212).
+- **ComboBox `/AP/N` for `Font::Custom`** now correctly emits hex-CID Tj content and a Type0 resource placeholder via `Document::fill_field`. This completes the v2.6.0 partial fix (PR #215) which addressed encoding for built-in WinAnsi values; the architectural Type0/CID path now works end-to-end for `FieldType::Text` and `FieldType::Choice` (addresses #212).
+
 ## [2.7.0] - 2026-05-07
 
 ### Added

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -542,6 +542,30 @@ impl Document {
     /// * `PdfError::FieldNotFound` if no field with the given `name` exists
     ///   in the `FormManager`.
     ///
+    /// # Custom Type0/CID font dispatch (issue #212)
+    ///
+    /// Both `FieldType::Text` (TextField) and `FieldType::Choice` (ComboBox)
+    /// honour the field's typed `/DA` and dispatch to the correct emission
+    /// path:
+    ///
+    /// - `Font::Custom(name)` with the font registered via
+    ///   `add_font_from_bytes` → Type0/CID path. Hex-CID `<HHHH> Tj` in the
+    ///   appearance content stream and a `/Subtype /Type0` /
+    ///   `/Encoding /Identity-H` resource entry that the writer rewrites to
+    ///   an indirect Reference to the document-level CIDFontType0 object.
+    /// - Built-in font (Helvetica, Times, Courier) → WinAnsi-strict path.
+    ///   Returns `PdfError::EncodingError` for any character outside the
+    ///   WinAnsi repertoire.
+    /// - No `/DA` → Helvetica fallback, same WinAnsi-strict path.
+    ///
+    /// To use a custom font with a ComboBox, call
+    /// `ComboBox::with_default_appearance(Font::Custom("name"), size, color)`
+    /// before passing it to `FormManager::add_combo_box`. The same
+    /// constructor on `TextField` covers text fields. For PushButton labels
+    /// with custom fonts the resource dict is correct (Type0 placeholder)
+    /// but the label-render block is currently skipped; full hex-CID Tj for
+    /// push button labels remains a follow-up.
+    ///
     /// # Path chosen (v2.5.6 Task 3)
     ///
     /// This method operates on an in-memory `Document` that was BUILT in

--- a/oxidize-pdf-core/src/forms/appearance.rs
+++ b/oxidize-pdf-core/src/forms/appearance.rs
@@ -1141,13 +1141,42 @@ impl AppearanceGenerator for ListBoxAppearance {
     fn generate_appearance(
         &self,
         widget: &Widget,
+        value: Option<&str>,
+        state: AppearanceState,
+    ) -> Result<AppearanceStream> {
+        Ok(self
+            .generate_appearance_with_font(widget, value, state, None)?
+            .stream)
+    }
+}
+
+impl ListBoxAppearance {
+    /// Type0/CID-aware appearance generator for ListBox fields.
+    ///
+    /// Mirrors [`TextFieldAppearance::generate_appearance_with_font`] and
+    /// [`ComboBoxAppearance::generate_appearance_with_font`]: dispatches on
+    /// `self.font.is_custom()` × the optional `custom_font` parameter to emit
+    /// hex-CID Tj for Type0/CID fonts, an explicit error when the font name
+    /// is custom but the resolved font object is missing, and the legacy
+    /// WinAnsi-strict path for built-in Type1 fonts.
+    ///
+    /// The `/Resources/Font/<name>` entry follows the same pattern: a Type0
+    /// placeholder when `is_custom()` (rewritten by the writer to an indirect
+    /// reference at serialisation time, see
+    /// `writer::pdf_writer::rewrite_ap_stream_font_resources`), and an inline
+    /// Type1 dict otherwise. Used in support of issue #212.
+    pub fn generate_appearance_with_font(
+        &self,
+        widget: &Widget,
         _value: Option<&str>,
         _state: AppearanceState,
-    ) -> Result<AppearanceStream> {
+        custom_font: Option<&crate::fonts::Font>,
+    ) -> Result<FieldAppearanceResult> {
         let width = widget.rect.upper_right.x - widget.rect.lower_left.x;
         let height = widget.rect.upper_right.y - widget.rect.lower_left.y;
 
         let mut content = String::new();
+        let mut used_chars_per_font: HashMap<String, HashSet<char>> = HashMap::new();
 
         // Draw background
         crate::graphics::color::write_fill_color(&mut content, Color::white());
@@ -1193,14 +1222,54 @@ impl AppearanceGenerator for ListBoxAppearance {
 
             content.push_str(&format!("5 {} Td\n", y + 2.0));
 
-            emit_tj_for_builtin(&mut content, option, &self.font)?;
+            // Same dispatch as ComboBoxAppearance / TextFieldAppearance.
+            match (self.font.is_custom(), custom_font) {
+                (true, Some(cf)) => {
+                    let font_name = self.font.pdf_name();
+                    let entry = used_chars_per_font.entry(font_name.clone()).or_default();
+                    emit_tj_for_custom(&mut content, option, &font_name, cf, entry)?;
+                }
+                (true, None) => {
+                    return Err(PdfError::EncodingError(format!(
+                        "Font {:?} is marked as Custom but was not found in the \
+                         document registry; call Document::add_font_from_bytes with \
+                         this name before fill_field/save. See issue #212.",
+                        self.font.pdf_name(),
+                    )));
+                }
+                (false, _) => emit_tj_for_builtin(&mut content, option, &self.font)?,
+            }
+
             content.push_str("ET\n");
 
             y -= self.item_height;
         }
 
+        // Resources dict — Type0 placeholder for custom, inline Type1 for built-in.
+        let mut resources = Dictionary::new();
+        let mut font_dict = Dictionary::new();
+        if self.font.is_custom() {
+            let mut placeholder = Dictionary::new();
+            placeholder.set("Type", Object::Name("Font".to_string()));
+            placeholder.set("Subtype", Object::Name("Type0".to_string()));
+            placeholder.set("BaseFont", Object::Name(self.font.pdf_name()));
+            placeholder.set("Encoding", Object::Name("Identity-H".to_string()));
+            font_dict.set(self.font.pdf_name(), Object::Dictionary(placeholder));
+        } else {
+            let mut font_res = Dictionary::new();
+            font_res.set("Type", Object::Name("Font".to_string()));
+            font_res.set("Subtype", Object::Name("Type1".to_string()));
+            font_res.set("BaseFont", Object::Name(self.font.pdf_name()));
+            font_dict.set(self.font.pdf_name(), Object::Dictionary(font_res));
+        }
+        resources.set("Font", Object::Dictionary(font_dict));
+
         let bbox = [0.0, 0.0, width, height];
-        Ok(AppearanceStream::new(content.into_bytes(), bbox))
+        let stream = AppearanceStream::new(content.into_bytes(), bbox).with_resources(resources);
+        Ok(FieldAppearanceResult {
+            stream,
+            used_chars_by_font: used_chars_per_font,
+        })
     }
 }
 

--- a/oxidize-pdf-core/src/forms/appearance.rs
+++ b/oxidize-pdf-core/src/forms/appearance.rs
@@ -891,8 +891,12 @@ impl AppearanceGenerator for PushButtonAppearance {
             }
         }
 
-        // Draw label text
-        if !self.label.is_empty() {
+        // Draw label text — skipped for custom Type0 fonts because the
+        // hex-CID Tj path requires the font's glyph mapping, which is not
+        // yet a parameter of this generator (see issue #212 follow-up).
+        // The resource dict below still emits the Type0 placeholder so the
+        // writer can rewrite the indirect reference correctly.
+        if !self.label.is_empty() && !self.font.is_custom() {
             crate::graphics::color::write_fill_color(&mut content, self.text_color);
 
             content.push_str("BT\n");
@@ -922,13 +926,27 @@ impl AppearanceGenerator for PushButtonAppearance {
         // Create resources dictionary
         let mut resources = Dictionary::new();
 
-        // Add font resource
+        // Font resource — Type0 placeholder for custom fonts so the writer's
+        // rewrite_ap_stream_font_resources can substitute an indirect
+        // reference to the document-level CIDFontType0 object. Built-in
+        // Type1 fonts continue to embed the inline Type1 dict (the writer
+        // does not rewrite Type1 inline dicts; viewers resolve base-14 by
+        // name).
         let mut font_dict = Dictionary::new();
-        let mut font_res = Dictionary::new();
-        font_res.set("Type", Object::Name("Font".to_string()));
-        font_res.set("Subtype", Object::Name("Type1".to_string()));
-        font_res.set("BaseFont", Object::Name(self.font.pdf_name()));
-        font_dict.set(self.font.pdf_name(), Object::Dictionary(font_res));
+        if self.font.is_custom() {
+            let mut placeholder = Dictionary::new();
+            placeholder.set("Type", Object::Name("Font".to_string()));
+            placeholder.set("Subtype", Object::Name("Type0".to_string()));
+            placeholder.set("BaseFont", Object::Name(self.font.pdf_name()));
+            placeholder.set("Encoding", Object::Name("Identity-H".to_string()));
+            font_dict.set(self.font.pdf_name(), Object::Dictionary(placeholder));
+        } else {
+            let mut font_res = Dictionary::new();
+            font_res.set("Type", Object::Name("Font".to_string()));
+            font_res.set("Subtype", Object::Name("Type1".to_string()));
+            font_res.set("BaseFont", Object::Name(self.font.pdf_name()));
+            font_dict.set(self.font.pdf_name(), Object::Dictionary(font_res));
+        }
         resources.set("Font", Object::Dictionary(font_dict));
 
         let stream = AppearanceStream::new(content.into_bytes(), [0.0, 0.0, width, height])

--- a/oxidize-pdf-core/src/forms/field_type.rs
+++ b/oxidize-pdf-core/src/forms/field_type.rs
@@ -515,6 +515,11 @@ pub struct ComboBox {
     pub selected: Option<usize>,
     /// Whether custom text entry is allowed
     pub editable: bool,
+    /// Typed `/DA` (default appearance) — drives the font/size/colour used
+    /// to regenerate the field's `/AP/N` when `Document::fill_field` is
+    /// called. When `None`, fill_field falls back to Helvetica + WinAnsi
+    /// (which fails for any non-WinAnsi value — see issue #212).
+    pub default_appearance: Option<DefaultAppearance>,
 }
 
 impl ComboBox {
@@ -526,7 +531,25 @@ impl ComboBox {
             value: None,
             selected: None,
             editable: false,
+            default_appearance: None,
         }
+    }
+
+    /// Attach a typed `/DA` so `Document::fill_field` knows which font to
+    /// pick when regenerating this combo box's `/AP/N` stream.
+    ///
+    /// Mirrors [`TextField::with_default_appearance`]. Selecting a custom
+    /// Type0/CID font here is the only path today that lets `fill_field`
+    /// emit a correct appearance for non-WinAnsi values (CJK, Arabic,
+    /// non-WinAnsi Latin) — the default built-in Helvetica cannot render
+    /// those and `fill_field` will otherwise return
+    /// `PdfError::EncodingError`. See issue #212.
+    ///
+    /// The font must be registered on the `Document` via
+    /// `add_font_from_bytes` if it's a `Font::Custom(_)`.
+    pub fn with_default_appearance(mut self, font: Font, font_size: f64, color: Color) -> Self {
+        self.default_appearance = Some(DefaultAppearance::new(font, font_size, color));
+        self
     }
 
     /// Add an option

--- a/oxidize-pdf-core/src/forms/form_data.rs
+++ b/oxidize-pdf-core/src/forms/form_data.rs
@@ -204,7 +204,18 @@ impl FormManager {
         widget: Widget,
         options: Option<FieldOptions>,
     ) -> Result<ObjectReference> {
+        // Preserve the typed /DA on the FormField so `Document::fill_field`
+        // can pick the right font without re-parsing the PDF string in
+        // `field_dict["DA"]`. Same pattern as `add_text_field` (issue #212).
+        let typed_da = combo.default_appearance.clone();
         let mut field_dict = combo.to_dict();
+
+        // If a typed DA is present and no explicit options.default_appearance
+        // overrides it, render the typed DA to its PDF string form so the
+        // serialised dict carries `/DA` for viewers that read it directly.
+        if let Some(ref da) = typed_da {
+            field_dict.set("DA", Object::String(da.to_da_string()));
+        }
 
         // Apply options
         if let Some(opts) = options {
@@ -218,6 +229,7 @@ impl FormManager {
 
         let field_name = combo.name;
         let mut form_field = FormField::new(field_dict);
+        form_field.default_appearance = typed_da;
         form_field.add_widget(widget);
 
         // Create object reference

--- a/oxidize-pdf-core/tests/issue_212_closing_invariants_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_closing_invariants_test.rs
@@ -10,7 +10,7 @@ use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
 use oxidize_pdf::geometry::{Point, Rectangle};
 use oxidize_pdf::graphics::Color;
 use oxidize_pdf::parser::objects::PdfObject;
-use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::text::Font;
 use oxidize_pdf::{Document, Page};
 use std::io::Cursor;
@@ -204,12 +204,26 @@ fn invariant_3_roundtrip_v_and_appearance_present() {
     let pdf = build_and_fill(cjk, value);
 
     let (ap_content, _) = extract_ap_n(&pdf);
+    // Verify AP carries a complete text section (BT…ET) plus the hex-CID Tj
+    // operator for the value — these are the structural invariants that a
+    // viewer needs to render the field. Asserting "non-empty" alone would be
+    // a smoke test (any 1-byte stream passes); we assert the actual operators.
+    let ap_str = String::from_utf8_lossy(&ap_content);
     assert!(
-        !ap_content.is_empty(),
-        "Invariant 3 FAIL: /AP/N content is empty"
+        ap_str.contains("BT\n") && ap_str.contains("ET\n"),
+        "Invariant 3 FAIL: /AP/N must contain a BT…ET text section; got {ap_str:?}"
+    );
+    assert!(
+        ap_str.contains("> Tj"),
+        "Invariant 3 FAIL: /AP/N must contain a hex-CID Tj operator; got {ap_str:?}"
     );
 
-    let mut reader = PdfReader::new(Cursor::new(&pdf)).expect("parse PDF");
+    // Strict parsing — the default lenient_encoding interprets 0x80–0xFF as
+    // Windows-1252 and re-encodes to UTF-8, which destroys byte-level
+    // fidelity of /V. For a PDF we just generated in-process we want the
+    // raw bytes back exactly as the writer emitted them.
+    let mut reader = PdfReader::new_with_options(Cursor::new(&pdf), ParseOptions::strict())
+        .expect("parse PDF (strict)");
     let catalog = reader.catalog().expect("catalog").clone();
     let acro_dict = match catalog.get("AcroForm").expect("/AcroForm") {
         PdfObject::Reference(n, g) => reader
@@ -227,20 +241,29 @@ fn invariant_3_roundtrip_v_and_appearance_present() {
         .and_then(|o| o.as_array())
         .expect("/AcroForm/Fields");
 
-    let mut found_nonempty_v = false;
+    // /V must equal the UTF-8 of the input value byte-for-byte. (The writer
+    // currently emits /V as a literal `(...)` carrying raw UTF-8; this test
+    // pins that contract. UTF-16BE-with-BOM conformance is tracked as a
+    // separate fidelity follow-up — when fixed, this assertion will need to
+    // accept the BOM-prefixed form.)
+    let mut v_found = false;
     for fr in &fields.0 {
         let (fn_, fg) = fr.as_reference().expect("field ref");
         let fobj = reader.get_object(fn_, fg).expect("field obj").clone();
         let fd = fobj.as_dict().expect("field dict").clone();
         if let Some(PdfObject::String(s)) = fd.get("V") {
-            if !s.0.is_empty() {
-                found_nonempty_v = true;
-            }
+            assert_eq!(
+                s.0.as_slice(),
+                value.as_bytes(),
+                "Invariant 3 FAIL: /V byte content must equal UTF-8 of '{value}'; got {:?}",
+                s.0
+            );
+            v_found = true;
         }
     }
     assert!(
-        found_nonempty_v,
-        "Invariant 3 FAIL: no AcroForm field with non-empty /V found after fill_field"
+        v_found,
+        "Invariant 3 FAIL: no AcroForm field with /V found after fill_field"
     );
 }
 
@@ -273,10 +296,6 @@ fn invariant_4_helvetica_builtin_regression() {
     let pdf = doc
         .to_bytes()
         .expect("Invariant 4 FAIL: to_bytes must succeed for Helvetica");
-    assert!(
-        !pdf.is_empty(),
-        "Invariant 4 FAIL: serialized PDF must be non-empty"
-    );
 
     let (ap_content, _) = extract_ap_n(&pdf);
     let content_str = String::from_utf8_lossy(&ap_content);

--- a/oxidize-pdf-core/tests/issue_212_closing_invariants_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_closing_invariants_test.rs
@@ -1,0 +1,295 @@
+//! Issue #212 — Closing invariants.
+//!
+//! These four tests are the acceptance criteria for the architectural fix.
+//! All must be green before the branch is considered ready for PR.
+//!
+//! Tests that depend on SourceHanSansSC-Regular.otf are skipped when the
+//! fixture is absent (CI without large test fixtures).
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+const CJK_PATH: &str = "../test-pdfs/SourceHanSansSC-Regular.otf";
+
+fn load_fixture(path: &str) -> Option<Vec<u8>> {
+    if std::path::Path::new(path).exists() {
+        Some(std::fs::read(path).expect("read fixture"))
+    } else {
+        eprintln!("SKIPPED: {path} not found");
+        None
+    }
+}
+
+/// Build a document with a single TextField using Font::Custom("CJK"),
+/// fill it with `value`, return the serialized PDF bytes.
+fn build_and_fill(cjk_data: Vec<u8>, value: &str) -> Vec<u8> {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("CJK", cjk_data)
+        .expect("register CJK font");
+
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("f1").with_default_appearance(
+        Font::Custom("CJK".to_string()),
+        14.0,
+        Color::black(),
+    );
+    let fref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(widget, fref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("f1", value).expect("fill_field with CJK");
+    doc.to_bytes().expect("serialize")
+}
+
+/// Extract first widget annotation /AP/N stream from first page.
+fn extract_ap_n(pdf: &[u8]) -> (Vec<u8>, oxidize_pdf::parser::objects::PdfDictionary) {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    let (pn, pg) = kids.0[0].as_reference().expect("page ref");
+    let page_obj = reader.get_object(pn, pg).expect("page obj").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("/Annots");
+    let (an, ag) = annots.0[0].as_reference().expect("annot ref");
+    let annot_obj = reader.get_object(an, ag).expect("annot obj").clone();
+    let annot_dict = annot_obj.as_dict().expect("annot dict").clone();
+    let ap = annot_dict
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("/AP")
+        .clone();
+    let n = ap.get("N").expect("/AP/N").clone();
+    match n {
+        PdfObject::Reference(n2, g2) => {
+            let s = reader.get_object(n2, g2).expect("AP/N stream").clone();
+            let stream = s.as_stream().expect("stream");
+            let data = stream.decode(reader.options()).expect("decode");
+            (data, stream.dict.clone())
+        }
+        PdfObject::Stream(ref s) => {
+            let data = s.decode(reader.options()).expect("decode inline");
+            (data, s.dict.clone())
+        }
+        _ => panic!("/AP/N is not a stream or reference"),
+    }
+}
+
+/// Resolve `/Resources/Font/<name>` whether it is an inline dict or an
+/// indirect reference, returning (subtype, encoding) names.
+fn resolve_ap_font_subtype_encoding(
+    pdf: &[u8],
+    ap_dict: &oxidize_pdf::parser::objects::PdfDictionary,
+    font_name: &str,
+) -> (String, String) {
+    let resources = ap_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    let fonts = resources
+        .get("Font")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources/Font");
+    let entry = fonts.get(font_name).expect("font entry");
+    match entry {
+        PdfObject::Reference(n, g) => {
+            let mut reader = PdfReader::new(Cursor::new(pdf)).expect("PdfReader resolve");
+            let obj = reader.get_object(*n, *g).expect("resolve font ref").clone();
+            let fd = obj.as_dict().expect("resolved font dict").clone();
+            (
+                fd.get("Subtype")
+                    .and_then(|o| o.as_name())
+                    .map(|nm| nm.as_str().to_string())
+                    .unwrap_or_default(),
+                fd.get("Encoding")
+                    .and_then(|o| o.as_name())
+                    .map(|nm| nm.as_str().to_string())
+                    .unwrap_or_default(),
+            )
+        }
+        PdfObject::Dictionary(d) => (
+            d.get("Subtype")
+                .and_then(|o| o.as_name())
+                .map(|nm| nm.as_str().to_string())
+                .unwrap_or_default(),
+            d.get("Encoding")
+                .and_then(|o| o.as_name())
+                .map(|nm| nm.as_str().to_string())
+                .unwrap_or_default(),
+        ),
+        other => panic!("unexpected /Resources/Font/{font_name}: {other:?}"),
+    }
+}
+
+/// Invariant 1: /AP/N /Resources/Font/CJK resolves to a dict with
+/// /Subtype /Type0 and /Encoding /Identity-H.
+#[test]
+fn invariant_1_ap_resources_font_cjk_is_type0_identity_h() {
+    let cjk = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+    let pdf = build_and_fill(cjk, "高效能");
+    let (_content, ap_dict) = extract_ap_n(&pdf);
+
+    let (subtype, encoding) = resolve_ap_font_subtype_encoding(&pdf, &ap_dict, "CJK");
+    assert_eq!(
+        subtype, "Type0",
+        "Invariant 1 FAIL: /Resources/Font/CJK must resolve to /Subtype /Type0; got {subtype:?}. \
+         A Type1 here is the exact bug issue #212 was filed about."
+    );
+    assert_eq!(
+        encoding, "Identity-H",
+        "Invariant 1 FAIL: Type0 font must declare /Encoding /Identity-H; got {encoding:?}"
+    );
+}
+
+/// Invariant 2: /AP/N content stream uses hex-encoded CIDs `<HHHH> Tj`,
+/// not literal `(...)` Tj, for custom fonts.
+#[test]
+fn invariant_2_ap_content_uses_hex_cid_tj_not_literal() {
+    let cjk = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+    let value = "高效能";
+    let pdf = build_and_fill(cjk, value);
+    let (ap_content, _) = extract_ap_n(&pdf);
+    let content_str = String::from_utf8_lossy(&ap_content);
+
+    assert!(
+        content_str.contains('<') && content_str.contains("> Tj"),
+        "Invariant 2 FAIL: /AP/N content must contain hex-CID Tj operator; \
+         content = {content_str:?}"
+    );
+
+    let utf8_bytes = value.as_bytes();
+    assert!(
+        !ap_content
+            .windows(utf8_bytes.len())
+            .any(|w| w == utf8_bytes),
+        "Invariant 2 FAIL: /AP/N content contains raw UTF-8 bytes of the CJK \
+         value — the WinAnsi/literal path was taken instead of hex-CID"
+    );
+}
+
+/// Invariant 3: Round-trip — /V on the field dict contains the filled value,
+/// and the appearance stream is present and non-empty.
+#[test]
+fn invariant_3_roundtrip_v_and_appearance_present() {
+    let cjk = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+    let value = "高效能";
+    let pdf = build_and_fill(cjk, value);
+
+    let (ap_content, _) = extract_ap_n(&pdf);
+    assert!(
+        !ap_content.is_empty(),
+        "Invariant 3 FAIL: /AP/N content is empty"
+    );
+
+    let mut reader = PdfReader::new(Cursor::new(&pdf)).expect("parse PDF");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_dict = match catalog.get("AcroForm").expect("/AcroForm") {
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve AcroForm")
+            .clone()
+            .as_dict()
+            .expect("AcroForm dict")
+            .clone(),
+        PdfObject::Dictionary(d) => d.clone(),
+        other => panic!("unexpected /AcroForm shape: {other:?}"),
+    };
+    let fields = acro_dict
+        .get("Fields")
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields");
+
+    let mut found_nonempty_v = false;
+    for fr in &fields.0 {
+        let (fn_, fg) = fr.as_reference().expect("field ref");
+        let fobj = reader.get_object(fn_, fg).expect("field obj").clone();
+        let fd = fobj.as_dict().expect("field dict").clone();
+        if let Some(PdfObject::String(s)) = fd.get("V") {
+            if !s.0.is_empty() {
+                found_nonempty_v = true;
+            }
+        }
+    }
+    assert!(
+        found_nonempty_v,
+        "Invariant 3 FAIL: no AcroForm field with non-empty /V found after fill_field"
+    );
+}
+
+/// Invariant 4: Regression — filling a widget with Font::Helvetica (built-in)
+/// must continue to work, and the Type1 literal-bytes path must remain the
+/// emission strategy (no hex-CID Tj for built-in Type1 fonts).
+#[test]
+fn invariant_4_helvetica_builtin_regression() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    let field = TextField::new("latin_field").with_default_appearance(
+        Font::Helvetica,
+        12.0,
+        Color::black(),
+    );
+    let fref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(widget, fref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("latin_field", "Hello World")
+        .expect("Invariant 4 FAIL: fill_field with Font::Helvetica must succeed");
+    let pdf = doc
+        .to_bytes()
+        .expect("Invariant 4 FAIL: to_bytes must succeed for Helvetica");
+    assert!(
+        !pdf.is_empty(),
+        "Invariant 4 FAIL: serialized PDF must be non-empty"
+    );
+
+    let (ap_content, _) = extract_ap_n(&pdf);
+    let content_str = String::from_utf8_lossy(&ap_content);
+
+    assert!(
+        content_str.contains("(Hello World) Tj"),
+        "Invariant 4 FAIL: Helvetica AP stream must contain literal '(Hello World) Tj'; \
+         content = {content_str:?}"
+    );
+    // The Type0/CID path must NOT have been taken for a built-in Type1 font.
+    assert!(
+        !content_str.contains("> Tj"),
+        "Invariant 4 FAIL: Helvetica AP stream must NOT contain hex-CID Tj operator; \
+         content = {content_str:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_212_combobox_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_combobox_custom_font_test.rs
@@ -1,0 +1,241 @@
+//! Issue #212 — ComboBox with Font::Custom round-trip verification.
+//!
+//! Validates that after `fill_field` on a FieldType::Choice (ComboBox) field:
+//! 1. /AP/N /Resources/Font/<name> resolves to a Type0 dict with /Identity-H.
+//!    (May appear as inline dict or indirect reference depending on the
+//!    writer's rewrite step; both forms are acceptable as long as the
+//!    underlying subtype is Type0, NOT Type1.)
+//! 2. /AP/N content stream contains <HHHH> Tj (hex-CID) — NOT raw UTF-8 of
+//!    the CJK value.
+//! 3. /V on the field dict is non-empty after fill_field.
+//!
+//! Uses SourceHanSansSC-Regular.otf fixture. Skipped if absent.
+
+use oxidize_pdf::forms::{ComboBox, FormManager, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+const CJK_PATH: &str = "../test-pdfs/SourceHanSansSC-Regular.otf";
+
+fn load_fixture(path: &str) -> Option<Vec<u8>> {
+    if std::path::Path::new(path).exists() {
+        Some(std::fs::read(path).expect("read fixture"))
+    } else {
+        eprintln!("SKIPPED: fixture not found at {path}");
+        None
+    }
+}
+
+/// Walk the produced PDF and return (decoded /AP/N content, /AP/N stream dict)
+/// for the first widget on the first page. Returns `None` only when the
+/// structure is missing — any decode/parse failure inside is `expect`-ed.
+fn extract_ap_n(pdf: &[u8]) -> Option<(Vec<u8>, oxidize_pdf::parser::objects::PdfDictionary)> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("PdfReader::new");
+    let page_tree = reader.pages().expect("pages tree").clone();
+    let kids = page_tree.get("Kids").and_then(|o| o.as_array())?;
+    let (pn, pg) = kids.0.first()?.as_reference()?;
+    let page_obj = reader.get_object(pn, pg).expect("page obj").clone();
+    let page_dict = page_obj.as_dict()?.clone();
+    let annots = page_dict.get("Annots").and_then(|o| o.as_array())?;
+    let (an, ag) = annots.0.first()?.as_reference()?;
+    let annot_obj = reader.get_object(an, ag).expect("annot obj").clone();
+    let annot_dict = annot_obj.as_dict()?.clone();
+    let ap = annot_dict.get("AP").and_then(|o| o.as_dict())?.clone();
+    let n_entry = ap.get("N")?.clone();
+    match n_entry {
+        PdfObject::Reference(n2, g2) => {
+            let s = reader.get_object(n2, g2).expect("AP/N stream").clone();
+            let stream = s.as_stream()?;
+            let data = stream.decode(reader.options()).expect("decode stream");
+            Some((data, stream.dict.clone()))
+        }
+        PdfObject::Stream(ref s) => {
+            let data = s.decode(reader.options()).expect("decode stream");
+            Some((data, s.dict.clone()))
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn combobox_custom_font_ap_emits_type0_and_hex_cid() {
+    let cjk_data = match load_fixture(CJK_PATH) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("CJK", cjk_data)
+        .expect("register CJK font");
+
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+
+    // ComboBox with typed Custom DA — Task 4 introduces ComboBox::with_default_appearance.
+    let combo = ComboBox::new("dropdown").with_default_appearance(
+        Font::Custom("CJK".to_string()),
+        14.0,
+        Color::black(),
+    );
+    let field_ref = fm
+        .add_combo_box(combo, widget.clone(), None)
+        .expect("add_combo_box");
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    let value = "高效能";
+    doc.fill_field("dropdown", value)
+        .expect("fill_field must succeed for CJK with typed Custom DA");
+
+    let pdf = doc.to_bytes().expect("serialize");
+
+    let (ap_content, ap_dict) = extract_ap_n(&pdf).expect("/AP/N stream");
+
+    // Invariant 1: content stream uses hex-CID Tj, not literal bytes.
+    let content_str = String::from_utf8_lossy(&ap_content);
+    assert!(
+        content_str.contains('<') && content_str.contains("> Tj"),
+        "/AP/N must contain hex-CID Tj for CJK value; content = {content_str:?}"
+    );
+    let utf8_bytes = value.as_bytes();
+    assert!(
+        !ap_content
+            .windows(utf8_bytes.len())
+            .any(|w| w == utf8_bytes),
+        "/AP/N must NOT contain raw UTF-8 bytes of the CJK value"
+    );
+
+    // Invariant 2: /Resources/Font/CJK is Type0 (inline or via indirect ref).
+    let resources = ap_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources");
+    let fonts = resources
+        .get("Font")
+        .and_then(|o| o.as_dict())
+        .expect("/Resources/Font");
+    let cjk_entry = fonts.get("CJK").expect("/Resources/Font/CJK");
+
+    let (subtype, encoding) = match cjk_entry {
+        PdfObject::Reference(n, g) => {
+            let mut reader2 = PdfReader::new(Cursor::new(&pdf)).expect("PdfReader for resolve");
+            let font_obj = reader2
+                .get_object(*n, *g)
+                .expect("resolve font ref")
+                .clone();
+            let fd = font_obj.as_dict().expect("resolved font dict").clone();
+            (
+                fd.get("Subtype")
+                    .and_then(|o| o.as_name())
+                    .map(|nm| nm.as_str().to_string())
+                    .unwrap_or_default(),
+                fd.get("Encoding")
+                    .and_then(|o| o.as_name())
+                    .map(|nm| nm.as_str().to_string())
+                    .unwrap_or_default(),
+            )
+        }
+        PdfObject::Dictionary(d) => (
+            d.get("Subtype")
+                .and_then(|o| o.as_name())
+                .map(|nm| nm.as_str().to_string())
+                .unwrap_or_default(),
+            d.get("Encoding")
+                .and_then(|o| o.as_name())
+                .map(|nm| nm.as_str().to_string())
+                .unwrap_or_default(),
+        ),
+        other => panic!("unexpected /Resources/Font/CJK shape: {other:?}"),
+    };
+
+    assert_eq!(
+        subtype, "Type0",
+        "/Resources/Font/CJK must be Type0 (got {subtype:?}) — issue #212 not fixed"
+    );
+    assert_eq!(
+        encoding, "Identity-H",
+        "Type0 font must declare /Encoding /Identity-H (got {encoding:?})"
+    );
+
+    // Invariant 3: /V on the field dict is non-empty.
+    let mut reader3 = PdfReader::new(Cursor::new(&pdf)).expect("PdfReader for /V");
+    let catalog = reader3.catalog().expect("catalog").clone();
+    let acro = match catalog.get("AcroForm").expect("/AcroForm") {
+        PdfObject::Reference(n, g) => reader3
+            .get_object(*n, *g)
+            .expect("resolve AcroForm")
+            .clone()
+            .as_dict()
+            .expect("AcroForm dict")
+            .clone(),
+        PdfObject::Dictionary(d) => d.clone(),
+        other => panic!("unexpected /AcroForm shape: {other:?}"),
+    };
+    let fields_arr = acro
+        .get("Fields")
+        .and_then(|o| o.as_array())
+        .expect("/AcroForm/Fields");
+    let mut found_v = false;
+    for field_ref in &fields_arr.0 {
+        let (fn_, fg) = field_ref.as_reference().expect("field ref");
+        let field_obj = reader3.get_object(fn_, fg).expect("field obj").clone();
+        let fd = field_obj.as_dict().expect("field dict").clone();
+        if let Some(v) = fd.get("V") {
+            if let PdfObject::String(s) = v {
+                assert!(!s.0.is_empty(), "/V must be non-empty after fill_field");
+                found_v = true;
+            }
+        }
+    }
+    assert!(
+        found_v,
+        "/AcroForm/Fields must contain a field with non-empty /V"
+    );
+}
+
+#[test]
+fn combobox_builtin_font_helvetica_regression() {
+    // Regression: ComboBox with Font::Helvetica must still work end-to-end.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(300.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+
+    let combo = ComboBox::new("dropdown_latin").with_default_appearance(
+        Font::Helvetica,
+        12.0,
+        Color::black(),
+    );
+    let field_ref = fm
+        .add_combo_box(combo, widget.clone(), None)
+        .expect("add_combo_box");
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("dropdown_latin", "Hello")
+        .expect("Helvetica fill must succeed");
+    let pdf = doc.to_bytes().expect("serialize");
+
+    let (ap_content, _ap_dict) = extract_ap_n(&pdf).expect("/AP/N stream");
+    let content_str = String::from_utf8_lossy(&ap_content);
+
+    // Helvetica path emits literal `(Hello) Tj`.
+    assert!(
+        content_str.contains("(Hello) Tj"),
+        "Helvetica AP stream must contain literal (Hello) Tj; content = {content_str:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_212_combobox_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_combobox_custom_font_test.rs
@@ -15,7 +15,7 @@ use oxidize_pdf::forms::{ComboBox, FormManager, Widget, WidgetAppearance};
 use oxidize_pdf::geometry::{Point, Rectangle};
 use oxidize_pdf::graphics::Color;
 use oxidize_pdf::parser::objects::PdfObject;
-use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::text::Font;
 use oxidize_pdf::{Document, Page};
 use std::io::Cursor;
@@ -168,7 +168,11 @@ fn combobox_custom_font_ap_emits_type0_and_hex_cid() {
     );
 
     // Invariant 3: /V on the field dict is non-empty.
-    let mut reader3 = PdfReader::new(Cursor::new(&pdf)).expect("PdfReader for /V");
+    // Strict parsing — the default lenient_encoding mangles non-ASCII bytes
+    // by interpreting them as Windows-1252 and re-encoding to UTF-8, which
+    // destroys byte-level fidelity of /V.
+    let mut reader3 = PdfReader::new_with_options(Cursor::new(&pdf), ParseOptions::strict())
+        .expect("PdfReader for /V (strict)");
     let catalog = reader3.catalog().expect("catalog").clone();
     let acro = match catalog.get("AcroForm").expect("/AcroForm") {
         PdfObject::Reference(n, g) => reader3
@@ -190,11 +194,20 @@ fn combobox_custom_font_ap_emits_type0_and_hex_cid() {
         let (fn_, fg) = field_ref.as_reference().expect("field ref");
         let field_obj = reader3.get_object(fn_, fg).expect("field obj").clone();
         let fd = field_obj.as_dict().expect("field dict").clone();
-        if let Some(v) = fd.get("V") {
-            if let PdfObject::String(s) = v {
-                assert!(!s.0.is_empty(), "/V must be non-empty after fill_field");
-                found_v = true;
-            }
+        if let Some(PdfObject::String(s)) = fd.get("V") {
+            // /V is currently written by the writer as raw UTF-8 bytes inside
+            // a literal `(...)` string. (ISO 32000-1 §12.7.3.3 prefers
+            // UTF-16BE-with-BOM for non-Latin field values; raw UTF-8 is
+            // tolerated by Adobe Reader and Chrome but is non-conformant —
+            // tracked as a separate fidelity follow-up. This test pins the
+            // current contract: /V bytes equal the UTF-8 of the input value.)
+            assert_eq!(
+                s.0.as_slice(),
+                value.as_bytes(),
+                "/V byte content must equal UTF-8 of filled value; got {:?}",
+                s.0
+            );
+            found_v = true;
         }
     }
     assert!(

--- a/oxidize-pdf-core/tests/issue_212_form_only_font_emission_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_form_only_font_emission_test.rs
@@ -1,0 +1,137 @@
+//! Issue #212 — verify the writer emits a custom font even when the only
+//! reference to it lives in a form-field /DA (no page content stream uses
+//! it). Without this, `write_fonts` skipped the font, leaving the AP
+//! placeholder dict's `/Resources/Font/<name>` entry unrewritten and the
+//! produced PDF malformed.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+const LATIN_FONT_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+
+fn load_latin_font() -> Option<Vec<u8>> {
+    if std::path::Path::new(LATIN_FONT_PATH).exists() {
+        Some(std::fs::read(LATIN_FONT_PATH).expect("read Roboto"))
+    } else {
+        eprintln!("SKIPPED: {LATIN_FONT_PATH} not found");
+        None
+    }
+}
+
+#[test]
+fn form_only_custom_font_is_emitted_after_fill_field() {
+    let font_data = match load_latin_font() {
+        Some(d) => d,
+        None => return,
+    };
+
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("register Roboto");
+
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let rect = Rectangle::new(Point::new(50.0, 700.0), Point::new(250.0, 720.0));
+    let widget = Widget::new(rect);
+
+    // The custom font is referenced ONLY in this form field's typed DA.
+    // No page content stream uses Roboto.
+    let field = TextField::new("f1").with_default_appearance(
+        Font::Custom("Roboto".to_string()),
+        12.0,
+        Color::black(),
+    );
+    let field_ref = fm
+        .add_text_field(field, widget.clone(), None)
+        .expect("add_text_field");
+    page.add_form_widget_with_ref(widget, field_ref)
+        .expect("add_form_widget_with_ref");
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+
+    doc.fill_field("f1", "Hello").expect("fill_field");
+
+    let pdf = doc.to_bytes().expect("serialize");
+
+    // Walk the PDF and find the /AP/N stream's /Resources/Font/Roboto.
+    // It must be either an inline Type0 dict (post-rewrite to indirect ref
+    // is not always applied for Latin TTFs that subset to Type0 — both
+    // shapes are valid here as long as the resolved subtype is Type0).
+    let mut reader = PdfReader::new(Cursor::new(&pdf)).expect("PdfReader::new");
+    let pages = reader.pages().expect("pages tree").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    let (pn, pg) = kids.0[0].as_reference().expect("page ref");
+    let page_obj = reader.get_object(pn, pg).expect("page obj").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let annots = page_dict
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .expect("/Annots");
+    let (an, ag) = annots.0[0].as_reference().expect("annot ref");
+    let annot_obj = reader.get_object(an, ag).expect("annot obj").clone();
+    let annot_dict = annot_obj.as_dict().expect("annot dict").clone();
+    let ap = annot_dict
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("/AP")
+        .clone();
+    let n_entry = ap.get("N").expect("/AP/N").clone();
+
+    let ap_stream_dict = match n_entry {
+        PdfObject::Reference(n2, g2) => {
+            let s = reader.get_object(n2, g2).expect("AP/N stream").clone();
+            s.as_stream().expect("AP/N is stream").dict.clone()
+        }
+        PdfObject::Stream(ref s) => s.dict.clone(),
+        other => panic!("unexpected /AP/N: {other:?}"),
+    };
+
+    let resources = ap_stream_dict
+        .get("Resources")
+        .and_then(|o| o.as_dict())
+        .expect("/AP/N /Resources");
+    let fonts = resources
+        .get("Font")
+        .and_then(|o| o.as_dict())
+        .expect("/AP/N /Resources/Font");
+    let roboto_entry = fonts.get("Roboto").expect("/AP/N /Resources/Font/Roboto");
+
+    let resolved_subtype = match roboto_entry {
+        PdfObject::Reference(n3, g3) => {
+            // Indirect ref — the writer rewrote the placeholder. The font
+            // object itself must exist and have /Subtype /Type0. If
+            // write_fonts had skipped this font, the indirect ref would
+            // either be unresolvable or still point to the placeholder.
+            let mut reader2 = PdfReader::new(Cursor::new(&pdf)).expect("reader2");
+            let font_obj = reader2.get_object(*n3, *g3).expect("resolve").clone();
+            let fd = font_obj.as_dict().expect("resolved dict").clone();
+            fd.get("Subtype")
+                .and_then(|o| o.as_name())
+                .map(|nm| nm.as_str().to_string())
+                .unwrap_or_default()
+        }
+        PdfObject::Dictionary(d) => d
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|nm| nm.as_str().to_string())
+            .unwrap_or_default(),
+        other => panic!("unexpected font entry shape: {other:?}"),
+    };
+
+    assert_eq!(
+        resolved_subtype, "Type0",
+        "/AP/N /Resources/Font/Roboto must resolve to /Subtype /Type0 even \
+         when the font is referenced only in a form field's /DA. Got {resolved_subtype:?} \
+         — this would mean write_fonts skipped the form-only font (issue #212 guard regression)."
+    );
+}

--- a/oxidize-pdf-core/tests/issue_212_listbox_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_listbox_custom_font_test.rs
@@ -28,19 +28,17 @@ fn listbox_custom_font_generate_appearance_with_font_emits_type0_resource() {
     // passing custom_font: None is acceptable for this test — what we are
     // verifying here is the resource dict shape.
 
-    let mut appearance_gen = ListBoxAppearance::default();
-    appearance_gen.font = Font::Custom("CJK".to_string());
-    appearance_gen.options = vec![];
+    let appearance_gen = ListBoxAppearance {
+        font: Font::Custom("CJK".to_string()),
+        options: vec![],
+        ..ListBoxAppearance::default()
+    };
 
     let widget = make_widget();
-    let result =
-        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
-    assert!(
-        result.is_ok(),
-        "generate_appearance_with_font with empty options must succeed: {:?}",
-        result.err()
-    );
-    let stream = result.unwrap().stream;
+    let stream = appearance_gen
+        .generate_appearance_with_font(&widget, None, AppearanceState::Normal, None)
+        .expect("generate_appearance_with_font with empty options must succeed")
+        .stream;
 
     let font_entry = stream
         .resources
@@ -85,19 +83,17 @@ fn listbox_custom_font_generate_appearance_with_font_emits_type0_resource() {
 
 #[test]
 fn listbox_builtin_font_generate_appearance_with_font_emits_type1() {
-    let mut appearance_gen = ListBoxAppearance::default();
-    appearance_gen.font = Font::Helvetica;
-    appearance_gen.options = vec!["Option A".to_string(), "Option B".to_string()];
+    let appearance_gen = ListBoxAppearance {
+        font: Font::Helvetica,
+        options: vec!["Option A".to_string(), "Option B".to_string()],
+        ..ListBoxAppearance::default()
+    };
 
     let widget = make_widget();
-    let result =
-        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
-    assert!(
-        result.is_ok(),
-        "built-in font must succeed: {:?}",
-        result.err()
-    );
-    let stream = result.unwrap().stream;
+    let stream = appearance_gen
+        .generate_appearance_with_font(&widget, None, AppearanceState::Normal, None)
+        .expect("built-in font must succeed")
+        .stream;
 
     let font_dict = stream
         .resources
@@ -133,15 +129,21 @@ fn listbox_custom_font_with_options_but_no_font_param_returns_error() {
     // caller passes None for the font parameter, the generator must reject
     // explicitly (matching ComboBox / TextField behaviour). Silent fallback
     // is forbidden — the result would be malformed.
-    let mut appearance_gen = ListBoxAppearance::default();
-    appearance_gen.font = Font::Custom("CJK".to_string());
-    appearance_gen.options = vec!["项目一".to_string()];
+    let appearance_gen = ListBoxAppearance {
+        font: Font::Custom("CJK".to_string()),
+        options: vec!["项目一".to_string()],
+        ..ListBoxAppearance::default()
+    };
 
     let widget = make_widget();
-    let result =
-        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
+    let err = appearance_gen
+        .generate_appearance_with_font(&widget, None, AppearanceState::Normal, None)
+        .expect_err("Custom font + non-empty options + custom_font=None must fail explicitly");
+    // Verify the error variant + message specifically — silent fallback is
+    // forbidden, but so is conflating this with an unrelated failure mode.
+    let msg = format!("{err}");
     assert!(
-        result.is_err(),
-        "Custom font + non-empty options + custom_font=None must fail explicitly; got Ok"
+        msg.contains("Custom") && msg.contains("not found"),
+        "expected EncodingError mentioning the missing custom font; got: {msg}"
     );
 }

--- a/oxidize-pdf-core/tests/issue_212_listbox_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_listbox_custom_font_test.rs
@@ -1,0 +1,147 @@
+//! ListBoxAppearance with Font::Custom: the new `generate_appearance_with_font`
+//! variant must emit a Type0 placeholder resource for custom fonts and keep the
+//! Type1 inline dict for built-ins.
+
+use oxidize_pdf::forms::{AppearanceState, ListBoxAppearance, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::objects::Object;
+use oxidize_pdf::text::Font;
+
+fn make_widget() -> Widget {
+    let rect = Rectangle::new(Point::new(0.0, 0.0), Point::new(150.0, 100.0));
+    Widget::new(rect).with_appearance(WidgetAppearance::default())
+}
+
+#[test]
+fn listbox_custom_font_generate_appearance_with_font_emits_type0_resource() {
+    // Pre-fix: ListBoxAppearance has no generate_appearance_with_font and
+    // its AppearanceGenerator::generate_appearance calls emit_tj_for_builtin
+    // unconditionally → custom fonts fail with EncodingError before any
+    // resource dict is constructed.
+    //
+    // Post-fix: generate_appearance_with_font dispatches on is_custom() and
+    // emits a Type0 placeholder resource entry that the writer's
+    // rewrite_ap_stream_font_resources can rewrite into an indirect
+    // reference to the document-level CIDFontType0 object.
+    //
+    // With an empty options list there are no Tj operators to encode, so
+    // passing custom_font: None is acceptable for this test — what we are
+    // verifying here is the resource dict shape.
+
+    let mut appearance_gen = ListBoxAppearance::default();
+    appearance_gen.font = Font::Custom("CJK".to_string());
+    appearance_gen.options = vec![];
+
+    let widget = make_widget();
+    let result =
+        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
+    assert!(
+        result.is_ok(),
+        "generate_appearance_with_font with empty options must succeed: {:?}",
+        result.err()
+    );
+    let stream = result.unwrap().stream;
+
+    let font_entry = stream
+        .resources
+        .get("Font")
+        .expect("/Resources/Font must be present");
+    let font_dict = match font_entry {
+        Object::Dictionary(d) => d,
+        other => panic!("/Resources/Font is not a dict: {:?}", other),
+    };
+    let cjk = font_dict
+        .get("CJK")
+        .expect("/Resources/Font/CJK must be present");
+    let placeholder_dict = match cjk {
+        Object::Dictionary(d) => d,
+        other => panic!("/Resources/Font/CJK is not a dict: {:?}", other),
+    };
+    let subtype = placeholder_dict
+        .get("Subtype")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Subtype present");
+    assert_eq!(
+        subtype, "Type0",
+        "Custom font resource must be a Type0 placeholder; got {:?}",
+        subtype
+    );
+
+    let encoding = placeholder_dict
+        .get("Encoding")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Encoding present");
+    assert_eq!(
+        encoding, "Identity-H",
+        "Type0 placeholder must declare /Encoding /Identity-H"
+    );
+}
+
+#[test]
+fn listbox_builtin_font_generate_appearance_with_font_emits_type1() {
+    let mut appearance_gen = ListBoxAppearance::default();
+    appearance_gen.font = Font::Helvetica;
+    appearance_gen.options = vec!["Option A".to_string(), "Option B".to_string()];
+
+    let widget = make_widget();
+    let result =
+        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
+    assert!(
+        result.is_ok(),
+        "built-in font must succeed: {:?}",
+        result.err()
+    );
+    let stream = result.unwrap().stream;
+
+    let font_dict = stream
+        .resources
+        .get("Font")
+        .and_then(|o| match o {
+            Object::Dictionary(d) => Some(d),
+            _ => None,
+        })
+        .expect("/Resources/Font present");
+    let helv = font_dict
+        .get("Helvetica")
+        .expect("/Resources/Font/Helvetica entry");
+    let placeholder_dict = match helv {
+        Object::Dictionary(d) => d,
+        other => panic!("Helvetica entry is not a dict: {:?}", other),
+    };
+    let subtype = placeholder_dict
+        .get("Subtype")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Subtype present");
+    assert_eq!(
+        subtype, "Type1",
+        "Built-in Helvetica regression: must still emit /Subtype /Type1"
+    );
+}
+
+#[test]
+fn listbox_custom_font_with_options_but_no_font_param_returns_error() {
+    // When options are non-empty AND the configured font is Custom AND the
+    // caller passes None for the font parameter, the generator must reject
+    // explicitly (matching ComboBox / TextField behaviour). Silent fallback
+    // is forbidden — the result would be malformed.
+    let mut appearance_gen = ListBoxAppearance::default();
+    appearance_gen.font = Font::Custom("CJK".to_string());
+    appearance_gen.options = vec!["项目一".to_string()];
+
+    let widget = make_widget();
+    let result =
+        appearance_gen.generate_appearance_with_font(&widget, None, AppearanceState::Normal, None);
+    assert!(
+        result.is_err(),
+        "Custom font + non-empty options + custom_font=None must fail explicitly; got Ok"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_212_pushbutton_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_pushbutton_custom_font_test.rs
@@ -17,9 +17,11 @@ fn make_widget() -> Widget {
 
 #[test]
 fn pushbutton_custom_font_resources_emit_type0_not_type1() {
-    let mut appearance_gen = PushButtonAppearance::default();
-    appearance_gen.font = Font::Custom("CJK".to_string());
-    appearance_gen.label = "Submit".to_string();
+    let appearance_gen = PushButtonAppearance {
+        font: Font::Custom("CJK".to_string()),
+        label: "Submit".to_string(),
+        ..PushButtonAppearance::default()
+    };
 
     let widget = make_widget();
     let stream = appearance_gen
@@ -83,9 +85,11 @@ fn pushbutton_builtin_font_resources_still_emit_type1() {
     // Regression: Helvetica (built-in) must continue to produce a Type1
     // inline dict — the Type1 path is correct for built-ins and the writer
     // does NOT attempt to rewrite it.
-    let mut appearance_gen = PushButtonAppearance::default();
-    appearance_gen.font = Font::Helvetica;
-    appearance_gen.label = "Click".to_string();
+    let appearance_gen = PushButtonAppearance {
+        font: Font::Helvetica,
+        label: "Click".to_string(),
+        ..PushButtonAppearance::default()
+    };
 
     let widget = make_widget();
     let stream = appearance_gen

--- a/oxidize-pdf-core/tests/issue_212_pushbutton_custom_font_test.rs
+++ b/oxidize-pdf-core/tests/issue_212_pushbutton_custom_font_test.rs
@@ -1,0 +1,129 @@
+//! Regression test: PushButtonAppearance with Font::Custom must emit
+//! /Resources/Font/<name> as a Type0 placeholder (not Type1) so the
+//! writer can rewrite it to an indirect Reference to the document-level
+//! Type0 font object (issue #212).
+
+use oxidize_pdf::forms::{
+    AppearanceGenerator, AppearanceState, PushButtonAppearance, Widget, WidgetAppearance,
+};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::objects::Object;
+use oxidize_pdf::text::Font;
+
+fn make_widget() -> Widget {
+    let rect = Rectangle::new(Point::new(0.0, 0.0), Point::new(100.0, 30.0));
+    Widget::new(rect).with_appearance(WidgetAppearance::default())
+}
+
+#[test]
+fn pushbutton_custom_font_resources_emit_type0_not_type1() {
+    let mut appearance_gen = PushButtonAppearance::default();
+    appearance_gen.font = Font::Custom("CJK".to_string());
+    appearance_gen.label = "Submit".to_string();
+
+    let widget = make_widget();
+    let stream = appearance_gen
+        .generate_appearance(&widget, None, AppearanceState::Normal)
+        .expect("generate_appearance must not fail");
+
+    let font_entry = stream
+        .resources
+        .get("Font")
+        .expect("/Resources/Font must be present");
+
+    let font_dict = match font_entry {
+        Object::Dictionary(d) => d,
+        other => panic!("/Resources/Font is not a dict: {:?}", other),
+    };
+
+    let cjk_entry = font_dict
+        .get("CJK")
+        .expect("/Resources/Font/CJK must be present when font is Font::Custom(\"CJK\")");
+
+    let placeholder_dict = match cjk_entry {
+        Object::Dictionary(d) => d,
+        other => panic!(
+            "/Resources/Font/CJK must be an inline placeholder dict; got {:?}",
+            other
+        ),
+    };
+
+    let subtype = placeholder_dict
+        .get("Subtype")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Subtype must be present in the font placeholder dict");
+
+    assert_eq!(
+        subtype, "Type0",
+        "PushButtonAppearance with Font::Custom must emit /Subtype /Type0 in the \
+         placeholder, not /Type1 (the writer can only rewrite Type0 placeholders \
+         into indirect references — see rewrite_ap_stream_font_resources). Got: {:?}",
+        subtype
+    );
+
+    let encoding = placeholder_dict
+        .get("Encoding")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Encoding must be present");
+
+    assert_eq!(
+        encoding, "Identity-H",
+        "Type0 placeholder must declare /Encoding /Identity-H"
+    );
+}
+
+#[test]
+fn pushbutton_builtin_font_resources_still_emit_type1() {
+    // Regression: Helvetica (built-in) must continue to produce a Type1
+    // inline dict — the Type1 path is correct for built-ins and the writer
+    // does NOT attempt to rewrite it.
+    let mut appearance_gen = PushButtonAppearance::default();
+    appearance_gen.font = Font::Helvetica;
+    appearance_gen.label = "Click".to_string();
+
+    let widget = make_widget();
+    let stream = appearance_gen
+        .generate_appearance(&widget, None, AppearanceState::Normal)
+        .expect("generate_appearance for Helvetica must succeed");
+
+    let font_entry = stream
+        .resources
+        .get("Font")
+        .expect("/Resources/Font must be present");
+
+    let font_dict = match font_entry {
+        Object::Dictionary(d) => d,
+        other => panic!("/Resources/Font is not a dict: {:?}", other),
+    };
+
+    let helv_entry = font_dict
+        .get("Helvetica")
+        .expect("/Resources/Font/Helvetica must be present");
+
+    let placeholder_dict = match helv_entry {
+        Object::Dictionary(d) => d,
+        other => panic!(
+            "/Resources/Font/Helvetica must be an inline dict; got {:?}",
+            other
+        ),
+    };
+
+    let subtype = placeholder_dict
+        .get("Subtype")
+        .and_then(|o| match o {
+            Object::Name(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .expect("/Subtype present");
+
+    assert_eq!(
+        subtype, "Type1",
+        "Built-in Helvetica must still emit /Subtype /Type1 (regression guard)"
+    );
+}


### PR DESCRIPTION
## Summary

Architectural completion of issue #212 — form-field appearance streams
now correctly handle `Font::Custom` (Type0/CID) for TextField, ComboBox,
ListBox, and PushButton (resource dict). Builds on the v2.6.0 partial
fix (PR #215) which addressed encoding for built-in WinAnsi values.

### What was broken

`forms::appearance` had hardcoded `/Subtype /Type1` in the AP
`/Resources/Font` dict for several generators. For `Font::Custom` (CJK,
Arabic, etc.) the document-level font is a CIDFontType0/2, so the AP
referenced the font under the wrong subtype — viewers rendered `.notdef`
or rejected the AP entirely.

### What changed

- **PushButtonAppearance** now emits `/Subtype /Type0` placeholder for
  custom fonts and skips the label-render block (the hex-CID Tj path
  needs a `custom_font` parameter, tracked as a follow-up). Built-in
  Type1 fonts continue producing the inline Type1 dict unchanged.
- **ListBoxAppearance** gains `generate_appearance_with_font(widget,
  value, state, custom_font)` mirroring the existing pattern on
  TextField/ComboBox. Dispatches `(is_custom, custom_font)` with explicit
  `EncodingError` on `(true, None)`.
- **ComboBox** gains `with_default_appearance(font, size, color)` and
  `FormManager::add_combo_box` now propagates the typed DA to
  `FormField.default_appearance` (parity with `add_text_field`). Without
  this, `fill_field` on a Choice field could not select a custom font.
- **`Document::fill_field` doc-comment** updated to describe the
  Type0/CID dispatch.
- **CHANGELOG** entry under Unreleased.

### Test plan

- [x] Lib tests green: 6364 passed.
- [x] Lib clippy clean: `cargo clippy --lib -- -D warnings`.
- [x] **Four closing-invariant tests** (the contract from the issue body)
  in `tests/issue_212_closing_invariants_test.rs`:
    1. `/AP/N /Resources/Font/CJK` resolves to `/Subtype /Type0` +
       `/Encoding /Identity-H`.
    2. `/AP/N` content stream uses hex-CID `<HHHH> Tj`, not literal
       `(...)` Tj.
    3. Round-trip `/V` byte-equal to UTF-8 of input + AP carries `BT…ET`
       text section + hex-CID Tj.
    4. Helvetica regression — Type1 path unchanged.
- [x] Unit tests per generator: PushButton (2), ListBox (3), ComboBox
  (2 end-to-end with SourceHanSansSC), form-only-font emission (1).

### Out of scope (tracked separately as follow-ups)

- PushButton label hex-CID rendering for custom fonts (requires
  `custom_font` parameter on `PushButtonAppearance::generate_appearance`).
- `/V` UTF-16BE-with-BOM conformance — current writer emits raw UTF-8
  inside literal `(...)`; tolerated by Adobe Reader/Chrome but not
  ISO 32000-1 §12.7.3.3 strict conformance. Tests use
  `ParseOptions::strict()` to compare byte-equal pre-fix.
- `forms/button_widget.rs::create_pushbutton_appearance` legacy path
  still has `/Subtype /Type1` hardcoded — unreachable via `fill_field`,
  documented in plan.

### Plan + reviews

Implementation plan: `docs/superpowers/plans/2026-05-09-issue-212-form-appearance-type0.md` (untracked, kept local).
Reviews ran: quality-rust + security-expert-advisor (both APPROVE-WITH-FOLLOWUPS, no blockers). Smoke tests detected and removed in commit 9211a5e per project policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)