### PR TITLE
feat(graphics): ICC colour spaces as conformant streams + typed colour-space bridges (#282, #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Added
+
+- `Page::add_icc_color_space(name, &IccProfile)` — register an ICC-profile-backed
+  colour space that the writer emits as a conformant `/ICCBased` **stream**
+  `[/ICCBased <ref>]` carrying the embedded profile bytes (ISO 32000-1 §8.6.5.5),
+  closing the gap where ICC profiles registered as `PageColorSpace::Parameterised`
+  were written as an inline dictionary with the profile data dropped (#282).
+- `impl From<&CalGrayColorSpace>` / `From<&CalRgbColorSpace>` / `From<&LabColorSpace>`
+  / `From<&IccProfile>` for `PageColorSpace`, plus `CalGrayColorSpace::params_dictionary`
+  / `CalRgbColorSpace::params_dictionary` / `LabColorSpace::params_dictionary` — bridge
+  typed calibrated/Lab/ICC colour-space structs directly into `Page::add_color_space`
+  without hand-building a parameter `Dictionary` (#283).
+- `PageColorSpace::IccStream` variant — stream-backed ICC colour space carrying the
+  raw profile bytes, `N`, `Alternate`, and optional `Range`.
+
+### Fixed
+
+- `ICCBased` colour spaces registered via the new `Page::add_icc_color_space` are now
+  emitted as conformant indirect streams with the embedded profile, instead of an inline
+  parameter dictionary that silently dropped the profile bytes (#282).
+
 ## [2.11.0] - 2026-05-30
 
 ### Added

--- a/oxidize-pdf-core/src/graphics/calibrated_color.rs
+++ b/oxidize-pdf-core/src/graphics/calibrated_color.rs
@@ -63,10 +63,11 @@ impl CalGrayColorSpace {
         Self::new().with_white_point([0.9504, 1.0000, 1.0888])
     }
 
-    /// Convert to PDF color space array
-    pub fn to_pdf_array(&self) -> Vec<Object> {
-        let mut array = vec![Object::Name("CalGray".to_string())];
-
+    /// Build the `CalGray` parameter dictionary (`WhitePoint`, optional
+    /// `BlackPoint`/`Gamma`). Single source of the dict shape, shared by
+    /// [`Self::to_pdf_array`] and the `PageColorSpace` bridge
+    /// (`impl From<&CalGrayColorSpace> for PageColorSpace`).
+    pub fn params_dictionary(&self) -> Dictionary {
         let mut dict = Dictionary::new();
 
         // White point (required)
@@ -88,8 +89,15 @@ impl CalGrayColorSpace {
             dict.set("Gamma", Object::Real(self.gamma));
         }
 
-        array.push(Object::Dictionary(dict));
-        array
+        dict
+    }
+
+    /// Convert to PDF color space array
+    pub fn to_pdf_array(&self) -> Vec<Object> {
+        vec![
+            Object::Name("CalGray".to_string()),
+            Object::Dictionary(self.params_dictionary()),
+        ]
     }
 
     /// Apply gamma correction to a gray value
@@ -181,10 +189,11 @@ impl CalRgbColorSpace {
         Self::new().with_white_point([0.9504, 1.0000, 1.0888])
     }
 
-    /// Convert to PDF color space array
-    pub fn to_pdf_array(&self) -> Vec<Object> {
-        let mut array = vec![Object::Name("CalRGB".to_string())];
-
+    /// Build the `CalRGB` parameter dictionary (`WhitePoint`, optional
+    /// `BlackPoint`/`Gamma`/`Matrix`). Single source of the dict shape, shared
+    /// by [`Self::to_pdf_array`] and the `PageColorSpace` bridge
+    /// (`impl From<&CalRgbColorSpace> for PageColorSpace`).
+    pub fn params_dictionary(&self) -> Dictionary {
         let mut dict = Dictionary::new();
 
         // White point (required)
@@ -218,8 +227,15 @@ impl CalRgbColorSpace {
             );
         }
 
-        array.push(Object::Dictionary(dict));
-        array
+        dict
+    }
+
+    /// Convert to PDF color space array
+    pub fn to_pdf_array(&self) -> Vec<Object> {
+        vec![
+            Object::Name("CalRGB".to_string()),
+            Object::Dictionary(self.params_dictionary()),
+        ]
     }
 
     /// Apply gamma correction to RGB values

--- a/oxidize-pdf-core/src/graphics/lab_color.rs
+++ b/oxidize-pdf-core/src/graphics/lab_color.rs
@@ -67,10 +67,11 @@ impl LabColorSpace {
         Self::new().with_white_point([0.9504, 1.0000, 1.0888])
     }
 
-    /// Convert to PDF color space array
-    pub fn to_pdf_array(&self) -> Vec<Object> {
-        let mut array = vec![Object::Name("Lab".to_string())];
-
+    /// Build the `Lab` parameter dictionary (`WhitePoint`, optional
+    /// `BlackPoint`/`Range`). Single source of the dict shape, shared by
+    /// [`Self::to_pdf_array`] and the `PageColorSpace` bridge
+    /// (`impl From<&LabColorSpace> for PageColorSpace`).
+    pub fn params_dictionary(&self) -> Dictionary {
         let mut dict = Dictionary::new();
 
         // White point (required)
@@ -95,8 +96,15 @@ impl LabColorSpace {
             );
         }
 
-        array.push(Object::Dictionary(dict));
-        array
+        dict
+    }
+
+    /// Convert to PDF color space array
+    pub fn to_pdf_array(&self) -> Vec<Object> {
+        vec![
+            Object::Name("Lab".to_string()),
+            Object::Dictionary(self.params_dictionary()),
+        ]
     }
 
     /// Convert Lab values to CIE XYZ

--- a/oxidize-pdf-core/src/graphics/page_color_space.rs
+++ b/oxidize-pdf-core/src/graphics/page_color_space.rs
@@ -20,9 +20,10 @@
 //! (the enum is `#[non_exhaustive]` to preserve that option).
 
 use super::calibrated_color::{CalGrayColorSpace, CalRgbColorSpace};
-use super::color_profiles::IccProfile;
+use super::color_profiles::{IccColorSpace, IccProfile};
 use super::lab_color::LabColorSpace;
 use crate::objects::{Dictionary, Object};
+use std::sync::Arc;
 
 /// A colour space eligible for registration on a [`crate::Page`] under
 /// `/Resources/ColorSpace/<name>`.
@@ -59,11 +60,17 @@ pub enum PageColorSpace {
     IccStream {
         /// Number of colour components (`/N`: 1, 3, or 4).
         n: u8,
-        /// Device colour space to fall back to (`/Alternate`).
+        /// Device colour space to fall back to (`/Alternate`). Must not be
+        /// `Pattern` (ISO 32000-1 §8.6.5.5 forbids it as an alternate space).
         alternate: DeviceColorSpace,
-        /// Raw ICC profile bytes, written verbatim into the stream.
-        profile_data: Vec<u8>,
-        /// Optional `/Range` for the components.
+        /// Raw ICC profile bytes, written verbatim into the stream. Wrapped in
+        /// `Arc` so cloning a `PageColorSpace` (e.g. when a templated page is
+        /// reused across a document) shares the buffer instead of copying a
+        /// potentially large profile.
+        profile_data: Arc<Vec<u8>>,
+        /// Optional `/Range` for the components. Omitted from the stream when
+        /// it equals the ISO 32000-1 §8.6.5.5 Table 66 default (`[0 1]` per
+        /// component); see [`Self::icc_stream_parts`].
         range: Option<Vec<f64>>,
     },
 }
@@ -141,30 +148,14 @@ impl PageColorSpace {
                 Object::Name(family.pdf_name().to_string()),
                 Object::Dictionary(params.clone()),
             ]),
-            // Inline fallback only. The conformant emission for ICC profiles is
-            // a stream (see `icc_stream_parts`); the writer routes `IccStream`
-            // there and never calls `to_object` for it. This arm keeps the
-            // method total and yields the non-stream `[/ICCBased <<dict>>]`
-            // shape (profile bytes omitted) should a caller invoke it directly.
-            PageColorSpace::IccStream {
-                n,
-                alternate,
-                range,
-                ..
-            } => {
-                let mut dict = Dictionary::new();
-                dict.set("N", Object::Integer(*n as i64));
-                dict.set("Alternate", Object::Name(alternate.pdf_name().to_string()));
-                if let Some(r) = range {
-                    dict.set(
-                        "Range",
-                        Object::Array(r.iter().map(|&x| Object::Real(x)).collect()),
-                    );
-                }
-                Object::Array(vec![
-                    Object::Name("ICCBased".to_string()),
-                    Object::Dictionary(dict),
-                ])
+            // `IccStream` has no inline `Object` form: a PDF stream MUST be an
+            // indirect object, so it cannot be inlined into the resource dict.
+            // The writer emits it via `icc_stream_parts` (allocating a stream
+            // object) and never routes `IccStream` through `to_object`. Reaching
+            // here is a programmer error — panic rather than silently emit a
+            // dict that drops the profile bytes.
+            PageColorSpace::IccStream { .. } => {
+                unreachable!("IccStream must be emitted via icc_stream_parts, not to_object")
             }
         }
     }
@@ -173,6 +164,11 @@ impl PageColorSpace {
     /// (`/N`, `/Alternate`, optional `/Range`) and the raw profile bytes for
     /// the writer to emit as an indirect stream object. Returns `None` for the
     /// inline (name / parameterised-dict) variants.
+    ///
+    /// `/Range` is omitted when it equals the ISO 32000-1 §8.6.5.5 Table 66
+    /// default (`[0 1]` per component), keeping the stream dict minimal for the
+    /// common device-range profiles while preserving non-default ranges (e.g.
+    /// Lab's `[0 100 -128 127 -128 127]`).
     pub(crate) fn icc_stream_parts(&self) -> Option<(Dictionary, Vec<u8>)> {
         match self {
             PageColorSpace::IccStream {
@@ -181,16 +177,25 @@ impl PageColorSpace {
                 profile_data,
                 range,
             } => {
+                debug_assert!(
+                    !matches!(alternate, DeviceColorSpace::Pattern),
+                    "/Alternate must not be Pattern (ISO 32000-1 §8.6.5.5)"
+                );
                 let mut dict = Dictionary::new();
                 dict.set("N", Object::Integer(*n as i64));
                 dict.set("Alternate", Object::Name(alternate.pdf_name().to_string()));
                 if let Some(r) = range {
-                    dict.set(
-                        "Range",
-                        Object::Array(r.iter().map(|&x| Object::Real(x)).collect()),
-                    );
+                    // The ICCBased default range is `[0 1]` per component; only
+                    // emit `/Range` when the profile deviates from it.
+                    let default: Vec<f64> = (0..*n).flat_map(|_| [0.0, 1.0]).collect();
+                    if *r != default {
+                        dict.set(
+                            "Range",
+                            Object::Array(r.iter().map(|&x| Object::Real(x)).collect()),
+                        );
+                    }
                 }
-                Some((dict, profile_data.clone()))
+                Some((dict, (**profile_data).clone()))
             }
             _ => None,
         }
@@ -235,17 +240,29 @@ impl From<&IccProfile> for PageColorSpace {
     /// Bridge an [`IccProfile`] into a stream-backed ICC colour space
     /// ([`PageColorSpace::IccStream`]), carrying the profile bytes so the
     /// writer emits a conformant `/ICCBased` stream (ISO 32000-1 §8.6.5.5).
-    /// `/Alternate` is the device space matching the component count.
+    ///
+    /// `/Alternate` is derived from the profile's semantic
+    /// [`IccColorSpace`](crate::graphics::IccColorSpace), not just its component
+    /// count. `Lab` profiles fall back to `DeviceRGB` — the closest device space
+    /// (`DeviceColorSpace` has no `Lab` variant; `DeviceRGB` is spec-valid as an
+    /// alternate per §8.6.5.5). `Generic(n)` maps by component count, defaulting
+    /// to `DeviceRGB` for component counts with no exact device space (2, 5, …);
+    /// such alternates are a best-effort fallback only.
     fn from(profile: &IccProfile) -> Self {
-        let alternate = match profile.components {
-            1 => DeviceColorSpace::Gray,
-            4 => DeviceColorSpace::Cmyk,
-            _ => DeviceColorSpace::Rgb,
+        let alternate = match profile.color_space {
+            IccColorSpace::Gray => DeviceColorSpace::Gray,
+            IccColorSpace::Cmyk => DeviceColorSpace::Cmyk,
+            IccColorSpace::Rgb | IccColorSpace::Lab => DeviceColorSpace::Rgb,
+            IccColorSpace::Generic(n) => match n {
+                1 => DeviceColorSpace::Gray,
+                4 => DeviceColorSpace::Cmyk,
+                _ => DeviceColorSpace::Rgb,
+            },
         };
         PageColorSpace::IccStream {
             n: profile.components,
             alternate,
-            profile_data: profile.data.clone(),
+            profile_data: Arc::new(profile.data.clone()),
             range: profile.range.clone(),
         }
     }

--- a/oxidize-pdf-core/src/graphics/page_color_space.rs
+++ b/oxidize-pdf-core/src/graphics/page_color_space.rs
@@ -19,6 +19,9 @@
 //! dedicated constructors added in a future SemVer-compatible superset
 //! (the enum is `#[non_exhaustive]` to preserve that option).
 
+use super::calibrated_color::{CalGrayColorSpace, CalRgbColorSpace};
+use super::color_profiles::IccProfile;
+use super::lab_color::LabColorSpace;
 use crate::objects::{Dictionary, Object};
 
 /// A colour space eligible for registration on a [`crate::Page`] under
@@ -42,6 +45,26 @@ pub enum PageColorSpace {
         /// Parameter dictionary — e.g. `WhitePoint`, `Gamma`, `Matrix`
         /// for CalRGB; `N`, `Alternate`, `Metadata` for ICCBased.
         params: Dictionary,
+    },
+    /// An ICC-profile-backed colour space emitted as a conformant indirect
+    /// **stream**: `[/ICCBased <ref>]` where `<ref>` resolves to a stream
+    /// `<< /N n /Alternate … /Range … >> stream <profile bytes> endstream`
+    /// (ISO 32000-1 §8.6.5.5). Unlike [`Self::Parameterised`] with
+    /// [`ParameterisedFamily::IccBased`] — which can only express an inline
+    /// dict and therefore drops the profile bytes — this variant carries the
+    /// raw profile so the writer can embed it. The stream object id is
+    /// allocated by the writer at emit time (a stream cannot be inlined into a
+    /// resource dict), so the conversion goes through
+    /// [`Self::icc_stream_parts`], not [`Self::to_object`].
+    IccStream {
+        /// Number of colour components (`/N`: 1, 3, or 4).
+        n: u8,
+        /// Device colour space to fall back to (`/Alternate`).
+        alternate: DeviceColorSpace,
+        /// Raw ICC profile bytes, written verbatim into the stream.
+        profile_data: Vec<u8>,
+        /// Optional `/Range` for the components.
+        range: Option<Vec<f64>>,
     },
 }
 
@@ -118,6 +141,112 @@ impl PageColorSpace {
                 Object::Name(family.pdf_name().to_string()),
                 Object::Dictionary(params.clone()),
             ]),
+            // Inline fallback only. The conformant emission for ICC profiles is
+            // a stream (see `icc_stream_parts`); the writer routes `IccStream`
+            // there and never calls `to_object` for it. This arm keeps the
+            // method total and yields the non-stream `[/ICCBased <<dict>>]`
+            // shape (profile bytes omitted) should a caller invoke it directly.
+            PageColorSpace::IccStream {
+                n,
+                alternate,
+                range,
+                ..
+            } => {
+                let mut dict = Dictionary::new();
+                dict.set("N", Object::Integer(*n as i64));
+                dict.set("Alternate", Object::Name(alternate.pdf_name().to_string()));
+                if let Some(r) = range {
+                    dict.set(
+                        "Range",
+                        Object::Array(r.iter().map(|&x| Object::Real(x)).collect()),
+                    );
+                }
+                Object::Array(vec![
+                    Object::Name("ICCBased".to_string()),
+                    Object::Dictionary(dict),
+                ])
+            }
+        }
+    }
+
+    /// If this is an [`Self::IccStream`], return the ICC stream dictionary
+    /// (`/N`, `/Alternate`, optional `/Range`) and the raw profile bytes for
+    /// the writer to emit as an indirect stream object. Returns `None` for the
+    /// inline (name / parameterised-dict) variants.
+    pub(crate) fn icc_stream_parts(&self) -> Option<(Dictionary, Vec<u8>)> {
+        match self {
+            PageColorSpace::IccStream {
+                n,
+                alternate,
+                profile_data,
+                range,
+            } => {
+                let mut dict = Dictionary::new();
+                dict.set("N", Object::Integer(*n as i64));
+                dict.set("Alternate", Object::Name(alternate.pdf_name().to_string()));
+                if let Some(r) = range {
+                    dict.set(
+                        "Range",
+                        Object::Array(r.iter().map(|&x| Object::Real(x)).collect()),
+                    );
+                }
+                Some((dict, profile_data.clone()))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<&CalGrayColorSpace> for PageColorSpace {
+    /// Bridge a typed [`CalGrayColorSpace`] into a registrable colour space,
+    /// reusing the struct's own [`CalGrayColorSpace::params_dictionary`]
+    /// (ISO 32000-1 §8.6.5.1).
+    fn from(cs: &CalGrayColorSpace) -> Self {
+        PageColorSpace::Parameterised {
+            family: ParameterisedFamily::CalGray,
+            params: cs.params_dictionary(),
+        }
+    }
+}
+
+impl From<&CalRgbColorSpace> for PageColorSpace {
+    /// Bridge a typed [`CalRgbColorSpace`] into a registrable colour space
+    /// (ISO 32000-1 §8.6.5.2).
+    fn from(cs: &CalRgbColorSpace) -> Self {
+        PageColorSpace::Parameterised {
+            family: ParameterisedFamily::CalRgb,
+            params: cs.params_dictionary(),
+        }
+    }
+}
+
+impl From<&LabColorSpace> for PageColorSpace {
+    /// Bridge a typed [`LabColorSpace`] into a registrable colour space
+    /// (ISO 32000-1 §8.6.5.4).
+    fn from(cs: &LabColorSpace) -> Self {
+        PageColorSpace::Parameterised {
+            family: ParameterisedFamily::Lab,
+            params: cs.params_dictionary(),
+        }
+    }
+}
+
+impl From<&IccProfile> for PageColorSpace {
+    /// Bridge an [`IccProfile`] into a stream-backed ICC colour space
+    /// ([`PageColorSpace::IccStream`]), carrying the profile bytes so the
+    /// writer emits a conformant `/ICCBased` stream (ISO 32000-1 §8.6.5.5).
+    /// `/Alternate` is the device space matching the component count.
+    fn from(profile: &IccProfile) -> Self {
+        let alternate = match profile.components {
+            1 => DeviceColorSpace::Gray,
+            4 => DeviceColorSpace::Cmyk,
+            _ => DeviceColorSpace::Rgb,
+        };
+        PageColorSpace::IccStream {
+            n: profile.components,
+            alternate,
+            profile_data: profile.data.clone(),
+            range: profile.range.clone(),
         }
     }
 }

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -1191,6 +1191,29 @@ impl Page {
         Ok(())
     }
 
+    /// Register an ICC-profile-backed colour space under `name`, embedding the
+    /// profile bytes so the writer emits a conformant `/ICCBased` **stream**
+    /// `[/ICCBased <ref>]` (ISO 32000-1 §8.6.5.5).
+    ///
+    /// This is the ergonomic entry point for ICC colour: it bridges an
+    /// [`IccProfile`](crate::graphics::IccProfile) into the stream-backed
+    /// [`PageColorSpace::IccStream`](crate::graphics::PageColorSpace) variant.
+    /// Unlike registering `PageColorSpace::Parameterised` with the `IccBased`
+    /// family — which can only express an inline dictionary and drops the
+    /// profile data — this path preserves the profile in the output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid PDF
+    /// resource name per ISO 32000-1 §7.3.5.
+    pub fn add_icc_color_space(
+        &mut self,
+        name: impl Into<String>,
+        profile: &crate::graphics::IccProfile,
+    ) -> Result<()> {
+        self.add_color_space(name, crate::graphics::PageColorSpace::from(profile))
+    }
+
     /// Returns all colour spaces registered on this page.
     ///
     /// Map values are typed as [`crate::graphics::PageColorSpace`]; the

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2595,11 +2595,29 @@ impl<W: Write> PdfWriter<W> {
         // same sequence, producing byte-identical xref entries).
         if !page.color_spaces().is_empty() {
             let mut cs_dict = Dictionary::new();
-            for (name, cs) in page.color_spaces() {
-                // Conversion lives on the enum (see `PageColorSpace::to_object`)
-                // so a future shape change (e.g. streams for ICCBased) is a
-                // single-file edit, not a writer-wide sweep.
-                cs_dict.set(name, cs.to_object());
+            // Sort by name before allocating any stream object ids so id
+            // allocation stays reproducible (mirrors the Pattern/Shading blocks).
+            let mut entries: Vec<(&String, &crate::graphics::PageColorSpace)> =
+                page.color_spaces().iter().collect();
+            entries.sort_by_key(|(name, _)| name.as_str());
+            for (name, cs) in entries {
+                // ICCBased colour spaces MUST be an indirect stream carrying the
+                // profile bytes (ISO 32000-1 §8.6.5.5) — a stream cannot be
+                // inlined into the resource dict. Every other shape (device-name
+                // alias, Cal*/Lab parameterised dict) is inline via `to_object`.
+                if let Some((icc_dict, icc_data)) = cs.icc_stream_parts() {
+                    let icc_id = self.allocate_object_id();
+                    self.write_object(icc_id, Object::Stream(icc_dict, icc_data))?;
+                    cs_dict.set(
+                        name,
+                        Object::Array(vec![
+                            Object::Name("ICCBased".to_string()),
+                            Object::Reference(icc_id),
+                        ]),
+                    );
+                } else {
+                    cs_dict.set(name, cs.to_object());
+                }
             }
             resources.set("ColorSpace", Object::Dictionary(cs_dict));
         }

--- a/oxidize-pdf-core/tests/common/colorspace_inspect.rs
+++ b/oxidize-pdf-core/tests/common/colorspace_inspect.rs
@@ -1,0 +1,50 @@
+//! Read-back helper for `/Resources/ColorSpace` round-trip tests.
+//!
+//! Several test crates write a `Document`, re-parse it, and inspect the first
+//! page's colour-space resource map. This navigator (Kids → page → Resources →
+//! ColorSpace, resolving indirect references at each hop) is shared here so the
+//! walk lives in one place rather than being copied per test file.
+//!
+//! `dead_code` is suppressed at the module level: each `tests/*.rs` file is its
+//! own crate, so crates that don't call this flag it as unused.
+#![allow(dead_code)]
+
+use oxidize_pdf::parser::objects::{PdfDictionary, PdfObject};
+use oxidize_pdf::parser::PdfReader;
+
+/// Walk the first page's `/Resources/ColorSpace` dict, resolving through
+/// indirect references if the writer chose to emit any hop that way.
+pub fn resolve_page0_colorspace<R: std::io::Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+) -> PdfDictionary {
+    let pages = reader.pages().expect("/Pages").clone();
+    let kids = pages
+        .get("Kids")
+        .and_then(|o| o.as_array())
+        .expect("/Pages/Kids");
+    let (page_n, page_g) = kids.0[0].as_reference().expect("/Pages/Kids[0] ref");
+    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
+    let page_dict = page_obj.as_dict().expect("page dict").clone();
+    let resources = match page_dict.get("Resources").expect("/Resources") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /Resources")
+            .clone()
+            .as_dict()
+            .expect("/Resources is dict")
+            .clone(),
+        other => panic!("/Resources: unexpected {:?}", other),
+    };
+    match resources.get("ColorSpace").expect("/Resources/ColorSpace") {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .expect("resolve /ColorSpace")
+            .clone()
+            .as_dict()
+            .expect("/ColorSpace dict")
+            .clone(),
+        other => panic!("/ColorSpace: unexpected {:?}", other),
+    }
+}

--- a/oxidize-pdf-core/tests/common/mod.rs
+++ b/oxidize-pdf-core/tests/common/mod.rs
@@ -7,6 +7,7 @@
 //! conventional pattern for `tests/common/` shared helpers in Rust.
 #![allow(dead_code)]
 
+pub mod colorspace_inspect;
 pub mod synthetic_pdf;
 
 /// Count the number of /Type /Page entries in PDF bytes (excluding /Type /Pages).

--- a/oxidize-pdf-core/tests/gfx_019_icc_graphics_color_test.rs
+++ b/oxidize-pdf-core/tests/gfx_019_icc_graphics_color_test.rs
@@ -16,7 +16,8 @@
 //! the .NET wrapper needs.
 
 use oxidize_pdf::graphics::{
-    CalRgbColorSpace, CalibratedColor, PageColorSpace, ParameterisedFamily,
+    CalRgbColorSpace, CalibratedColor, IccColorSpace, IccProfile, PageColorSpace,
+    ParameterisedFamily,
 };
 use oxidize_pdf::objects::{Dictionary, Object};
 use oxidize_pdf::parser::objects::{PdfDictionary, PdfObject};
@@ -161,6 +162,61 @@ fn icc_fill_color_emits_resource_and_content_stream() {
     assert!(
         cs_pos < comp_pos,
         "colour space `/ICCRGB1 cs` must precede its components in the stream:\n{content}"
+    );
+}
+
+/// End-to-end for issue #282: registering an ICC profile via
+/// `add_icc_color_space` and painting through it with `set_fill_color_icc`
+/// must yield BOTH a content stream that selects `/ICC1 cs` and a
+/// `/Resources/ColorSpace/ICC1` that resolves to a conformant `/ICCBased`
+/// **stream** carrying the embedded profile bytes — closing the
+/// "appears supported but profile dropped" gap.
+#[test]
+fn add_icc_color_space_emits_stream_resource_and_drives_content() {
+    const PROFILE: &[u8] = &[0x00, 0x00, 0x02, 0x0C, b'a', b'c', b's', b'p', 0xDE, 0xAD];
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space(
+        "ICC1",
+        &IccProfile::new("rgb".to_string(), PROFILE.to_vec(), IccColorSpace::Rgb),
+    )
+    .expect("register ICC stream colour space");
+    page.graphics()
+        .set_fill_color_icc("ICC1", vec![0.1, 0.2, 0.3]);
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+
+    // (a) resource resolves to an /ICCBased stream with the profile bytes.
+    let page = page0_dict(&mut reader);
+    let resources = resources_of(&mut reader, &page);
+    let cs = colorspace_dict(&mut reader, &resources);
+    let arr = cs
+        .get("ICC1")
+        .and_then(|o| o.as_array())
+        .expect("ICC1 array")
+        .clone();
+    assert_eq!(arr.0[0].as_name().map(|n| n.as_str()), Some("ICCBased"));
+    let (n, g) = arr.0[1]
+        .as_reference()
+        .expect("ICCBased operand must be a stream ref");
+    let icc = reader.get_object(n, g).expect("resolve").clone();
+    let icc = icc
+        .as_stream()
+        .expect("ICCBased operand resolves to a stream");
+    assert_eq!(icc.data, PROFILE, "embedded profile bytes must survive");
+    assert_eq!(icc.dict.get("N").and_then(|o| o.as_integer()), Some(3));
+
+    // (b) content stream paints through the named space.
+    let content = page0_content(&mut reader);
+    assert!(
+        content.contains("/ICC1 cs"),
+        "content must select the ICC space:\n{content}"
+    );
+    assert!(
+        content.contains("0.1000 0.2000 0.3000 sc"),
+        "content must set the ICC components:\n{content}"
     );
 }
 

--- a/oxidize-pdf-core/tests/gfx_019_icc_graphics_color_test.rs
+++ b/oxidize-pdf-core/tests/gfx_019_icc_graphics_color_test.rs
@@ -15,6 +15,10 @@
 //! these tests assert on the colour operators directly, which is exactly what
 //! the .NET wrapper needs.
 
+#[path = "common/mod.rs"]
+mod common;
+
+use common::colorspace_inspect::resolve_page0_colorspace;
 use oxidize_pdf::graphics::{
     CalRgbColorSpace, CalibratedColor, IccColorSpace, IccProfile, PageColorSpace,
     ParameterisedFamily,
@@ -41,39 +45,6 @@ fn page0_dict<R: Read + Seek>(reader: &mut PdfReader<R>) -> PdfDictionary {
         .as_dict()
         .expect("page dict")
         .clone()
-}
-
-/// Resolve a page dictionary's `/Resources` dict (inline or indirect).
-fn resources_of<R: Read + Seek>(reader: &mut PdfReader<R>, page: &PdfDictionary) -> PdfDictionary {
-    match page.get("Resources").expect("/Resources") {
-        PdfObject::Dictionary(d) => d.clone(),
-        PdfObject::Reference(n, g) => reader
-            .get_object(*n, *g)
-            .expect("resolve /Resources")
-            .clone()
-            .as_dict()
-            .expect("/Resources dict")
-            .clone(),
-        other => panic!("/Resources: unexpected {other:?}"),
-    }
-}
-
-/// Resolve `/Resources/ColorSpace` (inline or indirect).
-fn colorspace_dict<R: Read + Seek>(
-    reader: &mut PdfReader<R>,
-    resources: &PdfDictionary,
-) -> PdfDictionary {
-    match resources.get("ColorSpace").expect("/Resources/ColorSpace") {
-        PdfObject::Dictionary(d) => d.clone(),
-        PdfObject::Reference(n, g) => reader
-            .get_object(*n, *g)
-            .expect("resolve /ColorSpace")
-            .clone()
-            .as_dict()
-            .expect("/ColorSpace dict")
-            .clone(),
-        other => panic!("/ColorSpace: unexpected {other:?}"),
-    }
 }
 
 /// Decode the first page's content stream(s) to a UTF-8 string. `/Contents`
@@ -130,9 +101,7 @@ fn icc_fill_color_emits_resource_and_content_stream() {
     let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse document");
 
     // (a) the ICCBased entry survives in /Resources/ColorSpace.
-    let page = page0_dict(&mut reader);
-    let resources = resources_of(&mut reader, &page);
-    let cs = colorspace_dict(&mut reader, &resources);
+    let cs = resolve_page0_colorspace(&mut reader);
     let entry = cs.get("ICCRGB1").expect("ICCRGB1 registered").clone();
     let arr = match entry {
         PdfObject::Array(a) => a,
@@ -189,9 +158,7 @@ fn add_icc_color_space_emits_stream_resource_and_drives_content() {
     let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
 
     // (a) resource resolves to an /ICCBased stream with the profile bytes.
-    let page = page0_dict(&mut reader);
-    let resources = resources_of(&mut reader, &page);
-    let cs = colorspace_dict(&mut reader, &resources);
+    let cs = resolve_page0_colorspace(&mut reader);
     let arr = cs
         .get("ICC1")
         .and_then(|o| o.as_array())
@@ -309,9 +276,7 @@ fn two_named_calibrated_spaces_coexist_on_one_page() {
     let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
 
     // Both calibrated spaces survive in the resource dict.
-    let page = page0_dict(&mut reader);
-    let resources = resources_of(&mut reader, &page);
-    let cs = colorspace_dict(&mut reader, &resources);
+    let cs = resolve_page0_colorspace(&mut reader);
     for name in ["CalA", "CalB"] {
         let entry = cs
             .get(name)

--- a/oxidize-pdf-core/tests/icc_colorspace_stream_test.rs
+++ b/oxidize-pdf-core/tests/icc_colorspace_stream_test.rs
@@ -160,6 +160,119 @@ fn icc_cmyk_profile_round_trips_with_four_components() {
     assert_eq!(stream.data, PROFILE_BYTES);
 }
 
+/// A Gray profile registers with `/N` 1 and `/Alternate /DeviceGray`.
+#[test]
+fn icc_gray_profile_round_trips_with_one_component() {
+    let profile = IccProfile::new(
+        "MyGray".to_string(),
+        PROFILE_BYTES.to_vec(),
+        IccColorSpace::Gray,
+    );
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICCG", &profile)
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("ICCG")
+        .and_then(|o| o.as_array())
+        .expect("ICCG array");
+    let (n, g) = arr.0[1].as_reference().expect("ICCBased ref");
+    let stream = reader.get_object(n, g).expect("resolve").clone();
+    let stream = stream.as_stream().expect("stream");
+    assert_eq!(stream.dict.get("N").and_then(|o| o.as_integer()), Some(1));
+    assert_eq!(
+        stream
+            .dict
+            .get("Alternate")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceGray")
+    );
+    assert_eq!(stream.data, PROFILE_BYTES);
+}
+
+/// An RGB profile's `/Range` equals the ISO 32000-1 §8.6.5.5 Table 66 default
+/// (`[0 1]` per component), so it must be omitted from the stream dict rather
+/// than written verbatim.
+#[test]
+fn icc_rgb_default_range_is_omitted() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICC1", &rgb_icc_profile())
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("ICC1")
+        .and_then(|o| o.as_array())
+        .expect("ICC1 array");
+    let (n, g) = arr.0[1].as_reference().expect("ICCBased ref");
+    let stream = reader.get_object(n, g).expect("resolve").clone();
+    let stream = stream.as_stream().expect("stream");
+    assert!(
+        stream.dict.get("Range").is_none(),
+        "an RGB profile whose Range is the [0 1]-per-component default must omit /Range, got {:?}",
+        stream.dict.get("Range")
+    );
+}
+
+/// A Lab ICC profile carries a non-default `/Range` ([0 100 -128 127 -128 127])
+/// which MUST survive the round-trip, and falls back to `/Alternate /DeviceRGB`
+/// (the closest device space; `DeviceColorSpace` has no Lab variant).
+#[test]
+fn icc_lab_profile_emits_non_default_range_and_rgb_alternate() {
+    let profile = IccProfile::new(
+        "MyLab".to_string(),
+        PROFILE_BYTES.to_vec(),
+        IccColorSpace::Lab,
+    );
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICCL", &profile)
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("ICCL")
+        .and_then(|o| o.as_array())
+        .expect("ICCL array");
+    let (n, g) = arr.0[1].as_reference().expect("ICCBased ref");
+    let stream = reader.get_object(n, g).expect("resolve").clone();
+    let stream = stream.as_stream().expect("stream");
+    assert_eq!(stream.dict.get("N").and_then(|o| o.as_integer()), Some(3));
+    assert_eq!(
+        stream
+            .dict
+            .get("Alternate")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceRGB"),
+        "a Lab ICC profile falls back to DeviceRGB (no Lab device space)"
+    );
+    let range = stream
+        .dict
+        .get("Range")
+        .and_then(|o| o.as_array())
+        .expect("Lab profile must emit its non-default /Range");
+    let values: Vec<f64> = range.0.iter().filter_map(|o| o.as_real()).collect();
+    assert_eq!(
+        values,
+        vec![0.0, 100.0, -128.0, 127.0, -128.0, 127.0],
+        "Lab /Range must round-trip verbatim"
+    );
+}
+
 /// Converting an `IccProfile` via `PageColorSpace::from` yields a stream-backed
 /// variant (not `Parameterised`), so the writer takes the stream path.
 #[test]

--- a/oxidize-pdf-core/tests/icc_colorspace_stream_test.rs
+++ b/oxidize-pdf-core/tests/icc_colorspace_stream_test.rs
@@ -1,0 +1,173 @@
+//! Issue #282 — `ICCBased` colour spaces must be emitted as a conformant
+//! indirect **stream** carrying the embedded profile bytes, not an inline
+//! parameter dictionary that drops the profile (ISO 32000-1 §8.6.5.5).
+//!
+//! Before this fix, registering an ICC profile produced
+//! `/Resources/ColorSpace/<name> = [/ICCBased <<N Alternate>>]` — an inline
+//! dict with no stream and the `IccProfile.data: Vec<u8>` never written. A
+//! conforming reader cannot resolve the profile and falls back to `/Alternate`,
+//! so ICC colour management is absent while appearing supported.
+//!
+//! These tests write a real ICC-profile-backed colour space through the public
+//! `Page` API, re-parse the output, and assert the resource resolves to a
+//! stream whose raw bytes equal the input profile and whose `/N` matches the
+//! component count. A negative assertion rejects the old inline-dict shape.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::colorspace_inspect::resolve_page0_colorspace;
+use oxidize_pdf::graphics::{IccColorSpace, IccProfile, PageColorSpace};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Distinctive non-UTF8 bytes standing in for a real ICC profile payload. The
+/// fix must write these verbatim into the stream; the test compares them back.
+const PROFILE_BYTES: &[u8] = &[
+    0x00, 0x00, 0x02, 0x0C, b'a', b'c', b's', b'p', 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04,
+];
+
+fn rgb_icc_profile() -> IccProfile {
+    IccProfile::new(
+        "MyRGB".to_string(),
+        PROFILE_BYTES.to_vec(),
+        IccColorSpace::Rgb,
+    )
+}
+
+/// Register an ICC profile, write, re-parse: the colour-space resource must be
+/// `[/ICCBased <ref>]` where `<ref>` resolves to a stream whose bytes equal the
+/// input profile and whose `/N` is 3 (RGB).
+#[test]
+fn icc_based_colour_space_is_emitted_as_stream_with_profile_bytes() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICC1", &rgb_icc_profile())
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+
+    let arr = map
+        .get("ICC1")
+        .and_then(|o| o.as_array())
+        .expect("ICC1 must be an array")
+        .clone();
+    assert_eq!(
+        arr.0.len(),
+        2,
+        "ICCBased must serialise as [/ICCBased <ref>]"
+    );
+    assert_eq!(
+        arr.0[0].as_name().map(|n| n.as_str()),
+        Some("ICCBased"),
+        "first array element must be /ICCBased"
+    );
+
+    // Second element MUST be an indirect reference to a stream, NOT an inline dict.
+    let (n, g) = match &arr.0[1] {
+        PdfObject::Reference(n, g) => (*n, *g),
+        other => panic!(
+            "ICCBased operand must be an indirect stream reference, got inline {:?}",
+            other
+        ),
+    };
+    let stream = reader.get_object(n, g).expect("resolve ICC stream").clone();
+    let stream = stream
+        .as_stream()
+        .expect("ICCBased operand must resolve to a stream object");
+
+    assert_eq!(
+        stream.data, PROFILE_BYTES,
+        "the stream's raw bytes must equal the embedded ICC profile"
+    );
+    assert_eq!(
+        stream.dict.get("N").and_then(|o| o.as_integer()),
+        Some(3),
+        "/N must equal the RGB component count (3)"
+    );
+    assert_eq!(
+        stream
+            .dict
+            .get("Alternate")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceRGB"),
+        "/Alternate must be the device fallback for an RGB profile"
+    );
+}
+
+/// Negative shape lock: the registered ICC colour space must NOT serialise as
+/// the old inline `[/ICCBased <<dict>>]` form (profile bytes dropped).
+#[test]
+fn icc_based_colour_space_is_not_inline_dict() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICC1", &rgb_icc_profile())
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("ICC1")
+        .and_then(|o| o.as_array())
+        .expect("ICC1 array");
+    assert!(
+        !matches!(arr.0[1], PdfObject::Dictionary(_)),
+        "ICCBased operand must not be an inline dictionary (profile bytes would be dropped)"
+    );
+}
+
+/// A CMYK profile registers with `/N` 4 and `/Alternate /DeviceCMYK`.
+#[test]
+fn icc_cmyk_profile_round_trips_with_four_components() {
+    let profile = IccProfile::new(
+        "MyCMYK".to_string(),
+        PROFILE_BYTES.to_vec(),
+        IccColorSpace::Cmyk,
+    );
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_icc_color_space("ICCK", &profile)
+        .expect("add_icc_color_space");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("ICCK")
+        .and_then(|o| o.as_array())
+        .expect("ICCK array");
+    let (n, g) = arr.0[1].as_reference().expect("ICCBased ref");
+    let stream = reader.get_object(n, g).expect("resolve").clone();
+    let stream = stream.as_stream().expect("stream");
+    assert_eq!(stream.dict.get("N").and_then(|o| o.as_integer()), Some(4));
+    assert_eq!(
+        stream
+            .dict
+            .get("Alternate")
+            .and_then(|o| o.as_name())
+            .map(|n| n.as_str()),
+        Some("DeviceCMYK")
+    );
+    assert_eq!(stream.data, PROFILE_BYTES);
+}
+
+/// Converting an `IccProfile` via `PageColorSpace::from` yields a stream-backed
+/// variant (not `Parameterised`), so the writer takes the stream path.
+#[test]
+fn icc_profile_converts_to_stream_backed_variant() {
+    let cs = PageColorSpace::from(&rgb_icc_profile());
+    // Must not be the inline Parameterised/IccBased dict form.
+    assert!(
+        !matches!(cs, PageColorSpace::Parameterised { .. }),
+        "an IccProfile must convert to a stream-backed colour space, not an inline dict"
+    );
+}

--- a/oxidize-pdf-core/tests/page_color_spaces_typed_api_test.rs
+++ b/oxidize-pdf-core/tests/page_color_spaces_typed_api_test.rs
@@ -15,49 +15,19 @@
 //! this stage; adding them in the future is a backwards-compatible
 //! superset (new enum variants guarded by `#[non_exhaustive]`).
 
-use oxidize_pdf::graphics::{DeviceColorSpace, PageColorSpace, ParameterisedFamily};
+#[path = "common/mod.rs"]
+mod common;
+
+use common::colorspace_inspect::resolve_page0_colorspace;
+use oxidize_pdf::graphics::{
+    CalGrayColorSpace, CalRgbColorSpace, DeviceColorSpace, LabColorSpace, PageColorSpace,
+    ParameterisedFamily,
+};
 use oxidize_pdf::objects::Dictionary;
 use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::PdfReader;
 use oxidize_pdf::{Document, Page};
 use std::io::Cursor;
-
-/// Walk the first page's `/Resources/ColorSpace` dict, resolving through
-/// indirect references if the writer chose to emit the map that way.
-fn resolve_page0_colorspace<R: std::io::Read + std::io::Seek>(
-    reader: &mut PdfReader<R>,
-) -> oxidize_pdf::parser::objects::PdfDictionary {
-    let pages = reader.pages().expect("/Pages").clone();
-    let kids = pages
-        .get("Kids")
-        .and_then(|o| o.as_array())
-        .expect("/Pages/Kids");
-    let (page_n, page_g) = kids.0[0].as_reference().expect("/Pages/Kids[0] ref");
-    let page_obj = reader.get_object(page_n, page_g).expect("page").clone();
-    let page_dict = page_obj.as_dict().expect("page dict").clone();
-    let resources = match page_dict.get("Resources").expect("/Resources") {
-        PdfObject::Dictionary(d) => d.clone(),
-        PdfObject::Reference(n, g) => reader
-            .get_object(*n, *g)
-            .expect("resolve /Resources")
-            .clone()
-            .as_dict()
-            .expect("/Resources is dict")
-            .clone(),
-        other => panic!("/Resources: unexpected {:?}", other),
-    };
-    match resources.get("ColorSpace").expect("/Resources/ColorSpace") {
-        PdfObject::Dictionary(d) => d.clone(),
-        PdfObject::Reference(n, g) => reader
-            .get_object(*n, *g)
-            .expect("resolve /ColorSpace")
-            .clone()
-            .as_dict()
-            .expect("/ColorSpace dict")
-            .clone(),
-        other => panic!("/ColorSpace: unexpected {:?}", other),
-    }
-}
 
 /// `DeviceAlias` variants serialise as single PDF names, not one-element
 /// arrays. Aliasing `/CS1` → `/DeviceRGB` is the wire-format shape expected
@@ -220,6 +190,131 @@ fn color_spaces_accessor_returns_typed_map() {
     match map.get("CS1") {
         Some(PageColorSpace::DeviceAlias(DeviceColorSpace::Rgb)) => {}
         other => panic!("expected DeviceAlias(Rgb), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #283 — typed CalGray/CalRGB/Lab → PageColorSpace bridge
+// ---------------------------------------------------------------------------
+
+/// `CalRgbColorSpace` (non-default WhitePoint + Gamma + Matrix) converts to a
+/// `PageColorSpace` that round-trips to `[/CalRGB <<WhitePoint Gamma Matrix>>]`
+/// with the struct's exact parameters — no hand-built `Dictionary` required.
+#[test]
+fn cal_rgb_struct_registers_and_round_trips() {
+    let cs = CalRgbColorSpace::srgb();
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_color_space("CalRGB1", PageColorSpace::from(&cs))
+        .expect("add_color_space from CalRgbColorSpace");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("CalRGB1")
+        .and_then(|o| o.as_array())
+        .expect("CalRGB1 array");
+    assert_eq!(arr.0.len(), 2, "CalRGB must serialise as [Name, Dict]");
+    assert_eq!(arr.0[0].as_name().map(|n| n.as_str()), Some("CalRGB"));
+    let params = arr.0[1].as_dict().expect("param dict");
+    // sRGB sets Gamma [2.2,2.2,2.2] and a non-identity Matrix → both present
+    let gamma = params
+        .get("Gamma")
+        .and_then(|o| o.as_array())
+        .expect("/Gamma present for non-default gamma");
+    assert_eq!(gamma.0.len(), 3, "CalRGB Gamma is a 3-element array");
+    assert!(
+        (gamma.0[0].as_real().expect("gamma[0]") - 2.2).abs() < 1e-9,
+        "Gamma must carry the struct value 2.2, got {:?}",
+        gamma.0[0]
+    );
+    assert!(
+        params.get("Matrix").and_then(|o| o.as_array()).is_some(),
+        "sRGB's non-identity Matrix must be emitted"
+    );
+}
+
+/// `CalGrayColorSpace` with a non-default gamma converts and round-trips to
+/// `[/CalGray <<WhitePoint Gamma>>]`.
+#[test]
+fn cal_gray_struct_registers_and_round_trips() {
+    let cs = CalGrayColorSpace::new().with_gamma(2.2);
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_color_space("Gray1", PageColorSpace::from(&cs))
+        .expect("add_color_space from CalGrayColorSpace");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("Gray1")
+        .and_then(|o| o.as_array())
+        .expect("Gray1 array");
+    assert_eq!(arr.0[0].as_name().map(|n| n.as_str()), Some("CalGray"));
+    let params = arr.0[1].as_dict().expect("param dict");
+    assert!(
+        (params
+            .get("Gamma")
+            .and_then(|o| o.as_real())
+            .expect("/Gamma")
+            - 2.2)
+            .abs()
+            < 1e-9,
+        "CalGray Gamma must carry the struct value 2.2"
+    );
+}
+
+/// `LabColorSpace` with a custom a*/b* range converts and round-trips to
+/// `[/Lab <<WhitePoint Range>>]`.
+#[test]
+fn lab_struct_registers_and_round_trips() {
+    let cs = LabColorSpace::new().with_range(-90.0, 90.0, -80.0, 80.0);
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_color_space("Lab1", PageColorSpace::from(&cs))
+        .expect("add_color_space from LabColorSpace");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let map = resolve_page0_colorspace(&mut reader);
+    let arr = map
+        .get("Lab1")
+        .and_then(|o| o.as_array())
+        .expect("Lab1 array");
+    assert_eq!(arr.0[0].as_name().map(|n| n.as_str()), Some("Lab"));
+    let params = arr.0[1].as_dict().expect("param dict");
+    let range = params
+        .get("Range")
+        .and_then(|o| o.as_array())
+        .expect("/Range present for custom range");
+    assert_eq!(range.0.len(), 4, "Lab Range is [aMin aMax bMin bMax]");
+    assert!(
+        (range.0[0].as_real().expect("range[0]") - (-90.0)).abs() < 1e-9,
+        "Range must carry the struct's aMin = -90.0"
+    );
+}
+
+/// The conversion must keep the dict-building in one place: the params produced
+/// by `PageColorSpace::from(&cs)` equal those of `cs.params_dictionary()`, the
+/// same source `to_pdf_array` delegates to.
+#[test]
+fn bridge_reuses_single_params_source() {
+    let cs = CalRgbColorSpace::adobe_rgb();
+    match PageColorSpace::from(&cs) {
+        PageColorSpace::Parameterised { family, params } => {
+            assert_eq!(family, ParameterisedFamily::CalRgb);
+            assert_eq!(
+                params,
+                cs.params_dictionary(),
+                "bridge must reuse the struct's own params_dictionary, not rebuild it"
+            );
+        }
+        other => panic!("CalRgb must map to Parameterised, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Addresses **#282** (ICCBased emitted as inline dict, profile bytes dropped) and **#283** (no bridge from typed CalGray/CalRGB/Lab structs to `Page::add_color_space`).

## #282 — ICCBased now emitted as a conformant stream

Per ISO 32000-1 §8.6.5.5 the `ICCBased` operand MUST be a stream. Previously, ICC profiles registered as `PageColorSpace::Parameterised { family: IccBased, .. }` were written as an inline parameter dictionary and the embedded profile bytes (`IccProfile.data`) were never emitted, so ICC colour management appeared supported but was absent (readers fell back to `/Alternate`).

- New `PageColorSpace::IccStream` variant carrying the profile bytes (`Arc<Vec<u8>>`), `N`, `Alternate`, optional `Range`.
- New `Page::add_icc_color_space(name, &IccProfile)` ergonomic entry point.
- The writer allocates an indirect stream object `<< /N n /Alternate X /Range … >> stream <profile bytes> endstream` and references it as `[/ICCBased <ref>]`. ColorSpace entries are sorted by name before allocating ids so allocation stays reproducible.
- The pre-existing inline `Parameterised { IccBased, .. }` path is unchanged (the form callers should migrate away from).

## #283 — typed colour-space bridges

- `impl From<&CalGrayColorSpace | CalRgbColorSpace | LabColorSpace | IccProfile> for PageColorSpace`.
- Each calibrated/Lab struct exposes `params_dictionary()` as the single source of its dict shape, reused by both `to_pdf_array()` and the `From` bridge (DRY).

## Quality-review follow-ups (applied in 2nd commit)

- `/Alternate` derived from `IccProfile.color_space` (semantic), not the raw component count — fixes the latent `Generic(2)`/`Generic(5)` → 3-component DeviceRGB mismatch; Lab → DeviceRGB (documented; no Lab device space).
- `/Range` omitted when it equals the ISO §8.6.5.5 Table 66 default (`[0 1]` per component); non-default ranges (Lab) preserved.
- `PageColorSpace::to_object` is `unreachable!()` for `IccStream` (a stream has no inline `Object` form) — also removes the duplicated dict-building.
- `debug_assert` guards `/Alternate != Pattern`.
- Shared page-0 ColorSpace read-back navigator extracted into `tests/common/colorspace_inspect.rs`; `gfx_019` and `page_color_spaces_typed_api` tests migrated to it (DRY).

## Verification (content-based, no smoke tests)

- `icc_colorspace_stream_test` (7): resource resolves to a stream whose raw bytes equal the input profile; `/N` and `/Alternate` correct (RGB/CMYK/Gray); RGB default `/Range` omitted; Lab non-default `/Range` round-trips; negative: not an inline dict.
- `gfx_019` end-to-end: `add_icc_color_space` + `set_fill_color_icc` → content selects `/ICC1 cs` AND the resource is an `/ICCBased` stream with the profile bytes.
- `page_color_spaces_typed_api_test` (+4): typed bridges round-trip to `[/CalRGB|CalGray|Lab <<params>>]` with the struct's exact parameters.

Lib suite green (6489/0), clippy clean, fmt OK. Colour integration: icc_stream 7/7, gfx_019 5/5, typed_api 10/10; calibrated/devicen/page_color_spaces regression green. Tests only beyond the additive API — no behaviour change to existing paths.

Addresses #282, #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)