### PR TITLE
feat(rag): ruling-based table detection in partition pipeline (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ruling-based (vector-grid) table detection wired into the partition pipeline:
+  bordered tables are now reconstructed from the PDF's drawn grid (primary path),
+  with the spatial detector handling the rest. Controlled by
+  `PartitionConfig::prefer_ruling_tables` (default true). Cell-granular fragments
+  are re-extracted only for pages with a drawn grid, so table-free documents pay
+  no extra cost (#292).
 - Per-chunk and document-level language detection for RAG chunks, behind the
   opt-in `language-detection` feature (pure-Rust `whatlang`). `ChunkMetadata`
   gains `language: Option<DetectedLanguage>` (ISO 639-3 code + confidence +

--- a/docs/superpowers/plans/2026-06-06-issue-292-ruling-table-partition.md
+++ b/docs/superpowers/plans/2026-06-06-issue-292-ruling-table-partition.md
@@ -1,0 +1,568 @@
+# Ruling-based Table Detection in Partition — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing ruling-based `TableDetector` into the partition pipeline as the primary path for bordered tables (page-level, grid-first), with the spatial detector filling the remaining fragments.
+
+**Architecture:** A new `prefer_ruling_tables` config (default true) makes `do_partition_pages` extract per-page vector graphics and pass them to a new non-breaking `Partitioner::partition_fragments_with_graphics`. When the page has table-grid line structure, `TableDetector` runs first, emits bordered tables, and claims their fragments; the existing spatial detector then runs on the unclaimed remainder.
+
+**Tech Stack:** Rust (MSRV 1.88), `cargo test`. Tests are integration-level in `oxidize-pdf-core/tests/`, content-verifying per `CLAUDE.md` (no smoke tests). Spike-verified 2026-06-06: a writer-generated bordered table round-trips to `has_table_structure()==true` (H=18,V=18) and `TableDetector` reconstructs a 3×3 grid at confidence 1.00 with exact cell text, **when text is extracted with `preserve_layout: true`** (the partition pipeline already uses that).
+
+---
+
+## Verified interfaces (do not re-derive)
+
+- `Partitioner::partition_fragments(&self, fragments: &[TextFragment], page: u32, page_height: f64) -> Vec<Element>` — `pipeline/partition.rs:122`. Table block at lines 246–310.
+- `PartitionConfig` — `pipeline/partition.rs:21`; `Default` at line 44 (`detect_tables: true`, `min_table_confidence: 0.5`).
+- `TableDetector::default()`, `TableDetector::detect(&self, graphics: &ExtractedGraphics, text_fragments: &[TextFragment]) -> Result<Vec<DetectedTable>, TableDetectionError>` — `text/table_detection.rs`.
+- `DetectedTable { bbox: BoundingBox, cells: Vec<TableCell>, rows: usize, columns: usize, confidence: f64 }`; `TableCell { row: usize, column: usize, bbox, text: String, has_borders: bool }`; `BoundingBox { x, y, width, height }`.
+- `ExtractedGraphics { lines: Vec<VectorLine>, horizontal_count, vertical_count }` + `has_table_structure(&self) -> bool` — `graphics/extraction.rs`. `GraphicsExtractor::default()`, `extract_from_page<R>(&mut self, &PdfDocument<R>, page_index: usize) -> Result<ExtractedGraphics, ExtractionError>`.
+- `VectorLine::new(...)` — `graphics/extraction.rs:100` (used to hand-build graphics in a unit test; the implementer reads its exact signature there).
+- `TableElementData { rows: Vec<Vec<String>>, metadata: ElementMetadata }` — `pipeline/element.rs:211`.
+- `do_partition_pages(&self, options, config)` — `parser/document.rs:1565`; loop calls `partitioner.partition_fragments(&page_text.fragments, page_idx_u32, page_height)`. Public entries: `Document::partition()` (1532), `partition_with(options, config)` (1537).
+- Writer table: `oxidize_pdf::text::Table::with_equal_columns(cols, total_width)`, `set_position(x, y)`, `add_row(Vec<String>) -> Result<...>`; `Page::add_table(&Table)`. Default borders on.
+
+---
+
+## File Structure
+
+- `oxidize-pdf-core/src/pipeline/partition.rs` — add `prefer_ruling_tables` config field; split `partition_fragments` into a `_with_graphics` variant + delegator; add ruling-first block + `ruling_table_to_rows` helper.
+- `oxidize-pdf-core/src/parser/document.rs` — plumb per-page graphics in `do_partition_pages`.
+- `oxidize-pdf-core/tests/ruling_table_partition_test.rs` — new integration tests (synthetic round-trip, hand-built multi-line, full pipeline, flag-off, borderless fallback). Shared PDF-builder helper lives here.
+
+---
+
+## Task 1: `prefer_ruling_tables` config field
+
+**Files:** Modify `oxidize-pdf-core/src/pipeline/partition.rs` (struct ~21, `Default` ~44).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to a new file `oxidize-pdf-core/tests/ruling_table_partition_test.rs`:
+
+```rust
+use oxidize_pdf::pipeline::PartitionConfig;
+
+#[test]
+fn prefer_ruling_tables_defaults_on() {
+    assert!(PartitionConfig::default().prefer_ruling_tables);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test prefer_ruling_tables_defaults_on 2>&1 | head -20`
+Expected: compile error — no field `prefer_ruling_tables` on `PartitionConfig`.
+
+- [ ] **Step 3: Add the field and default**
+
+In the `PartitionConfig` struct (after `min_table_confidence`):
+
+```rust
+    /// Prefer the ruling-based (vector-grid) table detector for bordered tables,
+    /// falling back to the spatial detector for the rest. When false, only the
+    /// spatial detector runs and no page graphics are extracted. Default: true.
+    pub prefer_ruling_tables: bool,
+```
+
+In `impl Default for PartitionConfig` (alongside `min_table_confidence: 0.5,`):
+
+```rust
+            prefer_ruling_tables: true,
+```
+
+If `PartitionConfig` is also constructed by struct literal in profile presets (search `PartitionConfig {` across `src/`), add `prefer_ruling_tables: true,` to each, or change them to `..Default::default()` if they already partially do. Verify with: `grep -rn "PartitionConfig {" oxidize-pdf-core/src/`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test prefer_ruling_tables_defaults_on`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/ruling_table_partition_test.rs
+git commit -m "feat(rag): add prefer_ruling_tables config (default true) (#292)"
+```
+
+---
+
+## Task 2: Non-breaking `partition_fragments_with_graphics`
+
+**Files:** Modify `oxidize-pdf-core/src/pipeline/partition.rs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `oxidize-pdf-core/tests/ruling_table_partition_test.rs`:
+
+```rust
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::TextFragment;
+
+#[test]
+fn with_graphics_none_matches_legacy_partition() {
+    // A trivial fragment set; both entry points must produce identical elements.
+    let frags: Vec<TextFragment> = vec![];
+    let p = Partitioner::new(PartitionConfig::default());
+    let legacy = p.partition_fragments(&frags, 1, 800.0);
+    let with_graphics = p.partition_fragments_with_graphics(&frags, None, 1, 800.0);
+    assert_eq!(legacy.len(), with_graphics.len());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test with_graphics_none_matches_legacy_partition 2>&1 | head -20`
+Expected: compile error — no method `partition_fragments_with_graphics`.
+
+- [ ] **Step 3: Refactor `partition_fragments` into a `_with_graphics` variant + delegator**
+
+At the top of `partition.rs`, add the import:
+
+```rust
+use crate::graphics::extraction::ExtractedGraphics;
+```
+
+Rename the existing `pub fn partition_fragments(&self, fragments: &[TextFragment], page: u32, page_height: f64) -> Vec<Element>` to:
+
+```rust
+    pub fn partition_fragments_with_graphics(
+        &self,
+        fragments: &[TextFragment],
+        graphics: Option<&ExtractedGraphics>,
+        page: u32,
+        page_height: f64,
+    ) -> Vec<Element> {
+```
+
+(Keep the entire existing body unchanged for now; `graphics` is unused this task — prefix with `_` ONLY if clippy complains, but Task 3 uses it, so add `#[allow(unused_variables)]` is NOT needed; instead leave it and complete Task 3 in the same PR. If committing Task 2 alone triggers `-D warnings` on unused `graphics`, bind it: `let _ = graphics;` at the top of the body, removed in Task 3.)
+
+Add the delegator immediately above it:
+
+```rust
+    /// Partition fragments without page graphics (spatial table detection only).
+    pub fn partition_fragments(
+        &self,
+        fragments: &[TextFragment],
+        page: u32,
+        page_height: f64,
+    ) -> Vec<Element> {
+        self.partition_fragments_with_graphics(fragments, None, page, page_height)
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test with_graphics_none_matches_legacy_partition`
+Expected: PASS.
+Run: `cargo build -p oxidize-pdf --lib` — Expected: Finished, warning-clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/ruling_table_partition_test.rs
+git commit -m "refactor(rag): add partition_fragments_with_graphics delegator (#292)"
+```
+
+---
+
+## Task 3: Ruling-first detection + mapping helper
+
+**Files:** Modify `oxidize-pdf-core/src/pipeline/partition.rs`; add tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `oxidize-pdf-core/tests/ruling_table_partition_test.rs`. First a shared helper that builds a bordered table PDF and returns its graphics + fragments:
+
+```rust
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, GraphicsExtractor};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::pipeline::Element;
+use oxidize_pdf::text::{ExtractionOptions, Table, TextExtractor};
+use oxidize_pdf::{Document, Page};
+
+/// Build a 3-column bordered table PDF with the given rows; return (graphics, fragments).
+fn bordered_table_inputs(rows: &[[&str; 3]]) -> (ExtractedGraphics, Vec<oxidize_pdf::text::TextFragment>) {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut table = Table::with_equal_columns(3, 400.0);
+    table.set_position(50.0, 700.0);
+    for r in rows {
+        table.add_row(vec![r[0].to_string(), r[1].to_string(), r[2].to_string()]).unwrap();
+    }
+    page.add_table(&table).unwrap();
+    doc.add_page(page);
+    let path = std::env::temp_dir().join(format!("rt_{}.pdf", rows.len()));
+    doc.save(&path).unwrap();
+
+    let pdoc = PdfReader::open_document(&path).unwrap();
+    let mut gx = GraphicsExtractor::default();
+    let graphics = gx.extract_from_page(&pdoc, 0).unwrap();
+    let opts = ExtractionOptions { preserve_layout: true, ..Default::default() };
+    let mut tx = TextExtractor::with_options(opts);
+    let frags = tx.extract_from_page(&pdoc, 0).unwrap().fragments;
+    (graphics, frags)
+}
+
+fn table_rows(elements: &[Element]) -> Vec<Vec<String>> {
+    elements
+        .iter()
+        .find_map(|e| match e {
+            Element::Table(t) => Some(t.rows.clone()),
+            _ => None,
+        })
+        .expect("a Table element")
+}
+
+#[test]
+fn ruling_detects_exact_bordered_grid() {
+    let (graphics, frags) =
+        bordered_table_inputs(&[["H1", "H2", "H3"], ["a1", "a2", "a3"], ["b1", "b2", "b3"]]);
+    assert!(graphics.has_table_structure(), "writer borders must yield grid lines");
+
+    let p = Partitioner::new(PartitionConfig::default());
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+
+    assert_eq!(
+        table_rows(&elements),
+        vec![
+            vec!["H1".to_string(), "H2".to_string(), "H3".to_string()],
+            vec!["a1".to_string(), "a2".to_string(), "a3".to_string()],
+            vec!["b1".to_string(), "b2".to_string(), "b3".to_string()],
+        ]
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test ruling_detects_exact_bordered_grid -- --nocapture 2>&1 | tail -25`
+Expected: FAIL — without ruling wiring, the spatial path may emit different rows or no Table; the `assert_eq!` (or `expect("a Table element")`) fails.
+
+- [ ] **Step 3: Add the mapping helper**
+
+Near the other free functions in `partition.rs` (e.g. beside `segment_into_table_regions`), add:
+
+```rust
+/// Flatten a ruling-detected table into row-major `Vec<Vec<String>>`, filling
+/// absent cells with empty strings.
+fn ruling_table_to_rows(table: &crate::text::table_detection::DetectedTable) -> Vec<Vec<String>> {
+    let mut grid = vec![vec![String::new(); table.columns]; table.rows];
+    for cell in &table.cells {
+        if cell.row < table.rows && cell.column < table.columns {
+            grid[cell.row][cell.column] = cell.text.clone();
+        }
+    }
+    grid
+}
+```
+
+- [ ] **Step 4: Add the ruling-first block**
+
+Inside `partition_fragments_with_graphics`, at the START of the `if self.config.detect_tables {` block (before `let unclaimed_frags` at line ~247), insert:
+
+```rust
+            // Ruling-first: when the page has a drawn table grid, detect bordered
+            // tables from vector lines and claim their fragments so the spatial
+            // pass below only sees the remainder. region_looks_like_list is NOT
+            // applied here — drawn borders are strong table evidence.
+            if self.config.prefer_ruling_tables {
+                if let Some(graphics) = graphics {
+                    if graphics.has_table_structure() {
+                        let detector = crate::text::table_detection::TableDetector::default();
+                        if let Ok(tables) = detector.detect(graphics, fragments) {
+                            for table in &tables {
+                                if table.confidence < self.config.min_table_confidence {
+                                    continue;
+                                }
+                                let rows = ruling_table_to_rows(table);
+                                let bbox = ElementBBox::new(
+                                    table.bbox.x,
+                                    table.bbox.y,
+                                    table.bbox.width,
+                                    table.bbox.height,
+                                );
+                                elements.push(Element::Table(TableElementData {
+                                    rows,
+                                    metadata: ElementMetadata {
+                                        page,
+                                        bbox,
+                                        confidence: table.confidence,
+                                        ..Default::default()
+                                    },
+                                }));
+                                let (rx, ry) = (table.bbox.x, table.bbox.y);
+                                let (rr, rt) = (table.bbox.x + table.bbox.width, table.bbox.y + table.bbox.height);
+                                for (i, f) in fragments.iter().enumerate() {
+                                    if !claimed[i]
+                                        && f.x >= rx - 1.0
+                                        && f.x <= rr + 1.0
+                                        && f.y >= ry - 1.0
+                                        && f.y <= rt + 1.0
+                                    {
+                                        claimed[i] = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+```
+
+If you added `let _ = graphics;` in Task 2, remove it now.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test ruling_detects_exact_bordered_grid -- --nocapture 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 6: Add the multi-line cell fidelity test (hand-built graphics)**
+
+This proves the ruling path keeps a wrapped cell as one cell. Build a 2-column × 1-row grid by hand and place two text fragments stacked inside the single left cell. Append:
+
+`VectorLine::new` is `(x1, y1, x2, y2, stroke_width, is_stroked, color)` — orientation
+is computed internally (no orientation arg). `TextFragment` does NOT derive
+`Default` (it derives only `Debug, Clone`); build it via an explicit helper with
+all 15 fields. Both verified in `src/text/extraction.rs` / `src/graphics/extraction.rs`
+on 2026-06-06.
+
+```rust
+use oxidize_pdf::graphics::extraction::VectorLine;
+use oxidize_pdf::text::TextFragment;
+
+fn h_line(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+fn v_line(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x,
+        y,
+        width: 10.0,
+        height: 8.0,
+        font_size: 8.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: vec![],
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn ruling_keeps_wrapped_cell_as_single_cell() {
+    // A 2-col x 2-row grid: x in {100,200,300}, y in {100,150,200}.
+    // Cells: top row y 150..200, bottom row y 100..150; left col x 100..200.
+    let mut graphics = ExtractedGraphics::new();
+    for y in [100.0, 150.0, 200.0] {
+        graphics.add_line(h_line(100.0, 300.0, y));
+    }
+    for x in [100.0, 200.0, 300.0] {
+        graphics.add_line(v_line(x, 100.0, 200.0));
+    }
+    assert!(graphics.has_table_structure());
+
+    // Two stacked fragments in the SAME top-left cell (a wrapped line) + one
+    // fragment in each of the other three cells. Centers fall inside their cell.
+    let frags = vec![
+        frag("Wrapped", 120.0, 180.0), // top-left, upper line
+        frag("Line", 120.0, 160.0),    // top-left, lower line
+        frag("B", 220.0, 170.0),       // top-right
+        frag("c", 120.0, 120.0),       // bottom-left
+        frag("d", 220.0, 120.0),       // bottom-right
+    ];
+
+    let p = Partitioner::new(PartitionConfig::default());
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let rows = table_rows(&elements);
+    // The wrapped top-left cell must be ONE cell holding both words, not two rows.
+    assert_eq!(rows.len(), 2, "grid has exactly two rows, got {:?}", rows);
+    assert!(
+        rows[0][0].contains("Wrapped") && rows[0][0].contains("Line"),
+        "wrapped lines stay in one cell, got {:?}",
+        rows[0][0]
+    );
+}
+```
+
+Note: `TableCell.text` joins fragments whose center falls in the cell bbox; the
+exact join separator (space vs newline) is whatever `table_detection.rs` uses —
+the assertion checks `contains`, so it is robust to the separator. If the two
+words land in different rows (assertion fails), the cell-assignment y-banding in
+`table_detection.rs` is the thing to inspect, not the test.
+
+- [ ] **Step 7: Run both Task-3 tests**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test ruling_ -- --nocapture 2>&1 | tail -15`
+Expected: both PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/ruling_table_partition_test.rs
+git commit -m "feat(rag): ruling-first bordered-table detection in partition (#292)"
+```
+
+---
+
+## Task 4: Plumb per-page graphics in `do_partition_pages`
+
+**Files:** Modify `oxidize-pdf-core/src/parser/document.rs` (~1565); add a full-pipeline test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `oxidize-pdf-core/tests/ruling_table_partition_test.rs`:
+
+```rust
+#[test]
+fn full_pipeline_partition_emits_bordered_table() {
+    // Build the same bordered table, save, reopen, run the public partition entry.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut table = Table::with_equal_columns(3, 400.0);
+    table.set_position(50.0, 700.0);
+    for r in [["N", "Qty", "Price"], ["Apple", "3", "1.20"], ["Pear", "5", "0.90"]] {
+        table.add_row(vec![r[0].into(), r[1].into(), r[2].into()]).unwrap();
+    }
+    page.add_table(&table).unwrap();
+    doc.add_page(page);
+    let path = std::env::temp_dir().join("rt_fullpipe.pdf");
+    doc.save(&path).unwrap();
+
+    let pdoc = PdfReader::open_document(&path).unwrap();
+    let elements = pdoc.partition().unwrap();
+    let rows = table_rows(&elements);
+    assert_eq!(rows[0], vec!["N".to_string(), "Qty".to_string(), "Price".to_string()]);
+    assert_eq!(rows[2], vec!["Pear".to_string(), "5".to_string(), "0.90".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test full_pipeline_partition_emits_bordered_table -- --nocapture 2>&1 | tail -20`
+Expected: FAIL — graphics not yet plumbed, so the pipeline still uses spatial-only and the exact bordered rows aren't produced (or no Table element).
+
+- [ ] **Step 3: Plumb graphics in `do_partition_pages`**
+
+In `parser/document.rs`, in `do_partition_pages`, before the page loop add the gated extractor, and inside the loop compute per-page graphics and call the new method. Replace the existing call
+`partitioner.partition_fragments(&page_text.fragments, page_idx_u32, page_height)` with the graphics-aware path:
+
+```rust
+        let extract_graphics = config.detect_tables && config.prefer_ruling_tables;
+        let mut graphics_extractor = crate::graphics::extraction::GraphicsExtractor::default();
+        // ... inside the `for (page_idx, page_text) in pages.iter().enumerate()` loop,
+        //     after page_height is computed:
+        let page_graphics = if extract_graphics {
+            graphics_extractor.extract_from_page(self, page_idx).ok()
+        } else {
+            None
+        };
+        let page_elements = partitioner.partition_fragments_with_graphics(
+            &page_text.fragments,
+            page_graphics.as_ref(),
+            page_idx_u32,
+            page_height,
+        );
+```
+
+Keep whatever the existing code does with the returned elements (it currently collects them — preserve that; only the call changes). Read the surrounding loop to wire `page_elements` exactly as the old return value was used.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test full_pipeline_partition_emits_bordered_table -- --nocapture 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/parser/document.rs
+git commit -m "feat(rag): extract per-page graphics for ruling tables in partition pipeline (#292)"
+```
+
+---
+
+## Task 5: Fallback/flag-off regression tests, verification, CHANGELOG
+
+**Files:** add tests; `CHANGELOG.md`.
+
+- [ ] **Step 1: Add flag-off and borderless-fallback tests**
+
+Append to `oxidize-pdf-core/tests/ruling_table_partition_test.rs`:
+
+```rust
+#[test]
+fn flag_off_uses_spatial_only() {
+    // With the same bordered table inputs but prefer_ruling_tables = false,
+    // the ruling path is skipped; passing graphics must not change the result
+    // versus passing None (graphics are ignored when the flag is off).
+    let (graphics, frags) =
+        bordered_table_inputs(&[["H1", "H2", "H3"], ["a1", "a2", "a3"], ["b1", "b2", "b3"]]);
+    let cfg = PartitionConfig { prefer_ruling_tables: false, ..Default::default() };
+    let p = Partitioner::new(cfg);
+    let with_g = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let without_g = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
+    assert_eq!(with_g.len(), without_g.len(), "graphics ignored when flag off");
+}
+
+#[test]
+fn no_grid_falls_back_to_spatial() {
+    // Graphics with no table structure -> ruling path skipped, spatial still runs.
+    let empty = ExtractedGraphics::new();
+    assert!(!empty.has_table_structure());
+    let (_g, frags) =
+        bordered_table_inputs(&[["x1", "x2", "x3"], ["y1", "y2", "y3"]]);
+    let p = Partitioner::new(PartitionConfig::default());
+    // Passing empty graphics must not panic and must still classify via spatial.
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&empty), 0, 842.0);
+    // Spatial may or may not find a table from these fragments; the contract here
+    // is only that the ruling path is skipped and partition returns without panic
+    // and produces the same element count as the None path.
+    let none_path = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
+    assert_eq!(elements.len(), none_path.len());
+}
+```
+
+- [ ] **Step 2: Run the full test file**
+
+Run: `cargo test -p oxidize-pdf --test ruling_table_partition_test 2>&1 | tail -15`
+Expected: all tests PASS.
+
+- [ ] **Step 3: Full verification**
+
+Run each and confirm:
+- `cargo test -p oxidize-pdf --lib 2>&1 | tail -3` → no regressions (~6500+ pass).
+- `cargo clippy --all -- -D warnings 2>&1 | tail -2` → exit 0.
+- `cargo +1.88 build --lib --all-features --locked 2>&1 | tail -2` → Finished, 0 warnings.
+- `cargo fmt --all -- --check` → clean.
+
+- [ ] **Step 4: Update CHANGELOG**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added` (create if absent, above `### Changed`):
+
+```markdown
+- Ruling-based (vector-grid) table detection wired into the partition pipeline:
+  bordered tables are now reconstructed from the PDF's drawn grid (primary path),
+  with the spatial detector handling the rest. Controlled by
+  `PartitionConfig::prefer_ruling_tables` (default true) (#292).
+```
+
+Commit:
+
+```bash
+git add CHANGELOG.md oxidize-pdf-core/tests/ruling_table_partition_test.rs
+git commit -m "test(rag): ruling table fallback/flag-off coverage + changelog (#292)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** selection policy + claiming (Task 3), graphics plumbing + gating (Task 4), config (Task 1), non-breaking API (Task 2), mapping helper (Task 3), tests for synthetic-exact / multi-line fidelity / full-pipeline / flag-off / borderless-fallback (Tasks 3–5). `region_looks_like_list` skipped for ruling path (Task 3 block comment).
+- **Type consistency:** `partition_fragments_with_graphics(&[TextFragment], Option<&ExtractedGraphics>, u32, f64)`, `ruling_table_to_rows(&DetectedTable) -> Vec<Vec<String>>`, `prefer_ruling_tables: bool`, `TableDetector::default()/detect`, `ExtractedGraphics::new()/add_line/has_table_structure` — consistent across tasks.
+- **Known implementer follow-ups (not placeholders, explicit):** (a) confirm/adjust other `PartitionConfig {` literals in `src/` (Task 1 Step 3); (b) wire `page_elements` exactly as the prior return value was consumed in `do_partition_pages` (Task 4 Step 3). `VectorLine::new` (7 args, no orientation) and `TextFragment` (15 fields, no `Default`) are already verified and given as concrete helpers in Task 3 Step 6.

--- a/docs/superpowers/specs/2026-06-06-issue-292-ruling-table-partition-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-292-ruling-table-partition-design.md
@@ -1,0 +1,113 @@
+# Design — wire ruling-based table detector into partition (#292)
+
+**Date:** 2026-06-06
+**Issue:** #292 (RAG: wire ruling-based table detector into partition pipeline)
+**Branch:** `feature/issue-292-ruling-table-partition` (from `develop`)
+
+## Motivation
+
+Read-side table extraction in `pipeline/partition.rs` currently uses only the
+**spatial** detector (`text/structured/table.rs`, X/Y clustering of text
+positions). The **ruling-based** detector (`text/table_detection.rs`, which
+reconstructs a grid from the PDF's vector H/V lines) exists but is standalone,
+never wired into partition. Bordered tables — common in gov/financial corpora,
+typical RAG input — are therefore processed by text clustering, which is
+inferior when the grid is already drawn, and degrades on merged/multi-line cells
+(independent X/Y clustering produces a cartesian product). Wiring the ruling
+detector raises table fidelity in RAG chunks using PDF-native graphics a generic
+multi-format pipeline cannot exploit.
+
+## Verified current state (interfaces)
+
+- `Partitioner::partition_fragments(&self, fragments: &[TextFragment], page: u32, page_height: f64) -> Vec<Element>` (`partition.rs:122`). Receives **text only**. Table block at lines 246–309: `StructuredDataDetector::new(...)`, `segment_into_table_regions`, `region_looks_like_list` anti-FP, `min_table_confidence` filter, builds `TableElementData`.
+- Ruling detector: `TableDetector::detect(&self, graphics: &ExtractedGraphics, text_fragments: &[TextFragment]) -> Result<Vec<DetectedTable>, TableDetectionError>` (`text/table_detection.rs:268`). Requires **both** graphics and text. Gate: `graphics.has_table_structure()` (≥2 H + ≥2 V lines).
+- `DetectedTable { bbox: BoundingBox, cells: Vec<TableCell>, rows: usize, columns: usize, confidence: f64 }`. `TableCell { row: usize, column: usize, bbox, text: String, has_borders: bool }`.
+- `ExtractedGraphics { lines, horizontal_count, vertical_count }` produced by `GraphicsExtractor::extract_from_page(&PdfDocument<R>, page_index) -> Result<ExtractedGraphics, ExtractionError>` (`graphics/extraction.rs:258`).
+- Partition input flows from `document.rs::do_partition_pages` (~line 1565), which holds `&self: PdfDocument<R>` and the per-page index — the correct place to extract graphics. `ExtractedText { text, fragments }` carries **no** graphics.
+- `TableElementData { rows: Vec<Vec<String>>, metadata: ElementMetadata }` (`pipeline/element.rs:211`). Flat cell text, no per-cell bbox.
+
+## Design
+
+### Selection policy — page-level ruling-first, spatial fills the rest
+
+Per page, in the table-detection block:
+
+1. If `config.prefer_ruling_tables` AND graphics are present AND
+   `graphics.has_table_structure()`: run `TableDetector::detect(graphics, fragments)`.
+   For each `DetectedTable` whose `confidence >= config.min_table_confidence`,
+   emit a `TableElementData` and claim the fragments inside its `bbox`
+   (same ±1pt overlap claiming the spatial path already uses).
+   `region_looks_like_list` is **not** applied to ruling tables — drawn borders
+   are strong table evidence; that anti-FP heuristic governs only the spatial path.
+2. Run the existing **spatial** detector on the **remaining unclaimed**
+   fragments (catches borderless tables). Unchanged behavior.
+3. If graphics absent / no line structure / flag off: spatial only — exactly
+   today's behavior.
+
+Ruling-first then spatial-on-the-rest avoids double-detecting the same region.
+
+### Graphics plumbing
+
+In `do_partition_pages`, only when `config.detect_tables && config.prefer_ruling_tables`,
+extract graphics per page: `GraphicsExtractor::extract_from_page(self, idx).ok()`
+→ `Option<ExtractedGraphics>`. Extraction failure → `None` → spatial fallback;
+never fails partition. When the flag is off, graphics are not extracted at all
+(zero added cost for users who opt out).
+
+### Partition API (non-breaking)
+
+Add `Partitioner::partition_fragments_with_graphics(&self, fragments: &[TextFragment], graphics: Option<&ExtractedGraphics>, page: u32, page_height: f64) -> Vec<Element>`.
+The existing `partition_fragments(fragments, page, page_height)` delegates with
+`graphics: None`, preserving the public API. `do_partition_pages` calls the new
+method with the per-page graphics.
+
+### Config
+
+Add `prefer_ruling_tables: bool` to `PartitionConfig`, **default `true`**.
+`Default` and any preset profiles set it `true`. Documented as: prefer the
+ruling-based detector for bordered tables; set `false` to force the legacy
+spatial-only path (and skip graphics extraction entirely).
+
+### Mapping `DetectedTable` → `TableElementData`
+
+`rows: Vec<Vec<String>>` built by grouping `cells` by `row` (0..rows), within
+each row ordering by `column` (0..columns), taking `cell.text` (empty string for
+absent cells). `metadata.bbox` from `DetectedTable.bbox`; `metadata.confidence`
+from `DetectedTable.confidence`; `metadata.page = page`. `TableElementData` stays
+flat — per-cell bbox / `has_borders` are not surfaced (YAGNI; markdown table
+export consumes flat rows).
+
+## Error handling
+
+- Graphics extraction error → `None` → spatial path. No new error variants;
+  partition signatures still return `Vec<Element>` / existing `Result`.
+- `TableDetector::detect` error → log and fall back to spatial for that page.
+- Empty / too-few line sets → `has_table_structure()` false → spatial.
+
+## Testing (content-verifying, no smoke tests)
+
+1. **Synthetic bordered table (exact cells).** Generate a PDF containing a known
+   bordered table via the oxidize-pdf writer (the `advanced_tables_example`
+   pattern draws ruled tables). Partition it with defaults; assert the emitted
+   `TableElementData.rows` equals the exact known cell matrix.
+   **Feasibility spike required first:** confirm the writer emits the borders as
+   stroked vector lines that `GraphicsExtractor` recovers as H/V lines and
+   `has_table_structure()` returns true. If the writer's borders are not
+   recovered, fall back to a committed real bordered-table fixture for the
+   primary assertion.
+2. **Multi-line / merged cell.** A bordered table with a cell whose text wraps to
+   two lines: assert the ruling path keeps it as one cell, and document that the
+   spatial path splits it (the concrete fidelity gain). Drives the value claim.
+3. **Real corpus.** A gov/financial PDF with a bordered table (fixture identified
+   during implementation); assert specific known cell values.
+4. **Borderless fallback (regression).** A table with no ruling lines → spatial
+   path still produces the expected table; ruling path is skipped.
+5. **Flag off.** `prefer_ruling_tables = false` → output matches the legacy
+   spatial-only result and no graphics extraction occurs.
+
+## Out of scope (YAGNI)
+
+- Enriching `TableElementData` with per-cell bboxes / span info.
+- Implementing the stubbed `detect_borderless` path in `table_detection.rs`.
+- Caching graphics extraction across pipeline stages.
+- Region-level (vs page-level) ruling/spatial selection.

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1567,8 +1567,32 @@ impl<R: Read + Seek> PdfDocument<R> {
         options: crate::text::ExtractionOptions,
         config: crate::pipeline::PartitionConfig,
     ) -> ParseResult<Vec<crate::pipeline::Element>> {
+        // Read the gating flags before `config` is moved into the partitioner,
+        // so we avoid cloning the config just to inspect two bools.
+        let extract_graphics = config.detect_tables && config.prefer_ruling_tables;
+
         let pages = self.extract_text_with_options(options)?;
+
+        // The reconstructed `pages` above merge per-cell fragments into
+        // paragraph-granular fragments (issue #261), which the ruling-based
+        // table detector cannot map back to grid cells. When ruling-table
+        // detection is active, extract a second, cell-granular fragment set
+        // (reconstruct_paragraphs = false) and feed it to the detector while
+        // the reconstructed fragments still drive prose classification.
+        let raw_pages = if extract_graphics {
+            Some(
+                self.extract_text_with_options(crate::text::ExtractionOptions {
+                    preserve_layout: true,
+                    reconstruct_paragraphs: false,
+                    ..Default::default()
+                })?,
+            )
+        } else {
+            None
+        };
+
         let partitioner = crate::pipeline::Partitioner::new(config);
+        let mut graphics_extractor = crate::graphics::extraction::GraphicsExtractor::default();
 
         let mut all_elements = Vec::new();
         for (page_idx, page_text) in pages.iter().enumerate() {
@@ -1580,8 +1604,22 @@ impl<R: Read + Seek> PdfDocument<R> {
                 .get_page(page_idx_u32)
                 .map(|p| p.height())
                 .unwrap_or(842.0);
-            let elements =
-                partitioner.partition_fragments(&page_text.fragments, page_idx_u32, page_height);
+            let page_graphics = if extract_graphics {
+                graphics_extractor.extract_from_page(self, page_idx).ok()
+            } else {
+                None
+            };
+            let raw_fragments = raw_pages
+                .as_ref()
+                .and_then(|rp| rp.get(page_idx))
+                .map(|pt| pt.fragments.as_slice());
+            let elements = partitioner.partition_fragments_with_graphics_raw(
+                &page_text.fragments,
+                raw_fragments,
+                page_graphics.as_ref(),
+                page_idx_u32,
+                page_height,
+            );
             all_elements.extend(elements);
         }
 

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1571,25 +1571,27 @@ impl<R: Read + Seek> PdfDocument<R> {
         // so we avoid cloning the config just to inspect two bools.
         let extract_graphics = config.detect_tables && config.prefer_ruling_tables;
 
+        // The reconstructed `pages` (extracted with `reconstruct_paragraphs = true`)
+        // merge per-cell fragments into paragraph-granular fragments (issue #261),
+        // which the ruling-based table detector cannot map back to grid cells. When
+        // a page actually has a drawn table grid we re-extract just that page with
+        // `reconstruct_paragraphs = false` to recover cell-granular fragments for
+        // the detector; the reconstructed fragments still drive prose
+        // classification. Inherit every other option (notably `space_threshold`
+        // and `detect_columns`, which profiles override) so cell text is assembled
+        // identically to the primary pass. Built before `options` is moved into
+        // `extract_text_with_options`.
+        let mut raw_options = options.clone();
+        raw_options.reconstruct_paragraphs = false;
+
         let pages = self.extract_text_with_options(options)?;
 
         let partitioner = crate::pipeline::Partitioner::new(config);
         let mut graphics_extractor = crate::graphics::extraction::GraphicsExtractor::default();
-        // The reconstructed `pages` above merge per-cell fragments into
-        // paragraph-granular fragments (issue #261), which the ruling-based
-        // table detector cannot map back to grid cells. When a page actually has
-        // a drawn table grid we re-extract just that page with
-        // `reconstruct_paragraphs = false` to recover cell-granular fragments for
-        // the detector; the reconstructed fragments still drive prose
-        // classification. Extracting per table-bearing page (rather than a second
-        // whole-document pass) keeps the cost proportional to pages that need it
-        // and zero for table-free documents even with `prefer_ruling_tables` on.
-        let mut raw_extractor =
-            crate::text::TextExtractor::with_options(crate::text::ExtractionOptions {
-                preserve_layout: true,
-                reconstruct_paragraphs: false,
-                ..Default::default()
-            });
+        // Extracting per table-bearing page (rather than a second whole-document
+        // pass) keeps the cost proportional to pages that need it and zero for
+        // table-free documents even with `prefer_ruling_tables` on.
+        let mut raw_extractor = crate::text::TextExtractor::with_options(raw_options);
 
         let mut all_elements = Vec::new();
         for (page_idx, page_text) in pages.iter().enumerate() {

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1573,26 +1573,23 @@ impl<R: Read + Seek> PdfDocument<R> {
 
         let pages = self.extract_text_with_options(options)?;
 
-        // The reconstructed `pages` above merge per-cell fragments into
-        // paragraph-granular fragments (issue #261), which the ruling-based
-        // table detector cannot map back to grid cells. When ruling-table
-        // detection is active, extract a second, cell-granular fragment set
-        // (reconstruct_paragraphs = false) and feed it to the detector while
-        // the reconstructed fragments still drive prose classification.
-        let raw_pages = if extract_graphics {
-            Some(
-                self.extract_text_with_options(crate::text::ExtractionOptions {
-                    preserve_layout: true,
-                    reconstruct_paragraphs: false,
-                    ..Default::default()
-                })?,
-            )
-        } else {
-            None
-        };
-
         let partitioner = crate::pipeline::Partitioner::new(config);
         let mut graphics_extractor = crate::graphics::extraction::GraphicsExtractor::default();
+        // The reconstructed `pages` above merge per-cell fragments into
+        // paragraph-granular fragments (issue #261), which the ruling-based
+        // table detector cannot map back to grid cells. When a page actually has
+        // a drawn table grid we re-extract just that page with
+        // `reconstruct_paragraphs = false` to recover cell-granular fragments for
+        // the detector; the reconstructed fragments still drive prose
+        // classification. Extracting per table-bearing page (rather than a second
+        // whole-document pass) keeps the cost proportional to pages that need it
+        // and zero for table-free documents even with `prefer_ruling_tables` on.
+        let mut raw_extractor =
+            crate::text::TextExtractor::with_options(crate::text::ExtractionOptions {
+                preserve_layout: true,
+                reconstruct_paragraphs: false,
+                ..Default::default()
+            });
 
         let mut all_elements = Vec::new();
         for (page_idx, page_text) in pages.iter().enumerate() {
@@ -1609,10 +1606,16 @@ impl<R: Read + Seek> PdfDocument<R> {
             } else {
                 None
             };
-            let raw_fragments = raw_pages
+            // Re-extract cell-granular fragments only for pages with a drawn grid.
+            let raw_page = if page_graphics
                 .as_ref()
-                .and_then(|rp| rp.get(page_idx))
-                .map(|pt| pt.fragments.as_slice());
+                .is_some_and(|g| g.has_table_structure())
+            {
+                raw_extractor.extract_from_page(self, page_idx_u32).ok()
+            } else {
+                None
+            };
+            let raw_fragments = raw_page.as_ref().map(|pt| pt.fragments.as_slice());
             let elements = partitioner.partition_fragments_with_graphics_raw(
                 &page_text.fragments,
                 raw_fragments,

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -1,3 +1,4 @@
+use crate::graphics::extraction::ExtractedGraphics;
 use crate::pipeline::reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 use crate::pipeline::{
     Element, ElementBBox, ElementData, ElementMetadata, KeyValueElementData, TableElementData,
@@ -124,12 +125,32 @@ impl Partitioner {
     /// * `fragments` — text fragments from one page (with `preserve_layout`)
     /// * `page` — 0-indexed page number
     /// * `page_height` — page height in PDF points (for header/footer zones)
+    ///
+    /// Partition fragments without page graphics (spatial table detection only).
     pub fn partition_fragments(
         &self,
         fragments: &[TextFragment],
         page: u32,
         page_height: f64,
     ) -> Vec<Element> {
+        self.partition_fragments_with_graphics(fragments, None, page, page_height)
+    }
+
+    /// Partition a page's text fragments into typed elements, optionally using
+    /// page graphics (vector lines) for ruling-based table detection.
+    ///
+    /// * `fragments` — text fragments from one page (with `preserve_layout`)
+    /// * `graphics` — extracted vector lines for the page, if available
+    /// * `page` — 0-indexed page number
+    /// * `page_height` — page height in PDF points (for header/footer zones)
+    pub fn partition_fragments_with_graphics(
+        &self,
+        fragments: &[TextFragment],
+        graphics: Option<&ExtractedGraphics>,
+        page: u32,
+        page_height: f64,
+    ) -> Vec<Element> {
+        let _ = graphics;
         if fragments.is_empty() {
             return Vec::new();
         }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -150,9 +150,39 @@ impl Partitioner {
         page: u32,
         page_height: f64,
     ) -> Vec<Element> {
+        self.partition_fragments_with_graphics_raw(fragments, None, graphics, page, page_height)
+    }
+
+    /// Partition a page's text fragments, using a separate **raw** (un-reconstructed)
+    /// fragment set for ruling-based table cell assignment.
+    ///
+    /// The partition pipeline (`PdfDocument::partition`) extracts text with
+    /// `reconstruct_paragraphs: true`, which merges per-cell fragments into
+    /// paragraph-granular fragments. The ruling-based table detector needs
+    /// **cell-granular** fragments to assign text to grid cells, so this method
+    /// accepts `raw_fragments` (extracted with `reconstruct_paragraphs: false`)
+    /// for that purpose while `fragments` (reconstructed) drives prose
+    /// classification (titles, headers, paragraphs) and fragment claiming.
+    ///
+    /// * `fragments` — reconstructed fragments used for classification + claiming
+    /// * `raw_fragments` — cell-granular fragments for the ruling detector; when
+    ///   `None`, `fragments` is used for ruling too (legacy/unit-test behavior)
+    /// * `graphics` — extracted vector lines for the page, if available
+    /// * `page` — 0-indexed page number
+    /// * `page_height` — page height in PDF points (for header/footer zones)
+    pub fn partition_fragments_with_graphics_raw(
+        &self,
+        fragments: &[TextFragment],
+        raw_fragments: Option<&[TextFragment]>,
+        graphics: Option<&ExtractedGraphics>,
+        page: u32,
+        page_height: f64,
+    ) -> Vec<Element> {
         if fragments.is_empty() {
             return Vec::new();
         }
+        // Fragments fed to the ruling detector for cell-text assignment.
+        let ruling_fragments = raw_fragments.unwrap_or(fragments);
 
         // Apply reading order strategy to fragments BEFORE classification
         let fragments: std::borrow::Cow<[TextFragment]> = match &self.config.reading_order {
@@ -277,7 +307,7 @@ impl Partitioner {
                 if let Some(graphics) = graphics {
                     if graphics.has_table_structure() {
                         let detector = crate::text::table_detection::TableDetector::default();
-                        if let Ok(tables) = detector.detect(graphics, fragments) {
+                        if let Ok(tables) = detector.detect(graphics, ruling_fragments) {
                             for table in &tables {
                                 if table.confidence < self.config.min_table_confidence {
                                     continue;

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -170,7 +170,11 @@ impl Partitioner {
     /// * `graphics` — extracted vector lines for the page, if available
     /// * `page` — 0-indexed page number
     /// * `page_height` — page height in PDF points (for header/footer zones)
-    pub fn partition_fragments_with_graphics_raw(
+    ///
+    /// Internal to the partition pipeline (`do_partition_pages` supplies the raw
+    /// fragments); the public entry points are `partition_fragments` and
+    /// `partition_fragments_with_graphics`.
+    pub(crate) fn partition_fragments_with_graphics_raw(
         &self,
         fragments: &[TextFragment],
         raw_fragments: Option<&[TextFragment]>,

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -1297,6 +1297,69 @@ mod tests {
         }
     }
 
+    /// Narrow fragment (width 10) whose center sits at (x+5, y) — for placing
+    /// text unambiguously inside a single grid cell.
+    fn cell_frag(text: &str, x: f64, y: f64) -> TextFragment {
+        let mut f = frag_at(text, x, y, 8.0);
+        f.width = 10.0;
+        f
+    }
+
+    #[test]
+    fn raw_fragments_drive_cell_text_while_reconstructed_drive_claiming() {
+        use crate::graphics::extraction::{ExtractedGraphics, VectorLine};
+
+        // 2x2 grid: x in {100,200,300}, y in {100,150,200}.
+        let mut graphics = ExtractedGraphics::new();
+        for y in [100.0, 150.0, 200.0] {
+            graphics.add_line(VectorLine::new(100.0, y, 300.0, y, 1.0, true, None));
+        }
+        for x in [100.0, 200.0, 300.0] {
+            graphics.add_line(VectorLine::new(x, 100.0, x, 200.0, 1.0, true, None));
+        }
+        assert!(graphics.has_table_structure());
+
+        // Cell-granular "raw" fragments: one per cell.
+        let raw = vec![
+            cell_frag("TL", 120.0, 175.0),
+            cell_frag("TR", 220.0, 175.0),
+            cell_frag("BL", 120.0, 125.0),
+            cell_frag("BR", 220.0, 125.0),
+        ];
+        // Reconstructed set: a single merged fragment (what reconstruct_paragraphs
+        // produces). No usable per-cell text, but its position is inside the table
+        // bbox so it must be claimed and NOT resurface as a prose element.
+        let reconstructed = vec![cell_frag("TL TR BL BR", 120.0, 175.0)];
+
+        let p = Partitioner::new(PartitionConfig::default());
+        let elements = p.partition_fragments_with_graphics_raw(
+            &reconstructed,
+            Some(&raw),
+            Some(&graphics),
+            0,
+            842.0,
+        );
+
+        let rows = elements
+            .iter()
+            .find_map(|e| match e {
+                Element::Table(t) => Some(t.rows.clone()),
+                _ => None,
+            })
+            .expect("a Table element");
+        // Cells came from the raw set, not the merged reconstructed fragment.
+        assert_eq!(rows.len(), 2, "two grid rows, got {rows:?}");
+        assert_eq!(rows[0], vec!["TL".to_string(), "TR".to_string()]);
+        assert_eq!(rows[1], vec!["BL".to_string(), "BR".to_string()]);
+        // The merged reconstructed fragment was claimed, so the Table is the only
+        // element (it does not also appear as prose).
+        assert_eq!(
+            elements.len(),
+            1,
+            "merged fragment must be claimed, got {elements:?}"
+        );
+    }
+
     #[test]
     fn struct_tag_h1_yields_title_no_font_ratio_needed() {
         let mut f = frag_at("Section One", 50.0, 400.0, 12.0);

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -150,7 +150,6 @@ impl Partitioner {
         page: u32,
         page_height: f64,
     ) -> Vec<Element> {
-        let _ = graphics;
         if fragments.is_empty() {
             return Vec::new();
         }
@@ -270,6 +269,56 @@ impl Partitioner {
         // c) Detected tables whose confidence is below `min_table_confidence` are
         //    discarded and their fragments fall through to prose classification.
         if self.config.detect_tables {
+            // Ruling-first: when the page has a drawn table grid, detect bordered
+            // tables from vector lines and claim their fragments so the spatial
+            // pass below only sees the remainder. region_looks_like_list is NOT
+            // applied here — drawn borders are strong table evidence.
+            if self.config.prefer_ruling_tables {
+                if let Some(graphics) = graphics {
+                    if graphics.has_table_structure() {
+                        let detector = crate::text::table_detection::TableDetector::default();
+                        if let Ok(tables) = detector.detect(graphics, fragments) {
+                            for table in &tables {
+                                if table.confidence < self.config.min_table_confidence {
+                                    continue;
+                                }
+                                let rows = ruling_table_to_rows(table);
+                                let bbox = ElementBBox::new(
+                                    table.bbox.x,
+                                    table.bbox.y,
+                                    table.bbox.width,
+                                    table.bbox.height,
+                                );
+                                elements.push(Element::Table(TableElementData {
+                                    rows,
+                                    metadata: ElementMetadata {
+                                        page,
+                                        bbox,
+                                        confidence: table.confidence,
+                                        ..Default::default()
+                                    },
+                                }));
+                                let (rx, ry) = (table.bbox.x, table.bbox.y);
+                                let (rr, rt) = (
+                                    table.bbox.x + table.bbox.width,
+                                    table.bbox.y + table.bbox.height,
+                                );
+                                for (i, f) in fragments.iter().enumerate() {
+                                    if !claimed[i]
+                                        && f.x >= rx - 1.0
+                                        && f.x <= rr + 1.0
+                                        && f.y >= ry - 1.0
+                                        && f.y <= rt + 1.0
+                                    {
+                                        claimed[i] = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             let unclaimed_frags: Vec<&TextFragment> = fragments
                 .iter()
                 .enumerate()
@@ -606,6 +655,18 @@ fn is_list_item(text: &str) -> bool {
         }
     }
     false
+}
+
+/// Flatten a ruling-detected table into row-major `Vec<Vec<String>>`, filling
+/// absent cells with empty strings.
+fn ruling_table_to_rows(table: &crate::text::table_detection::DetectedTable) -> Vec<Vec<String>> {
+    let mut grid = vec![vec![String::new(); table.columns]; table.rows];
+    for cell in &table.cells {
+        if cell.row < table.rows && cell.column < table.columns {
+            grid[cell.row][cell.column] = cell.text.clone();
+        }
+    }
+    grid
 }
 
 /// Splits unclaimed fragments into Y-separated table candidate regions.

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -39,6 +39,10 @@ pub struct PartitionConfig {
     /// fragments fall through to the prose classification steps.
     /// Range: `[0.0, 1.0]`. Default: `0.5`.
     pub min_table_confidence: f64,
+    /// Prefer the ruling-based (vector-grid) table detector for bordered tables,
+    /// falling back to the spatial detector for the rest. When false, only the
+    /// spatial detector runs and no page graphics are extracted. Default: true.
+    pub prefer_ruling_tables: bool,
 }
 
 impl Default for PartitionConfig {
@@ -51,6 +55,7 @@ impl Default for PartitionConfig {
             footer_zone: 0.05,
             reading_order: ReadingOrderStrategy::Simple,
             min_table_confidence: 0.5,
+            prefer_ruling_tables: true,
         }
     }
 }

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -10,11 +10,21 @@ use oxidize_pdf::text::TextFragment;
 
 #[test]
 fn with_graphics_none_matches_legacy_partition() {
-    let frags: Vec<TextFragment> = vec![];
+    // Non-trivial fragment set: the delegator must produce element-for-element
+    // identical output (same count AND same element types) as the legacy entry.
+    let (_g, frags) = bordered_table_inputs(&[["A", "B", "C"], ["1", "2", "3"]]);
+    assert!(!frags.is_empty(), "fixture must yield fragments");
     let p = Partitioner::new(PartitionConfig::default());
     let legacy = p.partition_fragments(&frags, 1, 800.0);
     let with_graphics = p.partition_fragments_with_graphics(&frags, None, 1, 800.0);
     assert_eq!(legacy.len(), with_graphics.len());
+    for (l, r) in legacy.iter().zip(with_graphics.iter()) {
+        assert_eq!(
+            std::mem::discriminant(l),
+            std::mem::discriminant(r),
+            "delegator must emit the same element types as legacy"
+        );
+    }
 }
 
 use oxidize_pdf::graphics::extraction::{ExtractedGraphics, GraphicsExtractor};
@@ -189,11 +199,9 @@ fn flag_off_uses_spatial_only() {
     let p = Partitioner::new(cfg);
     let with_g = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
     let without_g = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
-    assert_eq!(
-        with_g.len(),
-        without_g.len(),
-        "graphics ignored when flag off"
-    );
+    // Not just the count: with the flag off, supplying graphics must yield the
+    // exact same elements (types + table contents) as supplying None.
+    assert_same_elements(&with_g, &without_g);
 }
 
 #[test]
@@ -207,5 +215,73 @@ fn no_grid_falls_back_to_spatial() {
     // producing the same element count as the None path.
     let elements = p.partition_fragments_with_graphics(&frags, Some(&empty), 0, 842.0);
     let none_path = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
-    assert_eq!(elements.len(), none_path.len());
+    // Empty graphics must be a no-op: same elements (types + contents) as None.
+    assert_same_elements(&elements, &none_path);
+}
+
+/// Assert two element lists are equivalent: same length, same per-position
+/// element type, and identical row contents for `Table` elements.
+fn assert_same_elements(a: &[Element], b: &[Element]) {
+    assert_eq!(a.len(), b.len(), "element count differs: {a:?} vs {b:?}");
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert_eq!(
+            std::mem::discriminant(x),
+            std::mem::discriminant(y),
+            "element type differs"
+        );
+        if let (Element::Table(tx), Element::Table(ty)) = (x, y) {
+            assert_eq!(tx.rows, ty.rows, "table rows differ");
+        }
+    }
+}
+
+#[test]
+fn ruling_table_and_prose_elements_are_disjoint() {
+    // A drawn grid (y 100..200) plus prose fragments well below it (y ~ 40-50).
+    // The prose must become its own element(s), and no emitted element's bbox may
+    // overlap another's (partition disjointness invariant).
+    let mut graphics = ExtractedGraphics::new();
+    for y in [100.0, 150.0, 200.0] {
+        graphics.add_line(h_line(100.0, 300.0, y));
+    }
+    for x in [100.0, 200.0, 300.0] {
+        graphics.add_line(v_line(x, 100.0, 200.0));
+    }
+    assert!(graphics.has_table_structure());
+
+    let frags = vec![
+        frag("TL", 120.0, 175.0),
+        frag("TR", 220.0, 175.0),
+        frag("BL", 120.0, 125.0),
+        frag("BR", 220.0, 125.0),
+        // prose line below the grid (outside the table bbox)
+        frag("Prose", 120.0, 50.0),
+        frag("below", 160.0, 50.0),
+        frag("table", 200.0, 50.0),
+    ];
+
+    let p = Partitioner::new(PartitionConfig::default());
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+
+    let has_table = elements.iter().any(|e| matches!(e, Element::Table(_)));
+    assert!(has_table, "expected a ruling Table, got {elements:?}");
+    assert!(
+        elements.len() >= 2,
+        "expected table + prose element(s), got {elements:?}"
+    );
+
+    // Pairwise bbox disjointness across all emitted elements.
+    let boxes: Vec<_> = elements.iter().map(|e| e.bbox()).collect();
+    for i in 0..boxes.len() {
+        for j in (i + 1)..boxes.len() {
+            let a = &boxes[i];
+            let b = &boxes[j];
+            let overlap_x = a.x < b.x + b.width && b.x < a.x + a.width;
+            let overlap_y = a.y < b.y + b.height && b.y < a.y + a.height;
+            assert!(
+                !(overlap_x && overlap_y),
+                "elements {i} and {j} have overlapping bboxes: {a:?} vs {b:?}"
+            );
+        }
+    }
 }

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -4,3 +4,15 @@ use oxidize_pdf::pipeline::PartitionConfig;
 fn prefer_ruling_tables_defaults_on() {
     assert!(PartitionConfig::default().prefer_ruling_tables);
 }
+
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::TextFragment;
+
+#[test]
+fn with_graphics_none_matches_legacy_partition() {
+    let frags: Vec<TextFragment> = vec![];
+    let p = Partitioner::new(PartitionConfig::default());
+    let legacy = p.partition_fragments(&frags, 1, 800.0);
+    let with_graphics = p.partition_fragments_with_graphics(&frags, None, 1, 800.0);
+    assert_eq!(legacy.len(), with_graphics.len());
+}

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -174,3 +174,38 @@ fn full_pipeline_partition_emits_bordered_table() {
         vec!["Pear".to_string(), "5".to_string(), "0.90".to_string()]
     );
 }
+
+#[test]
+fn flag_off_uses_spatial_only() {
+    // With the same bordered table inputs but prefer_ruling_tables = false,
+    // the ruling path is skipped; passing graphics must not change the result
+    // versus passing None (graphics are ignored when the flag is off).
+    let (graphics, frags) =
+        bordered_table_inputs(&[["H1", "H2", "H3"], ["a1", "a2", "a3"], ["b1", "b2", "b3"]]);
+    let cfg = PartitionConfig {
+        prefer_ruling_tables: false,
+        ..Default::default()
+    };
+    let p = Partitioner::new(cfg);
+    let with_g = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let without_g = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
+    assert_eq!(
+        with_g.len(),
+        without_g.len(),
+        "graphics ignored when flag off"
+    );
+}
+
+#[test]
+fn no_grid_falls_back_to_spatial() {
+    // Graphics with no table structure -> ruling path skipped, spatial still runs.
+    let empty = ExtractedGraphics::new();
+    assert!(!empty.has_table_structure());
+    let (_g, frags) = bordered_table_inputs(&[["x1", "x2", "x3"], ["y1", "y2", "y3"]]);
+    let p = Partitioner::new(PartitionConfig::default());
+    // Passing empty graphics must not panic and must still classify via spatial,
+    // producing the same element count as the None path.
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&empty), 0, 842.0);
+    let none_path = p.partition_fragments_with_graphics(&frags, None, 0, 842.0);
+    assert_eq!(elements.len(), none_path.len());
+}

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -16,3 +16,127 @@ fn with_graphics_none_matches_legacy_partition() {
     let with_graphics = p.partition_fragments_with_graphics(&frags, None, 1, 800.0);
     assert_eq!(legacy.len(), with_graphics.len());
 }
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, GraphicsExtractor};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::pipeline::Element;
+use oxidize_pdf::text::{ExtractionOptions, Table, TextExtractor};
+use oxidize_pdf::{Document, Page};
+
+/// Build a 3-column bordered table PDF with the given rows; return (graphics, fragments).
+fn bordered_table_inputs(
+    rows: &[[&str; 3]],
+) -> (ExtractedGraphics, Vec<oxidize_pdf::text::TextFragment>) {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut table = Table::with_equal_columns(3, 400.0);
+    table.set_position(50.0, 700.0);
+    for r in rows {
+        table
+            .add_row(vec![r[0].to_string(), r[1].to_string(), r[2].to_string()])
+            .unwrap();
+    }
+    page.add_table(&table).unwrap();
+    doc.add_page(page);
+    let path = std::env::temp_dir().join(format!("rt_{}.pdf", rows.len()));
+    doc.save(&path).unwrap();
+
+    let pdoc = PdfReader::open_document(&path).unwrap();
+    let mut gx = GraphicsExtractor::default();
+    let graphics = gx.extract_from_page(&pdoc, 0).unwrap();
+    let opts = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut tx = TextExtractor::with_options(opts);
+    let frags = tx.extract_from_page(&pdoc, 0).unwrap().fragments;
+    (graphics, frags)
+}
+
+fn table_rows(elements: &[Element]) -> Vec<Vec<String>> {
+    elements
+        .iter()
+        .find_map(|e| match e {
+            Element::Table(t) => Some(t.rows.clone()),
+            _ => None,
+        })
+        .expect("a Table element")
+}
+
+#[test]
+fn ruling_detects_exact_bordered_grid() {
+    let (graphics, frags) =
+        bordered_table_inputs(&[["H1", "H2", "H3"], ["a1", "a2", "a3"], ["b1", "b2", "b3"]]);
+    assert!(
+        graphics.has_table_structure(),
+        "writer borders must yield grid lines"
+    );
+
+    let p = Partitioner::new(PartitionConfig::default());
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+
+    assert_eq!(
+        table_rows(&elements),
+        vec![
+            vec!["H1".to_string(), "H2".to_string(), "H3".to_string()],
+            vec!["a1".to_string(), "a2".to_string(), "a3".to_string()],
+            vec!["b1".to_string(), "b2".to_string(), "b3".to_string()],
+        ]
+    );
+}
+
+use oxidize_pdf::graphics::extraction::VectorLine;
+
+fn h_line(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+fn v_line(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x,
+        y,
+        width: 10.0,
+        height: 8.0,
+        font_size: 8.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: vec![],
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn ruling_keeps_wrapped_cell_as_single_cell() {
+    let mut graphics = ExtractedGraphics::new();
+    for y in [100.0, 150.0, 200.0] {
+        graphics.add_line(h_line(100.0, 300.0, y));
+    }
+    for x in [100.0, 200.0, 300.0] {
+        graphics.add_line(v_line(x, 100.0, 200.0));
+    }
+    assert!(graphics.has_table_structure());
+
+    let frags = vec![
+        frag("Wrapped", 120.0, 180.0),
+        frag("Line", 120.0, 160.0),
+        frag("B", 220.0, 170.0),
+        frag("c", 120.0, 120.0),
+        frag("d", 220.0, 120.0),
+    ];
+
+    let p = Partitioner::new(PartitionConfig::default());
+    let elements = p.partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let rows = table_rows(&elements);
+    assert_eq!(rows.len(), 2, "grid has exactly two rows, got {:?}", rows);
+    assert!(
+        rows[0][0].contains("Wrapped") && rows[0][0].contains("Line"),
+        "wrapped lines stay in one cell, got {:?}",
+        rows[0][0]
+    );
+}

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -140,3 +140,37 @@ fn ruling_keeps_wrapped_cell_as_single_cell() {
         rows[0][0]
     );
 }
+
+#[test]
+fn full_pipeline_partition_emits_bordered_table() {
+    // Build the same bordered table, save, reopen, run the public partition entry.
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut table = Table::with_equal_columns(3, 400.0);
+    table.set_position(50.0, 700.0);
+    for r in [
+        ["N", "Qty", "Price"],
+        ["Apple", "3", "1.20"],
+        ["Pear", "5", "0.90"],
+    ] {
+        table
+            .add_row(vec![r[0].into(), r[1].into(), r[2].into()])
+            .unwrap();
+    }
+    page.add_table(&table).unwrap();
+    doc.add_page(page);
+    let path = std::env::temp_dir().join("rt_fullpipe.pdf");
+    doc.save(&path).unwrap();
+
+    let pdoc = PdfReader::open_document(&path).unwrap();
+    let elements = pdoc.partition().unwrap();
+    let rows = table_rows(&elements);
+    assert_eq!(
+        rows[0],
+        vec!["N".to_string(), "Qty".to_string(), "Price".to_string()]
+    );
+    assert_eq!(
+        rows[2],
+        vec!["Pear".to_string(), "5".to_string(), "0.90".to_string()]
+    );
+}

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -1,0 +1,6 @@
+use oxidize_pdf::pipeline::PartitionConfig;
+
+#[test]
+fn prefer_ruling_tables_defaults_on() {
+    assert!(PartitionConfig::default().prefer_ruling_tables);
+}


### PR DESCRIPTION
## Summary

Wires the existing ruling-based `TableDetector` (vector-grid reconstruction) into the partition pipeline as the primary path for bordered tables, with the spatial detector filling the remaining fragments. Bordered tables — common in gov/financial RAG corpora — are now reconstructed from the PDF's drawn grid instead of text clustering, which is inferior when the grid is already drawn and degrades on multi-line/merged cells.

Addresses #292.

### What changed
- **`PartitionConfig::prefer_ruling_tables`** (default `true`): when on and a page has a drawn grid, the ruling detector runs first; set `false` for legacy spatial-only (and no graphics extraction).
- **`Partitioner::partition_fragments_with_graphics`** (public) + `partition_fragments_with_graphics_raw` (`pub(crate)`). The old `partition_fragments` delegates with `graphics: None` — non-breaking.
- **Ruling-first block**: detects bordered tables from vector lines, emits `Element::Table`, and claims the fragments inside each table bbox so the spatial pass only sees the remainder (no double-detection). `region_looks_like_list` is intentionally not applied to ruling tables — drawn borders are strong table evidence.
- **`do_partition_pages`**: extracts per-page graphics (gated on `detect_tables && prefer_ruling_tables`). Because the pipeline extracts text with `reconstruct_paragraphs=true` (#261) — which merges per-cell fragments — it re-extracts **cell-granular** fragments (`reconstruct_paragraphs=false`) only for pages whose graphics report a drawn grid, inheriting the profile's other extraction options. Cost is proportional to table-bearing pages and zero for table-free documents.

### Design / plan
- Spec: `docs/superpowers/specs/2026-06-06-issue-292-ruling-table-partition-design.md`
- Plan: `docs/superpowers/plans/2026-06-06-issue-292-ruling-table-partition.md`

## Test Plan
- [x] `cargo test -p oxidize-pdf --test ruling_table_partition_test` — 8/8 (synthetic exact bordered grid, multi-line cell fidelity, full-pipeline, flag-off content equivalence, borderless fallback, table/prose disjointness, delegator equivalence)
- [x] `partition.rs` unit test for the dual raw/reconstructed fragment semantics
- [x] `cargo test -p oxidize-pdf --lib` — 6525/0
- [x] `cargo clippy --workspace --lib -- -D warnings` (+ pre-commit extra lints) — clean
- [x] `cargo +1.88 build --lib --all-features --locked` — clean
- [x] `cargo fmt --all -- --check` — clean

## Notes
- Per repo testing standards, all tests are content-verifying (exact cell matrices / element-type + row-content equivalence), no smoke tests.
- A real-corpus assertion (gov/financial bordered-table fixture) was in the spec's testing list but not in the executable plan's tasks; can be added as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)