### PR TITLE
feat(fonts): glyph-coverage diagnostics for custom fonts (addresses #287)

### DIFF
--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -476,6 +476,28 @@ impl Document {
         Ok(())
     }
 
+    /// Get a registered custom font by name, if present.
+    ///
+    /// Useful for inspecting glyph coverage via [`crate::fonts::Font::has_glyph`]
+    /// or [`crate::fonts::Font::missing_glyphs`] (issue #287).
+    pub fn custom_font(&self, name: &str) -> Option<std::sync::Arc<CustomFont>> {
+        self.custom_fonts.get_font(name)
+    }
+
+    /// Characters in `text` that the named custom font cannot render because
+    /// its embedded glyph set has no glyph for them (they would appear as
+    /// `.notdef`, an empty box — issue #287). Deduplicated, first-seen order.
+    ///
+    /// Returns an empty vector when the font is not registered (nothing can be
+    /// determined). This lets callers detect coverage gaps before rendering,
+    /// e.g. to substitute a character or pick a different font.
+    pub fn font_missing_glyphs(&self, font_name: &str, text: &str) -> Vec<char> {
+        match self.custom_fonts.get_font(font_name) {
+            Some(font) => font.missing_glyphs(text),
+            None => Vec::new(),
+        }
+    }
+
     /// Add a custom font from byte data
     ///
     /// # Example

--- a/oxidize-pdf-core/src/document.rs
+++ b/oxidize-pdf-core/src/document.rs
@@ -476,11 +476,13 @@ impl Document {
         Ok(())
     }
 
-    /// Get a registered custom font by name, if present.
+    /// Get a registered embedded font by name, if present.
     ///
-    /// Useful for inspecting glyph coverage via [`crate::fonts::Font::has_glyph`]
-    /// or [`crate::fonts::Font::missing_glyphs`] (issue #287).
-    pub fn custom_font(&self, name: &str) -> Option<std::sync::Arc<CustomFont>> {
+    /// Returns the embedding-layer [`crate::fonts::Font`] (not the
+    /// `oxidize_pdf::CustomFont` builder type). Useful for inspecting glyph
+    /// coverage via [`crate::fonts::Font::has_glyph`] or
+    /// [`crate::fonts::Font::missing_glyphs`] (issue #287).
+    pub fn embedded_font(&self, name: &str) -> Option<std::sync::Arc<CustomFont>> {
         self.custom_fonts.get_font(name)
     }
 

--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -107,9 +107,10 @@ impl Font {
     /// (issue #287). Use this to detect coverage gaps before rendering rather
     /// than discovering empty boxes in the output.
     pub fn missing_glyphs(&self, text: &str) -> Vec<char> {
-        // Coverage cannot be determined if no cmap was parsed (e.g. some CFF
-        // fonts): report nothing rather than flagging every character.
-        if self.glyph_mapping.is_empty() {
+        // Coverage cannot be determined if the real cmap was not parsed (no
+        // cmap, or the ASCII fallback fired): report nothing rather than
+        // flagging every character as missing.
+        if !self.glyph_mapping.coverage_known() {
             return Vec::new();
         }
         let mut seen = std::collections::HashSet::new();
@@ -118,7 +119,9 @@ impl Font {
             if ch.is_control() {
                 continue;
             }
-            if !self.has_glyph(ch) && seen.insert(ch) {
+            // `seen` dedups across all characters so repeated present
+            // characters skip the per-occurrence `has_glyph` lookup.
+            if seen.insert(ch) && !self.has_glyph(ch) {
                 missing.push(ch);
             }
         }

--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -98,6 +98,33 @@ impl Font {
         self.glyph_mapping.char_to_glyph(ch).is_some()
     }
 
+    /// Characters in `text` the font has no glyph for, deduplicated and in
+    /// first-seen order. Control characters (newlines, tabs, …) are ignored
+    /// because they are never rendered.
+    ///
+    /// Such characters render as `.notdef` (an empty box) — this is the
+    /// correct PDF behaviour when the embedded font genuinely lacks the glyph
+    /// (issue #287). Use this to detect coverage gaps before rendering rather
+    /// than discovering empty boxes in the output.
+    pub fn missing_glyphs(&self, text: &str) -> Vec<char> {
+        // Coverage cannot be determined if no cmap was parsed (e.g. some CFF
+        // fonts): report nothing rather than flagging every character.
+        if self.glyph_mapping.is_empty() {
+            return Vec::new();
+        }
+        let mut seen = std::collections::HashSet::new();
+        let mut missing = Vec::new();
+        for ch in text.chars() {
+            if ch.is_control() {
+                continue;
+            }
+            if !self.has_glyph(ch) && seen.insert(ch) {
+                missing.push(ch);
+            }
+        }
+        missing
+    }
+
     /// Measure text using this font at a specific size
     pub fn measure_text(&self, text: &str, font_size: f32) -> TextMeasurement {
         self.metrics

--- a/oxidize-pdf-core/src/fonts/ttf_parser.rs
+++ b/oxidize-pdf-core/src/fonts/ttf_parser.rs
@@ -16,6 +16,10 @@ pub struct GlyphMapping {
     glyph_to_char: HashMap<u16, u32>,
     /// Glyph widths in font units
     glyph_widths: HashMap<u16, u16>,
+    /// `true` when the real cmap could not be parsed and `char_to_glyph` holds
+    /// only a synthetic ASCII fallback. In that case glyph coverage is NOT
+    /// reliable and must not be reported as authoritative.
+    cmap_unparsed: bool,
 }
 
 impl GlyphMapping {
@@ -24,10 +28,11 @@ impl GlyphMapping {
         self.char_to_glyph.get(&(ch as u32)).copied()
     }
 
-    /// Whether the character→glyph table is empty (no cmap could be parsed).
-    /// When empty, glyph coverage cannot be determined for this font.
-    pub fn is_empty(&self) -> bool {
-        self.char_to_glyph.is_empty()
+    /// Whether glyph coverage can be reliably determined: the table is
+    /// non-empty AND was built from the font's real cmap (not the ASCII
+    /// fallback used when cmap parsing fails).
+    pub(crate) fn coverage_known(&self) -> bool {
+        !self.char_to_glyph.is_empty() && !self.cmap_unparsed
     }
 
     /// Get character for a glyph index
@@ -364,7 +369,10 @@ impl<'a> TtfParser<'a> {
         let cmap_data = cmap_table;
 
         if self.parse_cmap_table(cmap_data, &mut mapping).is_err() {
-            // Fallback to basic ASCII mapping if cmap parsing fails
+            // Fallback to basic ASCII mapping if cmap parsing fails. This is a
+            // best-effort guess, not the font's real coverage — flag it so
+            // coverage diagnostics do not treat it as authoritative.
+            mapping.cmap_unparsed = true;
             for ch in 0x20..=0x7E {
                 mapping.add_mapping(char::from(ch), ch as u16);
             }

--- a/oxidize-pdf-core/src/fonts/ttf_parser.rs
+++ b/oxidize-pdf-core/src/fonts/ttf_parser.rs
@@ -24,6 +24,12 @@ impl GlyphMapping {
         self.char_to_glyph.get(&(ch as u32)).copied()
     }
 
+    /// Whether the character→glyph table is empty (no cmap could be parsed).
+    /// When empty, glyph coverage cannot be determined for this font.
+    pub fn is_empty(&self) -> bool {
+        self.char_to_glyph.is_empty()
+    }
+
     /// Get character for a glyph index
     pub fn glyph_to_char(&self, glyph: u16) -> Option<char> {
         self.glyph_to_char

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1551,6 +1551,9 @@ impl<W: Write> PdfWriter<W> {
         // as .notdef (empty boxes). This is correct when the font genuinely
         // lacks the glyph, but warn so it is not a silent failure — the most
         // common cause of "my ✓/✗ show as boxes" reports (issue #287).
+        // Fires once per font per save; a document saved repeatedly logs it
+        // each time. `missing_glyphs` returns nothing when coverage is unknown
+        // (e.g. an unparseable cmap), so this never produces false positives.
         let used_text: String = used_chars.iter().copied().collect();
         let mut missing = font.missing_glyphs(&used_text);
         if !missing.is_empty() {

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1546,6 +1546,30 @@ impl<W: Write> PdfWriter<W> {
                 }
                 chars
             });
+
+        // Diagnose characters the embedded font has no glyph for: they render
+        // as .notdef (empty boxes). This is correct when the font genuinely
+        // lacks the glyph, but warn so it is not a silent failure — the most
+        // common cause of "my ✓/✗ show as boxes" reports (issue #287).
+        let used_text: String = used_chars.iter().copied().collect();
+        let mut missing = font.missing_glyphs(&used_text);
+        if !missing.is_empty() {
+            missing.sort_unstable();
+            let list = missing
+                .iter()
+                .map(|c| format!("U+{:04X} {:?}", *c as u32, c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            tracing::warn!(
+                "Custom font '{}' has no glyph for {} character(s): {}. \
+                 They will render as .notdef (empty boxes); the embedded font \
+                 does not contain these glyphs.",
+                font_name,
+                missing.len(),
+                list
+            );
+        }
+
         // Allocate IDs for all font objects
         let font_id = self.allocate_object_id();
         let descendant_font_id = self.allocate_object_id();

--- a/oxidize-pdf-core/tests/issue_287_glyph_coverage_test.rs
+++ b/oxidize-pdf-core/tests/issue_287_glyph_coverage_test.rs
@@ -1,0 +1,131 @@
+//! Issue #287: custom TTF glyphs render as .notdef when the embedded font has
+//! no glyph for them. This is correct PDF behaviour (the font genuinely lacks
+//! the glyph), but the library used to map missing characters to GID 0
+//! silently, giving no way to tell a font-coverage gap from a library bug.
+//!
+//! These tests cover the diagnostic API added to detect that gap up front.
+//! Roboto-Regular covers Basic Latin, Latin-1 accents and general punctuation
+//! (— •) but has no glyph for U+2713 (✓) / U+2717 (✗) — the exact profile of
+//! the reporter's DMSans.
+
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::sync::{Arc, Mutex};
+
+fn roboto_bytes() -> Vec<u8> {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../test-pdfs/Roboto-Regular.ttf"
+    );
+    std::fs::read(path).expect("Roboto-Regular.ttf fixture")
+}
+
+/// `MakeWriter` that appends all log output into a shared buffer.
+#[derive(Clone)]
+struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for BufWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+    type Writer = BufWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn test_font_missing_glyphs_reports_uncovered_characters() {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
+
+    // ✓ and ✗ are absent from Roboto; A, É, — and • are present.
+    let missing =
+        doc.font_missing_glyphs("Roboto", "A \u{00C9} \u{2713} \u{2717} \u{2014} \u{2022}");
+    assert_eq!(
+        missing,
+        vec!['\u{2713}', '\u{2717}'],
+        "only the uncovered ✓/✗ must be reported, in first-seen order"
+    );
+}
+
+#[test]
+fn test_font_missing_glyphs_empty_when_all_covered() {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
+
+    let missing = doc.font_missing_glyphs("Roboto", "Hello \u{00E9}\u{00F1} \u{2014}\u{2022}");
+    assert!(
+        missing.is_empty(),
+        "fully covered text must report no missing glyphs, got {missing:?}"
+    );
+}
+
+#[test]
+fn test_font_missing_glyphs_deduplicates_and_ignores_controls() {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
+
+    // Repeated ✓ and a newline (control) must not produce duplicates/entries.
+    let missing = doc.font_missing_glyphs("Roboto", "\u{2713}\n\u{2713}\t\u{2713}");
+    assert_eq!(missing, vec!['\u{2713}']);
+}
+
+#[test]
+fn test_font_missing_glyphs_unknown_font_is_empty() {
+    let doc = Document::new();
+    assert!(doc
+        .font_missing_glyphs("NotRegistered", "\u{2713}")
+        .is_empty());
+}
+
+#[test]
+fn test_font_has_glyph_reflects_cmap_coverage() {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
+    let font = doc
+        .custom_font("Roboto")
+        .expect("registered font must be retrievable");
+
+    assert!(font.has_glyph('A'));
+    assert!(font.has_glyph('\u{00C9}')); // É
+    assert!(font.has_glyph('\u{2014}')); // —
+    assert!(!font.has_glyph('\u{2713}')); // ✓ absent
+    assert!(!font.has_glyph('\u{2717}')); // ✗ absent
+}
+
+#[test]
+fn test_saving_warns_about_missing_glyphs() {
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(BufWriter(buf.clone()))
+        .with_max_level(tracing::Level::WARN)
+        .without_time()
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let mut doc = Document::new();
+        doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Custom("Roboto".to_string()), 12.0)
+            .at(50.0, 700.0)
+            .write("OK \u{2713}") // ✓ has no glyph in Roboto
+            .unwrap();
+        doc.add_page(page);
+        let _ = doc.to_bytes().expect("save must succeed");
+    });
+
+    let logged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(
+        logged.contains("Roboto") && logged.contains("U+2713") && logged.contains(".notdef"),
+        "save must warn, naming the font and the missing code point. Got:\n{logged}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_287_glyph_coverage_test.rs
+++ b/oxidize-pdf-core/tests/issue_287_glyph_coverage_test.rs
@@ -91,7 +91,7 @@ fn test_font_has_glyph_reflects_cmap_coverage() {
     let mut doc = Document::new();
     doc.add_font_from_bytes("Roboto", roboto_bytes()).unwrap();
     let font = doc
-        .custom_font("Roboto")
+        .embedded_font("Roboto")
         .expect("registered font must be retrievable");
 
     assert!(font.has_glyph('A'));


### PR DESCRIPTION
Addresses #287. Investigation (DejaVuSans vs the reporter's DMSans, verified at the cmap level) showed this is **not** an encoding bug: the writer already emits UTF-16BE → Type0/Identity-H and maps every code point to its real GID via `CIDToGIDMap`. With DejaVuSans, ✓/✗ render (GID 7/8). DMSans simply has no glyph for U+2713/U+2717 in its cmap, so the viewer shows `.notdef` — correct PDF behaviour for a font-coverage gap. #287 was closed with that evidence.

The real gap: missing glyphs mapped to GID 0 **silently**, so users couldn't tell a font-coverage gap from a library bug. This adds diagnostics:

- `Font::missing_glyphs(text)` — characters with no glyph in the embedded font (deduplicated, control chars ignored; empty when coverage can't be determined).
- `Document::font_missing_glyphs(name, text)` and `Document::embedded_font(name)` — query coverage before rendering.
- The Type0 writer logs a `tracing::warn!` naming the font and the uncovered code points instead of failing silently.

## Quality hardening (second commit)
- `GlyphMapping::coverage_known()` replaces a naive emptiness check: the TTF parser falls back to a synthetic ASCII map when the real cmap can't be parsed, which would otherwise make `missing_glyphs` flag every non-ASCII character (false positives). Coverage is now reported only when the real cmap was parsed.
- `Document::embedded_font` (renamed from `custom_font`, which collided with the re-exported `oxidize_pdf::CustomFont` builder type).

oxidize-pdf is pure-embed (no system-font fallback), so this surfaces the cause rather than changing rendering — it cannot conjure glyphs a font lacks.

## Tests
`tests/issue_287_glyph_coverage_test.rs` (Roboto-Regular has the same profile as DMSans: Latin + — • but no ✓/✗): 6 content-verifying tests incl. an end-to-end check that saving captures the warning naming the font and U+2713.

Lib 6489/0; font integration suites green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)