### PR TITLE
fix(partition): consume struct_tag + heading heuristics for tagged PDFs (addresses #271)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-issue-271-partitioner-classifier.md
+++ b/docs/superpowers/plans/2026-05-28-issue-271-partitioner-classifier.md
@@ -1,0 +1,974 @@
+# Issue #271 — Partitioner classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate two partitioner bugs on tightly-spaced structured PDFs (NCSC CAF v4.0):
+1. Body paragraphs in the top 5% of the page get reclassified as `Element::Header`.
+2. `Element::Title` count is 0 because heading fragments don't exceed the font-size ratio threshold and `TextFragment.struct_tag` is ignored.
+
+**Architecture:** Single-file change in `oxidize-pdf-core/src/pipeline/partition.rs`. Adds a `struct_tag` precedence step before the existing 1-6 pipeline, two new gates on Header/Footer detection (length cap + struct_tag check), and two new heuristic Title detectors (bold-short, numeric-prefix) running in parallel with the existing font-ratio check.
+
+**Tech Stack:** Rust 2021 edition, MSRV 1.77, `cargo test`, pre-commit hook running fmt + clippy + build.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-issue-271-partitioner-classifier-design.md`
+**Branch:** `fix/issue-271-partitioner-classifier`
+
+---
+
+## File Structure
+
+- **Modify** `oxidize-pdf-core/src/pipeline/partition.rs`:
+  - Add module-level constants (`MAX_HEADER_TEXT_LEN`, `MAX_BOLD_TITLE_LEN`, `MAX_NUMERIC_TITLE_LEN`).
+  - Add private enum `StructTagClass`.
+  - Add helpers: `classify_by_struct_tag`, `struct_tag_is_body`, `bold_short_title`, `numeric_prefix_title`, `matches_section_prefix`, `strip_section_prefix`, `ends_with_sentence_terminator`.
+  - Insert Step 0 (struct_tag-driven classification) in `partition_fragments` before the existing Step 1.
+  - Modify Step 1 (Header/Footer) to add length cap + struct_tag-body gates.
+  - Modify Step 4 (Title detection) to OR the three signals.
+  - Add unit tests in existing `#[cfg(test)] mod tests` (if absent, create) — about 12 helpers tests.
+- **Create** `oxidize-pdf-core/tests/partition_classifier_test.rs` — synthetic-fragment unit tests on the public `Partitioner` API.
+- **Create** `oxidize-pdf-core/tests/partition_struct_tag_test.rs` — integration tests building tagged PDFs via writer, extracting, partitioning.
+- **Create** `oxidize-pdf-core/tests/partition_ncsc_classifier_test.rs` — real-corpus NCSC tests (conditional on `corpus_cache/e0e3ff11371c09c2.pdf`).
+- **Create** `oxidize-pdf-core/tests/partition_classifier_regression_test.rs` — real-corpus Higgs/BSI/ENS regression tests (conditional on cached fixtures).
+
+No public API change. No Cargo.toml change. No new crate dependencies.
+
+---
+
+## Task 1: TDD — `classify_by_struct_tag` + `struct_tag_is_body` helpers
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+In `oxidize-pdf-core/src/pipeline/partition.rs`, append a `#[cfg(test)] mod tests` block at the bottom of the file (if one already exists, append the cases inside it):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_heading_tags() {
+        for tag in &["H", "H1", "H2", "H3", "H4", "H5", "H6", "Title"] {
+            assert_eq!(
+                classify_by_struct_tag(tag),
+                Some(StructTagClass::Heading),
+                "tag {} should classify as Heading",
+                tag
+            );
+        }
+    }
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_list_tags() {
+        assert_eq!(classify_by_struct_tag("L"), Some(StructTagClass::List));
+        assert_eq!(classify_by_struct_tag("LI"), Some(StructTagClass::ListItem));
+        assert_eq!(classify_by_struct_tag("Lbl"), Some(StructTagClass::ListItem));
+        assert_eq!(classify_by_struct_tag("LBody"), Some(StructTagClass::ListItem));
+    }
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_artifact() {
+        assert_eq!(classify_by_struct_tag("Artifact"), Some(StructTagClass::Artifact));
+    }
+
+    #[test]
+    fn classify_by_struct_tag_returns_none_for_passthrough_tags() {
+        for tag in &["P", "Span", "Figure", "Table", "Caption", "Form", "Note", "Random"] {
+            assert_eq!(
+                classify_by_struct_tag(tag),
+                None,
+                "tag {} should be None (fall through)",
+                tag
+            );
+        }
+    }
+
+    #[test]
+    fn struct_tag_is_body_recognizes_body_tags() {
+        for tag in &["P", "Span", "L", "LI", "H1", "H2", "H6", "Title", "Lbl", "LBody"] {
+            assert!(
+                struct_tag_is_body(&Some(tag.to_string())),
+                "tag {} should be body",
+                tag
+            );
+        }
+    }
+
+    #[test]
+    fn struct_tag_is_body_returns_false_for_artifact() {
+        assert!(!struct_tag_is_body(&Some("Artifact".to_string())));
+    }
+
+    #[test]
+    fn struct_tag_is_body_returns_false_for_none() {
+        assert!(!struct_tag_is_body(&None));
+    }
+}
+```
+
+Run `cargo test -p oxidize-pdf --lib partition::tests::classify_by_struct_tag` — must fail with `cannot find function 'classify_by_struct_tag'` etc.
+
+- [ ] **Step 2: Implement the helpers**
+
+Add to `oxidize-pdf-core/src/pipeline/partition.rs` after the existing `compute_kv_confidence` function (around line 668):
+
+```rust
+/// Classification class implied by a PDF structural tag (`/H1`, `/L`, `/Artifact`, …).
+///
+/// Returned by [`classify_by_struct_tag`] when the tag carries an unambiguous
+/// document-role signal. Untagged or pass-through tags return `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StructTagClass {
+    Heading,
+    List,
+    ListItem,
+    Artifact,
+}
+
+/// Map a PDF structural tag string to a partitioner classification class.
+///
+/// Recognizes the heading family (`H`, `H1..H6`, `Title`), list family
+/// (`L`, `LI`, `Lbl`, `LBody`), and `Artifact`. Returns `None` for
+/// pass-through tags (`P`, `Span`, `Figure`, …) so they flow into the
+/// heuristic classifier.
+fn classify_by_struct_tag(tag: &str) -> Option<StructTagClass> {
+    match tag {
+        "H" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "Title" => Some(StructTagClass::Heading),
+        "L" => Some(StructTagClass::List),
+        "LI" | "Lbl" | "LBody" => Some(StructTagClass::ListItem),
+        "Artifact" => Some(StructTagClass::Artifact),
+        _ => None,
+    }
+}
+
+/// `true` when the struct tag indicates the fragment is body content (paragraph,
+/// span, heading, list item). Used by Header/Footer detection to skip claiming
+/// fragments whose author already declared them as body.
+///
+/// `None` (no tag) returns `false` because absence of evidence does not imply
+/// body. `Artifact` returns `false` because artifacts ARE page furniture.
+fn struct_tag_is_body(tag: &Option<String>) -> bool {
+    let Some(t) = tag.as_deref() else { return false };
+    matches!(
+        t,
+        "P" | "Span"
+            | "H"
+            | "H1"
+            | "H2"
+            | "H3"
+            | "H4"
+            | "H5"
+            | "H6"
+            | "Title"
+            | "L"
+            | "LI"
+            | "Lbl"
+            | "LBody"
+    )
+}
+```
+
+Run `cargo test -p oxidize-pdf --lib partition::tests::classify_by_struct_tag` — all 7 tests pass.
+
+- [ ] **Step 3: `cargo clippy --workspace --tests -p oxidize-pdf -- -D warnings`** clean.
+
+- [ ] **Step 4: commit**
+  - Message: `feat(partition): struct_tag classification helpers (addresses #271)`
+  - Files: `oxidize-pdf-core/src/pipeline/partition.rs`
+
+---
+
+## Task 2: TDD — `ends_with_sentence_terminator` + `bold_short_title` + `numeric_prefix_title` heuristics
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs`
+
+- [ ] **Step 1: Add failing unit tests**
+
+In the same `#[cfg(test)] mod tests` block, append:
+
+```rust
+fn frag(text: &str, bold: bool, font_size: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x: 0.0,
+        y: 0.0,
+        width: 100.0,
+        height: 12.0,
+        font_size,
+        font_name: None,
+        is_bold: bold,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn ends_with_sentence_terminator_table() {
+    assert!(ends_with_sentence_terminator("This is a paragraph."));
+    assert!(ends_with_sentence_terminator("Really?"));
+    assert!(ends_with_sentence_terminator("Stop!"));
+    assert!(!ends_with_sentence_terminator("Section heading"));
+    assert!(!ends_with_sentence_terminator("A2.a Risk Management"));
+    assert!(!ends_with_sentence_terminator(""));
+}
+
+#[test]
+fn bold_short_title_accepts_bold_short_no_terminator() {
+    assert!(bold_short_title(&frag("Section Heading", true, 12.0)));
+    assert!(bold_short_title(&frag("Principle A2", true, 11.0)));
+}
+
+#[test]
+fn bold_short_title_rejects_non_bold() {
+    assert!(!bold_short_title(&frag("Section Heading", false, 12.0)));
+}
+
+#[test]
+fn bold_short_title_rejects_long_text() {
+    let long = "x".repeat(150);
+    assert!(!bold_short_title(&frag(&long, true, 12.0)));
+}
+
+#[test]
+fn bold_short_title_rejects_sentence_with_period() {
+    assert!(!bold_short_title(&frag("This is a complete sentence.", true, 12.0)));
+}
+
+#[test]
+fn bold_short_title_rejects_empty() {
+    assert!(!bold_short_title(&frag("   ", true, 12.0)));
+}
+
+#[test]
+fn numeric_prefix_title_accepts_known_patterns() {
+    let cases = &[
+        "A2.a Risk Management Process",
+        "A1.b Roles and Responsibilities",
+        "1.1 Overview",
+        "3.2.1 Detailed Requirements",
+        "Section 4: Implementation",
+        "Chapter 7 Conclusion",
+        "IV. Findings",
+    ];
+    for c in cases {
+        assert!(
+            numeric_prefix_title(&frag(c, false, 12.0)),
+            "should match: {}",
+            c
+        );
+    }
+}
+
+#[test]
+fn numeric_prefix_title_rejects_money_amount() {
+    assert!(!numeric_prefix_title(&frag("1.2 million users were affected", false, 12.0)));
+}
+
+#[test]
+fn numeric_prefix_title_rejects_version_string() {
+    assert!(!numeric_prefix_title(&frag("version 3.0.1 release notes", false, 12.0)));
+}
+
+#[test]
+fn numeric_prefix_title_rejects_lowercase_continuation() {
+    assert!(!numeric_prefix_title(&frag("1. take action now", false, 12.0)));
+}
+
+#[test]
+fn numeric_prefix_title_rejects_text_without_prefix() {
+    assert!(!numeric_prefix_title(&frag("Overview of the system", false, 12.0)));
+}
+
+#[test]
+fn numeric_prefix_title_rejects_too_long() {
+    let mut s = String::from("A2.a ");
+    s.push_str(&"X".repeat(220));
+    assert!(!numeric_prefix_title(&frag(&s, false, 12.0)));
+}
+```
+
+Run `cargo test -p oxidize-pdf --lib partition::tests::numeric_prefix` — fails (helpers don't exist).
+
+- [ ] **Step 2: Implement helpers**
+
+Add after `struct_tag_is_body`:
+
+```rust
+const MAX_HEADER_TEXT_LEN: usize = 100;
+const MAX_BOLD_TITLE_LEN: usize = 120;
+const MAX_NUMERIC_TITLE_LEN: usize = 200;
+
+fn ends_with_sentence_terminator(s: &str) -> bool {
+    matches!(s.chars().last(), Some('.') | Some('!') | Some('?'))
+}
+
+fn bold_short_title(f: &TextFragment) -> bool {
+    if !f.is_bold {
+        return false;
+    }
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_BOLD_TITLE_LEN {
+        return false;
+    }
+    !ends_with_sentence_terminator(trimmed)
+}
+
+/// Section-prefix regex matching:
+/// - `A2.a Foo`, `A1.b Bar` (capital letter + digits + optional `.digit*` + optional lowercase letter)
+/// - `1.1 Foo`, `3.2.1 Bar` (digits + optional `.digit*`)
+/// - `Section 4: Foo`, `Chapter 7 Foo`
+/// - `IV. Findings` (uppercase Roman numerals followed by `.`)
+fn section_prefix_regex() -> &'static regex::Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"^([A-Z]\d+(\.\d+)*([a-z]\.?)?|\d+(\.\d+)*\.?|Section\s+\d+:?|Chapter\s+\d+:?|[IVX]+\.)\s+",
+        )
+        .expect("section_prefix_regex must compile")
+    })
+}
+
+fn matches_section_prefix(s: &str) -> bool {
+    section_prefix_regex().is_match(s)
+}
+
+fn strip_section_prefix(s: &str) -> &str {
+    if let Some(m) = section_prefix_regex().find(s) {
+        &s[m.end()..]
+    } else {
+        s
+    }
+}
+
+fn numeric_prefix_title(f: &TextFragment) -> bool {
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_NUMERIC_TITLE_LEN {
+        return false;
+    }
+    if !matches_section_prefix(trimmed) {
+        return false;
+    }
+    let rest = strip_section_prefix(trimmed).trim_start();
+    matches!(rest.chars().next(), Some(c) if c.is_uppercase())
+}
+```
+
+**Dependency check:** verify `regex` is already in `oxidize-pdf-core/Cargo.toml`. If absent, add as a dev-and-runtime dep. (Run `grep regex oxidize-pdf-core/Cargo.toml` in Task setup before this step.)
+
+Run `cargo test -p oxidize-pdf --lib partition::tests` — all 17 tests pass.
+
+- [ ] **Step 3: clippy + commit**
+  - Message: `feat(partition): heading detection heuristics (addresses #271)`
+
+---
+
+## Task 3: TDD — Header/Footer length cap + struct_tag gates
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs`
+
+- [ ] **Step 1: Failing unit tests** (in `mod tests`):
+
+```rust
+fn frag_at(text: &str, x: f64, y: f64, font_size: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x,
+        y,
+        width: 100.0,
+        height: font_size,
+        font_size,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn header_zone_rejects_long_text() {
+    // page_height=800, header_zone=0.05 → threshold y >= 760
+    // Fragment at y=780 (in zone) but text = 200 chars → not Header.
+    let long = "X".repeat(200);
+    let frags = vec![frag_at(&long, 50.0, 780.0, 12.0)];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    let header_count = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .count();
+    assert_eq!(header_count, 0, "long text in header zone must not classify as Header");
+}
+
+#[test]
+fn header_zone_accepts_short_text() {
+    let frags = vec![frag_at("My Report 2026", 50.0, 780.0, 12.0)];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert!(
+        elements.iter().any(|e| matches!(e, Element::Header(_))),
+        "short text in header zone must classify as Header"
+    );
+}
+
+#[test]
+fn header_zone_rejects_p_struct_tag() {
+    let mut f = frag_at("Short body text", 50.0, 780.0, 12.0);
+    f.struct_tag = Some("P".to_string());
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    let header_count = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .count();
+    assert_eq!(header_count, 0, "struct_tag=P in header zone must not classify as Header");
+}
+
+#[test]
+fn footer_zone_rejects_long_text() {
+    let long = "X".repeat(200);
+    let frags = vec![frag_at(&long, 50.0, 10.0, 12.0)];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    let footer_count = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Footer(_)))
+        .count();
+    assert_eq!(footer_count, 0);
+}
+```
+
+Run `cargo test header_zone` — failing (Header still claims long text).
+
+- [ ] **Step 2: Modify Step 1 of `partition_fragments`**
+
+Replace the body of the `if f.y >= header_threshold` branch (around lines 161-171):
+
+```rust
+if f.y >= header_threshold
+    && f.text.chars().count() <= MAX_HEADER_TEXT_LEN
+    && !struct_tag_is_body(&f.struct_tag)
+{
+    let zone_size = page_height * self.config.header_zone;
+    let distance = f.y - header_threshold;
+    let header_confidence = compute_zone_confidence(distance, zone_size);
+    let mut meta = meta_from_fragment(f, page);
+    meta.confidence = header_confidence;
+    elements.push(Element::Header(ElementData {
+        text: f.text.clone(),
+        metadata: meta,
+    }));
+    claimed[i] = true;
+}
+```
+
+And symmetrically for the footer branch:
+
+```rust
+} else if f.y + f.height <= footer_threshold
+    && f.text.chars().count() <= MAX_HEADER_TEXT_LEN
+    && !struct_tag_is_body(&f.struct_tag)
+{
+    let zone_size = page_height * self.config.footer_zone;
+    let distance = footer_threshold - (f.y + f.height);
+    let footer_confidence = compute_zone_confidence(distance, zone_size);
+    let mut meta = meta_from_fragment(f, page);
+    meta.confidence = footer_confidence;
+    elements.push(Element::Footer(ElementData {
+        text: f.text.clone(),
+        metadata: meta,
+    }));
+    claimed[i] = true;
+}
+```
+
+Note: keep the existing `else if` chain structure. The two `if`s should remain mutually exclusive within the same loop iteration.
+
+Run `cargo test header_zone footer_zone` — all 4 tests pass.
+
+- [ ] **Step 3: Run full library tests + clippy**
+  - `cargo test -p oxidize-pdf --lib`
+  - Watch for regressions in existing partition tests.
+
+- [ ] **Step 4: commit**
+  - Message: `fix(partition): length cap and struct_tag gate on Header/Footer (addresses #271)`
+
+---
+
+## Task 4: TDD — Step 0 struct_tag-driven classification + extended Title detection
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs`
+
+- [ ] **Step 1: Failing integration tests** added to `mod tests`:
+
+```rust
+#[test]
+fn struct_tag_h1_yields_title_no_font_ratio_needed() {
+    let mut f = frag_at("Section One", 50.0, 400.0, 12.0); // same as body font
+    f.struct_tag = Some("H1".to_string());
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::Title(_))).count(),
+        1,
+        "H1-tagged fragment must classify as Title regardless of font size"
+    );
+}
+
+#[test]
+fn struct_tag_p_overrides_bold_short_heuristic() {
+    // Bold + short would normally fire bold-short heuristic. struct_tag=P forces paragraph.
+    let mut f = frag_at("Bold Short Text", 50.0, 400.0, 12.0);
+    f.is_bold = true;
+    f.struct_tag = Some("P".to_string());
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert!(elements.iter().any(|e| matches!(e, Element::Paragraph(_))));
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::Title(_))).count(),
+        0
+    );
+}
+
+#[test]
+fn bold_short_title_fires_without_struct_tag() {
+    let mut f = frag_at("Risk Management", 50.0, 400.0, 12.0);
+    f.is_bold = true;
+    // no struct_tag, no font size elevation, no numeric prefix
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::Title(_))).count(),
+        1,
+        "bold-short heuristic must fire when no other signals present"
+    );
+}
+
+#[test]
+fn numeric_prefix_title_fires_without_bold() {
+    let f = frag_at("A2.a Risk Management Process", 50.0, 400.0, 12.0);
+    // no bold, no font elevation, no struct_tag
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::Title(_))).count(),
+        1,
+        "numeric-prefix heuristic must fire on NCSC-style sections"
+    );
+}
+
+#[test]
+fn struct_tag_li_yields_list_item() {
+    let mut f = frag_at("Bullet content", 50.0, 400.0, 12.0);
+    f.struct_tag = Some("LI".to_string());
+    let frags = vec![f];
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::ListItem(_))).count(),
+        1
+    );
+}
+
+#[test]
+fn font_ratio_title_still_works() {
+    // Verify the existing font-ratio path is not broken by adding new signals.
+    // Body fragments at 12pt + one fragment at 20pt → 20pt one is Title.
+    let mut frags = vec![];
+    for i in 0..5 {
+        frags.push(frag_at(&format!("body line {}", i), 50.0, 400.0 - (i as f64) * 15.0, 12.0));
+    }
+    frags.push(frag_at("Big Heading", 50.0, 500.0, 20.0));
+
+    let partitioner = Partitioner::new(PartitionConfig::default());
+    let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+    assert_eq!(
+        elements.iter().filter(|e| matches!(e, Element::Title(_))).count(),
+        1,
+        "font-ratio Title path must still fire"
+    );
+}
+```
+
+Run these tests — must fail (struct_tag not consumed, heuristics not wired).
+
+- [ ] **Step 2: Wire Step 0 — struct_tag-driven classification**
+
+In `partition_fragments` immediately AFTER `let mut elements = Vec::new();` and BEFORE the Step 1 (Header/Footer) block, insert:
+
+```rust
+// 0. Struct-tag-driven classification (consumes TextFragment.struct_tag populated by #269 Phase 1).
+//    Heading/List/ListItem tags are classified here with confidence 1.0 (structural ground truth);
+//    other tags (P, Span, Figure, Table, …) fall through to the heuristic pipeline.
+for (i, f) in fragments.iter().enumerate() {
+    if claimed[i] {
+        continue;
+    }
+    let Some(tag) = f.struct_tag.as_deref() else {
+        continue;
+    };
+    match classify_by_struct_tag(tag) {
+        Some(StructTagClass::Heading) => {
+            let mut meta = meta_from_fragment(f, page);
+            meta.confidence = 1.0;
+            elements.push(Element::Title(ElementData {
+                text: f.text.trim().to_string(),
+                metadata: meta,
+            }));
+            claimed[i] = true;
+        }
+        Some(StructTagClass::ListItem) => {
+            let mut meta = meta_from_fragment(f, page);
+            meta.confidence = 1.0;
+            elements.push(Element::ListItem(ElementData {
+                text: f.text.trim().to_string(),
+                metadata: meta,
+            }));
+            claimed[i] = true;
+        }
+        Some(StructTagClass::List) | Some(StructTagClass::Artifact) | None => {
+            // `L` is an outer list container — children are LI; nothing to do here.
+            // `Artifact` flows through to Header/Footer detection.
+            // None: pass through.
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Extend Step 4 Title detection**
+
+Replace the existing block at lines 334-346 with:
+
+```rust
+// 4. Title detection — three signals OR'd together; struct_tag=P/Span block heuristic fallbacks.
+let struct_tag_blocks_heuristic = matches!(
+    f.struct_tag.as_deref(),
+    Some("P") | Some("Span")
+);
+
+let mut is_title = false;
+let mut title_confidence = 0.0_f64;
+
+// 4a. Font-ratio (existing logic)
+if f.font_size >= title_threshold && f.font_size > body_font_size {
+    is_title = true;
+    let ratio = f.font_size / body_font_size;
+    title_confidence = title_confidence
+        .max(compute_title_confidence(ratio, self.config.title_min_font_ratio));
+}
+
+// 4b. Bold-short heuristic (only if struct_tag does not explicitly mark body)
+if !struct_tag_blocks_heuristic && bold_short_title(f) {
+    is_title = true;
+    title_confidence = title_confidence.max(0.7);
+}
+
+// 4c. Numeric-prefix heuristic (only if struct_tag does not explicitly mark body)
+if !struct_tag_blocks_heuristic && numeric_prefix_title(f) {
+    is_title = true;
+    title_confidence = title_confidence.max(0.8);
+}
+
+if is_title {
+    let mut meta = meta;
+    meta.confidence = title_confidence.clamp(0.5, 1.0);
+    elements.push(Element::Title(ElementData {
+        text: text.to_string(),
+        metadata: meta,
+    }));
+    continue;
+}
+```
+
+- [ ] **Step 4: Run unit tests**
+  - `cargo test -p oxidize-pdf --lib partition` — all green.
+  - Watch for regression in any existing partition test.
+
+- [ ] **Step 5: clippy + commit**
+  - Message: `feat(partition): consume struct_tag and add bold-short / numeric-prefix heading detectors (addresses #271)`
+
+---
+
+## Task 5: Integration test — synthetic tagged-PDF roundtrip
+
+**Files:**
+- Create: `oxidize-pdf-core/tests/partition_struct_tag_test.rs`
+
+- [ ] **Step 1: Inspect writer API for marked-content emission**
+
+Run `grep -n "begin_marked_content\|BDC\|H1" oxidize-pdf-core/src/writer/`. Identify the public path for writing `BDC /H1 ... EMC` blocks. (Phase 1 of #269 added this on the read side; verify writer-side availability before authoring the test.) If absent, fall back to a fixture-based approach: hand-craft a minimal tagged PDF byte string and ship it as `tests/fixtures/issue_271_h1_tagged.pdf`.
+
+- [ ] **Step 2: Write the test**
+
+The test exercises:
+1. Open a PDF with a single page containing `BDC /H1 << /MCID 0 >> (Section One) Tj EMC` and `BDC /P << /MCID 1 >> (Body paragraph text here.) Tj EMC`.
+2. Extract with default options (Artifact filter on; mcid+struct_tag carried through).
+3. Pass to `Partitioner::new(PartitionConfig::default()).partition_fragments(...)`.
+4. Assert: 1 `Element::Title` with `text == "Section One"`, 1 `Element::Paragraph` with `text` containing `"Body paragraph"`. Zero `Element::Header`.
+
+If writer API not exposed: ship the PDF as a fixture and load it. Use a minimal PDF (no compression) so it's reviewable.
+
+- [ ] **Step 3: Run + commit**
+  - Message: `test(partition): struct_tag → Title integration test (addresses #271)`
+
+---
+
+## Task 6: NCSC real-corpus tests
+
+**Files:**
+- Create: `oxidize-pdf-core/tests/partition_ncsc_classifier_test.rs`
+
+- [ ] **Step 1: Mirror the pattern of `ncsc_no_alphabet_soup_test.rs`** for skip-if-missing behavior:
+
+```rust
+//! Issue #271 — NCSC CAF v4.0 partitioner classifier verification.
+//!
+//! Fixture: `corpus_cache/e0e3ff11371c09c2.pdf`. If missing, the tests
+//! `eprintln!` a skip notice and return — they do NOT fail (matches the
+//! pattern of `ncsc_no_alphabet_soup_test.rs`).
+
+use std::path::PathBuf;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{Element, PartitionConfig, Partitioner};
+use oxidize_pdf::text::extraction::{ExtractionOptions, TextExtractor};
+
+const NCSC_FIXTURE: &str = "corpus_cache/e0e3ff11371c09c2.pdf";
+
+fn ncsc_path() -> Option<PathBuf> {
+    let p = PathBuf::from(NCSC_FIXTURE);
+    if p.exists() { Some(p) } else { None }
+}
+
+fn extract_and_partition(path: &PathBuf) -> Vec<Element> {
+    let reader = PdfReader::open(path).expect("open NCSC corpus");
+    let document = PdfDocument::new(reader);
+    let mut all_elements = Vec::new();
+    let extractor = TextExtractor::with_options(ExtractionOptions::default());
+    let page_count = document.page_count().expect("page_count");
+    let partitioner = Partitioner::new(PartitionConfig::default());
+
+    for page_idx in 0..page_count {
+        let page = document.get_page(page_idx).expect("get_page");
+        let height = page.height();
+        let extracted = extractor.extract_from_page(&document, page_idx).expect("extract");
+        let elements = partitioner.partition_fragments(&extracted.fragments, page_idx as u32, height);
+        all_elements.extend(elements);
+    }
+    all_elements
+}
+
+#[test]
+fn ncsc_caf_v4_yields_at_least_30_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc_caf classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = extract_and_partition(&path);
+    let title_count = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Title(_)))
+        .count();
+    assert!(
+        title_count >= 30,
+        "NCSC CAF v4.0 must yield ≥30 Titles (got {})",
+        title_count
+    );
+}
+
+#[test]
+fn ncsc_caf_v4_no_body_text_in_headers() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc_caf classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = extract_and_partition(&path);
+    let long_headers: Vec<&Element> = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .filter(|e| e.text().chars().count() > 100)
+        .collect();
+    assert!(
+        long_headers.is_empty(),
+        "NCSC CAF v4.0 must not classify long body text as Header (found {} offenders, e.g. \"{}\")",
+        long_headers.len(),
+        long_headers.first().map(|e| e.text()).unwrap_or("")
+    );
+}
+
+#[test]
+fn ncsc_caf_v4_contains_principle_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc_caf classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = extract_and_partition(&path);
+    let has_principle = elements.iter().any(|e| match e {
+        Element::Title(d) => d.text.starts_with("Principle "),
+        _ => false,
+    });
+    assert!(has_principle, "NCSC CAF v4.0 must contain at least one 'Principle Ax' Title");
+}
+
+#[test]
+fn ncsc_caf_v4_contains_section_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc_caf classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = extract_and_partition(&path);
+    let has_section = elements.iter().any(|e| match e {
+        Element::Title(d) => {
+            // Section pattern: "A2.a", "A1.b", "A3.c", etc.
+            let trimmed = d.text.trim();
+            trimmed.len() >= 4 && {
+                let bytes = trimmed.as_bytes();
+                bytes[0].is_ascii_uppercase()
+                    && bytes[1].is_ascii_digit()
+                    && bytes[2] == b'.'
+                    && bytes[3].is_ascii_lowercase()
+            }
+        }
+        _ => false,
+    });
+    assert!(has_section, "NCSC CAF v4.0 must contain at least one 'Ax.y' section Title");
+}
+```
+
+**Note on imports:** confirm exact `TextExtractor` API. If `extract_from_page` doesn't exist (Phase 1 may have a different name), adapt to the actual signature.
+
+- [ ] **Step 2: Run**
+  - `cargo test -p oxidize-pdf --test partition_ncsc_classifier_test -- --nocapture`
+
+- [ ] **Step 3: commit**
+  - Message: `test(partition): NCSC CAF v4.0 classifier real-corpus tests (#271)`
+
+---
+
+## Task 7: Regression tests (Higgs, BSI, ENS)
+
+**Files:**
+- Create: `oxidize-pdf-core/tests/partition_classifier_regression_test.rs`
+
+- [ ] **Step 1: Implement parameterized regression tests**
+
+Use the same `extract_and_partition` helper pattern (extract to a shared `tests/common/` module if helpful, or inline). For each cached fixture:
+
+| Slug | Hash | Min Title Count |
+|---|---|---|
+| higgs | `b9cf1a025b683adf` | 100 |
+| bsi-tr-02102 | `6a001a0684cd51ca` | 80 |
+| ens | `6320a941c903a04f` | 3 |
+
+(Note: hashes need verification — they're the SHA1 of the URL, computable from `examples/rag_realworld.rs`. Run `grep "ens\|higgs\|bsi\|ncsc" examples/rag_realworld.rs` and `xxd corpus_cache/*.pdf | head -1` if needed to confirm mapping. The NCSC hash `e0e3ff11371c09c2` is already known.)
+
+Tests:
+- `higgs_yields_at_least_100_titles`
+- `bsi_yields_at_least_80_titles`
+- `ens_yields_at_least_3_titles`
+- `no_long_headers_on_tagged_corpora` — sum `Header(text > 100)` across all three; assert `<5%` of total `Header` count, or `== 0` if total Header count is 0.
+
+- [ ] **Step 2: Run + commit**
+  - Message: `test(partition): regression guards for Higgs/BSI/ENS Title counts (#271)`
+
+---
+
+## Task 8: End-to-end — rag_realworld + JSONL inspection
+
+**Files:**
+- Modify (optional): `oxidize-pdf-core/tests/rag_realworld_jsonl_test.rs` if it exists.
+
+- [ ] **Step 1: Run `cargo run --release --example rag_realworld`** and capture output.
+
+- [ ] **Step 2: Verify summary line for NCSC** shows `>= 30 headings` (previously `0 headings`).
+
+- [ ] **Step 3: Verify summary lines for other corpora** show counts in the bands established by Task 7.
+
+- [ ] **Step 4: Inspect `out/ncsc-caf.jsonl`** with `jq`:
+  - Heading chunks count >= 30.
+  - Long-text chunks (text length > 100) tagged `header` count == 0.
+
+- [ ] **Step 5: Save log to `.private/` (not committed)** for the PR body:
+  - `.private/rag_realworld_after_271_fix.log`
+
+---
+
+## Task 9: Full test suite + clippy + corpus tiers
+
+- [ ] **Step 1: `nice -n 10 cargo test -p oxidize-pdf --lib --no-fail-fast`** — clean.
+- [ ] **Step 2: `nice -n 10 cargo test -p oxidize-pdf --tests --no-fail-fast`** — all integration tests green. Do NOT rely on the summary alone; scan for `FAILED`, `panicked`, `test result: ok`.
+- [ ] **Step 3: `cargo test -p oxidize-pdf --test t1_spec`** (if present + corpus available) — pass rate ≥99% within timeouts.
+- [ ] **Step 4: `cargo test -p oxidize-pdf --test t3_stress`** (if present + corpus available) — 0 panics, 0 timeouts.
+- [ ] **Step 5: `cargo clippy --workspace --tests -- -D warnings`** — clean.
+
+If any tier regresses, do NOT proceed to push/PR. Stop and diagnose.
+
+---
+
+## Task 10: Verification + PR draft
+
+- [ ] **Step 1: `git log --oneline develop..HEAD`** — review commit sequence:
+  - feat(partition): struct_tag classification helpers
+  - feat(partition): heading detection heuristics
+  - fix(partition): length cap and struct_tag gate on Header/Footer
+  - feat(partition): consume struct_tag and add heading heuristics in classifier
+  - test(partition): struct_tag → Title integration test
+  - test(partition): NCSC CAF v4.0 classifier real-corpus tests
+  - test(partition): regression guards for Higgs/BSI/ENS Title counts
+
+- [ ] **Step 2: Draft PR body** in `.private/pr_271_body.md` (NOT committed):
+  - Summary: closes #271 (no auto-close keyword; use "addresses #271").
+  - Before/after table on NCSC (115 → 0 long headers, 0 → ≥30 titles).
+  - Regression numbers for Higgs/BSI/ENS.
+  - Detailed changes per file.
+  - Test plan executed.
+
+- [ ] **Step 3: STOP and request authorization** before:
+  - `git push -u origin fix/issue-271-partitioner-classifier`
+  - `gh pr create`
+  - Any GitHub issue comment.
+
+Per `feedback_no_auto_issue_comments.md`: never auto-close. Use "addresses #271", not "closes/fixes/resolves".
+
+---
+
+## Done criteria
+
+All of:
+
+- 10 tasks above marked complete.
+- `cargo test --workspace --no-fail-fast` clean (lib + tests).
+- `cargo clippy --workspace --tests -- -D warnings` clean.
+- NCSC: `≥30 Titles, 0 long-text Headers`.
+- Higgs/BSI/ENS: Title counts within bands; no regression on Header misclassification ratio.
+- `rag_realworld 5/5` succeeds.
+- Spec + plan committed.
+- PR body drafted in `.private/`; PR NOT opened without user authorization.

--- a/docs/superpowers/specs/2026-05-28-issue-271-partitioner-classifier-design.md
+++ b/docs/superpowers/specs/2026-05-28-issue-271-partitioner-classifier-design.md
@@ -1,0 +1,316 @@
+# Partitioner classifier — struct_tag consumption + heuristic heading detector + Header recalibration (#271)
+
+**Date:** 2026-05-28
+**Branch:** `fix/issue-271-partitioner-classifier`
+**Closes:** [#271](https://github.com/bzsanti/oxidizePdf/issues/271)
+**Scope:** Partitioner (`oxidize-pdf-core/src/pipeline/partition.rs`) only. No changes to extractor, parser, chunker, or writer.
+
+## Context
+
+`pipeline/partition.rs` produces two failure modes on the NCSC Cyber Assessment Framework v4.0 corpus that the issue documents:
+
+- **Bug A — body misclassified as `Element::Header`.** Lines 152-185 run header detection FIRST, before table detection, with only one signal: `f.y >= page_height * (1.0 - header_zone)` (default `header_zone = 0.05`). Any fragment that sits in the top 5% of the page is claimed as Header regardless of length, regardless of whether other fragments below it form a tightly-packed table region. NCSC's assessment tables ("Achieved / Partially / Not Achieved" cells of sections A1/A2/A3) begin within the top 5%, so the topmost row of each table — 150-210 char paragraph statements — gets reclassified as a running header and removed from the table detector's input. Measured on develop HEAD: 115 of 184 NCSC chunks tagged `element_types: ["header"]`; 75 of those have text length > 100 chars.
+
+- **Bug B — 0 `Element::Title` (the "heading" tag in `element_types`).** Title detection at lines 334-346 requires `font_size >= body_font_size * 1.3 && > body_font_size`. NCSC section headings (`"Principle A2 Risk Management"`, `"A2.a Risk Management Process"`, `"A1.b Roles and Responsibilities"`) are emitted bold but at the same font size as body text. They never satisfy the ratio gate. Furthermore, the partitioner does not consume `TextFragment.struct_tag` at all — verified with `grep`. The field is populated by #269 Phase 1 but its use was deferred to a hypothetical Phase 3.
+
+Joint effect: on a 60-page government / compliance PDF with clear hierarchical structure, the partitioner reports 0 headings and 115 body paragraphs reclassified as page furniture. Downstream, the chunker emits chunks without `parent_heading`, RAG retrieval loses the section context, and the document is effectively flat.
+
+## Goals
+
+- Close #271.
+- Honor `TextFragment.struct_tag` ("H1".."H6", "Title", "P", "L", "LI", "Artifact", "Figure", "Table", "Span") as the primary classification signal when present. Tagged PDFs that ship structural metadata get reading-aware classification for free.
+- Add a heuristic heading detector that activates when `struct_tag` is absent or ambiguous. Signals: bold-and-short, alphanumeric section prefix (`A2.a`, `1.1`, `IV.`), standalone non-terminated line.
+- Recalibrate Header detection so that a 200-char paragraph in the top 5% of the page is not classified as a running header.
+- Preserve existing behavior for the 4 corpora that already work (Higgs 205 headings, BSI 125, ENS 3, BOE-Sumario 0 — BOE is a separate font-encoding root cause, not a classifier issue).
+
+## Non-Goals
+
+- Parsing `StructTreeRoot` / `ParentTree` from the document catalog. The `struct_tag` already on `TextFragment` is the only structural input. (Phase 2 of the Tagged-PDF initiative.)
+- BOE-Sumario heading detection — root cause is CFF font encoding (separate issue, not classifier).
+- Multi-line title detection (a heading split across two fragments).
+- Cross-page running-header detection (compare same text at same Y across consecutive pages). Out of scope; future work.
+- Image / Figure / Code element classification beyond pass-through.
+- Reading-order changes.
+
+## Success Criteria
+
+All of the following must hold, verified by content-checking tests (no smoke tests per `CLAUDE.md`).
+
+### Functional
+
+1. **Struct-tag Title.** A synthetic PDF with `BDC /H1 << /MCID 0 >> ... EMC` containing `"Section Title"` (no font ratio elevation) produces `Element::Title` with `text == "Section Title"`.
+2. **Struct-tag H1..H6 all map to Title.** Same behavior for `H2`, `H3`, `H4`, `H5`, `H6`, `Title`. `H` (untagged-level heading per PDF 32000-1) maps to Title.
+3. **Struct-tag Paragraph short-circuit.** `BDC /P ... EMC` with bold short text does NOT classify as Title via the heuristic fallback; struct_tag takes precedence.
+4. **NCSC heading heuristic.** On NCSC CAF v4.0 (`corpus_cache/e0e3ff11371c09c2.pdf`), the partitioner produces **at least 30** `Element::Title` instances. Each must contain at least one of: a top-level "Principle Ax" label, an "Ax.y" sub-section label, an "Ax.z" sub-sub-section label.
+5. **Bold-short heuristic.** A synthetic fragment with `is_bold=true`, length ≤ 80 chars, no terminal `.`/`!`/`?`, font_size = body_size produces `Element::Title`.
+6. **Numeric prefix heuristic.** A non-bold fragment matching one of `^[A-Z]?\d+(\.\d+)*([a-z]\.?)?\s+\S` produces `Element::Title`. Examples that must match: `"A2.a Risk Management"`, `"1.1 Overview"`, `"3.2.1 Details"`, `"Section 4: Implementation"`. Examples that must NOT match: `"1.2 million"`, `"version 3.0.1"` (no trailing word), `"step 1. take action"` (lowercase verb after).
+7. **NCSC body NOT classified as Header.** On NCSC, **zero** `Element::Header` whose `text.chars().count() > 100`. Header detection rejects long fragments regardless of Y position.
+8. **Header length cap.** Synthetic fragment at `y = page_height * 0.97`, length = 250 chars: classified as `Paragraph`, not Header.
+9. **Real headers still detected.** Synthetic fragment at `y = page_height * 0.97`, length = 18 chars (`"My Report — 2026"`): classified as `Header`.
+
+### Regression (non-NCSC corpora)
+
+10. **rag_realworld 5/5.** `examples/rag_realworld.rs` continues to process 5/5 PDFs without panic.
+11. **Higgs Titles ≥ 100.** (Baseline 205 on develop. Floor enforced at 100 to leave room for incidental changes.)
+12. **BSI Titles ≥ 80.** (Baseline 125.)
+13. **ENS Titles ≥ 3.** (Baseline 3.)
+14. **No new Header misclassifications.** On Higgs+BSI+ENS combined: ratio of `Element::Header` with `text > 100 chars` divided by total `Element::Header` count must stay below 5%. (Baseline is already low on tagged corpora; guard is for regression.)
+
+### Suite
+
+15. `cargo test --workspace --no-fail-fast` passes. No existing test deleted, weakened, or marked `#[ignore]`.
+16. `cargo clippy --workspace --tests -- -D warnings` clean on touched files.
+
+## Architecture
+
+The partition pipeline order changes from:
+
+```
+1. Header/Footer (Y position only)
+2. Tables
+3. Key-Value
+4. Title (font ratio)
+5. List
+6. Paragraph (default)
+```
+
+to:
+
+```
+0. struct_tag-driven classification  [NEW]
+   - H1..H6 / H / Title  → Element::Title
+   - L / LI              → Element::ListItem
+   - Artifact            → flows into step 1 (Header/Footer)
+   - P / Span / (none)   → flow into steps 1..6
+1. Header/Footer (Y position AND length cap AND struct_tag check)
+2. Tables                                    (unchanged)
+3. Key-Value                                 (unchanged)
+4. Title — font ratio OR bold-short OR numeric-prefix  [EXTENDED]
+5. List                                      (unchanged)
+6. Paragraph
+```
+
+### Step 0: struct_tag classification
+
+```rust
+fn classify_by_struct_tag(tag: &str) -> Option<StructTagClass> {
+    match tag {
+        "H" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "Title" => Some(StructTagClass::Heading),
+        "L" => Some(StructTagClass::List),       // outer list — children handled per-fragment
+        "LI" | "Lbl" | "LBody" => Some(StructTagClass::ListItem),
+        "Artifact" => Some(StructTagClass::Artifact),
+        _ => None, // P, Span, Figure, Table, Caption, etc.: fall through to heuristics
+    }
+}
+```
+
+Fragments tagged `Heading` are emitted as `Element::Title` and removed from the unclaimed pool before steps 1-6. Confidence is set to `1.0` (structural ground truth) regardless of font size.
+
+`Artifact` fragments are not removed pre-emptively. Step 1 (Header/Footer) gives them priority — they almost always represent running headers/footers in practice. If step 1 doesn't claim them (e.g. Y position is mid-page), they fall through to paragraph classification, which is acceptable because the extractor already filters `Artifact` by default unless `include_artifacts = true`.
+
+### Step 1: Header/Footer recalibration
+
+Two new gates added to the existing zone check:
+
+```rust
+if f.y >= header_threshold
+    && f.text.chars().count() <= MAX_HEADER_TEXT_LEN  // NEW gate
+    && !struct_tag_is_body(&f.struct_tag)             // NEW gate
+{
+    // classify as Header
+}
+```
+
+Constants:
+
+```rust
+const MAX_HEADER_TEXT_LEN: usize = 100;  // 100 chars ≈ one typical wrapped header line
+```
+
+`struct_tag_is_body` returns true for `Some("P")`, `Some("Span")`, `Some(h)` where `h` matches H1..H6 (a heading is never a Header), `Some("L")`, `Some("LI")`. Returns false for `None` (no signal) or `Some("Artifact")`.
+
+Footer detection gets the symmetric treatment.
+
+### Step 4: Title detection — multi-signal
+
+Replaces single `font_size >= title_threshold` test with an `or` chain:
+
+```rust
+let is_title = font_ratio_title(f, body_font_size, title_threshold)
+    || bold_short_title(f)
+    || numeric_prefix_title(f);
+
+if is_title {
+    // emit Element::Title with combined confidence
+}
+```
+
+`bold_short_title`:
+
+```rust
+fn bold_short_title(f: &TextFragment) -> bool {
+    if !f.is_bold { return false; }
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_BOLD_TITLE_LEN { return false; }
+    if ends_with_sentence_terminator(trimmed) { return false; }
+    true
+}
+
+const MAX_BOLD_TITLE_LEN: usize = 120;
+
+fn ends_with_sentence_terminator(s: &str) -> bool {
+    matches!(s.chars().last(), Some('.') | Some('!') | Some('?'))
+}
+```
+
+`numeric_prefix_title`:
+
+```rust
+fn numeric_prefix_title(f: &TextFragment) -> bool {
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_NUMERIC_TITLE_LEN { return false; }
+    if !matches_section_prefix(trimmed) { return false; }
+    // Require a following word with capital letter (rules out "1.2 million", "version 3.0.1")
+    let rest = strip_section_prefix(trimmed);
+    let first_char = rest.trim_start().chars().next();
+    matches!(first_char, Some(c) if c.is_uppercase())
+}
+
+const MAX_NUMERIC_TITLE_LEN: usize = 200;
+```
+
+Section prefix regex (compiled once with `OnceLock`):
+
+```
+^([A-Z]\d+(\.\d+)*([a-z]\.?)?|\d+(\.\d+)*\.?|Section\s+\d+:?|Chapter\s+\d+:?|[IVX]+\.)\s+
+```
+
+Matches:
+- `A2.a Risk Management` ✓
+- `1.1 Overview` ✓
+- `3.2.1 Details` ✓
+- `Section 4: Implementation` ✓
+- `IV. Findings` ✓
+
+Rejects:
+- `1.2 million users` → `million` lowercase first char → rejected
+- `version 3.0.1` → no leading prefix match
+- `step 1. take action` → first char `t` lowercase → rejected
+
+### Confidence
+
+Struct-tag-driven Title: `1.0`.
+Font-ratio Title: existing `compute_title_confidence`.
+Bold-short Title: `0.7`.
+Numeric-prefix Title: `0.8`.
+Multi-signal Title (e.g. bold + numeric prefix): `clamp(0.7 + 0.2 + bonus, 0.5, 1.0)` capped at 1.0.
+
+Header (zone + length cap satisfied): unchanged `compute_zone_confidence`.
+
+## Data structures
+
+No new public API surface. Internal helpers added to `partition.rs`:
+
+```rust
+enum StructTagClass {
+    Heading,
+    List,
+    ListItem,
+    Artifact,
+}
+
+fn classify_by_struct_tag(tag: &str) -> Option<StructTagClass>;
+fn struct_tag_is_body(tag: &Option<String>) -> bool;
+fn bold_short_title(f: &TextFragment) -> bool;
+fn numeric_prefix_title(f: &TextFragment) -> bool;
+fn matches_section_prefix(s: &str) -> bool;  // OnceLock-cached regex
+fn strip_section_prefix(s: &str) -> &str;
+fn ends_with_sentence_terminator(s: &str) -> bool;
+```
+
+`Element::Title` already carries `parent_heading` via the post-classification pass — no change needed.
+
+## Test plan
+
+Content-verifying tests only (per `CLAUDE.md`). All in `oxidize-pdf-core/tests/`.
+
+### Unit tests (helpers) — `partition_classifier_test.rs` (NEW)
+
+- `struct_tag_h1_h2_h3_map_to_title` — table-driven, all `H1..H6` + `H` + `Title`.
+- `struct_tag_li_maps_to_list_item`.
+- `struct_tag_p_falls_through_to_heuristic` — `/P` tagged bold text does not become Title via the bold-short heuristic if explicitly tagged P. (Test verifies struct_tag precedence.)
+- `bold_short_classifies_as_title` — bold, 50 chars, no terminator → Title.
+- `bold_long_does_not_classify_as_title` — bold, 200 chars → Paragraph.
+- `bold_with_period_does_not_classify_as_title` — bold short ending in `.` → Paragraph.
+- `numeric_prefix_classifies_as_title` — table: `A2.a Risk`, `1.1 Overview`, `Section 4: Imp`, `IV. Findings`.
+- `numeric_prefix_rejects_money_amount` — `1.2 million dollars` → not Title.
+- `numeric_prefix_rejects_version_string` — `version 3.0.1` → not Title.
+- `header_zone_with_long_text_rejected` — `y` in top 5%, 200 chars → Paragraph.
+- `header_zone_with_short_text_accepted` — `y` in top 5%, 18 chars → Header.
+- `header_zone_with_p_struct_tag_rejected` — `y` in top 5%, 30 chars, struct_tag=`P` → Paragraph.
+
+### Integration — `partition_struct_tag_test.rs` (NEW)
+
+- `extract_then_partition_h1_tagged_pdf_yields_title` — build minimal tagged PDF via writer with `<H1>Section</H1>`, extract, partition, assert `Element::Title`.
+- `extract_then_partition_artifact_tagged_excluded_from_titles` — `<Artifact>Page 1</Artifact>` does not become Title.
+
+### Real-corpus — `partition_ncsc_classifier_test.rs` (NEW)
+
+Cached fixture `corpus_cache/e0e3ff11371c09c2.pdf`. Skip with `eprintln!` (not fail) if not present, matching the `ncsc_no_alphabet_soup_test.rs` pattern.
+
+- `ncsc_caf_v4_yields_at_least_30_titles` — open NCSC, partition all pages, count `Element::Title`, assert >= 30.
+- `ncsc_caf_v4_no_body_text_in_headers` — count `Element::Header` with `chars().count() > 100`, assert 0.
+- `ncsc_caf_v4_contains_principle_titles` — assert at least one Title text starts with `"Principle "`.
+- `ncsc_caf_v4_contains_section_titles` — assert at least one Title text matches the `Ax.y` section prefix.
+
+### Regression — `partition_classifier_regression_test.rs` (NEW)
+
+Each test conditional on fixture in `corpus_cache/`.
+
+- `higgs_yields_at_least_100_titles`.
+- `bsi_yields_at_least_80_titles`.
+- `ens_yields_at_least_3_titles`.
+- `no_long_text_misclassified_as_header_higgs_bsi_ens` — combined ratio of `Header(text > 100)` / total `Header` < 5%.
+
+### End-to-end — extend `rag_realworld_jsonl_test.rs` (if present) or add to integration
+
+- `rag_realworld_ncsc_emits_at_least_30_heading_chunks` — run the example pipeline, count chunks with `element_types: ["heading"]` or `["title"]` (verify mapping in `RagChunk`), assert >= 30.
+
+Total: 25 tests, all content-verifying.
+
+## Edge cases and rejections
+
+| Input | Expected | Reason |
+|---|---|---|
+| `font_size = 24, bold, 30 chars, struct_tag = "P"` | Paragraph | struct_tag takes precedence (caller said "this is body") |
+| `font_size = 12, bold, 80 chars, struct_tag = None, no terminator` | Title (bold-short) | heuristic fallback |
+| `font_size = 12, bold, 80 chars, struct_tag = "H2"` | Title | struct_tag confirms |
+| `font_size = 12, not bold, 80 chars, prefix "A2.a Section Name"` | Title (numeric-prefix) | heuristic fallback |
+| `font_size = 18, struct_tag = "H1"` | Title (confidence 1.0) | structural |
+| `text = "1.2 million users in 2025"` | Paragraph | prefix matches but next word is lowercase |
+| `y in top 5%, 200 chars, struct_tag = None` | Paragraph | header length cap |
+| `y in top 5%, 50 chars, struct_tag = "P"` | Paragraph | struct_tag says body |
+| `y in top 5%, 50 chars, struct_tag = "Artifact"` | Header | struct_tag confirms furniture |
+
+## Rollback
+
+Single file (`partition.rs`) + new test files. Revert by:
+
+```
+git revert <fix-commit-sha>
+```
+
+No data migration, no public API surface change, no Cargo.toml change.
+
+## Open questions
+
+None. All design decisions are local to the partitioner and tested.
+
+## Out of scope (tracked elsewhere)
+
+- BOE-Sumario heading detection (font encoding, separate issue).
+- Multi-fragment heading (heading wraps across two `TextFragment`s).
+- Cross-page running-header detection.
+- StructTreeRoot parsing (Phase 2 of Tagged-PDF initiative).

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -149,7 +149,54 @@ impl Partitioner {
         let mut claimed = vec![false; fragments.len()];
         let mut elements = Vec::new();
 
-        // 1. Header/footer detection
+        // 0. Struct-tag-driven classification (issue #271).
+        //    Consumes `TextFragment.struct_tag` populated by #269 Phase 1.
+        //    Heading/ListItem tags are accepted here with confidence 1.0
+        //    (structural ground truth); Artifact and pass-through tags
+        //    (P, Span, Figure, Table, ...) fall through to the heuristics.
+        for (i, f) in fragments.iter().enumerate() {
+            if claimed[i] {
+                continue;
+            }
+            let Some(tag) = f.struct_tag.as_deref() else {
+                continue;
+            };
+            match classify_by_struct_tag(tag) {
+                Some(StructTagClass::Heading) => {
+                    let trimmed = f.text.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let mut meta = meta_from_fragment(f, page);
+                    meta.confidence = 1.0;
+                    elements.push(Element::Title(ElementData {
+                        text: trimmed.to_string(),
+                        metadata: meta,
+                    }));
+                    claimed[i] = true;
+                }
+                Some(StructTagClass::ListItem) => {
+                    let trimmed = f.text.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let mut meta = meta_from_fragment(f, page);
+                    meta.confidence = 1.0;
+                    elements.push(Element::ListItem(ElementData {
+                        text: trimmed.to_string(),
+                        metadata: meta,
+                    }));
+                    claimed[i] = true;
+                }
+                Some(StructTagClass::List) | Some(StructTagClass::Artifact) | None => {
+                    // L is an outer container — children are LI; nothing to do here.
+                    // Artifact flows through to Header/Footer detection below.
+                    // None: pass through.
+                }
+            }
+        }
+
+        // 1. Header/footer detection (issue #271: length cap + body-tag gate).
         if self.config.detect_headers_footers && page_height > 0.0 {
             let header_threshold = page_height * (1.0 - self.config.header_zone);
             let footer_threshold = page_height * self.config.footer_zone;
@@ -158,7 +205,10 @@ impl Partitioner {
                 if claimed[i] {
                     continue;
                 }
-                if f.y >= header_threshold {
+                let text_too_long = f.text.chars().count() > MAX_HEADER_TEXT_LEN;
+                let is_body_tagged = struct_tag_is_body(&f.struct_tag);
+
+                if f.y >= header_threshold && !text_too_long && !is_body_tagged {
                     let zone_size = page_height * self.config.header_zone;
                     let distance = f.y - header_threshold;
                     let header_confidence = compute_zone_confidence(distance, zone_size);
@@ -169,7 +219,7 @@ impl Partitioner {
                         metadata: meta,
                     }));
                     claimed[i] = true;
-                } else if f.y + f.height <= footer_threshold {
+                } else if f.y + f.height <= footer_threshold && !text_too_long && !is_body_tagged {
                     let zone_size = page_height * self.config.footer_zone;
                     let distance = footer_threshold - (f.y + f.height);
                     let footer_confidence = compute_zone_confidence(distance, zone_size);
@@ -331,13 +381,42 @@ impl Partitioner {
                 }
             }
 
-            // 4. Title detection by font size
+            // 4. Title detection — three OR'd signals (issue #271).
+            //    struct_tag=P/Span explicitly marks body content; in that case
+            //    the bold-short and numeric-prefix heuristics are suppressed,
+            //    but a strong font-ratio signal still wins (defensive: tagged
+            //    PDFs occasionally mis-mark display text as P).
+            let struct_tag_blocks_heuristic =
+                matches!(f.struct_tag.as_deref(), Some("P") | Some("Span"));
+
+            let mut is_title = false;
+            let mut title_confidence = 0.0_f64;
+
+            // 4a. Font-size ratio
             if f.font_size >= title_threshold && f.font_size > body_font_size {
                 let ratio = f.font_size / body_font_size;
-                let title_confidence =
-                    compute_title_confidence(ratio, self.config.title_min_font_ratio);
+                is_title = true;
+                title_confidence = title_confidence.max(compute_title_confidence(
+                    ratio,
+                    self.config.title_min_font_ratio,
+                ));
+            }
+
+            // 4b. Bold-short heuristic
+            if !struct_tag_blocks_heuristic && bold_short_title(f) {
+                is_title = true;
+                title_confidence = title_confidence.max(0.7);
+            }
+
+            // 4c. Numeric-prefix heuristic
+            if !struct_tag_blocks_heuristic && numeric_prefix_title(f) {
+                is_title = true;
+                title_confidence = title_confidence.max(0.8);
+            }
+
+            if is_title {
                 let mut meta = meta;
-                meta.confidence = title_confidence;
+                meta.confidence = title_confidence.clamp(0.5, 1.0);
                 elements.push(Element::Title(ElementData {
                     text: text.to_string(),
                     metadata: meta,
@@ -666,4 +745,521 @@ fn compute_kv_confidence(key: &str) -> f64 {
         0.0
     };
     (1.0 - len_penalty - word_penalty).clamp(0.5, 1.0)
+}
+
+// --- struct_tag-driven classification (issue #271) ---
+
+const MAX_HEADER_TEXT_LEN: usize = 100;
+const MAX_BOLD_TITLE_LEN: usize = 120;
+const MAX_NUMERIC_TITLE_LEN: usize = 200;
+
+/// `true` when the trimmed text ends with `.`, `!`, or `?`. Used by the
+/// bold-short heading heuristic to exclude complete sentences.
+fn ends_with_sentence_terminator(s: &str) -> bool {
+    matches!(s.chars().last(), Some('.') | Some('!') | Some('?'))
+}
+
+/// Heading heuristic: `true` if the fragment is bold, has non-empty trimmed
+/// text up to `MAX_BOLD_TITLE_LEN` chars, and does not end with a sentence
+/// terminator. Designed for headings emitted at body font size without
+/// structural tagging (e.g. NCSC `"A2.a Risk Management Process"` in bold).
+fn bold_short_title(f: &TextFragment) -> bool {
+    if !f.is_bold {
+        return false;
+    }
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_BOLD_TITLE_LEN {
+        return false;
+    }
+    !ends_with_sentence_terminator(trimmed)
+}
+
+/// Section-prefix regex matching common heading shapes:
+/// - `A2.a Foo`, `A1.b Bar` (uppercase letter + digits + optional `.digit*` + optional lowercase letter)
+/// - `1.1 Foo`, `3.2.1 Bar`, `1. Foo` (digits + optional `.digit*` + optional `.`)
+/// - `Section 4: Foo`, `Chapter 7 Foo`
+/// - `IV. Findings` (uppercase Roman numerals followed by `.`)
+fn section_prefix_regex() -> &'static regex::Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"^([A-Z]\d+(\.\d+)*(\.[a-z]\.?)?|\d+(\.\d+)*\.?|Section\s+\d+:?|Chapter\s+\d+:?|[IVX]+\.)\s+",
+        )
+        .expect("section_prefix_regex must compile")
+    })
+}
+
+fn matches_section_prefix(s: &str) -> bool {
+    section_prefix_regex().is_match(s)
+}
+
+fn strip_section_prefix(s: &str) -> &str {
+    if let Some(m) = section_prefix_regex().find(s) {
+        &s[m.end()..]
+    } else {
+        s
+    }
+}
+
+/// Heading heuristic: `true` if the trimmed text begins with a recognized
+/// section prefix (`A2.a`, `1.1`, `Section 4:`, `IV.`) AND the next word
+/// after the prefix begins with an uppercase letter. The uppercase guard
+/// rejects measurement strings (`"1.2 million users"`) and instruction
+/// items (`"1. take action"`) that match the prefix but are not headings.
+fn numeric_prefix_title(f: &TextFragment) -> bool {
+    let trimmed = f.text.trim();
+    let char_count = trimmed.chars().count();
+    if char_count == 0 || char_count > MAX_NUMERIC_TITLE_LEN {
+        return false;
+    }
+    if !matches_section_prefix(trimmed) {
+        return false;
+    }
+    let rest = strip_section_prefix(trimmed).trim_start();
+    matches!(rest.chars().next(), Some(c) if c.is_uppercase())
+}
+
+/// Classification class implied by a PDF structural tag (`/H1`, `/L`, `/Artifact`, ...).
+///
+/// Returned by [`classify_by_struct_tag`] when the tag carries an unambiguous
+/// document-role signal. Pass-through tags (`/P`, `/Span`, ...) return `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StructTagClass {
+    Heading,
+    List,
+    ListItem,
+    Artifact,
+}
+
+/// Map a PDF structural tag string to a partitioner classification class.
+///
+/// Recognizes the heading family (`H`, `H1..H6`, `Title`), list family
+/// (`L`, `LI`, `Lbl`, `LBody`), and `Artifact`. Returns `None` for
+/// pass-through tags (`P`, `Span`, `Figure`, ...) so the fragment flows
+/// into the heuristic classifier.
+fn classify_by_struct_tag(tag: &str) -> Option<StructTagClass> {
+    match tag {
+        "H" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "Title" => Some(StructTagClass::Heading),
+        "L" => Some(StructTagClass::List),
+        "LI" | "Lbl" | "LBody" => Some(StructTagClass::ListItem),
+        "Artifact" => Some(StructTagClass::Artifact),
+        _ => None,
+    }
+}
+
+/// `true` when the struct tag indicates body content (paragraph, span, heading,
+/// list item). Used by Header/Footer detection to skip claiming fragments whose
+/// author has already declared them as body. `None` (no tag) returns `false`
+/// because absence of evidence does not imply body; `Artifact` returns `false`
+/// because artifacts ARE page furniture.
+fn struct_tag_is_body(tag: &Option<String>) -> bool {
+    let Some(t) = tag.as_deref() else {
+        return false;
+    };
+    matches!(
+        t,
+        "P" | "Span"
+            | "H"
+            | "H1"
+            | "H2"
+            | "H3"
+            | "H4"
+            | "H5"
+            | "H6"
+            | "Title"
+            | "L"
+            | "LI"
+            | "Lbl"
+            | "LBody"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_heading_tags() {
+        for tag in &["H", "H1", "H2", "H3", "H4", "H5", "H6", "Title"] {
+            assert_eq!(
+                classify_by_struct_tag(tag),
+                Some(StructTagClass::Heading),
+                "tag {tag} should classify as Heading"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_list_tags() {
+        assert_eq!(classify_by_struct_tag("L"), Some(StructTagClass::List));
+        assert_eq!(classify_by_struct_tag("LI"), Some(StructTagClass::ListItem));
+        assert_eq!(
+            classify_by_struct_tag("Lbl"),
+            Some(StructTagClass::ListItem)
+        );
+        assert_eq!(
+            classify_by_struct_tag("LBody"),
+            Some(StructTagClass::ListItem)
+        );
+    }
+
+    #[test]
+    fn classify_by_struct_tag_recognizes_artifact() {
+        assert_eq!(
+            classify_by_struct_tag("Artifact"),
+            Some(StructTagClass::Artifact)
+        );
+    }
+
+    #[test]
+    fn classify_by_struct_tag_returns_none_for_passthrough_tags() {
+        for tag in &[
+            "P", "Span", "Figure", "Table", "Caption", "Form", "Note", "Random",
+        ] {
+            assert_eq!(
+                classify_by_struct_tag(tag),
+                None,
+                "tag {tag} should be None (fall through)"
+            );
+        }
+    }
+
+    #[test]
+    fn struct_tag_is_body_recognizes_body_tags() {
+        for tag in &[
+            "P", "Span", "L", "LI", "H1", "H2", "H6", "Title", "Lbl", "LBody",
+        ] {
+            assert!(
+                struct_tag_is_body(&Some(tag.to_string())),
+                "tag {tag} should be body"
+            );
+        }
+    }
+
+    #[test]
+    fn struct_tag_is_body_returns_false_for_artifact() {
+        assert!(!struct_tag_is_body(&Some("Artifact".to_string())));
+    }
+
+    #[test]
+    fn struct_tag_is_body_returns_false_for_none() {
+        assert!(!struct_tag_is_body(&None));
+    }
+
+    fn frag(text: &str, bold: bool, font_size: f64) -> TextFragment {
+        TextFragment {
+            text: text.to_string(),
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 12.0,
+            font_size,
+            font_name: None,
+            is_bold: bold,
+            is_italic: false,
+            color: None,
+            space_decisions: Vec::new(),
+            mcid: None,
+            struct_tag: None,
+        }
+    }
+
+    #[test]
+    fn ends_with_sentence_terminator_table() {
+        assert!(ends_with_sentence_terminator("This is a paragraph."));
+        assert!(ends_with_sentence_terminator("Really?"));
+        assert!(ends_with_sentence_terminator("Stop!"));
+        assert!(!ends_with_sentence_terminator("Section heading"));
+        assert!(!ends_with_sentence_terminator("A2.a Risk Management"));
+        assert!(!ends_with_sentence_terminator(""));
+    }
+
+    #[test]
+    fn bold_short_title_accepts_bold_short_no_terminator() {
+        assert!(bold_short_title(&frag("Section Heading", true, 12.0)));
+        assert!(bold_short_title(&frag("Principle A2", true, 11.0)));
+    }
+
+    #[test]
+    fn bold_short_title_rejects_non_bold() {
+        assert!(!bold_short_title(&frag("Section Heading", false, 12.0)));
+    }
+
+    #[test]
+    fn bold_short_title_rejects_long_text() {
+        let long = "x".repeat(150);
+        assert!(!bold_short_title(&frag(&long, true, 12.0)));
+    }
+
+    #[test]
+    fn bold_short_title_rejects_sentence_with_period() {
+        assert!(!bold_short_title(&frag(
+            "This is a complete sentence.",
+            true,
+            12.0
+        )));
+    }
+
+    #[test]
+    fn bold_short_title_rejects_empty() {
+        assert!(!bold_short_title(&frag("   ", true, 12.0)));
+    }
+
+    #[test]
+    fn numeric_prefix_title_accepts_known_patterns() {
+        let cases = &[
+            "A2.a Risk Management Process",
+            "A1.b Roles and Responsibilities",
+            "1.1 Overview",
+            "3.2.1 Detailed Requirements",
+            "Section 4: Implementation",
+            "Chapter 7 Conclusion",
+            "IV. Findings",
+        ];
+        for c in cases {
+            assert!(
+                numeric_prefix_title(&frag(c, false, 12.0)),
+                "should match: {c}"
+            );
+        }
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_money_amount() {
+        assert!(!numeric_prefix_title(&frag(
+            "1.2 million users were affected",
+            false,
+            12.0
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_version_string() {
+        assert!(!numeric_prefix_title(&frag(
+            "version 3.0.1 release notes",
+            false,
+            12.0
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_lowercase_continuation() {
+        assert!(!numeric_prefix_title(&frag(
+            "1. take action now",
+            false,
+            12.0
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_text_without_prefix() {
+        assert!(!numeric_prefix_title(&frag(
+            "Overview of the system",
+            false,
+            12.0
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_too_long() {
+        let mut s = String::from("A2.a ");
+        s.push_str(&"X".repeat(220));
+        assert!(!numeric_prefix_title(&frag(&s, false, 12.0)));
+    }
+
+    // --- Partitioner-level integration tests (issue #271 wiring) ---
+
+    fn frag_at(text: &str, x: f64, y: f64, font_size: f64) -> TextFragment {
+        TextFragment {
+            text: text.to_string(),
+            x,
+            y,
+            width: 100.0,
+            height: font_size,
+            font_size,
+            font_name: None,
+            is_bold: false,
+            is_italic: false,
+            color: None,
+            space_decisions: Vec::new(),
+            mcid: None,
+            struct_tag: None,
+        }
+    }
+
+    #[test]
+    fn struct_tag_h1_yields_title_no_font_ratio_needed() {
+        let mut f = frag_at("Section One", 50.0, 400.0, 12.0);
+        f.struct_tag = Some("H1".to_string());
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn struct_tag_p_overrides_bold_short_heuristic() {
+        let mut f = frag_at("Bold Short Text", 50.0, 400.0, 12.0);
+        f.is_bold = true;
+        f.struct_tag = Some("P".to_string());
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert!(elements.iter().any(|e| matches!(e, Element::Paragraph(_))));
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn bold_short_title_fires_without_struct_tag() {
+        let mut f = frag_at("Risk Management", 50.0, 400.0, 12.0);
+        f.is_bold = true;
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count(),
+            1,
+            "bold-short heuristic must fire when no other signals present"
+        );
+    }
+
+    #[test]
+    fn numeric_prefix_title_fires_without_bold() {
+        let f = frag_at("A2.a Risk Management Process", 50.0, 400.0, 12.0);
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count(),
+            1,
+            "numeric-prefix heuristic must fire on NCSC-style sections"
+        );
+    }
+
+    #[test]
+    fn struct_tag_li_yields_list_item() {
+        let mut f = frag_at("Bullet content", 50.0, 400.0, 12.0);
+        f.struct_tag = Some("LI".to_string());
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::ListItem(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn font_ratio_title_still_works() {
+        let mut frags = vec![];
+        for i in 0..5 {
+            frags.push(frag_at(
+                &format!("body line {i}"),
+                50.0,
+                400.0 - (i as f64) * 15.0,
+                12.0,
+            ));
+        }
+        frags.push(frag_at("Big Heading", 50.0, 500.0, 20.0));
+
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count()
+                >= 1,
+            "font-ratio Title path must still fire"
+        );
+    }
+
+    #[test]
+    fn header_zone_rejects_long_text() {
+        // page_height=800, header_zone=0.05 → threshold y >= 760.
+        // Fragment at y=780 (in zone) but text = 200 chars → not Header.
+        let long = "X".repeat(200);
+        let frags = vec![frag_at(&long, 50.0, 780.0, 12.0)];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        let header_count = elements
+            .iter()
+            .filter(|e| matches!(e, Element::Header(_)))
+            .count();
+        assert_eq!(
+            header_count, 0,
+            "long text in header zone must not classify as Header"
+        );
+    }
+
+    #[test]
+    fn header_zone_accepts_short_text() {
+        let frags = vec![frag_at("My Report 2026", 50.0, 780.0, 12.0)];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert!(
+            elements.iter().any(|e| matches!(e, Element::Header(_))),
+            "short text in header zone must classify as Header"
+        );
+    }
+
+    #[test]
+    fn header_zone_rejects_p_struct_tag() {
+        let mut f = frag_at("Short body text", 50.0, 780.0, 12.0);
+        f.struct_tag = Some("P".to_string());
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        let header_count = elements
+            .iter()
+            .filter(|e| matches!(e, Element::Header(_)))
+            .count();
+        assert_eq!(header_count, 0);
+    }
+
+    #[test]
+    fn footer_zone_rejects_long_text() {
+        let long = "X".repeat(200);
+        let frags = vec![frag_at(&long, 50.0, 10.0, 12.0)];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        let footer_count = elements
+            .iter()
+            .filter(|e| matches!(e, Element::Footer(_)))
+            .count();
+        assert_eq!(footer_count, 0);
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -382,12 +382,14 @@ impl Partitioner {
             }
 
             // 4. Title detection — three OR'd signals (issue #271).
-            //    struct_tag=P/Span explicitly marks body content; in that case
-            //    the bold-short and numeric-prefix heuristics are suppressed,
-            //    but a strong font-ratio signal still wins (defensive: tagged
-            //    PDFs occasionally mis-mark display text as P).
-            let struct_tag_blocks_heuristic =
-                matches!(f.struct_tag.as_deref(), Some("P") | Some("Span"));
+            //    struct_tag=P/Span suppresses the weaker bold-short heuristic
+            //    (too easy to misfire on emphasized words inside paragraphs).
+            //    Font-ratio and numeric-prefix heuristics still fire under P:
+            //    real-world tagged PDFs (notably NCSC CAF v4.0) ship sub-section
+            //    headings like "A2.a Risk Management Process" tagged as P;
+            //    numeric_prefix_title's shape + capitalization guard is strict
+            //    enough to win over the (mis)tag.
+            let p_or_span = matches!(f.struct_tag.as_deref(), Some("P") | Some("Span"));
 
             let mut is_title = false;
             let mut title_confidence = 0.0_f64;
@@ -402,14 +404,14 @@ impl Partitioner {
                 ));
             }
 
-            // 4b. Bold-short heuristic
-            if !struct_tag_blocks_heuristic && bold_short_title(f) {
+            // 4b. Bold-short heuristic — suppressed by P/Span.
+            if !p_or_span && bold_short_title(f) {
                 is_title = true;
                 title_confidence = title_confidence.max(0.7);
             }
 
-            // 4c. Numeric-prefix heuristic
-            if !struct_tag_blocks_heuristic && numeric_prefix_title(f) {
+            // 4c. Numeric-prefix heuristic — fires even under P (strict pattern).
+            if numeric_prefix_title(f) {
                 is_title = true;
                 title_confidence = title_confidence.max(0.8);
             }
@@ -751,7 +753,8 @@ fn compute_kv_confidence(key: &str) -> f64 {
 
 const MAX_HEADER_TEXT_LEN: usize = 100;
 const MAX_BOLD_TITLE_LEN: usize = 120;
-const MAX_NUMERIC_TITLE_LEN: usize = 200;
+const MAX_NUMERIC_TITLE_LEN: usize = 120;
+const MAX_NUMERIC_TITLE_WORDS: usize = 14;
 
 /// `true` when the trimmed text ends with `.`, `!`, or `?`. Used by the
 /// bold-short heading heuristic to exclude complete sentences.
@@ -805,9 +808,16 @@ fn strip_section_prefix(s: &str) -> &str {
 
 /// Heading heuristic: `true` if the trimmed text begins with a recognized
 /// section prefix (`A2.a`, `1.1`, `Section 4:`, `IV.`) AND the next word
-/// after the prefix begins with an uppercase letter. The uppercase guard
-/// rejects measurement strings (`"1.2 million users"`) and instruction
-/// items (`"1. take action"`) that match the prefix but are not headings.
+/// after the prefix begins with an uppercase letter.
+///
+/// The uppercase guard rejects measurement strings (`"1.2 million users"`)
+/// and instruction items (`"1. take action"`) that match the prefix but
+/// are not headings.
+///
+/// Additional guards: real headings rarely contain commas (sentences do)
+/// and rarely exceed [`MAX_NUMERIC_TITLE_LEN`] chars; an ordered list item
+/// that starts with `"N. La ..."` followed by 100+ chars of prose is
+/// almost certainly body text in a Romance-language document, not a heading.
 fn numeric_prefix_title(f: &TextFragment) -> bool {
     let trimmed = f.text.trim();
     let char_count = trimmed.chars().count();
@@ -818,7 +828,26 @@ fn numeric_prefix_title(f: &TextFragment) -> bool {
         return false;
     }
     let rest = strip_section_prefix(trimmed).trim_start();
-    matches!(rest.chars().next(), Some(c) if c.is_uppercase())
+    if !matches!(rest.chars().next(), Some(c) if c.is_uppercase()) {
+        return false;
+    }
+    // Sentence-body discriminator: comma presence almost always indicates
+    // prose rather than a heading. Tradeoff: rare headings with commas
+    // ("Section 1: Foundations, Architecture, and Design") are missed,
+    // but the false-positive rate on Spanish/French ordered lists is much
+    // worse without this guard.
+    if trimmed.contains(',') {
+        return false;
+    }
+    // Word-count guard: numbered headings in Spanish/legal text are short
+    // (typically <= 14 words). Numbered list items that form full
+    // sentences run much longer ("1. La vigilancia continua permitira la
+    // deteccion de actividades o comportamientos anomalos y su oportuna
+    // respuesta." = 17 words).
+    if trimmed.split_whitespace().count() > MAX_NUMERIC_TITLE_WORDS {
+        return false;
+    }
+    true
 }
 
 /// Classification class implied by a PDF structural tag (`/H1`, `/L`, `/Artifact`, ...).
@@ -1069,6 +1098,36 @@ mod tests {
         assert!(!numeric_prefix_title(&frag(&s, false, 12.0)));
     }
 
+    #[test]
+    fn numeric_prefix_title_rejects_text_with_comma() {
+        // Spanish/French ordered list items: "1. La vigilancia, la deteccion, ..."
+        // are body sentences, not headings.
+        assert!(!numeric_prefix_title(&frag(
+            "1. La vigilancia continua permite detectar amenazas, vulnerabilidades y errores.",
+            false,
+            12.0,
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_long_sentence_without_comma() {
+        // Spanish numbered paragraph without commas but with many words:
+        // 17 words, no comma, ends in period. Must NOT be classified as Title.
+        assert!(!numeric_prefix_title(&frag(
+            "1. La vigilancia continua permitira la deteccion de actividades o comportamientos anomalos y su oportuna respuesta.",
+            false,
+            12.0,
+        )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_just_over_max_len() {
+        // Heading-like prefix but text length 121 chars > MAX_NUMERIC_TITLE_LEN.
+        let mut s = String::from("A2.a Risk Management ");
+        s.push_str(&"X".repeat(120));
+        assert!(!numeric_prefix_title(&frag(&s, false, 12.0)));
+    }
+
     // --- Partitioner-level integration tests (issue #271 wiring) ---
 
     fn frag_at(text: &str, x: f64, y: f64, font_size: f64) -> TextFragment {
@@ -1103,6 +1162,28 @@ mod tests {
                 .filter(|e| matches!(e, Element::Title(_)))
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn struct_tag_p_does_not_block_numeric_prefix_title() {
+        // Real NCSC pattern: sub-section headings like "A2.a Risk Management Process"
+        // are tagged P (only top-level "Principle Ax" carries H1). The numeric-prefix
+        // pattern is strict enough to fire even under P; without this, ~26 NCSC
+        // sub-section titles would be lost to the Paragraph classifier.
+        let mut f = frag_at("A2.a Risk Management Process", 50.0, 400.0, 12.0);
+        f.struct_tag = Some("P".to_string());
+        let frags = vec![f];
+        let partitioner = Partitioner::new(PartitionConfig::default());
+        let elements = partitioner.partition_fragments(&frags, 0, 800.0);
+
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| matches!(e, Element::Title(_)))
+                .count(),
+            1,
+            "numeric-prefix heuristic must fire even when struct_tag=P (NCSC sub-sections)"
         );
     }
 

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -827,6 +827,15 @@ fn numeric_prefix_title(f: &TextFragment) -> bool {
     if !matches_section_prefix(trimmed) {
         return false;
     }
+    // List-marker discriminator: a flat single-level numbered marker
+    // ("1. ", "10) ") is an ordered-list item, never a heading. Real
+    // headings carry multi-level ("3.1", "4.1.1"), lettered ("A2.a"),
+    // "Section N"/"Chapter N", or roman ("IV.") prefixes — none of which
+    // `is_list_item` recognizes. Yielding to ListItem here keeps Title and
+    // ListItem mutually exclusive on the ambiguous bare-integer prefix.
+    if is_list_item(trimmed) {
+        return false;
+    }
     let rest = strip_section_prefix(trimmed).trim_start();
     if !matches!(rest.chars().next(), Some(c) if c.is_uppercase()) {
         return false;
@@ -1080,6 +1089,25 @@ mod tests {
             false,
             12.0
         )));
+    }
+
+    #[test]
+    fn numeric_prefix_title_rejects_flat_numbered_list_marker() {
+        // Single-level "N. Word" / "N) Word" is an ordered-list item, not a
+        // heading — it must yield to is_list_item (regression for #271 / PR #276).
+        for c in &["1. First item", "2. Second item", "10) Tenth item"] {
+            assert!(
+                !numeric_prefix_title(&frag(c, false, 12.0)),
+                "flat numbered list marker must not be a Title: {c}"
+            );
+        }
+        // Multi-level and lettered prefixes remain headings.
+        for c in &["1.1 Overview", "A2.a Risk Management Process"] {
+            assert!(
+                numeric_prefix_title(&frag(c, false, 12.0)),
+                "multi-level/lettered prefix must remain a Title: {c}"
+            );
+        }
     }
 
     #[test]

--- a/oxidize-pdf-core/tests/partition_classifier_regression_test.rs
+++ b/oxidize-pdf-core/tests/partition_classifier_regression_test.rs
@@ -1,0 +1,153 @@
+//! Issue #271 — regression guards for partitioner classifier on the
+//! Higgs, BSI, ENS, and BOE corpora.
+//!
+//! Goal: ensure the heading-detection improvements done for NCSC do not
+//! degrade Title counts on other corpora and do not introduce body
+//! misclassification as Header.
+//!
+//! All tests skip gracefully (eprintln + return) if the cached fixture
+//! file is missing. Hashes map to URLs in `examples/rag_realworld.rs`.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::Element;
+use std::path::PathBuf;
+
+const HIGGS_HASH: &str = "60dcd5ef562aff29.pdf";
+const BSI_HASH: &str = "b9cf1a025b683adf.pdf";
+const ENS_HASH: &str = "6a001a0684cd51ca.pdf";
+
+fn corpus_path(hash: &str) -> Option<PathBuf> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("corpus_cache")
+        .join(hash);
+    if p.exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+fn partition_corpus(path: &PathBuf) -> Vec<Element> {
+    let reader = PdfReader::open(path).expect("open corpus");
+    let document = PdfDocument::new(reader);
+    document.partition().expect("partition corpus")
+}
+
+fn count_titles(elements: &[Element]) -> usize {
+    elements
+        .iter()
+        .filter(|e| matches!(e, Element::Title(_)))
+        .count()
+}
+
+fn count_long_headers(elements: &[Element]) -> usize {
+    elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .filter(|e| e.text().chars().count() > 100)
+        .count()
+}
+
+fn count_total_headers(elements: &[Element]) -> usize {
+    elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .count()
+}
+
+/// Higgs (arXiv 1207.7214) is a tagged academic paper that ships abundant
+/// H1/H2/H3 BDC tags. Pre-#271 baseline produced 205 Element::Title;
+/// the floor of 100 leaves comfortable room for incidental classifier
+/// changes without losing the signal.
+#[test]
+fn higgs_yields_at_least_100_titles() {
+    let Some(path) = corpus_path(HIGGS_HASH) else {
+        eprintln!("higgs regression test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let titles = count_titles(&elements);
+    assert!(
+        titles >= 100,
+        "Higgs (arXiv 1207.7214) Title count regressed: got {titles}, expected >= 100"
+    );
+}
+
+/// BSI TR-02102 is a German technical report with clear section structure.
+/// Pre-#271 baseline produced 125 Element::Title; floor at 80.
+#[test]
+fn bsi_yields_at_least_80_titles() {
+    let Some(path) = corpus_path(BSI_HASH) else {
+        eprintln!("bsi regression test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let titles = count_titles(&elements);
+    assert!(
+        titles >= 80,
+        "BSI TR-02102 Title count regressed: got {titles}, expected >= 80"
+    );
+}
+
+/// ENS (BOE Real Decreto 311/2022) is a Spanish government regulation
+/// with numbered article structure. Pre-#271 baseline produced 3
+/// Element::Title (only large-font ones); post-#271 detects hundreds
+/// of legitimate "Articulo N", "N.N", "N.N.N" numbered section headings.
+/// Floor at 50 — well above the original 3 to demonstrate the heuristic
+/// is firing, and below the actual ~100+ to absorb minor heuristic
+/// retuning in the future.
+#[test]
+fn ens_yields_at_least_50_titles() {
+    let Some(path) = corpus_path(ENS_HASH) else {
+        eprintln!("ens regression test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let titles = count_titles(&elements);
+    assert!(
+        titles >= 50,
+        "ENS Title count regressed: got {titles}, expected >= 50"
+    );
+}
+
+/// Combined regression on long-text Header misclassification across all
+/// three tagged corpora. Per Bug A in #271, no Element::Header should
+/// have text length > 100 chars. The pre-#271 baseline already had a
+/// low rate on these corpora (tagged PDFs rarely put body text at
+/// page-top Y positions); this test guards against future regressions
+/// while NCSC is locked in by `partition_ncsc_classifier_test.rs`.
+#[test]
+fn no_long_headers_across_corpora() {
+    let mut total_long = 0usize;
+    let mut total_headers = 0usize;
+    let mut checked = Vec::new();
+
+    for (slug, hash) in &[("higgs", HIGGS_HASH), ("bsi", BSI_HASH), ("ens", ENS_HASH)] {
+        let Some(path) = corpus_path(hash) else {
+            continue;
+        };
+        let elements = partition_corpus(&path);
+        let long = count_long_headers(&elements);
+        let total = count_total_headers(&elements);
+        total_long += long;
+        total_headers += total;
+        checked.push((*slug, long, total));
+    }
+
+    if checked.is_empty() {
+        eprintln!("no_long_headers_across_corpora: no corpus fixtures available, skipping");
+        return;
+    }
+
+    let report = checked
+        .iter()
+        .map(|(s, l, t)| format!("{s}: {l}/{t}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    assert_eq!(
+        total_long, 0,
+        "long-text Header count must be 0 across corpora; got total_long={total_long}, total_headers={total_headers}; per-corpus: {report}"
+    );
+}

--- a/oxidize-pdf-core/tests/partition_ncsc_classifier_test.rs
+++ b/oxidize-pdf-core/tests/partition_ncsc_classifier_test.rs
@@ -1,0 +1,116 @@
+//! Issue #271 — NCSC CAF v4.0 partitioner classifier verification.
+//!
+//! Fixture: `corpus_cache/e0e3ff11371c09c2.pdf`. If missing, the tests
+//! `eprintln!` a skip notice and return — they do NOT fail (matches the
+//! pattern of `ncsc_no_alphabet_soup_test.rs`).
+//!
+//! Locks in two regressions:
+//! 1. Body paragraphs at the top of NCSC table pages used to be claimed
+//!    as `Element::Header`. Post-fix: 0 long-text headers.
+//! 2. Section headings (`"Principle Ax"`, `"Ax.y Foo"`) used to produce
+//!    0 `Element::Title`. Post-fix: >= 30 Titles, with at least one
+//!    `"Principle "` and one alphanumeric section.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::Element;
+use std::path::PathBuf;
+
+const NCSC_FIXTURE_HASH: &str = "e0e3ff11371c09c2.pdf";
+
+fn ncsc_path() -> Option<PathBuf> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("corpus_cache")
+        .join(NCSC_FIXTURE_HASH);
+    if p.exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+fn partition_corpus(path: &PathBuf) -> Vec<Element> {
+    let reader = PdfReader::open(path).expect("open NCSC corpus");
+    let document = PdfDocument::new(reader);
+    document.partition().expect("partition NCSC corpus")
+}
+
+#[test]
+fn ncsc_caf_v4_yields_at_least_30_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let title_count = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Title(_)))
+        .count();
+    assert!(
+        title_count >= 30,
+        "NCSC CAF v4.0 must yield >= 30 Titles (got {title_count})"
+    );
+}
+
+#[test]
+fn ncsc_caf_v4_no_body_text_in_headers() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let long_headers: Vec<&Element> = elements
+        .iter()
+        .filter(|e| matches!(e, Element::Header(_)))
+        .filter(|e| e.text().chars().count() > 100)
+        .collect();
+    assert!(
+        long_headers.is_empty(),
+        "NCSC CAF v4.0 must not classify long body text as Header (found {} offenders, e.g. \"{}\")",
+        long_headers.len(),
+        long_headers.first().map(|e| e.text()).unwrap_or("")
+    );
+}
+
+#[test]
+fn ncsc_caf_v4_contains_principle_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let has_principle = elements.iter().any(|e| match e {
+        Element::Title(d) => d.text.starts_with("Principle "),
+        _ => false,
+    });
+    assert!(
+        has_principle,
+        "NCSC CAF v4.0 must contain at least one 'Principle Ax' Title"
+    );
+}
+
+#[test]
+fn ncsc_caf_v4_contains_section_titles() {
+    let Some(path) = ncsc_path() else {
+        eprintln!("ncsc classifier test: corpus missing, skipping");
+        return;
+    };
+    let elements = partition_corpus(&path);
+    let has_section = elements.iter().any(|e| match e {
+        Element::Title(d) => {
+            // Section pattern: uppercase letter + digit + `.` + lowercase letter (e.g. "A2.a", "A1.b").
+            let trimmed = d.text.trim();
+            let bytes = trimmed.as_bytes();
+            bytes.len() >= 4
+                && bytes[0].is_ascii_uppercase()
+                && bytes[1].is_ascii_digit()
+                && bytes[2] == b'.'
+                && bytes[3].is_ascii_lowercase()
+        }
+        _ => false,
+    });
+    assert!(
+        has_section,
+        "NCSC CAF v4.0 must contain at least one 'Ax.y' section Title"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses #271 — partitioner misclassifies NCSC headings and body text on tightly-spaced structured PDFs.

- **Bug A (NCSC: 115 body paragraphs tagged `header`, 75 of them >100 chars):** Header detection now requires `text length ≤ 100 chars` AND `struct_tag` is not body-tagged (P, Span, H1..H6, Title, L, LI, Lbl, LBody). Length cap + tag gate prevent reclaiming tightly-packed table rows as page headers.
- **Bug B (NCSC: 0 Element::Title):** Partitioner now consumes `TextFragment.struct_tag` (populated by #269 Phase 1 — previously dead data on the read side). Title detection now OR-combines three signals:
  - existing font-size ratio
  - bold-short heuristic (≤120 chars, no terminator)
  - numeric-prefix heuristic (`A2.a`, `1.1`, `Section 4:`, `IV.` with strict guards: ≤120 chars / ≤14 words / no comma / uppercase next letter)

The numeric-prefix heuristic fires even under `struct_tag=P` (NCSC tags sub-section headings as P; only top-level "Principle Ax" carries H1). The bold-short heuristic stays suppressed under P/Span (weaker signal).

## Before / After (rag_realworld 5/5)

| Corpus | Long-text Headers (was → now) | Element::Title (was → now) |
|---|---|---|
| NCSC CAF v4.0 | **75 → 0** ✓ | **0 → 57** ✓ (>= 30 floor) |
| Higgs (arXiv 1207.7214) | 0 → 0 | 205 → 215 |
| BSI TR-02102 | 0 → 0 | 125 → 149 |
| ENS (Real Decreto 311/2022) | 0 → 0 | 3 → 107 (Spanish numbered articles now detected) |
| BOE-Sumario | 0 → 0 | 0 → 5 |

NCSC sample titles after fix: `"Principle A1 Governance"`, `"A1.a Board Direction"`, `"A1.b Roles and Responsibilities"`, `"A1.c Decision-making"`, `"A2.a Risk Management Process"`, `"A3.a Asset Management"`, etc. — exactly the headings the issue called out.

## Detailed changes

### `oxidize-pdf-core/src/pipeline/partition.rs`

- New module-level constants: `MAX_HEADER_TEXT_LEN=100`, `MAX_BOLD_TITLE_LEN=120`, `MAX_NUMERIC_TITLE_LEN=120`, `MAX_NUMERIC_TITLE_WORDS=14`.
- New private enum `StructTagClass { Heading, List, ListItem, Artifact }` and helper `classify_by_struct_tag(&str) -> Option<StructTagClass>`.
- New helper `struct_tag_is_body(&Option<String>) -> bool` — used by Header/Footer gate.
- New helpers `ends_with_sentence_terminator`, `bold_short_title`, `section_prefix_regex` (`OnceLock`), `matches_section_prefix`, `strip_section_prefix`, `numeric_prefix_title`.
- `Partitioner::partition_fragments` gains a Step 0 (struct_tag-driven classification) before the existing Header/Footer step. Step 1 (Header/Footer) gains the length cap and body-tag gate. Step 4 (Title) extends with bold-short and numeric-prefix signals.
- 35 unit tests in `mod tests` cover helpers, individual heuristics, and `Partitioner::partition_fragments` end-to-end behavior.

### `oxidize-pdf-core/tests/partition_ncsc_classifier_test.rs` (NEW)

4 tests locked against `corpus_cache/e0e3ff11371c09c2.pdf` (skip-not-fail if absent):
- `ncsc_caf_v4_yields_at_least_30_titles`
- `ncsc_caf_v4_no_body_text_in_headers`
- `ncsc_caf_v4_contains_principle_titles`
- `ncsc_caf_v4_contains_section_titles` (asserts pattern `[A-Z]\d\.[a-z]`)

### `oxidize-pdf-core/tests/partition_classifier_regression_test.rs` (NEW)

4 regression tests on Higgs/BSI/ENS (skip-not-fail if absent):
- `higgs_yields_at_least_100_titles` (baseline 205)
- `bsi_yields_at_least_80_titles` (baseline 125)
- `ens_yields_at_least_50_titles` (baseline 3 → now 107, floor 50)
- `no_long_headers_across_corpora` (combined long-Header count must be 0)

### `docs/superpowers/{specs,plans}/2026-05-28-issue-271-partitioner-classifier{,-design}.md` (NEW)

Design spec + 10-task TDD plan. Spec documents the dual bug, the three-signal Title detection design, struct_tag precedence rules, and edge-case table.

## Test plan

- [x] `cargo test -p oxidize-pdf --lib` — 6474 / 0 failed (+33 vs develop)
- [x] `cargo test -p oxidize-pdf --tests --no-fail-fast` — 30 / 30 crates green (includes t1_pdfjs_corpus 51s, t3_zero_panics 159s, t6_adversarial)
- [x] `cargo clippy -p oxidize-pdf --lib -- -D warnings` clean
- [x] `cargo clippy -p oxidize-pdf --test partition_ncsc_classifier_test --test partition_classifier_regression_test -- -D warnings` clean
- [x] `cargo run --release --example rag_realworld` — 5/5 PDFs successful, 1063 total chunks (was 897)
- [x] Manual inspection of NCSC `out/ncsc-caf.jsonl` — Titles match the issue's "Principle Ax" + "Ax.y" call-out

## Scope

- In: `pipeline/partition.rs` only. Single-file change + 2 new test files + spec/plan docs.
- Out: BOE-Sumario heading detection still 0 (#272-class CFF font encoding root cause, separate issue closed in v2.10.0). Multi-fragment heading (heading wraps across two fragments). Cross-page running-header detection. Phase 2 of Tagged-PDF initiative (StructTreeRoot parsing).

## Compatibility

No public API change. No new crate dependencies (regex 1.10 already a runtime dep). No Cargo.toml change. PDFs without `struct_tag` (most of the corpus) see the heuristic improvements only; tagged PDFs see both struct_tag consumption and heuristics. No existing test deleted, weakened, or marked `#[ignore]`.

addresses #271