### PR TITLE
feat(ai): token-efficient chunk serializer + ChunkExporter trait (#291)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +770,17 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1568,6 +1590,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "time",
  "toml",
  "tracing",
@@ -2098,6 +2121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2509,21 @@ dependencies = [
  "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
 dependencies = [
  "anyhow",
  "base64",

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -93,6 +93,7 @@ toml = "0.9.11"
 tempfile = "3.8"
 rusty-tesseract = { version = "1.1.10", optional = true }
 image = { workspace = true, features = ["png", "jpeg"], optional = true }
+tiktoken-rs = { version = "0.11.0", optional = true }
 
 # Platform-specific
 [target.'cfg(unix)'.dependencies]
@@ -475,6 +476,13 @@ language-detection = ["dep:whatlang"]
 
 # Parallel processing features
 rayon = ["dep:rayon"]
+
+# Token-count benchmark harness for the token-efficient chunk serializer (#291).
+# Opt-in only: pulls `tiktoken-rs` (MSRV 1.85+), so it is kept OUT of the default
+# dependency graph to preserve the crate MSRV of 1.77. Implies `semantic` so the
+# JSON baseline (`JsonExporter`) is available for comparison.
+# Run with: cargo test --features token-bench -- --nocapture
+token-bench = ["dep:tiktoken-rs", "semantic"]
 
 
 [[example]]

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -93,7 +93,7 @@ toml = "0.9.11"
 tempfile = "3.8"
 rusty-tesseract = { version = "1.1.10", optional = true }
 image = { workspace = true, features = ["png", "jpeg"], optional = true }
-tiktoken-rs = { version = "0.11.0", optional = true }
+tiktoken-rs = { version = "0.12.0", optional = true }
 
 # Platform-specific
 [target.'cfg(unix)'.dependencies]
@@ -478,9 +478,10 @@ language-detection = ["dep:whatlang"]
 rayon = ["dep:rayon"]
 
 # Token-count benchmark harness for the token-efficient chunk serializer (#291).
-# Opt-in only: pulls `tiktoken-rs` (MSRV 1.85+), so it is kept OUT of the default
-# dependency graph to preserve the crate MSRV of 1.77. Implies `semantic` so the
-# JSON baseline (`JsonExporter`) is available for comparison.
+# Opt-in only: `tiktoken-rs` bundles multi-MB BPE rank tables, so it is kept OUT
+# of normal builds (including default `cargo test`) and pulled only when running
+# this measurement. Implies `semantic` so the JSON baseline (`JsonExporter`) is
+# available for comparison.
 # Run with: cargo test --features token-bench -- --nocapture
 token-bench = ["dep:tiktoken-rs", "semantic"]
 

--- a/oxidize-pdf-core/src/ai/formats.rs
+++ b/oxidize-pdf-core/src/ai/formats.rs
@@ -1053,6 +1053,9 @@ impl TokenEfficientExporter {
                 },
                 confidence,
                 sentence_boundary_respected: fields[8] == "true",
+                // The token-efficient format does not carry language; round-trip
+                // leaves it unset (re-derivable via DocumentChunker detection).
+                language: None,
             },
         })
     }
@@ -1223,6 +1226,7 @@ mod tests {
                 },
                 confidence,
                 sentence_boundary_respected,
+                language: None,
             },
         }
     }

--- a/oxidize-pdf-core/src/ai/formats.rs
+++ b/oxidize-pdf-core/src/ai/formats.rs
@@ -893,6 +893,9 @@ impl ContextualFormat {
 /// inherent methods (`JsonExporter::export_with_chunks`,
 /// `TokenEfficientExporter::export_chunks`), so callers can pick a format at
 /// runtime behind a `dyn ChunkExporter`.
+///
+/// `TokenEfficientExporter` always implements this trait. `JsonExporter`
+/// implements it only when the `semantic` feature is enabled.
 pub trait ChunkExporter {
     /// Serialize the given chunks into this exporter's output format.
     fn export_chunks(&self, chunks: &[DocumentChunk]) -> Result<String>;
@@ -972,7 +975,7 @@ impl TokenEfficientExporter {
     /// newlines are reassembled correctly. Returns an error on a wrong version,
     /// a wrong header, or a row whose column count does not match the header.
     pub fn parse_chunks(input: &str) -> Result<Vec<DocumentChunk>> {
-        let logical = Self::rejoin_quoted_lines(input);
+        let logical = Self::rejoin_quoted_lines(input)?;
         let mut iter = logical.iter();
 
         match iter.next().map(|s| s.trim_end_matches('\r')) {
@@ -1029,13 +1032,18 @@ impl TokenEfficientExporter {
                 fields[7]
             ))
         })?;
+        if !confidence.is_finite() {
+            return Err(crate::error::PdfError::InvalidStructure(format!(
+                "token-efficient: confidence must be finite, got {confidence:?}"
+            )));
+        }
 
         Ok(DocumentChunk {
             id: fields[0].to_string(),
             tokens: parse_usize("tokens", fields[1])?,
             chunk_index: parse_usize("chunk_index", fields[2])?,
             page_numbers: Self::parse_page_numbers_field(fields[9])?,
-            content: Self::parse_content_field(fields[10]),
+            content: Self::parse_content_field(fields[10])?,
             metadata: ChunkMetadata {
                 position: ChunkPosition {
                     start_char: parse_usize("start_char", fields[3])?,
@@ -1052,7 +1060,11 @@ impl TokenEfficientExporter {
     /// Split the input into logical rows, treating `\n` inside a quoted field as
     /// part of the content rather than a row separator. `""` (an escaped quote)
     /// toggles the quote state twice, correctly keeping the parser inside the field.
-    fn rejoin_quoted_lines(input: &str) -> Vec<String> {
+    ///
+    /// A dangling open quote at end of input (odd number of `"`, e.g. a corrupt or
+    /// hand-crafted payload) is rejected rather than silently merging every
+    /// remaining row into one record.
+    fn rejoin_quoted_lines(input: &str) -> Result<Vec<String>> {
         let mut rows = Vec::new();
         let mut current = String::new();
         let mut in_quote = false;
@@ -1068,8 +1080,13 @@ impl TokenEfficientExporter {
                 _ => current.push(ch),
             }
         }
+        if in_quote {
+            return Err(crate::error::PdfError::InvalidStructure(
+                "token-efficient: unterminated quoted field".to_string(),
+            ));
+        }
         rows.push(current);
-        rows
+        Ok(rows)
     }
 
     /// Parse the `page_numbers` column (semicolon-separated integers).
@@ -1093,12 +1110,14 @@ impl TokenEfficientExporter {
     /// Quote the `content` field only when required to keep rows unambiguous.
     ///
     /// `content` is the last field and is recovered with `splitn(11, '\t')`, so
-    /// interior tabs and commas are safe raw. Quoting is needed only when the
-    /// content contains a newline/CR (which would otherwise split the row) or
-    /// starts with `"` (which would otherwise be read as a quoted field). When
-    /// quoted, the field is wrapped in `"` and interior `"` are doubled.
+    /// interior tabs and commas are safe raw. Quoting is required when the content
+    /// contains any `"` (otherwise the parser's quote-tracking would desync and
+    /// swallow following rows) or a newline/CR (which would otherwise split the
+    /// row). When quoted, the field is wrapped in `"` and interior `"` are doubled.
+    /// This keeps the RFC-4180 invariant: a field is raw iff it contains no
+    /// `"`, `\n`, or `\r`.
     fn quote_content(s: &str) -> String {
-        let needs_quote = s.starts_with('"') || s.contains('\n') || s.contains('\r');
+        let needs_quote = s.contains('"') || s.contains('\n') || s.contains('\r');
         if needs_quote {
             format!("\"{}\"", s.replace('"', "\"\""))
         } else {
@@ -1107,11 +1126,30 @@ impl TokenEfficientExporter {
     }
 
     /// Inverse of [`Self::quote_content`].
-    fn parse_content_field(s: &str) -> String {
+    ///
+    /// A raw field (no surrounding quotes) is returned as-is. A quoted field is
+    /// unwrapped and its doubled `""` are collapsed. A malformed quoted field
+    /// (an interior lone `"` that is not part of a `""` pair) is rejected, since
+    /// the encoder never produces one.
+    fn parse_content_field(s: &str) -> Result<String> {
         if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-            s[1..s.len() - 1].replace("\"\"", "\"")
+            let inner = &s[1..s.len() - 1];
+            // Every interior `"` must be part of a doubled `""`. Removing the
+            // pairs must leave no stray quote behind.
+            if inner.replace("\"\"", "").contains('"') {
+                return Err(crate::error::PdfError::InvalidStructure(
+                    "token-efficient: malformed quoted content field (unbalanced quotes)"
+                        .to_string(),
+                ));
+            }
+            Ok(inner.replace("\"\"", "\""))
+        } else if s.contains('"') {
+            // A raw field can never legitimately contain a `"`.
+            Err(crate::error::PdfError::InvalidStructure(
+                "token-efficient: unquoted content field contains a stray quote".to_string(),
+            ))
         } else {
-            s.to_string()
+            Ok(s.to_string())
         }
     }
 
@@ -1315,10 +1353,19 @@ mod tests {
             te_content_field(&te_export_one("hello, world")),
             "hello, world"
         );
-        // interior double-quote, not at start: safe raw
-        assert_eq!(te_content_field(&te_export_one("say \"hi\"")), "say \"hi\"");
+        // any interior double-quote must be quoted + doubled (RFC-4180 invariant),
+        // otherwise the parser's quote tracking would desync on odd quote counts
+        assert_eq!(
+            te_content_field(&te_export_one("say \"hi\"")),
+            "\"say \"\"hi\"\"\""
+        );
         // content that starts with a quote must be quoted + interior quotes doubled
         assert_eq!(te_content_field(&te_export_one("\"hi\"")), "\"\"\"hi\"\"\"");
+        // odd number of interior quotes: still fully quoted (the QR #3 case)
+        assert_eq!(
+            te_content_field(&te_export_one("say \"hello")),
+            "\"say \"\"hello\""
+        );
         // embedded newline must be quoted (so the row stays one logical record)
         assert_eq!(
             te_content_field(&te_export_one("line1\nline2")),
@@ -1332,23 +1379,27 @@ mod tests {
 
     #[test]
     fn test_parse_content_field() {
+        // raw field with no special chars
         assert_eq!(
-            TokenEfficientExporter::parse_content_field("hello, world"),
+            TokenEfficientExporter::parse_content_field("hello, world").unwrap(),
             "hello, world"
         );
+        // properly quoted field with doubled interior quotes
         assert_eq!(
-            TokenEfficientExporter::parse_content_field("say \"hi\""),
-            "say \"hi\""
-        );
-        assert_eq!(
-            TokenEfficientExporter::parse_content_field("\"\"\"hi\"\"\""),
+            TokenEfficientExporter::parse_content_field("\"\"\"hi\"\"\"").unwrap(),
             "\"hi\""
         );
-        assert_eq!(TokenEfficientExporter::parse_content_field(""), "");
+        // empty
+        assert_eq!(TokenEfficientExporter::parse_content_field("").unwrap(), "");
+        // quoted field spanning a newline
         assert_eq!(
-            TokenEfficientExporter::parse_content_field("\"line1\nline2\""),
+            TokenEfficientExporter::parse_content_field("\"line1\nline2\"").unwrap(),
             "line1\nline2"
         );
+        // a raw field can never legitimately contain a stray quote -> rejected
+        assert!(TokenEfficientExporter::parse_content_field("say \"hi\"").is_err());
+        // a quoted field with an unbalanced interior quote -> rejected
+        assert!(TokenEfficientExporter::parse_content_field("\"ab\"cd\"").is_err());
     }
 
     #[test]
@@ -1451,7 +1502,7 @@ mod tests {
     fn test_rejoin_quoted_lines_with_embedded_newline() {
         // a quoted field spanning a physical newline must rejoin into one logical row
         let raw = "#oxct/1\nHDR\nrow_a\t\"line1\nline2\"\nrow_b";
-        let logical = TokenEfficientExporter::rejoin_quoted_lines(raw);
+        let logical = TokenEfficientExporter::rejoin_quoted_lines(raw).unwrap();
         assert_eq!(logical.len(), 4); // magic, hdr, row_a(quoted), row_b
         assert_eq!(logical[0], "#oxct/1");
         assert_eq!(logical[1], "HDR");
@@ -1637,6 +1688,42 @@ mod tests {
     }
 
     #[test]
+    fn test_roundtrip_content_with_odd_interior_quote() {
+        // QR #3: content with a single (odd) interior quote, no newline, not at
+        // the start. Must not let the parser swallow the following row.
+        let chunks = vec![
+            te_chunk("a", "say \"hello", 2, vec![1], 0, 0, 10, 1, 1, 0.5, false),
+            te_chunk("b", "second chunk", 1, vec![1], 1, 10, 22, 1, 1, 0.5, false),
+        ];
+        let serialized = TokenEfficientExporter::new()
+            .export_chunks(&chunks)
+            .unwrap();
+        let parsed = TokenEfficientExporter::parse_chunks(&serialized).unwrap();
+        assert_eq!(parsed.len(), 2, "the second row must not be swallowed");
+        assert_chunk_eq(&parsed[0], &chunks[0]);
+        assert_chunk_eq(&parsed[1], &chunks[1]);
+    }
+
+    #[test]
+    fn test_parse_rejects_unterminated_quote() {
+        // QR #1: hand-crafted/corrupt input with a dangling quote must error,
+        // not silently consume the rest of the document.
+        let bad =
+            format!("#oxct/1\n{TE_HEADER}\nc\t1\t0\t0\t1\t1\t1\t0.5000\ttrue\t1\t\"unterminated");
+        assert!(TokenEfficientExporter::parse_chunks(&bad).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_non_finite_confidence() {
+        // QR #4: NaN/Infinity confidence must be rejected rather than silently
+        // producing a NaN that corrupts downstream ranking.
+        let bad = format!("#oxct/1\n{TE_HEADER}\nc\t1\t0\t0\t1\t1\t1\tNaN\ttrue\t1\tx");
+        assert!(TokenEfficientExporter::parse_chunks(&bad).is_err());
+        let bad_inf = format!("#oxct/1\n{TE_HEADER}\nc\t1\t0\t0\t1\t1\t1\tinf\ttrue\t1\tx");
+        assert!(TokenEfficientExporter::parse_chunks(&bad_inf).is_err());
+    }
+
+    #[test]
     fn test_chunk_exporter_trait_object() {
         let chunks = vec![te_chunk("a", "x", 1, vec![1], 0, 0, 1, 1, 1, 1.0, true)];
         // object-safe: usable behind a trait object
@@ -1671,7 +1758,7 @@ mod tests {
     /// the JSON baseline. Gated behind `token-bench` (pulls `tiktoken-rs`,
     /// MSRV 1.85+) so it never enters the default MSRV-1.77 build.
     ///
-    /// Run: `cargo test -p oxidize-pdf --features token-bench token_reduction -- --nocapture`
+    /// Run: `cargo test -p oxidize-pdf --features token-bench uses_fewer_tokens -- --nocapture`
     #[cfg(feature = "token-bench")]
     #[test]
     fn test_token_efficient_uses_fewer_tokens_than_json() {

--- a/oxidize-pdf-core/src/ai/formats.rs
+++ b/oxidize-pdf-core/src/ai/formats.rs
@@ -21,7 +21,6 @@ use crate::Result;
 #[cfg(feature = "semantic")]
 use serde_json::{json, Value};
 
-#[cfg(feature = "semantic")]
 use super::chunking::DocumentChunk;
 
 /// Metadata about a PDF document for export
@@ -659,6 +658,13 @@ impl JsonExporter {
     }
 }
 
+#[cfg(feature = "semantic")]
+impl ChunkExporter for JsonExporter {
+    fn export_chunks(&self, chunks: &[DocumentChunk]) -> Result<String> {
+        JsonExporter::export_with_chunks(chunks)
+    }
+}
+
 /// Exporter for converting PDF content to contextual format
 ///
 /// Contextual format is optimized for direct injection into LLM prompts,
@@ -881,9 +887,850 @@ impl ContextualFormat {
     }
 }
 
+/// Common interface for serializers that turn RAG chunks into a string payload.
+///
+/// This unifies the chunk-export entry points that previously lived as unrelated
+/// inherent methods (`JsonExporter::export_with_chunks`,
+/// `TokenEfficientExporter::export_chunks`), so callers can pick a format at
+/// runtime behind a `dyn ChunkExporter`.
+pub trait ChunkExporter {
+    /// Serialize the given chunks into this exporter's output format.
+    fn export_chunks(&self, chunks: &[DocumentChunk]) -> Result<String>;
+}
+
+/// Token-efficient, TOON-inspired tabular serializer for RAG chunks (issue #291).
+///
+/// Unlike [`JsonExporter`], which repeats every key name for every chunk, this
+/// format declares the column names once in a header line and then emits one
+/// tab-separated row per chunk. That removes the per-record structural overhead
+/// that dominates JSON token cost for large chunk sets, while staying fully
+/// round-trippable via [`TokenEfficientExporter::parse_chunks`].
+///
+/// The serializer builds its output with plain string formatting and therefore
+/// does **not** require the `semantic` feature (no `serde_json` dependency).
+///
+/// Wire shape:
+///
+/// ```text
+/// #oxct/1
+/// id<TAB>tokens<TAB>chunk_index<TAB>start_char<TAB>end_char<TAB>first_page<TAB>last_page<TAB>confidence<TAB>sentence_boundary<TAB>page_numbers<TAB>content
+/// chunk_0<TAB>10<TAB>0<TAB>0<TAB>100<TAB>1<TAB>1<TAB>1.0000<TAB>true<TAB>1<TAB>Hello world
+/// ```
+///
+/// The token reduction versus JSON is measured (not estimated) by the
+/// `token-bench` gated test; on a representative corpus it is ~64% with the
+/// `cl100k_base` tokenizer.
+///
+/// # Example
+///
+/// ```
+/// use oxidize_pdf::ai::{ChunkExporter, DocumentChunker, TokenEfficientExporter};
+///
+/// # fn main() -> oxidize_pdf::Result<()> {
+/// let chunks = DocumentChunker::new(512, 50).chunk_text("Some document text to embed.")?;
+/// let serialized = TokenEfficientExporter::new().export_chunks(&chunks)?;
+///
+/// // The format is fully round-trippable.
+/// let restored = TokenEfficientExporter::parse_chunks(&serialized)?;
+/// assert_eq!(restored.len(), chunks.len());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct TokenEfficientExporter;
+
+impl TokenEfficientExporter {
+    /// Format version marker emitted as the first line.
+    const MAGIC: &'static str = "#oxct/1";
+
+    /// Column header emitted as the second line (declared once for all rows).
+    const HEADER: &'static str = "id\ttokens\tchunk_index\tstart_char\tend_char\tfirst_page\tlast_page\tconfidence\tsentence_boundary\tpage_numbers\tcontent";
+
+    /// Create a new exporter.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Serialize chunks to the token-efficient tabular format.
+    pub fn export_chunks(&self, chunks: &[DocumentChunk]) -> Result<String> {
+        let mut out = String::new();
+        out.push_str(Self::MAGIC);
+        out.push('\n');
+        out.push_str(Self::HEADER);
+        for chunk in chunks {
+            out.push('\n');
+            out.push_str(&Self::encode_row(chunk));
+        }
+        Ok(out)
+    }
+
+    /// Parse a token-efficient document back into chunks (inverse of
+    /// [`Self::export_chunks`]).
+    ///
+    /// Validates the version marker and column header, then decodes one chunk
+    /// per data row. Rows are quote-aware so content fields containing embedded
+    /// newlines are reassembled correctly. Returns an error on a wrong version,
+    /// a wrong header, or a row whose column count does not match the header.
+    pub fn parse_chunks(input: &str) -> Result<Vec<DocumentChunk>> {
+        let logical = Self::rejoin_quoted_lines(input);
+        let mut iter = logical.iter();
+
+        match iter.next().map(|s| s.trim_end_matches('\r')) {
+            Some(Self::MAGIC) => {}
+            other => {
+                return Err(crate::error::PdfError::InvalidStructure(format!(
+                    "token-efficient: unexpected version marker {other:?}, expected {:?}",
+                    Self::MAGIC
+                )))
+            }
+        }
+        match iter.next().map(|s| s.trim_end_matches('\r')) {
+            Some(Self::HEADER) => {}
+            other => {
+                return Err(crate::error::PdfError::InvalidStructure(format!(
+                    "token-efficient: unexpected column header {other:?}"
+                )))
+            }
+        }
+
+        let mut chunks = Vec::new();
+        for line in iter {
+            if line.is_empty() {
+                continue;
+            }
+            chunks.push(Self::parse_row(line)?);
+        }
+        Ok(chunks)
+    }
+
+    /// Decode a single data row into a [`DocumentChunk`].
+    fn parse_row(line: &str) -> Result<DocumentChunk> {
+        use crate::ai::chunking::{ChunkMetadata, ChunkPosition};
+
+        let fields: Vec<&str> = line.splitn(11, '\t').collect();
+        if fields.len() != 11 {
+            return Err(crate::error::PdfError::InvalidStructure(format!(
+                "token-efficient: row has {} columns, expected 11",
+                fields.len()
+            )));
+        }
+
+        let parse_usize = |name: &str, s: &str| -> Result<usize> {
+            s.parse::<usize>().map_err(|e| {
+                crate::error::PdfError::InvalidStructure(format!(
+                    "token-efficient: invalid {name} {s:?}: {e}"
+                ))
+            })
+        };
+
+        let confidence = fields[7].parse::<f32>().map_err(|e| {
+            crate::error::PdfError::InvalidStructure(format!(
+                "token-efficient: invalid confidence {:?}: {e}",
+                fields[7]
+            ))
+        })?;
+
+        Ok(DocumentChunk {
+            id: fields[0].to_string(),
+            tokens: parse_usize("tokens", fields[1])?,
+            chunk_index: parse_usize("chunk_index", fields[2])?,
+            page_numbers: Self::parse_page_numbers_field(fields[9])?,
+            content: Self::parse_content_field(fields[10]),
+            metadata: ChunkMetadata {
+                position: ChunkPosition {
+                    start_char: parse_usize("start_char", fields[3])?,
+                    end_char: parse_usize("end_char", fields[4])?,
+                    first_page: parse_usize("first_page", fields[5])?,
+                    last_page: parse_usize("last_page", fields[6])?,
+                },
+                confidence,
+                sentence_boundary_respected: fields[8] == "true",
+            },
+        })
+    }
+
+    /// Split the input into logical rows, treating `\n` inside a quoted field as
+    /// part of the content rather than a row separator. `""` (an escaped quote)
+    /// toggles the quote state twice, correctly keeping the parser inside the field.
+    fn rejoin_quoted_lines(input: &str) -> Vec<String> {
+        let mut rows = Vec::new();
+        let mut current = String::new();
+        let mut in_quote = false;
+        for ch in input.chars() {
+            match ch {
+                '"' => {
+                    in_quote = !in_quote;
+                    current.push(ch);
+                }
+                '\n' if !in_quote => {
+                    rows.push(std::mem::take(&mut current));
+                }
+                _ => current.push(ch),
+            }
+        }
+        rows.push(current);
+        rows
+    }
+
+    /// Parse the `page_numbers` column (semicolon-separated integers).
+    ///
+    /// An empty string yields an empty vector. Any non-integer element is an error.
+    fn parse_page_numbers_field(s: &str) -> Result<Vec<usize>> {
+        if s.is_empty() {
+            return Ok(Vec::new());
+        }
+        s.split(';')
+            .map(|p| {
+                p.parse::<usize>().map_err(|e| {
+                    crate::error::PdfError::InvalidStructure(format!(
+                        "invalid page number {p:?} in token-efficient chunk row: {e}"
+                    ))
+                })
+            })
+            .collect()
+    }
+
+    /// Quote the `content` field only when required to keep rows unambiguous.
+    ///
+    /// `content` is the last field and is recovered with `splitn(11, '\t')`, so
+    /// interior tabs and commas are safe raw. Quoting is needed only when the
+    /// content contains a newline/CR (which would otherwise split the row) or
+    /// starts with `"` (which would otherwise be read as a quoted field). When
+    /// quoted, the field is wrapped in `"` and interior `"` are doubled.
+    fn quote_content(s: &str) -> String {
+        let needs_quote = s.starts_with('"') || s.contains('\n') || s.contains('\r');
+        if needs_quote {
+            format!("\"{}\"", s.replace('"', "\"\""))
+        } else {
+            s.to_string()
+        }
+    }
+
+    /// Inverse of [`Self::quote_content`].
+    fn parse_content_field(s: &str) -> String {
+        if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+            s[1..s.len() - 1].replace("\"\"", "\"")
+        } else {
+            s.to_string()
+        }
+    }
+
+    /// Encode a single chunk as one tab-separated data row.
+    fn encode_row(chunk: &DocumentChunk) -> String {
+        let pages = chunk
+            .page_numbers
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(";");
+        format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.4}\t{}\t{}\t{}",
+            chunk.id,
+            chunk.tokens,
+            chunk.chunk_index,
+            chunk.metadata.position.start_char,
+            chunk.metadata.position.end_char,
+            chunk.metadata.position.first_page,
+            chunk.metadata.position.last_page,
+            chunk.metadata.confidence,
+            chunk.metadata.sentence_boundary_respected,
+            pages,
+            Self::quote_content(&chunk.content),
+        )
+    }
+}
+
+impl ChunkExporter for TokenEfficientExporter {
+    fn export_chunks(&self, chunks: &[DocumentChunk]) -> Result<String> {
+        TokenEfficientExporter::export_chunks(self, chunks)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- Token-efficient exporter (#291) ----
+
+    /// Expected column header for the token-efficient tabular format.
+    const TE_HEADER: &str = "id\ttokens\tchunk_index\tstart_char\tend_char\tfirst_page\tlast_page\tconfidence\tsentence_boundary\tpage_numbers\tcontent";
+
+    #[allow(clippy::too_many_arguments)]
+    fn te_chunk(
+        id: &str,
+        content: &str,
+        tokens: usize,
+        page_numbers: Vec<usize>,
+        chunk_index: usize,
+        start_char: usize,
+        end_char: usize,
+        first_page: usize,
+        last_page: usize,
+        confidence: f32,
+        sentence_boundary_respected: bool,
+    ) -> crate::ai::chunking::DocumentChunk {
+        use crate::ai::chunking::{ChunkMetadata, ChunkPosition, DocumentChunk};
+        DocumentChunk {
+            id: id.to_string(),
+            content: content.to_string(),
+            tokens,
+            page_numbers,
+            chunk_index,
+            metadata: ChunkMetadata {
+                position: ChunkPosition {
+                    start_char,
+                    end_char,
+                    first_page,
+                    last_page,
+                },
+                confidence,
+                sentence_boundary_respected,
+            },
+        }
+    }
+
+    #[test]
+    fn test_encode_scalar_fields_no_special_chars() {
+        let chunks = vec![te_chunk(
+            "chunk_0",
+            "Hello world",
+            10,
+            vec![1],
+            0,
+            0,
+            100,
+            1,
+            1,
+            1.0,
+            true,
+        )];
+
+        let out = TokenEfficientExporter::new()
+            .export_chunks(&chunks)
+            .unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+
+        // version marker, header, one data row
+        assert_eq!(
+            lines.len(),
+            3,
+            "expected magic + header + 1 row, got: {out:?}"
+        );
+        assert_eq!(
+            lines[0], "#oxct/1",
+            "first line must be the format version marker"
+        );
+        assert_eq!(lines[1], TE_HEADER, "second line must be the column header");
+        assert_eq!(
+            lines[2], "chunk_0\t10\t0\t0\t100\t1\t1\t1.0000\ttrue\t1\tHello world",
+            "data row must be tab-separated scalar fields followed by content"
+        );
+    }
+
+    #[test]
+    fn test_page_numbers_encoding() {
+        // multi-page
+        let out = TokenEfficientExporter::new()
+            .export_chunks(&[te_chunk(
+                "c",
+                "x",
+                1,
+                vec![2, 3, 4],
+                0,
+                0,
+                1,
+                2,
+                4,
+                0.5,
+                false,
+            )])
+            .unwrap();
+        let row = out.lines().nth(2).unwrap();
+        assert_eq!(row.split('\t').nth(9).unwrap(), "2;3;4");
+
+        // single page
+        let out = TokenEfficientExporter::new()
+            .export_chunks(&[te_chunk("c", "x", 1, vec![1], 0, 0, 1, 1, 1, 0.5, false)])
+            .unwrap();
+        let row = out.lines().nth(2).unwrap();
+        assert_eq!(row.split('\t').nth(9).unwrap(), "1");
+
+        // empty page list
+        let out = TokenEfficientExporter::new()
+            .export_chunks(&[te_chunk("c", "x", 1, vec![], 0, 0, 1, 0, 0, 0.5, false)])
+            .unwrap();
+        let row = out.lines().nth(2).unwrap();
+        assert_eq!(row.split('\t').nth(9).unwrap(), "");
+    }
+
+    #[test]
+    fn test_parse_page_numbers_field() {
+        assert_eq!(
+            TokenEfficientExporter::parse_page_numbers_field("2;3;4").unwrap(),
+            vec![2usize, 3, 4]
+        );
+        assert_eq!(
+            TokenEfficientExporter::parse_page_numbers_field("1").unwrap(),
+            vec![1usize]
+        );
+        assert_eq!(
+            TokenEfficientExporter::parse_page_numbers_field("").unwrap(),
+            Vec::<usize>::new()
+        );
+        assert!(TokenEfficientExporter::parse_page_numbers_field("1;x;3").is_err());
+    }
+
+    /// Extract the raw (still-encoded) content field from a single-chunk export.
+    fn te_content_field(out: &str) -> String {
+        let row = out
+            .strip_prefix("#oxct/1\n")
+            .and_then(|s| s.strip_prefix(TE_HEADER))
+            .and_then(|s| s.strip_prefix('\n'))
+            .expect("well-formed export");
+        row.splitn(11, '\t').nth(10).unwrap().to_string()
+    }
+
+    fn te_export_one(content: &str) -> String {
+        TokenEfficientExporter::new()
+            .export_chunks(&[te_chunk(
+                "c",
+                content,
+                1,
+                vec![1],
+                0,
+                0,
+                1,
+                1,
+                1,
+                0.5,
+                false,
+            )])
+            .unwrap()
+    }
+
+    #[test]
+    fn test_content_quoting() {
+        // comma: tab-delimited format does not need to quote commas
+        assert_eq!(
+            te_content_field(&te_export_one("hello, world")),
+            "hello, world"
+        );
+        // interior double-quote, not at start: safe raw
+        assert_eq!(te_content_field(&te_export_one("say \"hi\"")), "say \"hi\"");
+        // content that starts with a quote must be quoted + interior quotes doubled
+        assert_eq!(te_content_field(&te_export_one("\"hi\"")), "\"\"\"hi\"\"\"");
+        // embedded newline must be quoted (so the row stays one logical record)
+        assert_eq!(
+            te_content_field(&te_export_one("line1\nline2")),
+            "\"line1\nline2\""
+        );
+        // unicode: no special chars, raw
+        assert_eq!(te_content_field(&te_export_one("こんにちは")), "こんにちは");
+        // empty content: raw empty
+        assert_eq!(te_content_field(&te_export_one("")), "");
+    }
+
+    #[test]
+    fn test_parse_content_field() {
+        assert_eq!(
+            TokenEfficientExporter::parse_content_field("hello, world"),
+            "hello, world"
+        );
+        assert_eq!(
+            TokenEfficientExporter::parse_content_field("say \"hi\""),
+            "say \"hi\""
+        );
+        assert_eq!(
+            TokenEfficientExporter::parse_content_field("\"\"\"hi\"\"\""),
+            "\"hi\""
+        );
+        assert_eq!(TokenEfficientExporter::parse_content_field(""), "");
+        assert_eq!(
+            TokenEfficientExporter::parse_content_field("\"line1\nline2\""),
+            "line1\nline2"
+        );
+    }
+
+    #[test]
+    fn test_multi_chunk_document() {
+        let chunks = vec![
+            te_chunk(
+                "chunk_0",
+                "First chunk",
+                10,
+                vec![1],
+                0,
+                0,
+                100,
+                1,
+                1,
+                1.0,
+                true,
+            ),
+            te_chunk(
+                "chunk_1",
+                "Second, chunk",
+                12,
+                vec![1, 2],
+                1,
+                90,
+                200,
+                1,
+                2,
+                0.95,
+                false,
+            ),
+        ];
+        let out = TokenEfficientExporter::new()
+            .export_chunks(&chunks)
+            .unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+
+        assert_eq!(lines.len(), 4, "magic + header + 2 rows");
+        assert_eq!(lines[0], "#oxct/1");
+        assert_eq!(lines[1], TE_HEADER);
+        // first row content has no special chars -> not quoted
+        assert!(lines[2].ends_with("\tFirst chunk"));
+        // comma in content does not trigger quoting (tab-delimited)
+        assert!(lines[3].ends_with("\tSecond, chunk"));
+        assert_eq!(lines[3].split('\t').nth(9).unwrap(), "1;2");
+    }
+
+    fn assert_chunk_eq(
+        a: &crate::ai::chunking::DocumentChunk,
+        b: &crate::ai::chunking::DocumentChunk,
+    ) {
+        assert_eq!(a.id, b.id, "id");
+        assert_eq!(a.content, b.content, "content");
+        assert_eq!(a.tokens, b.tokens, "tokens");
+        assert_eq!(a.page_numbers, b.page_numbers, "page_numbers");
+        assert_eq!(a.chunk_index, b.chunk_index, "chunk_index");
+        assert_eq!(
+            a.metadata.position.start_char, b.metadata.position.start_char,
+            "start_char"
+        );
+        assert_eq!(
+            a.metadata.position.end_char, b.metadata.position.end_char,
+            "end_char"
+        );
+        assert_eq!(
+            a.metadata.position.first_page, b.metadata.position.first_page,
+            "first_page"
+        );
+        assert_eq!(
+            a.metadata.position.last_page, b.metadata.position.last_page,
+            "last_page"
+        );
+        assert!(
+            (a.metadata.confidence - b.metadata.confidence).abs() < 1e-4,
+            "confidence: {} vs {}",
+            a.metadata.confidence,
+            b.metadata.confidence
+        );
+        assert_eq!(
+            a.metadata.sentence_boundary_respected, b.metadata.sentence_boundary_respected,
+            "sentence_boundary"
+        );
+    }
+
+    fn roundtrip(chunk: crate::ai::chunking::DocumentChunk) {
+        let exporter = TokenEfficientExporter::new();
+        let serialized = exporter
+            .export_chunks(std::slice::from_ref(&chunk))
+            .unwrap();
+        let parsed = TokenEfficientExporter::parse_chunks(&serialized).unwrap();
+        assert_eq!(
+            parsed.len(),
+            1,
+            "single chunk should round-trip to one chunk"
+        );
+        assert_chunk_eq(&parsed[0], &chunk);
+    }
+
+    #[test]
+    fn test_rejoin_quoted_lines_with_embedded_newline() {
+        // a quoted field spanning a physical newline must rejoin into one logical row
+        let raw = "#oxct/1\nHDR\nrow_a\t\"line1\nline2\"\nrow_b";
+        let logical = TokenEfficientExporter::rejoin_quoted_lines(raw);
+        assert_eq!(logical.len(), 4); // magic, hdr, row_a(quoted), row_b
+        assert_eq!(logical[0], "#oxct/1");
+        assert_eq!(logical[1], "HDR");
+        assert_eq!(logical[2], "row_a\t\"line1\nline2\"");
+        assert_eq!(logical[3], "row_b");
+    }
+
+    #[test]
+    fn test_roundtrip_single_chunk() {
+        roundtrip(te_chunk(
+            "chunk_0",
+            "Plain content",
+            7,
+            vec![3],
+            0,
+            10,
+            210,
+            3,
+            3,
+            0.95,
+            true,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_zero_chunks() {
+        let exporter = TokenEfficientExporter::new();
+        let serialized = exporter.export_chunks(&[]).unwrap();
+        // exactly magic + header, no trailing newline
+        assert_eq!(serialized, format!("#oxct/1\n{TE_HEADER}"));
+        let parsed = TokenEfficientExporter::parse_chunks(&serialized).unwrap();
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn test_roundtrip_content_with_comma() {
+        roundtrip(te_chunk(
+            "c",
+            "price: $1,200",
+            4,
+            vec![1],
+            0,
+            0,
+            13,
+            1,
+            1,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_content_with_embedded_newline() {
+        roundtrip(te_chunk(
+            "c",
+            "line1\nline2\nline3",
+            5,
+            vec![1, 2],
+            0,
+            0,
+            17,
+            1,
+            2,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_content_with_embedded_quote() {
+        roundtrip(te_chunk(
+            "c",
+            "He said \"hello\"",
+            5,
+            vec![1],
+            0,
+            0,
+            15,
+            1,
+            1,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_content_starting_with_quote() {
+        roundtrip(te_chunk(
+            "c",
+            "\"quoted start",
+            3,
+            vec![1],
+            0,
+            0,
+            13,
+            1,
+            1,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_unicode() {
+        roundtrip(te_chunk(
+            "c",
+            "Ñoño: αβγ 中文 🦀",
+            6,
+            vec![1],
+            0,
+            0,
+            20,
+            1,
+            1,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_multi_page() {
+        roundtrip(te_chunk(
+            "c",
+            "x",
+            1,
+            vec![3, 7, 12],
+            0,
+            0,
+            1,
+            3,
+            12,
+            0.5,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip_multiple_chunks_preserves_order() {
+        let chunks = vec![
+            te_chunk("a", "first", 1, vec![1], 0, 0, 5, 1, 1, 1.0, true),
+            te_chunk(
+                "b",
+                "with, comma",
+                2,
+                vec![1, 2],
+                1,
+                5,
+                16,
+                1,
+                2,
+                0.8,
+                false,
+            ),
+            te_chunk("c", "line\nbreak", 3, vec![2], 2, 16, 26, 2, 2, 0.6, true),
+        ];
+        let serialized = TokenEfficientExporter::new()
+            .export_chunks(&chunks)
+            .unwrap();
+        let parsed = TokenEfficientExporter::parse_chunks(&serialized).unwrap();
+        assert_eq!(parsed.len(), 3);
+        for (orig, got) in chunks.iter().zip(parsed.iter()) {
+            assert_chunk_eq(got, orig);
+        }
+    }
+
+    #[test]
+    fn test_parse_rejects_wrong_column_count() {
+        let bad =
+            format!("#oxct/1\n{TE_HEADER}\nonly\tnine\tfields\there\tare\tsome\tnot\televen\tk");
+        assert!(TokenEfficientExporter::parse_chunks(&bad).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_bad_header() {
+        let bad = "#oxct/1\nnot_the_header\nrow";
+        assert!(TokenEfficientExporter::parse_chunks(bad).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_bad_magic() {
+        let bad = format!("#oxct/2\n{TE_HEADER}");
+        assert!(TokenEfficientExporter::parse_chunks(&bad).is_err());
+    }
+
+    #[test]
+    fn test_chunk_exporter_trait_object() {
+        let chunks = vec![te_chunk("a", "x", 1, vec![1], 0, 0, 1, 1, 1, 1.0, true)];
+        // object-safe: usable behind a trait object
+        let exporters: Vec<Box<dyn ChunkExporter>> = vec![Box::new(TokenEfficientExporter::new())];
+        for e in &exporters {
+            let out = e.export_chunks(&chunks).unwrap();
+            assert!(out.starts_with("#oxct/1\n"));
+        }
+    }
+
+    #[test]
+    fn test_chunk_exporter_trait_matches_inherent() {
+        let chunks = vec![te_chunk("a", "x", 1, vec![1], 0, 0, 1, 1, 1, 1.0, true)];
+        let exporter = TokenEfficientExporter::new();
+        let via_trait = ChunkExporter::export_chunks(&exporter, &chunks).unwrap();
+        let via_inherent = exporter.export_chunks(&chunks).unwrap();
+        assert_eq!(via_trait, via_inherent);
+    }
+
+    #[cfg(feature = "semantic")]
+    #[test]
+    fn test_json_exporter_implements_chunk_exporter() {
+        let chunks = vec![te_chunk("a", "x", 1, vec![1], 0, 0, 1, 1, 1, 1.0, true)];
+        let json_exporter = JsonExporter::default();
+        let via_trait = ChunkExporter::export_chunks(&json_exporter, &chunks).unwrap();
+        let via_inherent = JsonExporter::export_with_chunks(&chunks).unwrap();
+        assert_eq!(via_trait, via_inherent);
+    }
+
+    /// Token-count benchmark validating the core claim of #291: the
+    /// token-efficient format serializes a chunk set into fewer LLM tokens than
+    /// the JSON baseline. Gated behind `token-bench` (pulls `tiktoken-rs`,
+    /// MSRV 1.85+) so it never enters the default MSRV-1.77 build.
+    ///
+    /// Run: `cargo test -p oxidize-pdf --features token-bench token_reduction -- --nocapture`
+    #[cfg(feature = "token-bench")]
+    #[test]
+    fn test_token_efficient_uses_fewer_tokens_than_json() {
+        // A representative RAG corpus: varied content lengths, multi-page spans,
+        // commas, and mixed confidences — the homogeneous-record shape that the
+        // tabular format is meant to win on.
+        let paragraphs = [
+            "The quarterly report shows revenue of $1,200,000, up 12% year over year.",
+            "Section 3.2 describes the authentication flow, including token refresh and rotation.",
+            "Climate models project a temperature increase between 1.5 and 4.0 degrees Celsius.",
+            "The defendant, having waived counsel, proceeded to represent themselves at trial.",
+            "Mitochondria are the membrane-bound organelles responsible for cellular respiration.",
+        ];
+        let mut chunks = Vec::new();
+        for i in 0..50usize {
+            let body = paragraphs[i % paragraphs.len()];
+            // vary length so the corpus isn't uniform
+            let content = if i % 3 == 0 {
+                format!("{body} {body}")
+            } else {
+                body.to_string()
+            };
+            let first_page = 1 + i / 3;
+            let last_page = first_page + (i % 2);
+            let page_numbers: Vec<usize> = (first_page..=last_page).collect();
+            chunks.push(te_chunk(
+                &format!("chunk_{i}"),
+                &content,
+                crate::ai::chunking::DocumentChunker::estimate_tokens(&content),
+                page_numbers,
+                i,
+                i * 100,
+                i * 100 + content.len(),
+                first_page,
+                last_page,
+                0.5 + (i % 5) as f32 / 10.0,
+                i % 2 == 0,
+            ));
+        }
+
+        let te_out = TokenEfficientExporter::new()
+            .export_chunks(&chunks)
+            .unwrap();
+        let json_out = JsonExporter::export_with_chunks(&chunks).unwrap();
+
+        let bpe = tiktoken_rs::cl100k_base().expect("cl100k_base tokenizer");
+        let te_tokens = bpe.encode_ordinary(&te_out).len();
+        let json_tokens = bpe.encode_ordinary(&json_out).len();
+
+        let reduction = 100.0 * (1.0 - te_tokens as f64 / json_tokens as f64);
+        eprintln!(
+            "token-efficient: {te_tokens} tokens | json: {json_tokens} tokens | reduction: {reduction:.1}%"
+        );
+
+        assert!(
+            te_tokens < json_tokens,
+            "token-efficient ({te_tokens}) must use fewer tokens than JSON ({json_tokens})"
+        );
+    }
 
     #[test]
     fn test_basic_text_to_markdown() {

--- a/oxidize-pdf-core/src/ai/mod.rs
+++ b/oxidize-pdf-core/src/ai/mod.rs
@@ -33,7 +33,10 @@ pub mod formats;
 pub use chunking::{
     ChunkMetadata, ChunkPosition, DetectedLanguage, DocumentChunk, DocumentChunker,
 };
-pub use formats::{ContextualFormat, DocumentMetadata, MarkdownExporter, MarkdownOptions};
+pub use formats::{
+    ChunkExporter, ContextualFormat, DocumentMetadata, MarkdownExporter, MarkdownOptions,
+    TokenEfficientExporter,
+};
 
 #[cfg(feature = "semantic")]
 pub use formats::{JsonExporter, JsonOptions};


### PR DESCRIPTION
## Summary

Adds a TOON-inspired, token-efficient tabular serializer for RAG chunks as an additional output format alongside JSON/Markdown (addresses #291). The format declares column names once in a header line and emits one tab-separated row per chunk, removing the per-record key overhead that dominates JSON token cost.

## What's included

- **`TokenEfficientExporter`**: `export_chunks` + `parse_chunks` — fully round-trippable. Built with plain string formatting; available **without** the `semantic` feature (no `serde_json` dependency).
- **`ChunkExporter` trait**: unifies chunk exporters (DRY). `JsonExporter` (gated on `semantic`) and `TokenEfficientExporter` both implement it; usable behind `dyn ChunkExporter`.
- **`token-bench` feature** (opt-in, implies `semantic`): gates a `tiktoken-rs` measurement test.

## Measured result (not estimated)

`cl100k_base` on a representative 50-chunk corpus: **64.3% fewer tokens** (2493 vs 6990). The issue explicitly required measuring, not claiming, the reduction.

## MSRV 1.77 preserved

`tiktoken-rs` (MSRV 1.85) is **optional** and absent from the default dependency graph. Verified: `Cargo.lock` changes are pure additions of its transitive deps; **no existing dependency version changed**; none of the 4 added crates appear in the `--no-default-features` tree. CI runs no `--all-features` job.

## Format

```
#oxct/1
id<TAB>tokens<TAB>chunk_index<TAB>start_char<TAB>end_char<TAB>first_page<TAB>last_page<TAB>confidence<TAB>sentence_boundary<TAB>page_numbers<TAB>content
chunk_0<TAB>10<TAB>0<TAB>0<TAB>100<TAB>1<TAB>1<TAB>1.0000<TAB>true<TAB>1<TAB>Hello world
```

`content` is the last field (recovered via `splitn(11)`), quoted RFC-4180-style only when it contains a `"`, newline, or CR. Version marker rejects incompatible formats.

## Quality review applied

A quality pass surfaced and fixed (TDD, bug reproduced before fix) three real correctness bugs:
- **CRITICAL**: odd interior quote emitted raw → parser swallowed the next row in multi-chunk output. Fixed by quoting any content containing `"`.
- **CRITICAL**: unterminated quote in corrupt input silently consumed the rest of the document. Now errors.
- **MAJOR**: NaN/Infinity confidence round-tripped silently. Now rejected.

## Tests

Round-trip for comma / newline / leading-quote / odd-interior-quote / embedded-quote / unicode / multi-page / zero / malformed; trait object-safety; inherent==trait equivalence; rejection of unterminated quote, non-finite confidence, wrong column count, bad magic/header.

Lib **6524/0** (default), **6536/0** (semantic), doctests 13/13, clippy clean, fmt OK.