### PR TITLE
chore(metadata): fix crates.io categories + drop flaky timing test

### DIFF
--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 documentation = "https://docs.rs/oxidize-pdf"
 homepage = "https://github.com/bzsanti/oxidizePdf"
 description = "A pure Rust PDF generation and manipulation library with zero external dependencies"
-keywords = ["pdf", "document", "generation", "parser", "graphics"]
-categories = ["graphics", "text-processing", "parsing", "multimedia::images"]
+keywords = ["pdf", "pdf-parser", "text-extraction", "pdf-generation", "rag"]
+categories = ["parser-implementations", "text-processing", "graphics", "encoding"]
 readme = "../README.md"
 exclude = [
     "tests/fixtures/*.pdf",

--- a/oxidize-pdf-core/src/text/metrics.rs
+++ b/oxidize-pdf-core/src/text/metrics.rs
@@ -424,7 +424,14 @@ pub(crate) fn create_default_custom_metrics() -> FontMetrics {
     DEFAULT_CUSTOM_METRICS.clone()
 }
 
+#[cfg(test)]
+pub(crate) static DEFAULT_CUSTOM_METRICS_BUILD_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 fn build_default_custom_metrics() -> FontMetrics {
+    #[cfg(test)]
+    DEFAULT_CUSTOM_METRICS_BUILD_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
     let mut metrics = FontMetrics::new(556).with_widths(&[
         (' ', 278),
         ('!', 278),
@@ -940,18 +947,22 @@ mod tests {
 
     #[test]
     fn test_create_default_custom_metrics_is_cached() {
-        // With lazy_static caching, repeated calls should be fast (clone only).
-        // Without caching, each call does ~6,500 HashMap inserts.
-        use std::time::Instant;
-        let start = Instant::now();
+        // Verifies the lazy_static cache: build_default_custom_metrics must run
+        // at most once regardless of how many times create_default_custom_metrics
+        // is called. Instrumented via a #[cfg(test)] AtomicUsize counter so the
+        // assertion is invariant to runner load (the prior timing-based threshold
+        // was flaky under full-suite parallelism).
+        use std::sync::atomic::Ordering;
+        let before = DEFAULT_CUSTOM_METRICS_BUILD_COUNT.load(Ordering::Relaxed);
         for _ in 0..1000 {
             let _ = create_default_custom_metrics();
         }
-        let elapsed = start.elapsed();
+        let after = DEFAULT_CUSTOM_METRICS_BUILD_COUNT.load(Ordering::Relaxed);
+        let delta = after - before;
         assert!(
-            elapsed.as_millis() < 50,
-            "1000 calls took {}ms; expected < 50ms with caching",
-            elapsed.as_millis()
+            delta <= 1,
+            "build_default_custom_metrics ran {} times during 1000 calls; cache broken",
+            delta
         );
     }
 


### PR DESCRIPTION
## Summary

Two repo-hygiene fixes that ride together. No release on this PR — bump deferred per session decision (will be picked up by the next functional release).

### 1. `oxidize-pdf-core/Cargo.toml` — categories + keywords

The crate has been displayed on lib.rs under `multimedia/images` since the categories array included `"multimedia::images"`, which the lib.rs taxonomy reserves for image codecs / pixel processing (PNG, JPEG, etc.). Comparable PDF parser crates (e.g. `pdf_oxide`) surface under `parser-implementations`, which is the correct slug.

Also dropped `"parsing"` from the array — it is not a valid crates.io slug and was silently ignored by the registry.

```diff
-keywords = ["pdf", "document", "generation", "parser", "graphics"]
-categories = ["graphics", "text-processing", "parsing", "multimedia::images"]
+keywords = ["pdf", "pdf-parser", "text-extraction", "pdf-generation", "rag"]
+categories = ["parser-implementations", "text-processing", "graphics", "encoding"]
```

Keyword changes swap generic terms (`document`, `generation`, `graphics`) for compound terms that match how users actually search on crates.io / lib.rs (`pdf-parser`, `text-extraction`, `pdf-generation`), plus `rag` to surface the AI-oriented use case. Validated with `cargo publish --dry-run -p oxidize-pdf` — no warnings.

Effect only materialises on the next published version; `2.8.1` stays mis-categorised on crates.io until then.

### 2. `oxidize-pdf-core/src/text/metrics.rs` — drop flaky timing-based cache test

`test_create_default_custom_metrics_is_cached` asserted that 1000 calls completed in under 50ms. Under full-suite parallelism on the unoptimized profile this exceeded the threshold (observed 74–84ms) despite caching being functionally correct. Structural fragility of the threshold, not a regression.

Replaced with a deterministic check on the actual invariant: `build_default_custom_metrics` must run at most once. Instrumented via a `#[cfg(test)]` `AtomicUsize` counter the build function increments; the test reads the delta across the 1000-call loop. Counter and `fetch_add` are gated on `cfg(test)`, so the production build path is unchanged.

## Verification

- `cargo test -p oxidize-pdf --lib`: 6389/6389 (was 6388/6389 with flaky test) under full-suite parallelism.
- `cargo publish --dry-run -p oxidize-pdf`: no warnings on the new category/keyword slugs.
- `cargo clippy --workspace --lib -- -D warnings`: clean (pre-commit hook gate).
- `cargo fmt --all -- --check`: clean.

## Notes

- No version bump in this PR — per the 2026-05-18 error-log rule, bumps go in a dedicated `chore(release):` commit, and per session decision (option B) we are not cutting a 2.8.2 just for these changes.
- See the related issue triage filed against the Python bindings (`bzsanti/oxidize-python` #57, #58, #59) — unrelated to this PR but discovered in the same session.