### PR TITLE
chore(positioning): RAG-first messaging + OCR opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,94 +110,11 @@ for section in graph.top_level_sections() {
 }
 ```
 
-## Beyond RAG
+## Also in the box
 
-oxidize-pdf is a full-featured PDF library. Everything below works alongside the RAG pipeline.
+Beyond RAG, the same crate also handles PDF parsing (99.3 % success on 9,000+ real-world PDFs, CJK, lenient recovery), generation (3,000–4,000 pages/sec), encryption (RC4-40/128, AES-128, AES-256 R5/R6 — read and write), digital signatures (PKCS#7 verification), PDF/A validation (8 conformance levels), JBIG2 image decoding (pure-Rust ITU-T T.88), invoice extraction (ES/EN/DE/IT), and split/merge/rotate operations. One dependency for the full pipeline.
 
-### PDF Generation
-
-```rust
-use oxidize_pdf::{Document, Page, Font, Color, Result};
-
-fn main() -> Result<()> {
-    let mut doc = Document::new();
-    let mut page = Page::a4();
-
-    page.text()
-        .set_font(Font::Helvetica, 24.0)
-        .at(50.0, 700.0)
-        .write("Hello, PDF!")?;
-
-    page.graphics()
-        .set_fill_color(Color::rgb(0.0, 0.5, 1.0))
-        .circle(300.0, 400.0, 50.0)
-        .fill();
-
-    doc.add_page(page);
-    doc.save("hello.pdf")?;
-    Ok(())
-}
-```
-
-### PDF Parsing
-
-```rust
-use oxidize_pdf::parser::{PdfReader, PdfDocument};
-
-let doc = PdfDocument::open("document.pdf")?;
-let text = doc.extract_text()?;
-for (i, page) in text.iter().enumerate() {
-    println!("Page {}: {}", i + 1, &page.text[..80.min(page.text.len())]);
-}
-```
-
-### Encryption (Read + Write)
-
-```rust
-use oxidize_pdf::{Document, Page, DocumentEncryption, Permissions, EncryptionStrength};
-
-// Write encrypted PDFs
-let mut doc = Document::new();
-doc.add_page(Page::a4());
-doc.set_encryption(DocumentEncryption::new(
-    "user_password", "owner_password",
-    Permissions::all(), EncryptionStrength::Aes256,
-));
-doc.save("encrypted.pdf")?;
-
-// Read encrypted PDFs
-let mut reader = PdfReader::open("encrypted.pdf")?;
-reader.unlock("user_password")?;
-```
-
-### Invoice Extraction
-
-```rust
-use oxidize_pdf::text::invoice::InvoiceExtractor;
-
-let doc = PdfDocument::open("invoice.pdf")?;
-let text = doc.extract_text()?;
-let extractor = InvoiceExtractor::builder()
-    .with_language("es")
-    .build();
-let invoice = extractor.extract(&text[0].fragments)?;
-// invoice.fields: invoice number, dates, amounts, VAT, line items
-```
-
-### PDF Operations
-
-```rust
-use oxidize_pdf::operations::{PdfSplitter, PdfMerger, PageRange};
-
-// Split
-PdfSplitter::new("input.pdf")?.split_by_pages("page_{}.pdf")?;
-
-// Merge
-let mut merger = PdfMerger::new();
-merger.add_pdf("doc1.pdf", PageRange::All)?;
-merger.add_pdf("doc2.pdf", PageRange::Pages(vec![1, 3]))?;
-merger.save("merged.pdf")?;
-```
+See [`oxidize-pdf-core/examples/`](https://github.com/bzsanti/oxidizePdf/tree/main/oxidize-pdf-core/examples) for working samples (133 examples) and [docs.rs](https://docs.rs/oxidize-pdf) for the API surface.
 
 ## Full Feature Set
 
@@ -217,7 +134,6 @@ merger.save("merged.pdf")?;
 - Digital signatures: detection, PKCS#7 verification, certificate validation
 - PDF/A validation: 8 conformance levels (1a/b, 2a/b/u, 3a/b/u)
 - JBIG2 decoder: pure Rust (ITU-T T.88)
-- OCR via Tesseract (optional feature)
 - Split, merge, rotate operations
 - CJK text support (Chinese, Japanese, Korean)
 - Corruption recovery and lenient parsing

--- a/landing/index.html
+++ b/landing/index.html
@@ -175,16 +175,9 @@ let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
     </tbody>
   </table>
 
-  <h2>Beyond RAG</h2>
+  <h2>Also in the box</h2>
 
-  <div class="grid">
-    <div class="card"><h3>Parse</h3><p>PDF 1.0–1.7, 99.3% success on 9,000+ real-world PDFs. CJK text, lenient recovery, decompression-bomb protection.</p></div>
-    <div class="card"><h3>Generate</h3><p>Multi-page documents with text, graphics, images. 3,000–4,000 pages/sec.</p></div>
-    <div class="card"><h3>Encrypt</h3><p>RC4-40/128, AES-128, AES-256 (R5/R6). Read and write.</p></div>
-    <div class="card"><h3>Signatures</h3><p>Detection, PKCS#7 verification, certificate validation.</p></div>
-    <div class="card"><h3>PDF/A</h3><p>Validation across 8 conformance levels (1a/b, 2a/b/u, 3a/b/u).</p></div>
-    <div class="card"><h3>OCR &amp; JBIG2</h3><p>Pure-Rust JBIG2 decoder (ITU-T T.88). Tesseract integration optional.</p></div>
-  </div>
+  <p>Beyond RAG, the same crate also handles PDF parsing (99.3 % success on 9,000+ real-world PDFs, CJK, lenient recovery), generation (3,000–4,000 pages/sec), encryption (RC4-40/128, AES-128, AES-256 R5/R6 — read and write), digital signatures (PKCS#7 verification), PDF/A validation (8 conformance levels), and JBIG2 image decoding (pure-Rust ITU-T T.88). One dependency for the full pipeline. <a href="https://docs.rs/oxidize-pdf">Full API on docs.rs</a>.</p>
 
   <h2>Links</h2>
   <ul>

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/oxidize-pdf"
 homepage = "https://github.com/bzsanti/oxidizePdf"
-description = "A pure Rust PDF generation and manipulation library with zero external dependencies"
-keywords = ["pdf", "pdf-parser", "text-extraction", "pdf-generation", "rag"]
+description = "Pure Rust PDF library for AI/RAG: structure-aware chunking with bounding boxes, heading context, and token estimates. No Python, no ML, no C bindings."
+keywords = ["pdf", "rag", "chunking", "ai", "embeddings"]
 categories = ["parser-implementations", "text-processing", "graphics", "encoding"]
 readme = "../README.md"
 exclude = [
@@ -285,6 +285,7 @@ path = "examples/extreme_complexity_benchmark.rs"
 [[example]]
 name = "tesseract_debug"
 path = "examples/tesseract_debug.rs"
+required-features = ["ocr-tesseract"]
 
 
 [[example]]
@@ -343,10 +344,12 @@ path = "examples/debug_transparency.rs"
 [[example]]
 name = "convert_pdf_ocr"
 path = "examples/convert_pdf_ocr.rs"
+required-features = ["ocr-tesseract"]
 
 [[example]]
 name = "test_ocr_simple"
 path = "examples/test_ocr_simple.rs"
+required-features = ["ocr-tesseract"]
 
 [[example]]
 name = "extract_images_demo"
@@ -420,7 +423,7 @@ path = "examples/line_chart_dashboard_test.rs"
 # harness = false
 
 [features]
-default = ["compression", "ocr-tesseract"]
+default = ["compression", "external-images"]
 
 # Basic features
 compression = ["dep:flate2"]
@@ -428,10 +431,10 @@ compression = ["dep:flate2"]
 # Debug features
 verbose-debug = []  # Enable verbose debug logging (disabled by default for zero runtime cost)
 
-# Image processing features
+# Image processing features (pure Rust via `image` crate, used for PNG/JPEG/etc. extraction)
 external-images = ["dep:image"]
 
-# OCR features
+# OCR features (opt-in: pulls `rusty-tesseract`, which requires the C `tesseract` binary on PATH)
 ocr-tesseract = ["dep:rusty-tesseract", "external-images"]
 ocr-full = ["ocr-tesseract"]
 

--- a/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
+++ b/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
@@ -13,13 +13,18 @@
 //!
 //! # Usage
 //!
+//! The example below uses `MockOcrProvider` so it compiles under the
+//! default feature set. For real OCR, enable the `ocr-tesseract` feature
+//! and substitute `RustyTesseractProvider::new()` (which requires the
+//! Tesseract binary on `PATH`).
+//!
 //! ```rust,no_run
 //! use oxidize_pdf::operations::pdf_ocr_converter::{PdfOcrConverter, ConversionOptions};
-//! use oxidize_pdf::text::RustyTesseractProvider;
+//! use oxidize_pdf::text::MockOcrProvider;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let converter = PdfOcrConverter::new()?;
-//! let ocr_provider = RustyTesseractProvider::new();
+//! let ocr_provider = MockOcrProvider::new();
 //! let options = ConversionOptions::default();
 //!
 //! converter.convert_to_searchable_pdf(


### PR DESCRIPTION
## Summary

- README and landing demoted the long feature catalogue: the "Beyond RAG" section becomes a single "Also in the box" paragraph + links to `docs.rs` and `examples/`. RAG one-liner stays as the hero.
- `oxidize-pdf-core/Cargo.toml`: `description` rewritten as RAG-first one-liner, `keywords` switched to acquisition-oriented terms (`rag`, `chunking`, `ai`, `embeddings`).
- `oxidize-pdf-core/Cargo.toml`: `ocr-tesseract` removed from default features (BREAKING feature surface, not API). `external-images` added to default features. Rationale: keeping `ocr-tesseract` in defaults contradicted the "no C dependencies" claim because `rusty-tesseract` shells out to the C `tesseract` binary at runtime.
- OCR examples (`tesseract_debug`, `convert_pdf_ocr`, `test_ocr_simple`) now declare `required-features = ["ocr-tesseract"]`.

OCR API surface (`OcrProvider`, `OcrEngine`, `MockOcrProvider`, `OcrResult`) is exported unchanged; only `RustyTesseractProvider` is now feature-gated. Existing users that relied on default-feature OCR migrate with one line:

```toml
oxidize-pdf = { version = "2.9", features = ["ocr-tesseract"] }
```

Migration guidance is published as [Discussion #246](https://github.com/bzsanti/oxidizePdf/discussions/246). Broader positioning context as [Discussion #245](https://github.com/bzsanti/oxidizePdf/discussions/245).

## Versioning

Will ship as **2.9.0 minor** with explicit BREAKING-feature-flag entry in CHANGELOG.

## Test plan

- [x] `cargo check -p oxidize-pdf` (default features: `compression`, `external-images`) → clean
- [x] `cargo check -p oxidize-pdf --no-default-features --features compression,external-images` → clean
- [x] `cargo check -p oxidize-pdf --features ocr-tesseract` → clean (opt-in path still works)
- [x] Pre-commit hook (clippy + library tests, 6391+ unit tests) → clean
- [ ] CI on this PR (GitHub Actions)
- [ ] Verify `cargo build` on a machine without Tesseract installed (manual smoke; covered by the no-default-features check above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)