### PR TITLE
fix(text): unify non-stroking color + WinAnsi encoding across contexts (#239, #240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **`Page::set_fill_color` (graphics) now affects subsequent text rendering**
+  when no explicit text fill colour has been set. Per ISO 32000-1 §8.6.8,
+  the `rg` operator sets the non-stroking colour of the graphics state,
+  which applies to both path fills and glyph fills at text rendering
+  mode 0 (default). Pre-fix, `GraphicsContext.current_color` and
+  `TextContext.fill_color` were independent slots: a caller that drew a
+  filled rectangle in magenta and then wrote text without an explicit
+  text colour saw the glyphs painted in magenta (the last `rg` left in
+  the stream) instead of the colour they had set via
+  `graphics().set_fill_color(...)`. `Page::text()` and `Page::text_flow()`
+  now inherit the current graphics-state non-stroking colour when the
+  text context has no explicit colour of its own; an explicit
+  `text().set_fill_color(...)` still overrides the inherited value.
+  Addresses #239.
+- **`TextFlowContext::write_wrapped` now encodes text through
+  `TextEncoding::WinAnsiEncoding`** (matching `TextContext::write`),
+  fixing multi-byte Unicode characters (e.g. `€`, `—`, `ñ`, smart
+  quotes) being emitted as raw UTF-8 bytes that PDF viewers
+  reinterpreted as Windows-1252 mojibake (`€` → `â‚¬`, `—` → `â€"`).
+  Both `TextContext::write` and `TextFlowContext::write_wrapped` now
+  delegate to a shared `text::build_show_text_op` helper so they cannot
+  diverge again on encoding or escape rules per ISO 32000-1 §7.9.2 and
+  §9.10.3 (Custom CJK fonts continue to use UTF-16BE hex; builtin fonts
+  use WinAnsi + octal-escape literal strings). Addresses #240.
+
+### Changed
+
+- **Behavioural change in the emitted content stream** (no visual
+  difference): pages that emit text without an explicit text fill
+  colour now also emit the graphics-state default `0.000 g` (gray
+  black) inside the surrounding `BT … ET` block. The text was already
+  rendered in black via the inherited graphics state; the stream is now
+  explicit about it. Tests that asserted absence of `rg` / `g` inside
+  pure-text BT…ET blocks should be updated to assert presence of the
+  expected colour operator instead.
+
 ## [2.8.1] - 2026-05-17
 
 ### Fixed

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -685,10 +685,34 @@ impl Page {
     /// operations into the page-level ordered buffer (`page_ops`) so
     /// that subsequent text calls are emitted *after* the graphics that
     /// preceded them in call order (issue #227).
+    ///
+    /// As of issue #239, this also propagates the current graphics-state
+    /// non-stroking colour into the text context when the caller has not
+    /// set an explicit text fill colour. Per ISO 32000-1 §8.6.8, `rg` is
+    /// a graphics-state operator that applies both to path fills and to
+    /// glyph fills at text rendering mode 0 (default). Splitting the
+    /// fill-colour slot between `GraphicsContext` and `TextContext`
+    /// without this handoff produced a stream where the text was painted
+    /// in whatever colour the previous path fill left active, never the
+    /// colour the caller intended for the text. An explicit
+    /// `text().set_fill_color(...)` still overrides the inherited value.
+    ///
+    /// **Side effect on the returned `TextContext`:** when the handoff
+    /// fires, this call mutates `text_context.fill_color` from `None`
+    /// to `Some(<graphics-state colour>)` BEFORE returning the
+    /// reference. Code that probes `fill_color()` as a signal of
+    /// "user has set a colour" will see `Some(...)` even when the user
+    /// never called `set_fill_color`, because the graphics state is now
+    /// considered the source of truth for the non-stroking colour.
+    /// After `clear()`, the next `text()` call will repeat the handoff.
     pub fn text(&mut self) -> &mut TextContext {
         if !self.graphics_context.ops_slice().is_empty() {
             let drained = self.graphics_context.drain_ops();
             self.page_ops.extend(drained);
+        }
+        if self.text_context.fill_color().is_none() {
+            let inherited = self.graphics_context.fill_color();
+            self.text_context.set_fill_color(inherited);
         }
         &mut self.text_context
     }
@@ -981,9 +1005,15 @@ impl Page {
             self.text_context.current_font().clone(),
             self.text_context.font_size(),
         );
-        if let Some(color) = self.text_context.fill_color() {
-            ctx.set_fill_color(color);
-        }
+        // Issue #239: when no explicit text fill colour was set, fall
+        // back to the graphics-state non-stroking colour so the flow
+        // honours `graphics().set_fill_color(...)` per ISO 32000-1
+        // §8.6.8. Symmetric with the handoff in `Page::text()`.
+        let effective_fill = self
+            .text_context
+            .fill_color()
+            .unwrap_or_else(|| self.graphics_context.fill_color());
+        ctx.set_fill_color(effective_fill);
         if let Some(spacing) = self.text_context.character_spacing() {
             ctx.set_character_spacing(spacing);
         }

--- a/oxidize-pdf-core/src/text/encoding.rs
+++ b/oxidize-pdf-core/src/text/encoding.rs
@@ -455,6 +455,52 @@ pub fn macroman_encode_char(ch: char) -> Option<u8> {
     }
 }
 
+/// Escape `bytes` as the body of a PDF literal-string `(...)` show-text
+/// payload, suitable for direct use as the payload of `Op::ShowText`.
+///
+/// Produces `Vec<u8>` (vs `escape_pdf_string_literal`'s `String`) and
+/// uses the same six named escapes as that helper plus the octal
+/// fallback for everything else. The two helpers are kept in lock-step
+/// by sharing the named-escape table; only the output container differs.
+///
+/// - `(`, `)`, `\\` → backslash-prefixed.
+/// - `\n`, `\r`, `\t`, `\x08` (`BS`), `\x0C` (`FF`) → named two-character
+///   escapes per ISO 32000-1 §7.9.2 Table 3.
+/// - Printable ASCII `0x20..=0x7E` → passed through verbatim.
+/// - Everything else (including the WinAnsi high range `0x80..=0xFF`)
+///   → three-digit octal `\NNN`. The octal form keeps eight-bit bytes
+///   intact through 7-bit-safe intermediaries and matches ISO 32000-1
+///   §7.9.2.
+///
+/// Used by `text::build_show_text_op` to consolidate the encoding +
+/// escape pipeline between `TextContext::write` and
+/// `TextFlowContext::write_wrapped` (issue #240). The initial capacity
+/// (`bytes.len() * 4`) is the upper bound (every byte expanding to the
+/// four-char `\NNN` octal form); for the common ASCII-dominant case it
+/// is an over-allocation but avoids realloc cascades on
+/// multibyte-heavy text (French, German, typographic glyphs).
+pub(crate) fn escape_show_text_literal_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(bytes.len() * 4);
+    for &b in bytes {
+        match b {
+            b'(' => buf.extend_from_slice(b"\\("),
+            b')' => buf.extend_from_slice(b"\\)"),
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            b'\x08' => buf.extend_from_slice(b"\\b"),
+            b'\x0C' => buf.extend_from_slice(b"\\f"),
+            0x20..=0x7E => buf.push(b),
+            _ => {
+                use std::io::Write as _;
+                write!(&mut buf, "\\{b:03o}").expect("write to Vec<u8> never fails");
+            }
+        }
+    }
+    buf
+}
+
 /// Emit the UTF-8 bytes `input` as a PDF string-literal body, escaping
 /// characters that have special meaning inside `(...)` and writing bytes
 /// above 0x7F as three-digit octal escapes. Does NOT wrap the output in
@@ -499,6 +545,61 @@ pub fn escape_pdf_string_literal(input: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `escape_show_text_literal_bytes` must use the SAME named escapes
+    /// as `escape_pdf_string_literal` for the six controls listed in
+    /// ISO 32000-1 §7.9.2 Table 3 (`\\b`, `\\f`, `\\n`, `\\r`, `\\t`,
+    /// plus the literal backslash). Without this guard the two helpers
+    /// can drift again — pre-fix, `escape_show_text_literal_bytes`
+    /// emitted `\\010` and `\\014` for `BS`/`FF` while the sibling
+    /// emitted `\\b`/`\\f`.
+    #[test]
+    fn escape_show_text_literal_bytes_named_escape_parity() {
+        // Each byte must produce the exact named-escape form, byte-for-byte.
+        let cases: &[(u8, &[u8])] = &[
+            (b'(', b"\\("),
+            (b')', b"\\)"),
+            (b'\\', b"\\\\"),
+            (b'\n', b"\\n"),
+            (b'\r', b"\\r"),
+            (b'\t', b"\\t"),
+            (b'\x08', b"\\b"),
+            (b'\x0C', b"\\f"),
+        ];
+        for (input, expected) in cases {
+            let got = escape_show_text_literal_bytes(&[*input]);
+            assert_eq!(
+                got,
+                *expected,
+                "byte 0x{input:02X} must escape as {:?}, got {:?}",
+                std::str::from_utf8(expected).unwrap(),
+                String::from_utf8_lossy(&got),
+            );
+        }
+    }
+
+    /// The octal fallback must emit three digits for every byte in
+    /// `0x80..=0xFF` (Windows-1252 high range) and for any sub-`0x20`
+    /// control byte not covered by a named escape (e.g. `0x01`).
+    #[test]
+    fn escape_show_text_literal_bytes_octal_fallback_three_digits() {
+        // 0x80 → "\\200", 0xFF → "\\377", 0x01 → "\\001"
+        assert_eq!(escape_show_text_literal_bytes(&[0x80]), b"\\200");
+        assert_eq!(escape_show_text_literal_bytes(&[0xFF]), b"\\377");
+        assert_eq!(escape_show_text_literal_bytes(&[0x01]), b"\\001");
+    }
+
+    /// Printable ASCII (`0x20..=0x7E`) must pass through unchanged
+    /// (single byte each). Guard against a future change that adds
+    /// unnecessary escapes to this range.
+    #[test]
+    fn escape_show_text_literal_bytes_printable_ascii_passthrough() {
+        let printable: Vec<u8> = (0x20u8..=0x7E)
+            .filter(|b| !matches!(b, b'(' | b')' | b'\\'))
+            .collect();
+        let got = escape_show_text_literal_bytes(&printable);
+        assert_eq!(got, printable);
+    }
 
     #[test]
     fn test_text_encoding_variants() {

--- a/oxidize-pdf-core/src/text/flow.rs
+++ b/oxidize-pdf-core/src/text/flow.rs
@@ -333,23 +333,16 @@ impl TextFlowContext {
                 }
             }
 
-            // Show text — escape PDF literal-string special characters.
-            let mut buf = Vec::with_capacity(line_text.len());
-            for ch in line_text.chars() {
-                match ch {
-                    '(' => buf.extend_from_slice(b"\\("),
-                    ')' => buf.extend_from_slice(b"\\)"),
-                    '\\' => buf.extend_from_slice(b"\\\\"),
-                    '\n' => buf.extend_from_slice(b"\\n"),
-                    '\r' => buf.extend_from_slice(b"\\r"),
-                    '\t' => buf.extend_from_slice(b"\\t"),
-                    _ => {
-                        let mut tmp = [0u8; 4];
-                        buf.extend_from_slice(ch.encode_utf8(&mut tmp).as_bytes());
-                    }
-                }
-            }
-            self.operations.push(Op::ShowText(buf));
+            // Encode + escape through the shared show-text factory
+            // (issue #240). Pre-fix this branch wrote `ch.encode_utf8(...)`
+            // bytes directly, bypassing `TextEncoding::WinAnsiEncoding` so
+            // characters outside ASCII (`€`, `—`, smart quotes …) reached
+            // the content stream as raw UTF-8 multi-byte runs that any
+            // PDF viewer re-interpreted as Windows-1252 mojibake.
+            self.operations.push(crate::text::build_show_text_op(
+                &line_text,
+                &self.current_font,
+            ));
 
             // Record per-font char usage so the consuming page can
             // report it to the writer (issue #204).

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -86,6 +86,45 @@ pub enum TextRenderingMode {
     Clip = 7,
 }
 
+/// Build the show-text IR op for `text` rendered with `font`. Single
+/// emission path shared by `TextContext::write` and
+/// `TextFlowContext::write_wrapped` so the two cannot diverge on encoding
+/// or escaping (issue #240 — pre-fix, the flow path emitted raw UTF-8
+/// bytes inside the literal `( … ) Tj` and any character outside ASCII
+/// rendered as Windows-1252 mojibake).
+///
+/// - `Font::Custom(_)` → UTF-16BE hex string per ISO 32000-1 §9.10.3,
+///   wrapped in `Op::ShowTextHex` so the writer emits `< … > Tj`.
+/// - Any builtin font → bytes are first WinAnsi-encoded
+///   ([`TextEncoding::WinAnsiEncoding`]) and then escaped for inclusion
+///   in a PDF string literal via
+///   [`encoding::escape_show_text_literal_bytes`].
+pub(crate) fn build_show_text_op(text: &str, font: &Font) -> crate::graphics::ops::Op {
+    use crate::graphics::ops::Op;
+
+    match font {
+        Font::Custom(_) => {
+            let utf16_units: Vec<u16> = text.encode_utf16().collect();
+            let mut hex = String::with_capacity(utf16_units.len() * 4);
+            for unit in utf16_units {
+                use std::fmt::Write as _;
+                write!(
+                    &mut hex,
+                    "{:02X}{:02X}",
+                    (unit >> 8) as u8,
+                    (unit & 0xFF) as u8
+                )
+                .expect("write to String never fails");
+            }
+            Op::ShowTextHex(hex.into_bytes())
+        }
+        _ => {
+            let encoded = TextEncoding::WinAnsiEncoding.encode(text);
+            Op::ShowText(encoding::escape_show_text_literal_bytes(&encoded))
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct TextContext {
     operations: Vec<crate::graphics::ops::Op>,
@@ -287,48 +326,12 @@ impl TextContext {
         };
         self.operations.push(Op::SetTextPosition { x, y });
 
-        // Choose encoding based on font type
-        match &self.current_font {
-            Font::Custom(_) => {
-                // For custom fonts (CJK), use UTF-16BE encoding with hex strings
-                let utf16_units: Vec<u16> = text.encode_utf16().collect();
-                let mut hex = String::new();
-                for unit in utf16_units {
-                    use std::fmt::Write as _;
-                    write!(
-                        &mut hex,
-                        "{:02X}{:02X}",
-                        (unit >> 8) as u8,
-                        (unit & 0xFF) as u8
-                    )
-                    .expect("write to String never fails");
-                }
-                self.operations.push(Op::ShowTextHex(hex.into_bytes()));
-            }
-            _ => {
-                // For standard fonts, use WinAnsiEncoding with literal-string escaping.
-                let encoding = TextEncoding::WinAnsiEncoding;
-                let encoded_bytes = encoding.encode(text);
-
-                let mut buf = Vec::with_capacity(encoded_bytes.len());
-                for &byte in &encoded_bytes {
-                    match byte {
-                        b'(' => buf.extend_from_slice(b"\\("),
-                        b')' => buf.extend_from_slice(b"\\)"),
-                        b'\\' => buf.extend_from_slice(b"\\\\"),
-                        b'\n' => buf.extend_from_slice(b"\\n"),
-                        b'\r' => buf.extend_from_slice(b"\\r"),
-                        b'\t' => buf.extend_from_slice(b"\\t"),
-                        0x20..=0x7E => buf.push(byte),
-                        _ => {
-                            use std::io::Write as _;
-                            write!(&mut buf, "\\{byte:03o}").expect("write to Vec<u8> never fails");
-                        }
-                    }
-                }
-                self.operations.push(Op::ShowText(buf));
-            }
-        }
+        // Shared encoding + escape pipeline (issue #240): builtin fonts
+        // route through WinAnsi + literal-string escape; Custom (CJK)
+        // fonts route through UTF-16BE hex. Mirror of the same call in
+        // `TextFlowContext::write_wrapped` — single source of truth.
+        self.operations
+            .push(build_show_text_op(text, &self.current_font));
 
         // Track used characters for font subsetting bucketed by the
         // active custom font (issue #204).

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -84,6 +84,17 @@ impl WriterConfig {
 /// Correct ordering is essential: `\` MUST be escaped first (otherwise
 /// the `\` we insert to escape a `(` would itself get doubled). This
 /// helper walks the input exactly once and emits the escaped form.
+///
+/// **Scope clarification (issue #240 follow-up):** this helper serves
+/// only `Object::String` payloads (metadata, dict entries, array
+/// elements). The show-text `(text) Tj` payloads inside content
+/// streams take an independent path (`Op::ShowText` bytes are produced
+/// by `text::encoding::escape_show_text_literal_bytes`, which DOES
+/// escape the high byte range `0x80..=0xFF` as `\NNN` octal because
+/// those payloads carry WinAnsi-encoded text whose bytes must survive
+/// 7-bit-safe intermediaries). The two helpers solve different
+/// problems and intentionally have different coverage; they are not
+/// coordinated and one is not "downstream" of the other.
 fn escape_pdf_string_bytes(input: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(input.len());
     for &byte in input {

--- a/oxidize-pdf-core/tests/issue_239_unified_fill_color_test.rs
+++ b/oxidize-pdf-core/tests/issue_239_unified_fill_color_test.rs
@@ -1,0 +1,306 @@
+//! Regression tests for issue #239 — `Page::set_fill_color` on the
+//! graphics context did not propagate to text rendering. Per ISO 32000-1
+//! §8.6.8, `rg` is the **non-stroking colour** of the graphics state and
+//! applies both to path fills and to glyph fills at text rendering mode
+//! 0 (default). Pre-fix, `GraphicsContext.current_color` and
+//! `TextContext.fill_color` were independent slots, so a caller that
+//! set the fill colour via `graphics().set_fill_color(...)` and then
+//! emitted text saw the text painted in whichever colour the last
+//! emitted `rg` had left in the stream — typically the colour of the
+//! previous path fill, never the colour the caller intended for the
+//! text.
+//!
+//! The fix is a handoff in `Page::text()` (and `Page::text_flow()`):
+//! when the text context has no explicit fill colour of its own, it
+//! inherits the current graphics-state fill colour. An explicit
+//! `text().set_fill_color(...)` still overrides the inherited value.
+//!
+//! These tests are content-verifying (no smoke): they parse the
+//! uncompressed PDF content stream and assert that the expected `rg`
+//! / `g` operator appears inside the `BT … ET` block that surrounds the
+//! show-text literal.
+
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+use oxidize_pdf::{Document, Font, Page};
+use std::io::Cursor;
+
+/// Build an uncompressed PDF from `page` so the content stream is
+/// directly observable in the byte output.
+fn render(page: Page) -> Vec<u8> {
+    let mut doc = Document::new();
+    doc.set_compress(false);
+    doc.add_page(page);
+    doc.to_bytes().expect("to_bytes must succeed")
+}
+
+/// Find the `BT … ET` block that contains `needle` (a substring of the
+/// content stream, typically a `(text)` literal we just emitted), and
+/// return the bytes between the matching `BT\n` and `ET\n`. Used to
+/// scope assertions about non-stroking colour to the text block — the
+/// graphics-state `rg` that preceded the block is not relevant for what
+/// the GLYPHS are painted in, only the `rg` inside the block is.
+fn bt_et_window_containing<'a>(stream: &'a [u8], needle: &[u8]) -> &'a [u8] {
+    let pos = find_subsequence(stream, needle).unwrap_or_else(|| {
+        panic!(
+            "needle {:?} not found in content stream:\n{}",
+            std::str::from_utf8(needle).unwrap_or("<binary>"),
+            String::from_utf8_lossy(stream),
+        )
+    });
+    // Walk backwards for the nearest `BT\n` start.
+    let bt = b"BT\n";
+    let bt_start = (0..=pos.saturating_sub(bt.len()))
+        .rev()
+        .find(|&i| stream[i..].starts_with(bt))
+        .unwrap_or_else(|| {
+            panic!(
+                "no `BT\\n` precedes needle in content stream:\n{}",
+                String::from_utf8_lossy(stream),
+            )
+        });
+    // Walk forwards for the next `ET\n`.
+    let et = b"ET\n";
+    let et_end_offset = find_subsequence(&stream[pos..], et).unwrap_or_else(|| {
+        panic!(
+            "no `ET\\n` after needle in content stream:\n{}",
+            String::from_utf8_lossy(stream),
+        )
+    });
+    &stream[bt_start..pos + et_end_offset + et.len()]
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn window_contains(window: &[u8], needle: &[u8]) -> bool {
+    window.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Reproductor literal del issue body: una banda magenta dibujada con
+/// `graphics().set_fill_color(magenta).fill()`, luego
+/// `graphics().set_fill_color(white)` y `text().write("Hello white")`.
+/// El texto debe pintarse en BLANCO porque el caller dejó el último
+/// non-stroking colour del graphics state en blanco antes de emitir el
+/// texto, y el texto NO tiene colour explícito propio.
+///
+/// Pre-fix, el `BT … ET` de "Hello white" no contenía ningún `rg`, y el
+/// último `rg` del stream era el magenta de la banda; el viewer pintaba
+/// el texto en magenta.
+#[test]
+fn graphics_fill_color_inherited_by_text_when_text_has_no_explicit_color() {
+    let mut page = Page::a4();
+
+    page.graphics()
+        .set_fill_color(Color::Rgb(0.851, 0.275, 0.937))
+        .rect(0.0, 600.0, 595.0, 200.0)
+        .fill();
+
+    page.graphics().set_fill_color(Color::Rgb(1.0, 1.0, 1.0));
+
+    page.text()
+        .set_font(Font::HelveticaBold, 32.0)
+        .at(50.0, 700.0)
+        .write("Hello white")
+        .expect("text().write must succeed");
+
+    let pdf = render(page);
+    let window = bt_et_window_containing(&pdf, b"(Hello white)");
+
+    assert!(
+        window_contains(window, b"1.000 1.000 1.000 rg"),
+        "white `rg` must appear inside the BT…ET that emits (Hello white) — \
+         text inherits the current graphics-state non-stroking colour per \
+         ISO 32000-1 §8.6.8.\nBT…ET window:\n{}",
+        String::from_utf8_lossy(window),
+    );
+}
+
+/// Override semantics: an explicit `text().set_fill_color(blue)` after
+/// `graphics().set_fill_color(red)` must win. The text block emits the
+/// blue `rg`, not the red one inherited from the graphics state.
+#[test]
+fn explicit_text_fill_color_overrides_graphics_color() {
+    let mut page = Page::a4();
+
+    page.graphics()
+        .set_fill_color(Color::Rgb(1.0, 0.0, 0.0))
+        .rect(0.0, 600.0, 595.0, 200.0)
+        .fill();
+
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .set_fill_color(Color::Rgb(0.0, 0.0, 1.0))
+        .at(50.0, 700.0)
+        .write("Blue wins")
+        .expect("text().write must succeed");
+
+    let pdf = render(page);
+    let window = bt_et_window_containing(&pdf, b"(Blue wins)");
+
+    assert!(
+        window_contains(window, b"0.000 0.000 1.000 rg"),
+        "explicit blue `rg` must appear inside (Blue wins) BT…ET; got:\n{}",
+        String::from_utf8_lossy(window),
+    );
+    assert!(
+        !window_contains(window, b"1.000 0.000 0.000 rg"),
+        "inherited red `rg` must NOT appear inside (Blue wins) BT…ET; got:\n{}",
+        String::from_utf8_lossy(window),
+    );
+}
+
+/// Guard contra `is_none()` mal aplicado: si el caller fija un colour
+/// explícito en `text()` ANTES de cualquier `graphics().set_fill_color`,
+/// el handoff posterior NO debe sobreescribirlo. Secuencia:
+///   1. `text().set_fill_color(green)` → text_context.fill_color = Some(green).
+///   2. `graphics().set_fill_color(red).fill()` → graphics state = red.
+///   3. `text().write("X")` → segundo handoff; el guard `is_none()` es
+///      `false`, por tanto el verde sobrevive.
+#[test]
+fn text_fill_color_set_before_graphics_is_not_overwritten_by_handoff() {
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .set_fill_color(Color::Rgb(0.0, 1.0, 0.0));
+
+    page.graphics()
+        .set_fill_color(Color::Rgb(1.0, 0.0, 0.0))
+        .rect(0.0, 600.0, 595.0, 200.0)
+        .fill();
+
+    page.text()
+        .at(50.0, 700.0)
+        .write("Green stays")
+        .expect("text().write must succeed");
+
+    let pdf = render(page);
+    let window = bt_et_window_containing(&pdf, b"(Green stays)");
+
+    assert!(
+        window_contains(window, b"0.000 1.000 0.000 rg"),
+        "explicit green `rg` set before graphics must persist; got:\n{}",
+        String::from_utf8_lossy(window),
+    );
+    assert!(
+        !window_contains(window, b"1.000 0.000 0.000 rg"),
+        "red from graphics state must NOT overwrite the prior explicit \
+         text colour; got:\n{}",
+        String::from_utf8_lossy(window),
+    );
+}
+
+/// Edge case behavioural change: una página recién creada (sin que
+/// nadie haya llamado `set_fill_color`) ahora emite el operador del
+/// colour por defecto del graphics state (`Color::Gray(0.0)`) dentro
+/// del `BT … ET` del texto, en lugar de no emitir ningún colour. El
+/// resultado visual es idéntico (negro = default) pero el contenido del
+/// stream cambia. Documentado en CHANGELOG.
+#[test]
+fn graphics_default_black_propagates_to_text_on_fresh_page() {
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(50.0, 700.0)
+        .write("Default")
+        .expect("text().write must succeed");
+
+    let pdf = render(page);
+    let window = bt_et_window_containing(&pdf, b"(Default)");
+
+    // `Color::black()` is `Color::Gray(0.0)`, which serialises as
+    // `0.000 g` (gray non-stroking colour) per ISO 32000-1 §8.6.8.
+    assert!(
+        window_contains(window, b"0.000 g"),
+        "default black `0.000 g` must appear inside the BT…ET on a fresh \
+         page — the graphics-state default colour is now propagated. \
+         Window:\n{}",
+        String::from_utf8_lossy(window),
+    );
+}
+
+/// `Page::text_flow()` también debe heredar el non-stroking colour del
+/// graphics state cuando el text_context no tiene colour propio. Pre-fix,
+/// `Page::text_flow()` SOLO copiaba `text_context.fill_color()`; el del
+/// graphics state se perdía.
+#[test]
+fn text_flow_inherits_graphics_color_when_text_context_has_no_explicit_color() {
+    let mut page = Page::a4();
+    page.set_margins(50.0, 50.0, 50.0, 50.0);
+
+    page.graphics()
+        .set_fill_color(Color::Rgb(0.5, 0.0, 0.0))
+        .rect(0.0, 600.0, 595.0, 200.0)
+        .fill();
+
+    let mut flow = page.text_flow();
+    flow.set_font(Font::Helvetica, 14.0);
+    flow.at(100.0, 700.0);
+    flow.write_wrapped("Maroon flow")
+        .expect("write_wrapped must succeed");
+    page.add_text_flow(&flow);
+
+    let pdf = render(page);
+    let window = bt_et_window_containing(&pdf, b"(Maroon flow)");
+
+    assert!(
+        window_contains(window, b"0.500 0.000 0.000 rg"),
+        "graphics-state maroon `rg` must propagate into the BT…ET of the \
+         flow when the text_context has no explicit colour. Window:\n{}",
+        String::from_utf8_lossy(window),
+    );
+}
+
+/// Integración end-to-end del reproductor exacto del issue #239. Además
+/// de inspeccionar el stream emitido (cobertura del Ciclo 5), parseamos
+/// el PDF resultante con `PdfReader` + `TextExtractor` y verificamos
+/// que el texto "Hello white" sobrevive el round-trip. Esto asegura
+/// que el fix de colour no rompió la extracción de texto (regresión
+/// trivial pero documentada).
+#[test]
+fn issue_239_reproducer_white_text_on_colored_band_round_trip() {
+    let mut page = Page::a4();
+    page.graphics()
+        .set_fill_color(Color::Rgb(0.851, 0.275, 0.937))
+        .rect(0.0, 600.0, 595.0, 200.0)
+        .fill();
+    page.graphics().set_fill_color(Color::Rgb(1.0, 1.0, 1.0));
+    page.text()
+        .set_font(Font::HelveticaBold, 32.0)
+        .at(50.0, 700.0)
+        .write("Hello white")
+        .expect("text().write must succeed");
+
+    let pdf = render(page);
+
+    // Stream-level check: white `rg` precedes the show-text inside BT…ET.
+    let window = bt_et_window_containing(&pdf, b"(Hello white)");
+    assert!(
+        window_contains(window, b"1.000 1.000 1.000 rg"),
+        "stream-level: white rg must live inside (Hello white) BT…ET",
+    );
+
+    // Round-trip via the parser: the extracted text must contain the
+    // exact phrase we wrote — the fix must not alter the text payload.
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("PdfReader must open in-memory PDF");
+    let doc = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::new();
+    let extracted = extractor
+        .extract_from_document(&doc)
+        .expect("extract_from_document must succeed");
+    let all_text: String = extracted
+        .iter()
+        .map(|page_text| page_text.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        all_text.contains("Hello white"),
+        "round-trip extracted text must contain `Hello white`; got: {all_text:?}",
+    );
+}

--- a/oxidize-pdf-core/tests/issue_240_text_flow_encoding_test.rs
+++ b/oxidize-pdf-core/tests/issue_240_text_flow_encoding_test.rs
@@ -1,0 +1,274 @@
+//! Regression tests for issue #240 — `TextFlowContext::write_wrapped` was
+//! emitting raw UTF-8 bytes straight into `Op::ShowText`, bypassing the
+//! `TextEncoding::WinAnsiEncoding` pipeline that `TextContext::write` uses
+//! for builtin fonts. Result: `€`, `—`, smart quotes etc. surfaced in the
+//! content stream as multi-byte UTF-8 runs that any viewer reinterpreted
+//! as Windows-1252 — `€` → `â‚¬`, `—` → `â€"`, and so on.
+//!
+//! These tests are content-verifying (no smoke): they inspect the raw
+//! content-stream bytes of the produced PDF and assert that each
+//! special character lands at the WinAnsi octal escape `TextContext::write`
+//! would emit (`\200` for `€`, `\227` for `—`, …) and that no raw UTF-8
+//! multi-byte sequence appears.
+//!
+//! ISO 32000-1 references:
+//! - §7.9.2 — string objects, literal escapes, `\NNN` octal form
+//! - §9.4.3 — text-showing operators
+//! - §9.10  — text encoding (WinAnsi as the default for builtin fonts)
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{TextAlign, TextExtractor};
+use oxidize_pdf::{Document, Font, Page};
+use std::io::Cursor;
+
+/// Extract the bytes of the FIRST literal-string show-text body in a
+/// content stream — the bytes between `(` and the matching `) Tj`. Used
+/// to compare what `TextContext::write` emits vs what
+/// `TextFlowContext::write_wrapped` emits for the same input.
+///
+/// The parser honours PDF literal-string escape rules per ISO 32000-1
+/// §7.9.2: a `)` preceded by a backslash does not close the literal,
+/// and a `\\` consumes the backslash that follows it. Anything more
+/// complex is irrelevant here — the show-text payloads we emit never
+/// contain nested parentheses.
+fn extract_first_show_text_literal(pdf: &[u8]) -> Vec<u8> {
+    let mut i = 0;
+    while i < pdf.len() {
+        if pdf[i] == b'(' {
+            // Walk forward, tracking backslash escapes, looking for the
+            // matching `)` that immediately precedes ` Tj`.
+            let mut j = i + 1;
+            let mut body: Vec<u8> = Vec::new();
+            while j < pdf.len() {
+                match pdf[j] {
+                    b'\\' if j + 1 < pdf.len() => {
+                        body.push(pdf[j]);
+                        body.push(pdf[j + 1]);
+                        j += 2;
+                    }
+                    b')' if pdf[j..].starts_with(b") Tj") => {
+                        return body;
+                    }
+                    b => {
+                        body.push(b);
+                        j += 1;
+                    }
+                }
+            }
+            // Unterminated literal — skip and continue scanning.
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    panic!("no `(...) Tj` literal-string show-text found in content stream");
+}
+
+/// Render `text` through `text_flow().write_wrapped(...)` on a fresh page,
+/// return the uncompressed PDF bytes. Compression is disabled so the
+/// content stream bytes are directly observable.
+fn render_via_text_flow(text: &str) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.set_margins(50.0, 50.0, 50.0, 50.0);
+    {
+        let mut flow = page.text_flow();
+        flow.set_font(Font::Helvetica, 14.0);
+        flow.at(50.0, 700.0);
+        flow.set_alignment(TextAlign::Left);
+        flow.write_wrapped(text)
+            .expect("write_wrapped must succeed");
+        page.add_text_flow(&flow);
+    }
+    doc.set_compress(false);
+    doc.add_page(page);
+    doc.to_bytes().expect("to_bytes must succeed")
+}
+
+/// `€` must be encoded as a single WinAnsi byte `0x80`, escaped in the
+/// PDF literal-string form as `\200` (octal three-digit). The raw UTF-8
+/// representation of `€` is the three-byte sequence `0xE2 0x82 0xAC`,
+/// which would escape as `\342\202\254` — that sequence MUST NOT appear.
+#[test]
+fn write_wrapped_euro_sign_encodes_as_winansi_not_utf8() {
+    let bytes = render_via_text_flow("€100");
+
+    // WinAnsi-correct escape for the euro sign followed by ASCII "100".
+    let winansi = b"\\200100";
+    assert!(
+        bytes.windows(winansi.len()).any(|w| w == winansi),
+        "Expected WinAnsi euro escape `\\200100` in the content stream — \
+         `€` must be encoded as 0x80 per Windows-1252, not as the raw \
+         UTF-8 sequence."
+    );
+
+    // The raw UTF-8 escape sequence would look like `\342\202\254`. If
+    // this appears, `write_wrapped` is dumping UTF-8 bytes directly and
+    // the encoding pipeline is being bypassed.
+    let utf8_raw = b"\\342\\202\\254";
+    assert!(
+        !bytes.windows(utf8_raw.len()).any(|w| w == utf8_raw),
+        "Raw UTF-8 octal escape `\\342\\202\\254` appeared in content stream — \
+         `write_wrapped` is bypassing TextEncoding::WinAnsiEncoding."
+    );
+}
+
+/// Cover every special character the issue body called out: each must
+/// land at its Windows-1252 byte (encoded as `\NNN` octal in the PDF
+/// literal-string body). One assertion per character so a missing entry
+/// in the WinAnsi table or a divergence in the helper is pinpointed by
+/// the test name, not buried inside a multi-char compare.
+///
+/// `ñ` is a Latin-1 character (`0xF1`), the rest live in the
+/// Windows-1252 supplement (`0x80..=0x9F`). The combined coverage proves
+/// both branches of the WinAnsi mapping are exercised.
+#[test]
+fn write_wrapped_special_chars_encode_at_windows_1252_codepoints() {
+    let cases: &[(char, &[u8], &str)] = &[
+        ('€', b"\\200", "euro U+20AC -> 0x80"),
+        ('—', b"\\227", "em dash U+2014 -> 0x97"),
+        ('–', b"\\226", "en dash U+2013 -> 0x96"),
+        ('\u{2018}', b"\\221", "left single quote U+2018 -> 0x91"),
+        ('\u{2019}', b"\\222", "right single quote U+2019 -> 0x92"),
+        ('…', b"\\205", "horizontal ellipsis U+2026 -> 0x85"),
+        ('±', b"\\261", "plus-minus U+00B1 -> 0xB1"),
+        ('ñ', b"\\361", "n with tilde U+00F1 -> 0xF1"),
+    ];
+
+    for (ch, expected_escape, why) in cases {
+        let input: String = std::iter::once(*ch).collect();
+        let bytes = render_via_text_flow(&input);
+        assert!(
+            bytes
+                .windows(expected_escape.len())
+                .any(|w| w == *expected_escape),
+            "Expected `{}` (escape `{}`) in content stream for character {ch:?} ({why}).",
+            std::str::from_utf8(expected_escape).unwrap(),
+            std::str::from_utf8(expected_escape).unwrap(),
+        );
+    }
+}
+
+/// Render `text` via `page.text().write(...)` (no flow), return bytes.
+/// Mirror of `render_via_text_flow` so we can compare the show-text
+/// payloads byte-for-byte.
+fn render_via_text_at(text: &str) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.set_margins(50.0, 50.0, 50.0, 50.0);
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(50.0, 700.0)
+        .write(text)
+        .expect("text().write must succeed");
+    doc.set_compress(false);
+    doc.add_page(page);
+    doc.to_bytes().expect("to_bytes must succeed")
+}
+
+/// Count the number of `Tj` show-text operators in a content stream —
+/// each one corresponds to a line emitted by `write_wrapped`.
+fn count_tj_operators(pdf: &[u8]) -> usize {
+    pdf.windows(4).filter(|w| *w == b") Tj").count()
+}
+
+/// `write_wrapped` must wrap based on character widths, not on UTF-8
+/// byte length. Two paragraphs with the same character count but
+/// different UTF-8 byte length (one ASCII, one with a 2-byte Latin-1
+/// supplement char per word) must wrap to nearly the same number of
+/// lines — the character widths of `i` and `ï` are essentially equal in
+/// Helvetica, so any wrap-count divergence implies the measurement
+/// pipeline is summing bytes instead of glyph widths.
+#[test]
+fn write_wrapped_wraps_by_char_width_not_by_utf8_byte_length() {
+    let n_words = 30;
+    // "naïve" = 5 chars, 6 bytes UTF-8 (`ï` = 0xC3 0xAF in UTF-8).
+    let unicode_line: String = std::iter::repeat("naïve")
+        .take(n_words)
+        .collect::<Vec<_>>()
+        .join(" ");
+    // "naive" = 5 chars, 5 bytes UTF-8.
+    let ascii_line: String = std::iter::repeat("naive")
+        .take(n_words)
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let lines_unicode = count_tj_operators(&render_via_text_flow(&unicode_line));
+    let lines_ascii = count_tj_operators(&render_via_text_flow(&ascii_line));
+
+    assert!(
+        lines_unicode.abs_diff(lines_ascii) <= 1,
+        "wrap line count differs more than 1 between unicode={lines_unicode} \
+         and ascii={lines_ascii} — same char count, different UTF-8 byte \
+         length. measure_text_with is summing bytes instead of glyph widths."
+    );
+}
+
+/// Paridad de emisión: `text()` y `text_flow()` deben producir
+/// EXACTAMENTE los mismos bytes en el body de `Op::ShowText` para el
+/// mismo `(text, font)`. Antes del fix de #240 divergían: la ruta de
+/// flow emitía UTF-8 raw; la ruta de text emitía WinAnsi escapado.
+#[test]
+fn text_at_and_text_flow_at_emit_identical_show_text_bytes() {
+    let inputs = [
+        "ASCII only",
+        "€100",
+        "café — naïve",
+        "Hello \u{2018}quoted\u{2019} world",
+    ];
+
+    for input in inputs {
+        let via_text = render_via_text_at(input);
+        let via_flow = render_via_text_flow(input);
+
+        let body_text = extract_first_show_text_literal(&via_text);
+        let body_flow = extract_first_show_text_literal(&via_flow);
+
+        assert_eq!(
+            body_flow, body_text,
+            "show-text body diverges between text() and text_flow() for input {input:?}.\n\
+             text()      bytes: {body_text:?}\n\
+             text_flow() bytes: {body_flow:?}",
+        );
+    }
+}
+
+/// Integración E2E #240: round-trip a través del parser. Emitir `€ — ±`
+/// vía `text_flow().write_wrapped(...)`, parsear el PDF con `PdfReader`
+/// + `TextExtractor` y verificar que cada character especial sobrevive
+/// la decodificación WinAnsi → UTF-8. Pre-fix, el extractor leía los
+/// bytes UTF-8 raw como tres chars Windows-1252 separados produciendo
+/// mojibake (`€` → `â‚¬`).
+#[test]
+fn issue_240_reproducer_round_trip_special_chars_via_extractor() {
+    let input = "precio: €100 — oferta ±5%";
+    let pdf = render_via_text_flow(input);
+
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("PdfReader must open in-memory PDF");
+    let doc = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::new();
+    let extracted = extractor
+        .extract_from_document(&doc)
+        .expect("extract_from_document must succeed");
+    let all_text: String = extracted
+        .iter()
+        .map(|page_text| page_text.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for needle in ['€', '—', '±'] {
+        assert!(
+            all_text.contains(needle),
+            "round-trip extracted text must contain `{needle}`; got: {all_text:?}",
+        );
+    }
+
+    // Negative-space check: the UTF-8 mojibake the pre-fix produced
+    // (`â‚¬` for €) must NOT appear — that would indicate the extractor
+    // read raw UTF-8 bytes through the WinAnsi table.
+    assert!(
+        !all_text.contains("â‚¬"),
+        "extracted text contains WinAnsi mojibake `â‚¬` — write_wrapped \
+         is still emitting raw UTF-8. got: {all_text:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Fix #239 + #240 in a single coherent change. Both issues are symptoms of the same architectural defect: state asymmetry between `GraphicsContext`, `TextContext`, and `TextFlowContext`.

### #239 — `Page::set_fill_color` (graphics) didn't affect text rendering

Per ISO 32000-1 §8.6.8, `rg` is a graphics-state operator that applies to both path fills and glyph fills at text rendering mode 0 (default). Pre-fix, `GraphicsContext.current_color` and `TextContext.fill_color` were independent slots, so text was painted in whatever colour the last path fill left in the stream, never the colour the caller intended.

**Fix**: `Page::text()` and `Page::text_flow()` now inherit `graphics_context.fill_color()` when `text_context.fill_color()` is `None`. An explicit `text().set_fill_color(...)` still overrides the inherited value.

### #240 — `TextFlowContext::write_wrapped` emitted raw UTF-8 bytes

`TextContext::write` routed text through `TextEncoding::WinAnsiEncoding.encode(...)` before emitting `Op::ShowText`. `TextFlowContext::write_wrapped` used `ch.encode_utf8(...)` and put raw UTF-8 bytes directly into the content stream — `€` → `â‚¬`, `—` → `â€"`, etc.

**Fix**: extracted shared `text::build_show_text_op(text, font) -> Op` factory used by both write paths. Builtin fonts go through `WinAnsiEncoding` + octal-escape literal-string per ISO 32000-1 §7.9.2. Custom CJK fonts continue to use UTF-16BE hex per §9.10.3.

### Quality review applied pre-commit

- `escape_show_text_literal_bytes` uses the same named escapes as `escape_pdf_string_literal` (added `\b` and `\f`; capacity bounded to `bytes.len() * 4` upper bound).
- `Page::text()` docstring documents the handoff's side effect (`fill_color` promoted `None` → `Some` before returning the reference).
- `pdf_writer::escape_pdf_string_bytes` carries a scope comment clarifying it is independent from the show-text path.

### Behavioural change (documented in CHANGELOG)

Pages emitting text without an explicit text fill colour now also emit the graphics-state default (`0.000 g` for black) inside the `BT … ET` block. Visual output unchanged; stream content is now explicit about the colour.

## Test plan

- [x] `cargo test --tests` — full suite green (6395 lib + ~700 integration tests, 0 regressions).
- [x] `cargo clippy --lib -- -D warnings` — clean.
- [x] `cargo fmt --all` — applied.
- [x] Pre-commit hook (formatting + clippy + build + lib tests) — passed.
- [x] New `tests/issue_239_unified_fill_color_test.rs` — 6 content-verifying tests covering reproducer, override semantics, `is_none()` guard, default-black edge case, `text_flow` propagation, round-trip via `TextExtractor`.
- [x] New `tests/issue_240_text_flow_encoding_test.rs` — 5 content-verifying tests covering WinAnsi byte for `€`, 8 special chars, byte-for-byte parity `text()`/`text_flow()`, wrap by char width not UTF-8 length, round-trip via `TextExtractor`.
- [x] New unit tests in `src/text/encoding.rs` — 3 tests guarding the helper's named-escape parity, octal fallback, and ASCII passthrough.
- [ ] CI green on Ubuntu / macOS / Windows.
- [ ] `oxidize-python` smoke verify (downstream caller from `oxidize-python#57` and `#58`) — to be done after merge + release.

## Out of scope

- Version bump: kept at `2.8.1` per the bump-in-dedicated-commit rule (see `.private/error-log.md` 2026-05-18). Workspace bump will happen in the release PR.
- `stroke_color` propagation between contexts: same class of defect but the issue scope is explicitly limited to fill.
- Text rendering modes ≠ 0: out of scope per the original issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)