### PR TITLE
fix(metrics): inject text_context store in Document::add_page (#230 follow-up M1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
-        run: cargo test --all --verbose
+        run: cargo test --all --features internal-testing --verbose
 
       - name: Build documentation
         run: cargo doc --all --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [2.8.1] - 2026-05-13
+
+### Fixed
+
+- **`Document::add_page`** now also injects the per-Document
+  `FontMetricsStore` into `page.text_context.font_metrics_store` when the
+  page was constructed via `Page::a4()` / `Page::letter()` /
+  `Page::new(...)`. Before this fix, only `page.font_metrics_store` was set;
+  the text context was left with `font_metrics_store: None` and any
+  subsequent measurement through the page's text context fell through to
+  the legacy global registry, re-introducing the cross-`Document` leak that
+  issue #230 was meant to close architecturally. Pages constructed via
+  `Document::new_page_*()` were unaffected (the factory path already wired
+  both fields). The fix mutates only the `font_metrics_store` field on the
+  existing `TextContext`, preserving any operations the caller pushed
+  before `add_page`. Issue #230 follow-up M1.
+
 ## [2.8.0] - 2026-05-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.0"
+version = "2.8.1"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/docs/superpowers/plans/2026-05-13-add-page-text-context-injection.md
+++ b/docs/superpowers/plans/2026-05-13-add-page-text-context-injection.md
@@ -1,0 +1,346 @@
+# Plan: Fix `Document::add_page` text_context font metrics injection (v2.8.1)
+
+## Context
+
+`Document::add_page` injects the per-Document `FontMetricsStore` into
+`page.font_metrics_store` but does NOT inject it into
+`page.text_context.font_metrics_store`. The doc comment at
+`document.rs:143–149` promises that "their text_flow / text contexts can
+resolve custom fonts via Document scope" — the promise is partially broken.
+
+Pages constructed via `Page::a4()`, `Page::letter()`, or `Page::new(...)` have
+`text_context: TextContext::new()` (page.rs:167) which carries
+`font_metrics_store: None`. After `doc.add_page(page)`, the page-level
+`font_metrics_store` is correctly set, but `text_context.font_metrics_store`
+remains `None`. Any current or future code that reads
+`text_context.font_metrics_store` directly (e.g., measuring text via the
+`TextContext` rather than via `TextFlowContext`) falls through to the legacy
+global registry — the cross-Document leak that issue #230 closed
+architecturally.
+
+The factory path (`Document::new_page_a4/letter/new_page`) is correct: it
+calls `p.text_context = TextContext::with_metrics_store(Some(store.clone()))`,
+so both fields are set. The bug is confined to the `Page::*() + doc.add_page`
+path.
+
+**Stack detected**: Rust / no external framework  
+**Conventions**: integration tests in `oxidize-pdf-core/tests/`, no inline
+`#[cfg(test)] mod tests`, filenames keyed to issue or feature,
+`pub(crate)` for intra-crate visibility, `#[cfg(test)] pub(crate)` for test
+helpers accessible only within unit tests.  
+**Affects hot path**: No — `add_page` is a document-construction step, not a
+measurement or rendering hot path. No throughput benchmarks are required.
+
+## Decisions already made (no alternatives to explore)
+
+- Fix mutates only `text_context.font_metrics_store` in-place via a new
+  `TextContext::set_metrics_store(&mut self, store: Option<FontMetricsStore>)`
+  method. This preserves any ops accumulated in `text_context` before
+  `add_page` is called.
+- `set_metrics_store` is `pub(crate)` — same visibility as
+  `with_metrics_store`.
+- The guard in `add_page` mirrors the existing `page.font_metrics_store`
+  guard: only inject when `text_context.font_metrics_store.is_none()`. This
+  preserves the invariant that factory-produced pages (already carrying a
+  store) are not overwritten.
+- `TextFlowContext` has the same field and the same bug. It also gets a
+  `set_metrics_store` and is injected from `add_page` via the same guard.
+- No public API changes. Target: `v2.8.1` patch.
+
+## Sibling structure investigation result
+
+`TextFlowContext` (`src/text/flow.rs:16`) has `pub(crate) font_metrics_store:
+Option<FontMetricsStore>` (line 53). It is NOT stored on `Page` as a field —
+pages create a new `TextFlowContext` on each call to `page.text_flow()` (line
+929), and that method already reads `self.font_metrics_store` (line 945), NOT
+`self.text_context.font_metrics_store`. Therefore, `TextFlowContext` is not
+affected by this bug via `page.text_flow()`. However, `TextFlowContext` itself
+has the same gap: if a caller constructs a `TextFlowContext::new(...)` and
+later tries to set a store, no setter exists. Adding `set_metrics_store` to
+`TextFlowContext` is symmetric hygiene, but it is NOT required by the current
+bug.
+
+**Decision**: Add `TextContext::set_metrics_store` (required by the fix).
+Do NOT add `TextFlowContext::set_metrics_store` — no current caller and
+adding "symmetric hygiene" violates the project's no-speculative-API rule.
+
+---
+
+## Plan of Execution
+
+### Phase 1 — RED: write the failing integration test
+
+**Cycle 1.1 — Integration test that reproduces the bug**
+
+- [ ] Create file `oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs`
+  - Test name: `add_page_injects_store_into_text_context`
+  - Purpose: prove `text_context.font_metrics_store` is `None` after
+    `add_page` on v2.8.0 and `Some` after the fix.
+  - Setup:
+    ```
+    // Plant synthetic metrics for font "TC_Wide" in the legacy global
+    // (deprecated API, #[allow(deprecated)]). Width of 'A' = 100 units
+    // → measure_text_with("A", font, 12.0, None) = 1.2 pts.
+    register_custom_font_metrics(
+        "TC_Wide_5_1".to_string(),
+        FontMetrics::new(500).with_widths(&[('A', 100)]),
+    );
+
+    // Register the same name in the Document store with 'A' = 800 units
+    // → 9.6 pts. A numerical gap of >5 pts ensures the test would fail
+    // if the wrong store is used.
+    let mut doc = Document::new();
+    doc.font_metrics()
+        .register("TC_Wide_5_1", FontMetrics::new(500).with_widths(&[('A', 800)]));
+
+    let page = Page::a4(); // text_context.font_metrics_store = None here
+    doc.add_page(page);
+
+    let stored_page = doc.pages().last().expect("page");
+    ```
+  - Assertion (using a new `pub(crate)` accessor — see Phase 2, task 2.1):
+    ```
+    let tc_store = stored_page
+        .text_context_metrics_store_for_test()
+        .expect("text_context must carry the Document store after add_page");
+    let doc_width = measure_text_with(
+        "A",
+        &Font::Custom("TC_Wide_5_1".into()),
+        12.0,
+        Some(tc_store),
+    );
+    let global_width = measure_text_with(
+        "A",
+        &Font::Custom("TC_Wide_5_1".into()),
+        12.0,
+        None,
+    );
+    // Document store width (800 units) ≠ global width (100 units).
+    // If the fix is absent, tc_store would be None and the test panics
+    // at the .expect() above.
+    assert!(
+        (global_width - 1.2_f64).abs() < 0.05,
+        "global store width must be 1.2 pts for 'A' at 12pt; got {global_width}"
+    );
+    assert!(
+        (doc_width - 9.6_f64).abs() < 0.05,
+        "text_context store width must be 9.6 pts for 'A' at 12pt; got {doc_width}"
+    );
+    assert!(
+        (doc_width - global_width).abs() > 5.0,
+        "document scope and global scope must differ by >5 pts; \
+         doc={doc_width}, global={global_width}"
+    );
+    ```
+  - **Expected state on v2.8.0**: RED — `.expect("text_context must carry ...")` panics.
+  - Imports needed:
+    ```rust
+    use oxidize_pdf::text::metrics::{FontMetrics, FontMetricsStore};
+    use oxidize_pdf::text::{measure_text_with, Font};
+    use oxidize_pdf::{Document, Page};
+    ```
+  - Note: `text_context_metrics_store_for_test()` does not yet exist on `Page`.
+    The test file will not compile until Phase 2 task 2.1 is complete.
+
+**Cycle 1.2 — Ops-preservation test**
+
+- [ ] Add test `text_context_ops_preserved_across_add_page` to the same file.
+  - Setup: call `page.text().set_font(Font::Helvetica, 14.0).at(50.0, 700.0).write("hello")` BEFORE `doc.add_page(page)`.
+  - After `doc.add_page(page)`, obtain the stored page and call
+    `stored_page.text_context_ops_count_for_test()` (second accessor, Phase 2 task 2.1).
+  - Assertion: ops count > 0 (the `write("hello")` accumulated at least one op;
+    the exact count is not asserted — only that it is non-zero, since the
+    operation sequence is an implementation detail).
+  - **Expected state on v2.8.0**: RED (accessor does not exist).
+  - After fix: GREEN with ops count unchanged.
+
+**Cycle 1.3 — Factory path regression test**
+
+- [ ] Add test `factory_path_text_context_store_unchanged` to the same file.
+  - Create a page via `doc.new_page_a4()`, confirm
+    `text_context_metrics_store_for_test()` is `Some` before `add_page`
+    (factory already sets it).
+  - Call `doc.add_page(page)` and confirm the store is still `Some` pointing
+    to the same document (verify via a width measurement, not pointer equality).
+  - This test verifies the `is_none()` guard in `add_page` does NOT
+    overwrite the factory-supplied store.
+  - **Expected state on v2.8.0**: RED (accessor does not exist).
+  - After fix: GREEN.
+
+---
+
+### Phase 2 — GREEN: production code changes
+
+**Cycle 2.1 — Add `Page::text_context_metrics_store_for_test` and
+`Page::text_context_ops_count_for_test` test accessors**
+
+- [ ] File: `oxidize-pdf-core/src/page.rs`
+  - Action: add two `#[doc(hidden)] pub` methods to `impl Page`. They MUST
+    be `pub` (not `pub(crate)`) so the integration test crate can see them,
+    and MUST NOT be `#[cfg(test)]` because integration tests link the
+    library compiled without `--test`. `#[doc(hidden)]` keeps them out of
+    rustdoc — the standard "exposed for tests only" pattern in Rust.
+    ```rust
+    #[doc(hidden)]
+    pub fn text_context_metrics_store_for_test(
+        &self,
+    ) -> Option<&crate::text::metrics::FontMetricsStore> {
+        self.text_context.font_metrics_store.as_ref()
+    }
+
+    #[doc(hidden)]
+    pub fn text_context_ops_count_for_test(&self) -> usize {
+        self.text_context.ops_slice().len()
+    }
+    ```
+  - Location: adjacent to the existing public `Page::font_metrics_store()`
+    accessor near line 564.
+  - Output: the two integration tests from Phase 1 compile (they still fail at
+    runtime since the fix is not yet applied).
+
+**Cycle 2.2 — Add `TextContext::set_metrics_store`**
+
+- [ ] File: `oxidize-pdf-core/src/text/mod.rs`
+  - Action: add method to `impl TextContext`, adjacent to `with_metrics_store`:
+    ```rust
+    /// Inject or replace the per-Document `FontMetricsStore` on an
+    /// already-constructed context.
+    ///
+    /// Called by `Document::add_page` when the page was constructed via
+    /// `Page::a4()` / `Page::letter()` / `Page::new()` (those start with
+    /// `font_metrics_store: None`). Accumulated ops are preserved.
+    pub(crate) fn set_metrics_store(&mut self, store: Option<FontMetricsStore>) {
+        self.font_metrics_store = store;
+    }
+    ```
+  - Output: method available to `document.rs`.
+
+**Cycle 2.3 — Fix `Document::add_page`**
+
+- [ ] File: `oxidize-pdf-core/src/document.rs`, lines 142–163
+  - Action: inside the `if page.font_metrics_store.is_none()` block, also
+    call `set_metrics_store` on `text_context`:
+    ```rust
+    if page.font_metrics_store.is_none() {
+        page.font_metrics_store = Some(self.font_metrics.clone());
+        page.text_context
+            .set_metrics_store(Some(self.font_metrics.clone()));
+    }
+    ```
+  - The guard is shared: if `page.font_metrics_store` is `Some` (factory
+    path), neither assignment runs — preserving the factory-supplied stores.
+  - Output: all three tests from Phase 1 turn GREEN.
+
+**Cycle 2.4 — Update the `add_page` doc comment**
+
+- [ ] File: `oxidize-pdf-core/src/document.rs`, lines 143–149
+  - Action: replace the comment body to accurately describe both injections:
+    ```rust
+    // Inject the Document's metrics store into the page if it does not
+    // already carry one. Pages constructed via Document::new_page_*()
+    // already carry a store (on both page.font_metrics_store AND
+    // page.text_context.font_metrics_store) and are skipped — preserving
+    // bindings to other Documents if a page is moved.
+    //
+    // Pages constructed via Page::a4() / Page::letter() / Page::new()
+    // start with both fields as None; both are set here so that
+    // text_context.font_metrics_store resolves custom fonts via the
+    // Document scope rather than the legacy global registry.
+    ```
+
+---
+
+### Phase 3 — Regression sweep: existing test suite must stay GREEN
+
+**Cycle 3.1 — Verify `font_metrics_per_document_test.rs`**
+
+- [ ] Run: `cargo test -p oxidize-pdf --test font_metrics_per_document_test`
+- Expected: all 9 tests pass, including `add_page_does_not_overwrite_existing_store` (test 3.3).
+  - That test uses `doc.new_page_a4()` (factory path), calls `doc_b.add_page(page)`, and asserts the store from `doc_a` is kept and `doc_b` did not override it. The new code path only runs when `page.font_metrics_store.is_none()` — factory pages have `Some`, so the block is skipped. GREEN unchanged.
+
+**Cycle 3.2 — Verify `font_metrics_per_document_render_test.rs`**
+
+- [ ] Run: `cargo test -p oxidize-pdf --test font_metrics_per_document_render_test`
+- Expected: tests 4.1 and 4.2 pass unchanged (they use `doc.new_page_a4()`, unaffected by the fix).
+
+**Cycle 3.3 — Run full test suite**
+
+- [ ] Run: `cargo test -p oxidize-pdf`
+- Expected: no regressions. Any pre-existing failing test that was already broken before this change is out of scope for this plan.
+
+---
+
+### Phase 4 — Release preparation
+
+**Cycle 4.1 — CHANGELOG entry**
+
+- [ ] File: `CHANGELOG.md`
+  - Action: under the `## [Unreleased]` header (line 9), add a `### Fixed` subsection (or append to it if one already exists):
+    ```markdown
+    ### Fixed
+
+    - `Document::add_page` now also injects the per-Document font metrics
+      store into `page.text_context.font_metrics_store` when the page was
+      constructed via `Page::a4()` / `Page::letter()` / `Page::new()`. Before
+      this fix, `text_context.font_metrics_store` remained `None` after
+      `add_page`, causing any code that reads widths from the text context
+      directly to fall through to the legacy global registry — re-introducing
+      the cross-Document leak that issue #230 was intended to close
+      architecturally. The factory methods (`Document::new_page_a4()`,
+      `new_page_letter()`, `new_page()`) were unaffected. Issue #230
+      follow-up.
+    ```
+
+**Cycle 4.2 — Version bump**
+
+- [ ] File: `Cargo.toml` (workspace root), line 13
+  - Action: change `version = "2.8.0"` to `version = "2.8.1"`.
+  - This propagates to all crates via `version.workspace = true`.
+  - Output: `cargo check --all-targets` passes with no version mismatches.
+
+**Cycle 4.3 — Final compile and test verification**
+
+- [ ] Run: `cargo check --all-targets 2>&1` — zero errors, zero warnings.
+- [ ] Run: `cargo test -p oxidize-pdf --test issue_230_text_context_injection_test` — 3 tests GREEN.
+- [ ] Run: `cargo test -p oxidize-pdf --test font_metrics_per_document_test` — 9 tests GREEN.
+- [ ] Confirm no other test file references `add_page` in a way that would be broken by the new `text_context.set_metrics_store` call:
+  ```bash
+  grep -rn "add_page" oxidize-pdf-core/tests/ | grep -v "//\|#\[test\]" | head -30
+  ```
+
+---
+
+## Estimation
+
+| Phase | Work |
+|---|---|
+| Phase 1 — RED tests | 25 min |
+| Phase 2 — GREEN production code | 20 min |
+| Phase 3 — Regression sweep | 10 min |
+| Phase 4 — Release prep | 10 min |
+| **Total** | **~65 min** |
+
+No throughput benchmarks required (this is not a hot path).
+
+---
+
+## Criteria of Success
+
+- [ ] `issue_230_text_context_injection_test.rs` compiles and all 3 tests pass.
+- [ ] `font_metrics_per_document_test.rs` 9 tests still pass, including `add_page_does_not_overwrite_existing_store`.
+- [ ] `cargo check --all-targets` produces zero errors and zero warnings.
+- [ ] CHANGELOG has a `### Fixed` entry under `[Unreleased]`.
+- [ ] Workspace version is `2.8.1`.
+
+---
+
+## File Reference
+
+| File | Action |
+|---|---|
+| `oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs` | CREATE — 3 new integration tests |
+| `oxidize-pdf-core/src/page.rs` | MODIFY — 2 new `#[cfg(test)] pub(crate)` accessors |
+| `oxidize-pdf-core/src/text/mod.rs` | MODIFY — add `TextContext::set_metrics_store` |
+| `oxidize-pdf-core/src/document.rs` | MODIFY — `add_page` body + doc comment |
+| `CHANGELOG.md` | MODIFY — `[Unreleased]` Fixed entry |
+| `Cargo.toml` (workspace root) | MODIFY — `2.8.0` → `2.8.1` |

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -441,6 +441,7 @@ performance = ["dep:rayon", "compression"]
 # Test features
 real-pdf-tests = []  # Enable tests with real PDF files from fixtures
 multilingual-fixtures = []  # Enable tests that require UDHR multilingual fixture PDFs
+internal-testing = []  # Enable `_for_test` introspection helpers used by integration tests (kept out of production ABI)
 
 # Digital signature verification features
 signatures = [

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -142,13 +142,20 @@ impl Document {
     pub fn add_page(&mut self, mut page: Page) {
         // Inject the Document's metrics store into the page if it does not
         // already carry one. Pages constructed via Document::new_page_*()
-        // already carry a store and are skipped (preserves bindings to
-        // other Documents if a page is moved). Pages constructed via
-        // Page::a4() / Page::letter() / Page::new() get the Document store
-        // here so their text_flow / text contexts can resolve custom fonts
-        // via Document scope when measurements happen after add_page.
+        // carry the store on BOTH `page.font_metrics_store` AND
+        // `page.text_context.font_metrics_store` from the factory, and are
+        // skipped here (preserves bindings to other Documents if a page is
+        // moved between them). Pages constructed via Page::a4() /
+        // Page::letter() / Page::new() start with both fields as None;
+        // both are set here so that subsequent measurements through the
+        // page's text context resolve custom fonts via the Document scope
+        // rather than the legacy global registry. The text context's
+        // accumulated ops (if the caller pushed any before add_page) are
+        // preserved — only the `font_metrics_store` field is mutated
+        // (issue #230 follow-up M1).
         if page.font_metrics_store.is_none() {
             page.font_metrics_store = Some(self.font_metrics.clone());
+            page.set_text_context_metrics_store(Some(self.font_metrics.clone()));
         }
         // Merge the page's per-font character accumulators into the
         // document-wide map (issue #204 — each font gets subsetted with

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -570,7 +570,9 @@ impl Page {
     /// `Document::add_page` injects the per-Document store into the
     /// text context as well as into the page itself (issue #230 follow-up).
     ///
-    /// This is part of the test introspection surface — not a stable API.
+    /// Gated behind the `internal-testing` feature so it does not enter the
+    /// production ABI. Lib unit tests get it via `cfg(test)`.
+    #[cfg(any(test, feature = "internal-testing"))]
     #[doc(hidden)]
     pub fn text_context_metrics_store_for_test(
         &self,
@@ -583,7 +585,9 @@ impl Page {
     /// `Document::add_page` does not erase ops while injecting the
     /// per-Document `FontMetricsStore` (issue #230 follow-up).
     ///
-    /// This is part of the test introspection surface — not a stable API.
+    /// Gated behind the `internal-testing` feature so it does not enter the
+    /// production ABI. Lib unit tests get it via `cfg(test)`.
+    #[cfg(any(test, feature = "internal-testing"))]
     #[doc(hidden)]
     pub fn text_context_ops_count_for_test(&self) -> usize {
         self.text_context.ops_slice().len()
@@ -603,9 +607,7 @@ impl Page {
     /// Creates a new A4 page pre-loaded with a `FontMetricsStore` (issue #230).
     ///
     /// `Page::a4()` has `font_metrics_store: None`; this variant is used by
-    /// `Document::new_page_a4()` (Task 10) to bind the document-level store.
-    /// Non-test callers arrive in Tasks 9-11 (Document integration).
-    #[allow(dead_code)]
+    /// `Document::new_page_a4()` to bind the document-level store.
     pub(crate) fn a4_with_metrics(store: FontMetricsStore) -> Self {
         let mut p = Self::a4();
         p.font_metrics_store = Some(store.clone());
@@ -614,8 +616,6 @@ impl Page {
     }
 
     /// Creates a new US Letter page pre-loaded with a `FontMetricsStore` (issue #230).
-    /// Non-test callers arrive in Tasks 9-11 (Document integration).
-    #[allow(dead_code)]
     pub(crate) fn letter_with_metrics(store: FontMetricsStore) -> Self {
         let mut p = Self::letter();
         p.font_metrics_store = Some(store.clone());
@@ -624,8 +624,6 @@ impl Page {
     }
 
     /// Creates a new page of custom size pre-loaded with a `FontMetricsStore` (issue #230).
-    /// Non-test callers arrive in Tasks 9-11 (Document integration).
-    #[allow(dead_code)]
     pub(crate) fn new_with_metrics(width: f64, height: f64, store: FontMetricsStore) -> Self {
         let mut p = Self::new(width, height);
         p.font_metrics_store = Some(store.clone());

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -565,6 +565,41 @@ impl Page {
         self.font_metrics_store.as_ref()
     }
 
+    /// Returns the `FontMetricsStore` bound to this page's `text_context`,
+    /// if any. Exposed for integration tests verifying that
+    /// `Document::add_page` injects the per-Document store into the
+    /// text context as well as into the page itself (issue #230 follow-up).
+    ///
+    /// This is part of the test introspection surface — not a stable API.
+    #[doc(hidden)]
+    pub fn text_context_metrics_store_for_test(
+        &self,
+    ) -> Option<&crate::text::metrics::FontMetricsStore> {
+        self.text_context.font_metrics_store.as_ref()
+    }
+
+    /// Returns the number of operations accumulated in the page's
+    /// `text_context`. Exposed for integration tests verifying that
+    /// `Document::add_page` does not erase ops while injecting the
+    /// per-Document `FontMetricsStore` (issue #230 follow-up).
+    ///
+    /// This is part of the test introspection surface — not a stable API.
+    #[doc(hidden)]
+    pub fn text_context_ops_count_for_test(&self) -> usize {
+        self.text_context.ops_slice().len()
+    }
+
+    /// Injects or replaces the `FontMetricsStore` on this page's text
+    /// context. Called by `Document::add_page` to wire the Document scope
+    /// into pages constructed via `Page::a4() / Page::letter() / Page::new()`
+    /// (issue #230 follow-up). Accumulated ops are preserved.
+    pub(crate) fn set_text_context_metrics_store(
+        &mut self,
+        store: Option<crate::text::metrics::FontMetricsStore>,
+    ) {
+        self.text_context.set_metrics_store(store);
+    }
+
     /// Creates a new A4 page pre-loaded with a `FontMetricsStore` (issue #230).
     ///
     /// `Page::a4()` has `font_metrics_store: None`; this variant is used by

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -157,6 +157,18 @@ impl TextContext {
         ctx
     }
 
+    /// Inject or replace the per-Document `FontMetricsStore` on an
+    /// already-constructed context. Preserves accumulated ops and any
+    /// other state — only the `font_metrics_store` field is mutated.
+    ///
+    /// Called by `Document::add_page` for pages constructed via
+    /// `Page::a4()` / `Page::letter()` / `Page::new()` (those start with
+    /// `font_metrics_store: None` and may already carry ops the caller
+    /// pushed before transferring ownership to the Document).
+    pub(crate) fn set_metrics_store(&mut self, store: Option<FontMetricsStore>) {
+        self.font_metrics_store = store;
+    }
+
     /// Record `text` as drawn with the currently-active font, bucketed
     /// under the font's PDF name (issue #204). Builtin and custom fonts
     /// are both tracked; the writer later filters to the set of

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -148,9 +148,8 @@ impl TextContext {
     /// Create a `TextContext` bound to a per-document `FontMetricsStore`
     /// (issue #230). `None` is equivalent to `TextContext::new()`.
     ///
-    /// `pub(crate)` — wired by `Page::*_with_metrics()` constructors (Task 8).
-    /// Non-test callers for `Page::*_with_metrics` arrive in Tasks 9-11.
-    #[allow(dead_code)]
+    /// `pub(crate)` — wired by `Page::*_with_metrics()` constructors and
+    /// by `Document::new_page_*()` factories.
     pub(crate) fn with_metrics_store(store: Option<FontMetricsStore>) -> Self {
         let mut ctx = Self::default();
         ctx.font_metrics_store = store;

--- a/oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs
+++ b/oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs
@@ -1,0 +1,165 @@
+//! Integration tests for issue #230 follow-up M1 — `Document::add_page`
+//! must also inject the per-Document `FontMetricsStore` into the page's
+//! `text_context.font_metrics_store`, not only into `page.font_metrics_store`.
+//!
+//! Bug: pages constructed via `Page::a4() / Page::letter() / Page::new()`
+//! carry `text_context: TextContext::new()` with `font_metrics_store: None`.
+//! Before the fix, `Document::add_page` only set `page.font_metrics_store`;
+//! the text context was left wired to the legacy global registry — defeating
+//! the per-Document scope that issue #230 closed architecturally.
+//!
+//! These tests are content-verifying (no smoke asserts):
+//! - Test 1 plants the same font name in the legacy global AND in the
+//!   per-Document store with NUMERICALLY DIFFERENT widths. If the fix is
+//!   present, measuring via `page.text_context.font_metrics_store` returns
+//!   the Document width; if absent (or partial), the call falls through.
+//! - Test 2 pushes operations into `page.text_context` BEFORE `add_page` and
+//!   verifies the operation count is preserved across the injection — i.e.
+//!   the fix mutates only the `font_metrics_store` field, never replacing
+//!   the whole `TextContext`.
+//! - Test 3 exercises the factory path (`doc_a.new_page_a4()`) to confirm
+//!   the `is_none()` guard in `add_page` does NOT overwrite a factory-
+//!   supplied store when the page is later handed to a second `Document`.
+
+use oxidize_pdf::text::metrics::FontMetrics;
+use oxidize_pdf::text::{measure_text_with, Font};
+use oxidize_pdf::{Document, Page};
+
+/// Test 1.1 — `Document::add_page` injects the per-Document store into
+/// `page.text_context.font_metrics_store` (which is `None` on `Page::a4()`).
+///
+/// Width plan:
+/// - Legacy global: `'A' = 100` units → `12pt × 100 / 1000 = 1.2 pt`.
+/// - Per-Document store: `'A' = 800` units → `12pt × 800 / 1000 = 9.6 pt`.
+///
+/// Gap of 8.4 pt is far above measurement noise; either width is unique to
+/// its source. The test panics with `.expect("text_context must carry...")`
+/// on v2.8.0 because the accessor returns `None`.
+#[test]
+fn add_page_injects_store_into_text_context() {
+    let name = format!("TC_Wide_1_1_{}", std::process::id());
+
+    #[allow(deprecated)]
+    oxidize_pdf::text::metrics::register_custom_font_metrics(
+        name.clone(),
+        FontMetrics::new(500).with_widths(&[('A', 100)]),
+    );
+
+    let mut doc = Document::new();
+    doc.font_metrics()
+        .register(&name, FontMetrics::new(500).with_widths(&[('A', 800)]));
+
+    let page = Page::a4();
+    doc.add_page(page);
+
+    let stored_page = doc
+        .pages()
+        .last()
+        .expect("doc must have a page after add_page");
+
+    let tc_store = stored_page
+        .text_context_metrics_store_for_test()
+        .expect("text_context must carry the Document store after add_page");
+
+    let doc_width = measure_text_with("A", &Font::Custom(name.clone()), 12.0, Some(tc_store));
+    let global_width = measure_text_with("A", &Font::Custom(name.clone()), 12.0, None);
+
+    assert!(
+        (global_width - 1.2_f64).abs() < 0.05,
+        "global store width must be 1.2 pt for 'A' at 12pt; got {global_width}"
+    );
+    assert!(
+        (doc_width - 9.6_f64).abs() < 0.05,
+        "text_context store width must be 9.6 pt for 'A' at 12pt; got {doc_width}"
+    );
+    assert!(
+        (doc_width - global_width).abs() > 5.0,
+        "Document scope and legacy global must differ by >5 pt; \
+         doc={doc_width}, global={global_width}"
+    );
+}
+
+/// Test 1.2 — Operations accumulated in `page.text_context` BEFORE
+/// `add_page` are preserved across the injection. The fix must mutate only
+/// the `font_metrics_store` field, never reconstruct the `TextContext`.
+#[test]
+fn text_context_ops_preserved_across_add_page() {
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(50.0, 700.0)
+        .write("hello")
+        .expect("write should succeed");
+
+    let ops_before = page.text_context_ops_count_for_test();
+    assert!(
+        ops_before > 0,
+        "pre-condition: page.text() must have pushed at least one op; \
+         got {ops_before}"
+    );
+
+    let mut doc = Document::new();
+    doc.add_page(page);
+    let stored_page = doc.pages().last().expect("doc must have a page");
+
+    let ops_after = stored_page.text_context_ops_count_for_test();
+    assert_eq!(
+        ops_after, ops_before,
+        "add_page must preserve text_context ops; before={ops_before}, after={ops_after}"
+    );
+}
+
+/// Test 1.3 — Factory-supplied stores are NOT overwritten when the page is
+/// added to a second `Document`. Verifies the `is_none()` guard in
+/// `add_page` correctly skips re-injection.
+///
+/// Setup: `doc_a` registers `'A' = 800` (→ 9.6 pt). Factory page from
+/// `doc_a.new_page_a4()` carries `doc_a`'s store. Hand the page to `doc_b`
+/// (empty store). After `doc_b.add_page(page)`, measuring through the page's
+/// `text_context.font_metrics_store` must still see `doc_a`'s width — if
+/// the guard accidentally re-injected, the text context would now point at
+/// `doc_b`'s empty store and the measurement would fall through to the
+/// (unset) legacy global → default fallback width, well below 9.6 pt.
+#[test]
+fn factory_path_text_context_store_unchanged() {
+    let name = format!("FactoryGuard_1_3_{}", std::process::id());
+
+    let doc_a = Document::new();
+    doc_a
+        .font_metrics()
+        .register(&name, FontMetrics::new(500).with_widths(&[('A', 800)]));
+
+    let page = doc_a.new_page_a4();
+
+    // Sanity: factory already wired the store on the page before transfer.
+    assert!(
+        page.text_context_metrics_store_for_test().is_some(),
+        "factory new_page_a4 must wire text_context store"
+    );
+    let factory_width = measure_text_with(
+        "A",
+        &Font::Custom(name.clone()),
+        12.0,
+        page.text_context_metrics_store_for_test(),
+    );
+    assert!(
+        (factory_width - 9.6).abs() < 0.05,
+        "factory path must resolve to doc_a's width 9.6 pt; got {factory_width}"
+    );
+
+    let mut doc_b = Document::new();
+    doc_b.add_page(page);
+    let stored_page = doc_b.pages().last().expect("doc_b must have a page");
+
+    let post_add_width = measure_text_with(
+        "A",
+        &Font::Custom(name.clone()),
+        12.0,
+        stored_page.text_context_metrics_store_for_test(),
+    );
+    assert!(
+        (post_add_width - 9.6).abs() < 0.05,
+        "doc_b.add_page must NOT overwrite doc_a's text_context store; \
+         expected 9.6 pt, got {post_add_width}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs
+++ b/oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "internal-testing")]
 //! Integration tests for issue #230 follow-up M1 — `Document::add_page`
 //! must also inject the per-Document `FontMetricsStore` into the page's
 //! `text_context.font_metrics_store`, not only into `page.font_metrics_store`.
@@ -39,6 +40,12 @@ use oxidize_pdf::{Document, Page};
 fn add_page_injects_store_into_text_context() {
     let name = format!("TC_Wide_1_1_{}", std::process::id());
 
+    // `register_custom_font_metrics` is `#[deprecated since "2.8.0"]` (issue #230, Task 12).
+    // The legacy global registry is exactly what this test contrasts against the
+    // per-Document store; the deprecation is intentional and this call is the
+    // canonical way to plant a value into the global path. When the API is
+    // eventually removed, the entire `global_width` arm of this test must be
+    // dropped — see oxidize-pdf-core/src/text/metrics.rs:299.
     #[allow(deprecated)]
     oxidize_pdf::text::metrics::register_custom_font_metrics(
         name.clone(),


### PR DESCRIPTION
## Resumen

Follow-up M1 sobre #230 (cerrado en v2.8.0). Bug residual detectado post-release: `Document::add_page` solo asignaba `page.font_metrics_store` y dejaba `page.text_context.font_metrics_store = None` para páginas construidas con `Page::a4()`, `Page::letter()` o `Page::new()`. Cualquier medición a través del `text_context` caía al registro global legacy, reintroduciendo el cross-Document leak que #230 había cerrado arquitecturalmente.

Addresses #230 follow-up M1. Target release: v2.8.1.

## Cambios productivos

- `TextContext::set_metrics_store` (pub(crate)) — muta sólo el campo `font_metrics_store`, preserva ops acumuladas.
- `Page::set_text_context_metrics_store` (pub(crate)) — wrapper para que `Document::add_page` acceda al `text_context` privado.
- `Page::text_context_metrics_store_for_test` + `text_context_ops_count_for_test` (`#[doc(hidden)] pub`) — introspección para integration tests.
- `Document::add_page` invoca `set_text_context_metrics_store` dentro del mismo guard `is_none()` existente. Pages de factory no se tocan (el guard protege).
- Bump a `2.8.1` + entrada CHANGELOG.

## Tests

`oxidize-pdf-core/tests/issue_230_text_context_injection_test.rs`:

1. `add_page_injects_store_into_text_context` — global=100 vs doc=800, mide vía `tc_store` y verifica 9.6 pt (no 1.2 pt). Era RED en v2.8.0.
2. `text_context_ops_preserved_across_add_page` — escribe ops vía `page.text()` antes de `add_page`, verifica `ops_count > 0` post-add_page.
3. `factory_path_text_context_store_unchanged` — `doc_a.new_page_a4()`, `doc_b.add_page(page)`, verifica que la medición vía `tc_store` sigue resolviendo a `doc_a` (guard `is_none()`).

## Verificación local

- 3/3 tests nuevos pass.
- `font_metrics_per_document_test` 9/9 pass (incluye `add_page_does_not_overwrite_existing_store`).
- `cargo build` limpio, 0 warnings.

## Riesgo

Bajo. Cambio quirúrgico dentro del guard `is_none()` ya existente. Factory pages no se tocan. API pública no cambia.