### PR TITLE
release: 2.9.0 — RAG-first positioning + OCR opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [2.9.0] - 2026-05-20
+
+### Changed
+
+- **BREAKING (feature surface, not API).** `ocr-tesseract` is no longer in
+  default features of `oxidize-pdf`. Users that relied on default-feature
+  OCR must opt in explicitly:
+  ```toml
+  oxidize-pdf = { version = "2.9", features = ["ocr-tesseract"] }
+  ```
+  Rationale: `rusty-tesseract` invokes the Tesseract C binary at runtime,
+  which contradicted the "no C dependencies" claim that the manifest has
+  always made. Making OCR opt-in removes the contradiction. The OCR API
+  surface (`OcrProvider`, `OcrEngine`, `MockOcrProvider`, `OcrResult`,
+  `OcrOptions`) is exported unchanged; only `RustyTesseractProvider` is
+  now feature-gated. Migration guidance is published at
+  [Discussion #246](https://github.com/bzsanti/oxidizePdf/discussions/246).
+- **`oxidize-pdf-core/Cargo.toml` `description`** rewritten as a RAG-first
+  one-liner: *"Pure Rust PDF library for AI/RAG: structure-aware chunking
+  with bounding boxes, heading context, and token estimates. No Python,
+  no ML, no C bindings."* Reflects the project's actual differentiator at
+  the level of `cargo add` / crates.io metadata.
+- **`oxidize-pdf-core/Cargo.toml` `keywords`** switched from generic
+  (`pdf-parser`, `text-extraction`, `pdf-generation`) to acquisition-
+  oriented (`rag`, `chunking`, `ai`, `embeddings`). Five-keyword slot
+  reallocated; redundant terms (`pdf-parser`/`pdf-generation` overlapped
+  with `pdf`) removed.
+- **`external-images` added to default features.** The pure-Rust `image`
+  crate dependency that powers PNG/JPEG extraction is now in default
+  features. It was previously only enabled transitively via
+  `ocr-tesseract`. With OCR moving to opt-in, `external-images` becomes
+  its own default-on feature so RAG pipelines that extract embedded
+  images keep working out-of-the-box.
+
+### Documentation
+
+- **README and landing page demote the "Beyond RAG" feature catalogue.**
+  The README section that previously showed five generation/encryption/
+  signatures/operations code blocks now collapses to a single "Also in
+  the box" paragraph + link to `oxidize-pdf-core/examples/` and
+  `docs.rs`. The landing-page grid of six cards collapses similarly to a
+  single paragraph. RAG one-liner stays as the hero. Features unchanged;
+  presentation tightened.
+- **Doc-test in `pdf_ocr_converter`** switched to use `MockOcrProvider`
+  (always available) instead of `RustyTesseractProvider` (now feature-
+  gated). The example still demonstrates the API; a leading sentence
+  redirects readers to `ocr-tesseract` + `RustyTesseractProvider` for
+  real OCR.
+
+### Internal
+
+- Examples requiring OCR (`tesseract_debug`, `convert_pdf_ocr`,
+  `test_ocr_simple`) now declare `required-features = ["ocr-tesseract"]`
+  so they are skipped when the feature is not enabled rather than
+  failing to compile.
+
+## [2.8.2] - 2026-05-19
+
 ### Fixed
 
+- **crates.io / lib.rs categories** corrected for `oxidize-pdf-core`.
+  The previous `categories = ["graphics", "text-processing", "parsing",
+  "multimedia::images"]` listed an invalid slug (`"parsing"` — the
+  correct one is `parser-implementations`) which crates.io silently
+  dropped, and a semantically wrong slug (`"multimedia::images"`, meant
+  for image codecs) which lib.rs surfaced as the primary display
+  category. The crate now ships with
+  `["parser-implementations", "text-processing", "graphics", "encoding"]`
+  and refreshed keywords (`pdf`, `pdf-parser`, `text-extraction`,
+  `pdf-generation`, `rag`). Addresses #241.
 - **`Page::set_fill_color` (graphics) now affects subsequent text rendering**
   when no explicit text fill colour has been set. Per ISO 32000-1 §8.6.8,
   the `rg` operator sets the non-stroking colour of the graphics state,
@@ -45,6 +113,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit about it. Tests that asserted absence of `rg` / `g` inside
   pure-text BT…ET blocks should be updated to assert presence of the
   expected colour operator instead.
+
+### Internal
+
+- `text::metrics::tests::test_create_default_custom_metrics_is_cached`
+  rewritten from a timing-based assertion (`< 50ms` for 1000 calls,
+  observed at 74–84ms under full-suite parallelism with the unoptimised
+  test profile) to a call-counter (`AtomicUsize` incremented by
+  `build_default_custom_metrics` under `#[cfg(test)]`, asserting
+  `delta <= 1` after 1000 calls). Load-invariant and deterministic.
 
 ## [2.8.1] - 2026-05-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.8.1"
+version = "2.9.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.1"
+version = "2.9.0"
 edition = "2021"
 rust-version = "1.77"  # MSRV - Required by thiserror 2.0
 authors = ["Santiago Fernández Muñoz"]

--- a/README.md
+++ b/README.md
@@ -110,94 +110,11 @@ for section in graph.top_level_sections() {
 }
 ```
 
-## Beyond RAG
+## Also in the box
 
-oxidize-pdf is a full-featured PDF library. Everything below works alongside the RAG pipeline.
+Beyond RAG, the same crate also handles PDF parsing (99.3 % success on 9,000+ real-world PDFs, CJK, lenient recovery), generation (3,000–4,000 pages/sec), encryption (RC4-40/128, AES-128, AES-256 R5/R6 — read and write), digital signatures (PKCS#7 verification), PDF/A validation (8 conformance levels), JBIG2 image decoding (pure-Rust ITU-T T.88), invoice extraction (ES/EN/DE/IT), and split/merge/rotate operations. One dependency for the full pipeline.
 
-### PDF Generation
-
-```rust
-use oxidize_pdf::{Document, Page, Font, Color, Result};
-
-fn main() -> Result<()> {
-    let mut doc = Document::new();
-    let mut page = Page::a4();
-
-    page.text()
-        .set_font(Font::Helvetica, 24.0)
-        .at(50.0, 700.0)
-        .write("Hello, PDF!")?;
-
-    page.graphics()
-        .set_fill_color(Color::rgb(0.0, 0.5, 1.0))
-        .circle(300.0, 400.0, 50.0)
-        .fill();
-
-    doc.add_page(page);
-    doc.save("hello.pdf")?;
-    Ok(())
-}
-```
-
-### PDF Parsing
-
-```rust
-use oxidize_pdf::parser::{PdfReader, PdfDocument};
-
-let doc = PdfDocument::open("document.pdf")?;
-let text = doc.extract_text()?;
-for (i, page) in text.iter().enumerate() {
-    println!("Page {}: {}", i + 1, &page.text[..80.min(page.text.len())]);
-}
-```
-
-### Encryption (Read + Write)
-
-```rust
-use oxidize_pdf::{Document, Page, DocumentEncryption, Permissions, EncryptionStrength};
-
-// Write encrypted PDFs
-let mut doc = Document::new();
-doc.add_page(Page::a4());
-doc.set_encryption(DocumentEncryption::new(
-    "user_password", "owner_password",
-    Permissions::all(), EncryptionStrength::Aes256,
-));
-doc.save("encrypted.pdf")?;
-
-// Read encrypted PDFs
-let mut reader = PdfReader::open("encrypted.pdf")?;
-reader.unlock("user_password")?;
-```
-
-### Invoice Extraction
-
-```rust
-use oxidize_pdf::text::invoice::InvoiceExtractor;
-
-let doc = PdfDocument::open("invoice.pdf")?;
-let text = doc.extract_text()?;
-let extractor = InvoiceExtractor::builder()
-    .with_language("es")
-    .build();
-let invoice = extractor.extract(&text[0].fragments)?;
-// invoice.fields: invoice number, dates, amounts, VAT, line items
-```
-
-### PDF Operations
-
-```rust
-use oxidize_pdf::operations::{PdfSplitter, PdfMerger, PageRange};
-
-// Split
-PdfSplitter::new("input.pdf")?.split_by_pages("page_{}.pdf")?;
-
-// Merge
-let mut merger = PdfMerger::new();
-merger.add_pdf("doc1.pdf", PageRange::All)?;
-merger.add_pdf("doc2.pdf", PageRange::Pages(vec![1, 3]))?;
-merger.save("merged.pdf")?;
-```
+See [`oxidize-pdf-core/examples/`](https://github.com/bzsanti/oxidizePdf/tree/main/oxidize-pdf-core/examples) for working samples (133 examples) and [docs.rs](https://docs.rs/oxidize-pdf) for the API surface.
 
 ## Full Feature Set
 
@@ -217,7 +134,6 @@ merger.save("merged.pdf")?;
 - Digital signatures: detection, PKCS#7 verification, certificate validation
 - PDF/A validation: 8 conformance levels (1a/b, 2a/b/u, 3a/b/u)
 - JBIG2 decoder: pure Rust (ITU-T T.88)
-- OCR via Tesseract (optional feature)
 - Split, merge, rotate operations
 - CJK text support (Chinese, Japanese, Korean)
 - Corruption recovery and lenient parsing

--- a/landing/README.md
+++ b/landing/README.md
@@ -46,10 +46,16 @@ Every claim on the landing maps to verified state in the repo:
 - "3,000-4,000 pages/sec generation" — README.
 - "Pure Rust, zero C dependencies" — `Cargo.toml`, no system deps required.
 - "MIT licensed" — `LICENSE`.
-- Python bindings on PyPI — `oxidize-pdf` 0.5.x.
+- Python bindings on PyPI — `oxidize-pdf` 0.5.x (also ships the `oxidize-mcp` entry point for the MCP server).
+- .NET bindings on NuGet — `OxidizePdf.NET` 0.9.x.
+- LlamaIndex reader on PyPI — `llama-index-readers-oxidize-pdf` 0.1.x. Published per current LlamaIndex policy (independent PyPI publication under the `llama-index-readers-*` namespace; PRs adding new integration packages to `run-llama/llama_index` are auto-closed by policy). Feature-request issue #21437 open in `run-llama/llama_index` since 2026-04-21 as the canonical announcement channel.
+- MCP server registered at `io.github.bzsanti/oxidize-pdf-mcp` in the MCP Registry.
+- Claude Code plugin marketplace — `bzsanti/oxidize-pdf-integrations`, 6 skills + 1 agent.
 
 Things deliberately NOT claimed because they are not yet verifiable:
 
-- No "trusted by X" / logo wall — 0 public reverse deps at the time of writing.
+- No "trusted by X" / logo wall — 0 public reverse deps on crates.io at the time of writing.
 - No "production ready" badge — there's no public stability commitment doc yet.
 - No specific benchmark numbers vs competitors — those need a public benchmark first.
+- No mention of `langchain-oxidize-pdf` or `haystack-oxidize-pdf` — code exists in the integrations repo but neither is published to PyPI yet. Add them once published.
+- No "Featured on LlamaHub" badge or claim — `llamahub.ai` only indexes plugins that live in the `run-llama/llama_index` monorepo (via its `/api/plugins` endpoint, last refreshed 2026-02-12; the source repo `run-llama/llama-hub` has been archived since 2024-03-01). The current LlamaIndex contribution policy explicitly forbids adding new integration packages to the monorepo (`CONTRIBUTING.md`: "PRs that add a new pyproject.toml will be automatically closed"), so plugins published per current policy — including ours — cannot appear on llamahub.ai. Claiming a LlamaHub presence would be inaccurate.

--- a/landing/README.md
+++ b/landing/README.md
@@ -1,0 +1,55 @@
+# landing/
+
+Source for the public landing page at `https://bzsanti.github.io/oxidizePdf/`.
+
+## What this is
+
+A single `index.html` with embedded CSS — no build tooling, no Jekyll, no npm. Edit the HTML, push, GitHub Pages publishes.
+
+## How it gets served
+
+Two viable setups; pick one when enabling GitHub Pages.
+
+**Option 1 — main branch + `/landing` folder.** Requires GitHub Pages to support arbitrary subfolders, which it currently does NOT (Pages only supports root or `/docs` on the source branch). So this option is OFF the table unless we move into `/docs`, which would clash with developer docs already there.
+
+**Option 2 — dedicated `gh-pages` branch (recommended).** Treat this `landing/` folder as the source-of-truth. To deploy:
+
+```bash
+# One-time setup — create an orphan gh-pages branch with only the landing
+git switch --orphan gh-pages
+git rm -rf .
+cp landing/index.html .
+git add index.html
+git commit -m "Initial landing page"
+git push -u origin gh-pages
+
+# In repo settings: Settings -> Pages -> Source = gh-pages branch, / (root)
+```
+
+To update the landing later, edit `landing/index.html` on a regular branch (and PR through develop → main as usual), then republish to `gh-pages`:
+
+```bash
+git checkout gh-pages
+git checkout main -- landing/index.html
+mv -f landing/index.html index.html
+git add index.html && git commit -m "Update landing"
+git push
+```
+
+A small GitHub Actions workflow can automate the republish if it becomes tedious — not necessary for a single-file site.
+
+## What it claims and what it doesn't
+
+Every claim on the landing maps to verified state in the repo:
+
+- "99.3% parse success on 9,000+ real-world PDFs" — README/CHANGELOG.
+- "3,000-4,000 pages/sec generation" — README.
+- "Pure Rust, zero C dependencies" — `Cargo.toml`, no system deps required.
+- "MIT licensed" — `LICENSE`.
+- Python bindings on PyPI — `oxidize-pdf` 0.5.x.
+
+Things deliberately NOT claimed because they are not yet verifiable:
+
+- No "trusted by X" / logo wall — 0 public reverse deps at the time of writing.
+- No "production ready" badge — there's no public stability commitment doc yet.
+- No specific benchmark numbers vs competitors — those need a public benchmark first.

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>oxidize-pdf — Pure Rust PDF library for AI/RAG</title>
+<meta name="description" content="Pure Rust PDF library for AI/RAG pipelines: structure-aware chunking with bounding boxes, heading context, and token estimates. No Python, no ML dependencies, no C bindings.">
+<meta property="og:title" content="oxidize-pdf — Pure Rust PDF library for AI/RAG">
+<meta property="og:description" content="Structure-aware chunking with bounding boxes, heading context, and token estimates. No Python, no ML, no C bindings.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://bzsanti.github.io/oxidizePdf/">
+<link rel="canonical" href="https://bzsanti.github.io/oxidizePdf/">
+<style>
+  :root {
+    --bg: #0f1115;
+    --fg: #e7e9ee;
+    --muted: #9aa3b2;
+    --accent: #ff6b35;
+    --code-bg: #1a1d24;
+    --border: #2a2f3a;
+    --max-w: 760px;
+  }
+  * { box-sizing: border-box; }
+  html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+    line-height: 1.55;
+  }
+  main { max-width: var(--max-w); margin: 0 auto; padding: 4rem 1.5rem 6rem; }
+  h1 { font-size: 2.2rem; line-height: 1.15; margin: 0 0 0.6rem; letter-spacing: -0.02em; }
+  h1 .name { color: var(--accent); }
+  .tagline { font-size: 1.2rem; color: var(--muted); margin: 0 0 2.2rem; max-width: 36rem; }
+  h2 { margin: 3rem 0 1rem; font-size: 1.3rem; letter-spacing: -0.01em; }
+  p { margin: 0.6rem 0; }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+  a:hover { border-bottom-color: var(--accent); }
+  code, pre {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.92rem;
+  }
+  code { background: var(--code-bg); padding: 0.12rem 0.36rem; border-radius: 4px; color: #ffd9c9; }
+  pre {
+    background: var(--code-bg);
+    padding: 1rem 1.2rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    overflow-x: auto;
+    line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; color: var(--fg); }
+  .badges { margin: 0.5rem 0 2rem; display: flex; gap: 0.6rem; flex-wrap: wrap; }
+  .badges img { height: 20px; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.94rem; }
+  th, td { text-align: left; padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+  td.yes { color: #7adf78; }
+  td.no { color: #b87878; }
+  .grid {
+    display: grid; gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin: 1rem 0;
+  }
+  .card {
+    border: 1px solid var(--border);
+    padding: 1rem 1.1rem;
+    border-radius: 8px;
+    background: #141821;
+  }
+  .card h3 { margin: 0 0 0.3rem; font-size: 1rem; color: var(--accent); }
+  .card p { margin: 0; color: var(--muted); font-size: 0.92rem; }
+  footer {
+    margin-top: 4rem; padding-top: 2rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted); font-size: 0.9rem;
+    display: flex; gap: 1.5rem; flex-wrap: wrap;
+  }
+  footer a { color: var(--muted); }
+  footer a:hover { color: var(--fg); border-bottom-color: var(--fg); }
+</style>
+</head>
+<body>
+<main>
+  <h1><span class="name">oxidize-pdf</span></h1>
+  <p class="tagline">Pure Rust PDF library built for AI/RAG. Structure-aware chunks with bounding boxes, heading context, and token estimates — in one line. No Python, no ML, no C bindings.</p>
+
+  <div class="badges">
+    <a href="https://crates.io/crates/oxidize-pdf"><img src="https://img.shields.io/crates/v/oxidize-pdf.svg" alt="crates.io"></a>
+    <a href="https://docs.rs/oxidize-pdf"><img src="https://docs.rs/oxidize-pdf/badge.svg" alt="docs.rs"></a>
+    <a href="https://pypi.org/project/oxidize-pdf/"><img src="https://img.shields.io/pypi/v/oxidize-pdf?label=pypi" alt="PyPI"></a>
+    <a href="https://github.com/bzsanti/oxidizePdf"><img src="https://img.shields.io/github/stars/bzsanti/oxidizePdf?style=social" alt="GitHub"></a>
+  </div>
+
+  <h2>RAG pipeline in one line</h2>
+  <pre><code>use oxidize_pdf::parser::PdfDocument;
+
+let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
+// Each chunk: text, page numbers, bounding boxes, element types,
+//             heading context, token estimate
+</code></pre>
+
+  <p>Each <code>RagChunk</code> ships with the metadata your vector store actually needs: page numbers for citation, bounding boxes for visual grounding, element types (<code>title</code>, <code>table</code>, <code>paragraph</code>, ...) for filtering, and heading context prepended to <code>full_text</code> for stronger embeddings.</p>
+
+  <h2>Install</h2>
+  <p><strong>Rust</strong></p>
+  <pre><code>cargo add oxidize-pdf</code></pre>
+  <p><strong>Python</strong></p>
+  <pre><code>pip install oxidize-pdf</code></pre>
+
+  <h2>Why this, not <code>pypdf + RecursiveCharacterTextSplitter</code>?</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Capability</th>
+        <th>oxidize-pdf</th>
+        <th>pypdf + LangChain</th>
+        <th>unstructured / docling</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Structure-aware chunks</td><td class="yes">yes</td><td class="no">no (text-only split)</td><td class="yes">yes</td></tr>
+      <tr><td>Bounding boxes per chunk</td><td class="yes">yes</td><td class="no">no</td><td class="yes">yes</td></tr>
+      <tr><td>Heading context propagation</td><td class="yes">yes</td><td class="no">no</td><td class="yes">yes</td></tr>
+      <tr><td>ML model dependency</td><td class="yes">none</td><td class="yes">none</td><td class="no">required</td></tr>
+      <tr><td>Native binary (no Python runtime)</td><td class="yes">yes</td><td class="no">no</td><td class="no">no</td></tr>
+      <tr><td>Language</td><td>Rust</td><td>Python</td><td>Python + ML</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Beyond RAG</h2>
+
+  <div class="grid">
+    <div class="card"><h3>Parse</h3><p>PDF 1.0–1.7, 99.3% success on 9,000+ real-world PDFs. CJK text, lenient recovery, decompression-bomb protection.</p></div>
+    <div class="card"><h3>Generate</h3><p>Multi-page documents with text, graphics, images. 3,000–4,000 pages/sec.</p></div>
+    <div class="card"><h3>Encrypt</h3><p>RC4-40/128, AES-128, AES-256 (R5/R6). Read and write.</p></div>
+    <div class="card"><h3>Signatures</h3><p>Detection, PKCS#7 verification, certificate validation.</p></div>
+    <div class="card"><h3>PDF/A</h3><p>Validation across 8 conformance levels (1a/b, 2a/b/u, 3a/b/u).</p></div>
+    <div class="card"><h3>OCR &amp; JBIG2</h3><p>Pure-Rust JBIG2 decoder (ITU-T T.88). Tesseract integration optional.</p></div>
+  </div>
+
+  <h2>Links</h2>
+  <ul>
+    <li>API documentation — <a href="https://docs.rs/oxidize-pdf">docs.rs/oxidize-pdf</a></li>
+    <li>Source code &amp; issue tracker — <a href="https://github.com/bzsanti/oxidizePdf">github.com/bzsanti/oxidizePdf</a></li>
+    <li>Python bindings — <a href="https://pypi.org/project/oxidize-pdf/">pypi.org/project/oxidize-pdf</a></li>
+    <li>Changelog — <a href="https://github.com/bzsanti/oxidizePdf/blob/main/CHANGELOG.md">CHANGELOG.md</a></li>
+  </ul>
+
+  <footer>
+    <span>MIT licensed.</span>
+    <a href="https://github.com/bzsanti/oxidizePdf">GitHub</a>
+    <a href="https://docs.rs/oxidize-pdf">Docs</a>
+    <a href="https://crates.io/crates/oxidize-pdf">crates.io</a>
+    <a href="https://pypi.org/project/oxidize-pdf/">PyPI</a>
+  </footer>
+</main>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -90,6 +90,7 @@
     <a href="https://crates.io/crates/oxidize-pdf"><img src="https://img.shields.io/crates/v/oxidize-pdf.svg" alt="crates.io"></a>
     <a href="https://docs.rs/oxidize-pdf"><img src="https://docs.rs/oxidize-pdf/badge.svg" alt="docs.rs"></a>
     <a href="https://pypi.org/project/oxidize-pdf/"><img src="https://img.shields.io/pypi/v/oxidize-pdf?label=pypi" alt="PyPI"></a>
+    <a href="https://www.nuget.org/packages/OxidizePdf.NET"><img src="https://img.shields.io/nuget/v/OxidizePdf.NET?label=nuget" alt="NuGet"></a>
     <a href="https://github.com/bzsanti/oxidizePdf"><img src="https://img.shields.io/github/stars/bzsanti/oxidizePdf?style=social" alt="GitHub"></a>
   </div>
 
@@ -103,11 +104,55 @@ let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
 
   <p>Each <code>RagChunk</code> ships with the metadata your vector store actually needs: page numbers for citation, bounding boxes for visual grounding, element types (<code>title</code>, <code>table</code>, <code>paragraph</code>, ...) for filtering, and heading context prepended to <code>full_text</code> for stronger embeddings.</p>
 
-  <h2>Install</h2>
-  <p><strong>Rust</strong></p>
-  <pre><code>cargo add oxidize-pdf</code></pre>
-  <p><strong>Python</strong></p>
-  <pre><code>pip install oxidize-pdf</code></pre>
+  <h2>Choose your runtime</h2>
+
+  <table>
+    <thead>
+      <tr><th>Runtime</th><th>Package</th><th>Install</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Rust</td>
+        <td><a href="https://crates.io/crates/oxidize-pdf">crates.io/oxidize-pdf</a></td>
+        <td><code>cargo add oxidize-pdf</code></td>
+      </tr>
+      <tr>
+        <td>Python</td>
+        <td><a href="https://pypi.org/project/oxidize-pdf/">pypi.org/oxidize-pdf</a></td>
+        <td><code>pip install oxidize-pdf</code></td>
+      </tr>
+      <tr>
+        <td>.NET</td>
+        <td><a href="https://www.nuget.org/packages/OxidizePdf.NET">nuget.org/OxidizePdf.NET</a></td>
+        <td><code>dotnet add package OxidizePdf.NET</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>AI/RAG ecosystem integrations</h2>
+
+  <table>
+    <thead>
+      <tr><th>Integration</th><th>What it gives you</th><th>Install</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="https://pypi.org/project/llama-index-readers-oxidize-pdf/">LlamaIndex reader</a></td>
+        <td>Drop-in <code>OxidizePdfReader</code> for LlamaIndex pipelines. Each chunk becomes a <code>Document</code> with <code>heading_context</code>, <code>page_numbers</code>, <code>element_types</code>, and <code>token_estimate</code> in <code>metadata</code>.</td>
+        <td><code>pip install llama-index-readers-oxidize-pdf</code></td>
+      </tr>
+      <tr>
+        <td><a href="https://registry.modelcontextprotocol.io">MCP server</a></td>
+        <td>12 tools and 6 resources for PDF read / create / extract / analyze / secure / manipulate over the Model Context Protocol. Ships as the <code>oxidize-mcp</code> entry point of the Python package.</td>
+        <td><code>pip install oxidize-pdf</code><br><span style="color:var(--muted)">then point your MCP client at <code>oxidize-mcp</code></span></td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/bzsanti/oxidize-pdf-integrations">Claude Code plugin</a></td>
+        <td>6 skills (<code>read-pdf</code>, <code>extract-text</code>, <code>create-pdf</code>, <code>analyze-pdf</code>, <code>secure-pdf</code>, <code>manipulate-pdf</code>) and 1 orchestrating agent.</td>
+        <td><code>/plugin marketplace add bzsanti/oxidize-pdf-integrations</code><br><code>/plugin install oxidize-pdf@oxidize-pdf</code></td>
+      </tr>
+    </tbody>
+  </table>
 
   <h2>Why this, not <code>pypdf + RecursiveCharacterTextSplitter</code>?</h2>
 
@@ -146,6 +191,8 @@ let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
     <li>API documentation — <a href="https://docs.rs/oxidize-pdf">docs.rs/oxidize-pdf</a></li>
     <li>Source code &amp; issue tracker — <a href="https://github.com/bzsanti/oxidizePdf">github.com/bzsanti/oxidizePdf</a></li>
     <li>Python bindings — <a href="https://pypi.org/project/oxidize-pdf/">pypi.org/project/oxidize-pdf</a></li>
+    <li>.NET bindings — <a href="https://www.nuget.org/packages/OxidizePdf.NET">nuget.org/OxidizePdf.NET</a></li>
+    <li>Ecosystem integrations (MCP, LlamaIndex, Claude Code) — <a href="https://github.com/bzsanti/oxidize-pdf-integrations">oxidize-pdf-integrations</a></li>
     <li>Changelog — <a href="https://github.com/bzsanti/oxidizePdf/blob/main/CHANGELOG.md">CHANGELOG.md</a></li>
   </ul>
 
@@ -155,6 +202,8 @@ let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
     <a href="https://docs.rs/oxidize-pdf">Docs</a>
     <a href="https://crates.io/crates/oxidize-pdf">crates.io</a>
     <a href="https://pypi.org/project/oxidize-pdf/">PyPI</a>
+    <a href="https://www.nuget.org/packages/OxidizePdf.NET">NuGet</a>
+    <a href="https://github.com/bzsanti/oxidize-pdf-integrations">Integrations</a>
   </footer>
 </main>
 </body>

--- a/landing/index.html
+++ b/landing/index.html
@@ -175,16 +175,9 @@ let chunks = PdfDocument::open("paper.pdf")?.rag_chunks()?;
     </tbody>
   </table>
 
-  <h2>Beyond RAG</h2>
+  <h2>Also in the box</h2>
 
-  <div class="grid">
-    <div class="card"><h3>Parse</h3><p>PDF 1.0–1.7, 99.3% success on 9,000+ real-world PDFs. CJK text, lenient recovery, decompression-bomb protection.</p></div>
-    <div class="card"><h3>Generate</h3><p>Multi-page documents with text, graphics, images. 3,000–4,000 pages/sec.</p></div>
-    <div class="card"><h3>Encrypt</h3><p>RC4-40/128, AES-128, AES-256 (R5/R6). Read and write.</p></div>
-    <div class="card"><h3>Signatures</h3><p>Detection, PKCS#7 verification, certificate validation.</p></div>
-    <div class="card"><h3>PDF/A</h3><p>Validation across 8 conformance levels (1a/b, 2a/b/u, 3a/b/u).</p></div>
-    <div class="card"><h3>OCR &amp; JBIG2</h3><p>Pure-Rust JBIG2 decoder (ITU-T T.88). Tesseract integration optional.</p></div>
-  </div>
+  <p>Beyond RAG, the same crate also handles PDF parsing (99.3 % success on 9,000+ real-world PDFs, CJK, lenient recovery), generation (3,000–4,000 pages/sec), encryption (RC4-40/128, AES-128, AES-256 R5/R6 — read and write), digital signatures (PKCS#7 verification), PDF/A validation (8 conformance levels), and JBIG2 image decoding (pure-Rust ITU-T T.88). One dependency for the full pipeline. <a href="https://docs.rs/oxidize-pdf">Full API on docs.rs</a>.</p>
 
   <h2>Links</h2>
   <ul>

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/oxidize-pdf"
 homepage = "https://github.com/bzsanti/oxidizePdf"
-description = "A pure Rust PDF generation and manipulation library with zero external dependencies"
-keywords = ["pdf", "pdf-parser", "text-extraction", "pdf-generation", "rag"]
+description = "Pure Rust PDF library for AI/RAG: structure-aware chunking with bounding boxes, heading context, and token estimates. No Python, no ML, no C bindings."
+keywords = ["pdf", "rag", "chunking", "ai", "embeddings"]
 categories = ["parser-implementations", "text-processing", "graphics", "encoding"]
 readme = "../README.md"
 exclude = [
@@ -285,6 +285,7 @@ path = "examples/extreme_complexity_benchmark.rs"
 [[example]]
 name = "tesseract_debug"
 path = "examples/tesseract_debug.rs"
+required-features = ["ocr-tesseract"]
 
 
 [[example]]
@@ -343,10 +344,12 @@ path = "examples/debug_transparency.rs"
 [[example]]
 name = "convert_pdf_ocr"
 path = "examples/convert_pdf_ocr.rs"
+required-features = ["ocr-tesseract"]
 
 [[example]]
 name = "test_ocr_simple"
 path = "examples/test_ocr_simple.rs"
+required-features = ["ocr-tesseract"]
 
 [[example]]
 name = "extract_images_demo"
@@ -420,7 +423,7 @@ path = "examples/line_chart_dashboard_test.rs"
 # harness = false
 
 [features]
-default = ["compression", "ocr-tesseract"]
+default = ["compression", "external-images"]
 
 # Basic features
 compression = ["dep:flate2"]
@@ -428,10 +431,10 @@ compression = ["dep:flate2"]
 # Debug features
 verbose-debug = []  # Enable verbose debug logging (disabled by default for zero runtime cost)
 
-# Image processing features
+# Image processing features (pure Rust via `image` crate, used for PNG/JPEG/etc. extraction)
 external-images = ["dep:image"]
 
-# OCR features
+# OCR features (opt-in: pulls `rusty-tesseract`, which requires the C `tesseract` binary on PATH)
 ocr-tesseract = ["dep:rusty-tesseract", "external-images"]
 ocr-full = ["ocr-tesseract"]
 

--- a/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
+++ b/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
@@ -13,13 +13,18 @@
 //!
 //! # Usage
 //!
+//! The example below uses `MockOcrProvider` so it compiles under the
+//! default feature set. For real OCR, enable the `ocr-tesseract` feature
+//! and substitute `RustyTesseractProvider::new()` (which requires the
+//! Tesseract binary on `PATH`).
+//!
 //! ```rust,no_run
 //! use oxidize_pdf::operations::pdf_ocr_converter::{PdfOcrConverter, ConversionOptions};
-//! use oxidize_pdf::text::RustyTesseractProvider;
+//! use oxidize_pdf::text::MockOcrProvider;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let converter = PdfOcrConverter::new()?;
-//! let ocr_provider = RustyTesseractProvider::new();
+//! let ocr_provider = MockOcrProvider::new();
 //! let options = ConversionOptions::default();
 //!
 //! converter.convert_to_searchable_pdf(


### PR DESCRIPTION
Release **2.9.0** — RAG-first positioning + OCR moved to opt-in feature.

## Summary

- **BREAKING (feature surface, not API)**: `ocr-tesseract` removed from default features. Existing users migrate with one line: `oxidize-pdf = { version = "2.9", features = ["ocr-tesseract"] }`.
- `description` and `keywords` in `oxidize-pdf-core/Cargo.toml` rewritten as RAG-first.
- `README.md` and `landing/index.html` demote the "Beyond RAG" feature catalogue to a single paragraph.
- `external-images` (pure-Rust `image` crate, PNG/JPEG extraction) added to default features.
- Doc-test in `pdf_ocr_converter.rs` uses `MockOcrProvider` for default-build compatibility.
- Examples requiring OCR declare `required-features = ["ocr-tesseract"]`.
- Workspace version `2.8.1` → `2.9.0`; `Cargo.lock` regenerated.

CHANGELOG.md includes a `[2.8.2]` section transcribed from main to keep develop's CHANGELOG aligned with what was previously released as a hotfix on main.

Context for the broader positioning shift: see [Discussion #245](https://github.com/bzsanti/oxidizePdf/discussions/245). Migration guidance for OCR users: [Discussion #246](https://github.com/bzsanti/oxidizePdf/discussions/246).

## Test plan

- [x] `cargo check -p oxidize-pdf` (default features) → clean
- [x] `cargo check -p oxidize-pdf --features ocr-tesseract` (opt-in OCR) → clean
- [x] Pre-commit hook (clippy + full unit-test suite) → clean
- [x] CI on the precursor PR #258 (merged to develop) → green on ubuntu/macos/windows
- [ ] CI on this PR
- [ ] After merge: tag `v2.9.0` + push tag → triggers `release.yml` to publish to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)