### PR TITLE
fix(ci): release/coverage debug-assert test gating + Node 24 action bump

### DIFF
--- a/.github/workflows/benchmark-baseline.yml.disabled
+++ b/.github/workflows/benchmark-baseline.yml.disabled
@@ -21,7 +21,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.inputs.branch }}
         
@@ -29,7 +29,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -81,7 +81,7 @@ jobs:
         git push origin ${{ github.ref_name }}
         
     - name: Upload baseline artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: benchmark-baseline
         path: .github/benchmarks/baseline/

--- a/.github/workflows/benchmark-pr.yml.disabled
+++ b/.github/workflows/benchmark-pr.yml.disabled
@@ -22,13 +22,13 @@ jobs:
 
     steps:
     - name: Checkout PR code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -85,7 +85,7 @@ jobs:
         fi
 
     - name: Upload benchmark results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: pr-benchmark-results

--- a/.github/workflows/benchmarks.yml.disabled
+++ b/.github/workflows/benchmarks.yml.disabled
@@ -24,7 +24,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -32,7 +32,7 @@ jobs:
         components: rustfmt, clippy
         
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
         cargo bench --package oxidize-pdf --bench batch_processing_benchmark
 
     - name: Archive benchmark results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: benchmark-results
@@ -111,13 +111,13 @@ jobs:
     
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -165,7 +165,7 @@ jobs:
         fi
         
     - name: Upload comparison results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: benchmark-comparison
         path: target/criterion/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         rust: [stable]
         # beta temporarily disabled - needs API updates for benchmarks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -44,13 +44,13 @@ jobs:
           echo "C:\Program Files\Tesseract-OCR" >> $env:GITHUB_PATH
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/corpus-tests.yml
+++ b/.github/workflows/corpus-tests.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -37,7 +37,7 @@ jobs:
           key: ${{ runner.os }}-cargo-corpus-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache T1 corpus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-corpus/t1-spec
           key: corpus-t1-v1
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: results-commit-${{ github.sha }}
           path: test-corpus/results/
@@ -71,14 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -87,13 +87,13 @@ jobs:
           key: ${{ runner.os }}-cargo-corpus-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache T2 corpus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-corpus/t2-realworld
           key: corpus-t2-v1
 
       - name: Cache T3 corpus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-corpus/t3-stress
           key: corpus-t3-v1
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: results-nightly-${{ github.run_id }}
           path: test-corpus/results/
@@ -127,14 +127,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -143,7 +143,7 @@ jobs:
           key: ${{ runner.os }}-cargo-corpus-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache weekly corpora
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             test-corpus/t4-ai-target
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: results-weekly-${{ github.run_id }}
           path: test-corpus/results/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -31,13 +31,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev poppler-utils
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: 45
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       version_tag: ${{ steps.check_conditions.outputs.version_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           
@@ -76,7 +76,7 @@ jobs:
     if: needs.verify-release-conditions.outputs.should_release == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Wait for CI checks to complete
         env:
@@ -141,7 +141,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,13 +150,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -175,7 +175,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: false

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -3878,7 +3878,12 @@ mod tests {
         assert_eq!(ctx.operations(), expected);
     }
 
+    // The empty-components guard is a `debug_assert!`, compiled out in release
+    // builds (`cargo test --release`, tarpaulin coverage). Gating these tests to
+    // `debug_assertions` keeps them honest: they only run where the assert fires.
+    // Without the gate they fail in release with "did not panic as expected".
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "ICC fill colour components must not be empty")]
     fn set_fill_color_icc_empty_components_panics_in_debug() {
         // An empty component list would emit a bare `sc` operator with no
@@ -3889,6 +3894,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "ICC stroke colour components must not be empty")]
     fn set_stroke_color_icc_empty_components_panics_in_debug() {
         let mut ctx = GraphicsContext::new();


### PR DESCRIPTION
Dos arreglos de salud de CI necesarios para republicar v2.11.0 (el job Release del tag falló y dejó crates.io en 2.10.0).

## 1. Tests should_panic sobre debug_assert! (release-blocking)

`graphics::tests::set_fill_color_icc_empty_components_panics_in_debug` y `_stroke_` usan `#[should_panic]` sobre el guard `debug_assert!` de `set_fill_color_icc`/`set_stroke_color_icc`. `debug_assert!` se compila fuera en release → en `cargo test --all --release` (release.yml) y `cargo tarpaulin --release` (coverage.yml) la función no panica → `test did not panic as expected`. CI pasaba por correr en debug. El job Release abortaba antes de `cargo publish`.

Fix: `#[cfg(debug_assertions)]` en ambos tests. Contrato runtime sin cambios. Verificación: release lib 6487 passed / 0 failed; debug 2 passed.

## 2. Bump de actions a runtimes Node 24

GitHub fuerza Node 20 → Node 24 el 2026-06-16 y elimina Node 20 el 2026-09-16. Cada action JS subida a su menor major ya en node24 (verificado con action.yml runs.using): checkout v4→v5, cache v3+v4→v5, upload-artifact v4→v6, codecov-action v3→v5 (composite), action-gh-release v1→v3. dtolnay/rust-toolchain sin cambios (composite). Workflows .disabled bumpeados por consistencia. YAML validado.

Addresses the v2.11.0 publish blocker + Node 20 deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)