### PR TITLE
fix(extraction): resolve indirect /Font dicts + code-indexed glyph widths (#302)

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -6,7 +6,7 @@
 use crate::graphics::Color;
 use crate::parser::content::{ContentOperation, ContentParser, TextElement};
 use crate::parser::document::PdfDocument;
-use crate::parser::objects::PdfObject;
+use crate::parser::objects::{PdfDictionary, PdfObject};
 use crate::parser::page_tree::ParsedPage;
 use crate::parser::ParseResult;
 use crate::text::extraction_cmap::{CMapTextExtractor, FontInfo};
@@ -1355,26 +1355,45 @@ impl TextExtractor {
         if let Some(res_ref) = page.dict.get("Resources").and_then(|o| o.as_reference()) {
             if let Ok(PdfObject::Dictionary(resources)) = document.get_object(res_ref.0, res_ref.1)
             {
-                if let Some(PdfObject::Dictionary(font_dict)) = resources.get("Font") {
-                    for (font_name, font_obj) in font_dict.0.iter() {
-                        if let Some(font_ref) = font_obj.as_reference() {
-                            self.cache_font_by_ref::<R>(&font_name.0, font_ref, document);
-                        }
-                    }
-                }
+                self.cache_fonts_from_resources::<R>(&resources, document);
             }
         } else if let Some(resources) = page.get_resources() {
             // Fallback to get_resources() if Resources is not a reference
-            if let Some(PdfObject::Dictionary(font_dict)) = resources.get("Font") {
-                for (font_name, font_obj) in font_dict.0.iter() {
-                    if let Some(font_ref) = font_obj.as_reference() {
-                        self.cache_font_by_ref::<R>(&font_name.0, font_ref, document);
-                    }
-                }
-            }
+            self.cache_fonts_from_resources::<R>(resources, document);
         }
 
         Ok(())
+    }
+
+    /// Cache every font declared in a page's `/Resources` `/Font` dictionary.
+    ///
+    /// `/Font` itself may be either an inline dictionary or an indirect
+    /// reference (`/Font 191 0 R`); both are common in real PDFs (e.g. the
+    /// ATLAS Higgs paper references it). Resolving the reference is required —
+    /// otherwise the font cache stays empty, decoding loses ToUnicode, and
+    /// glyph widths fall back to a flat estimate that scrambles multi-column
+    /// layout (issue #302).
+    fn cache_fonts_from_resources<R: Read + Seek>(
+        &mut self,
+        resources: &PdfDictionary,
+        document: &PdfDocument<R>,
+    ) {
+        let font_dict = match resources.get("Font") {
+            Some(PdfObject::Dictionary(dict)) => Some(dict.clone()),
+            Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                Ok(PdfObject::Dictionary(dict)) => Some(dict),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        if let Some(font_dict) = font_dict {
+            for (font_name, font_obj) in font_dict.0.iter() {
+                if let Some(font_ref) = font_obj.as_reference() {
+                    self.cache_font_by_ref::<R>(&font_name.0, font_ref, document);
+                }
+            }
+        }
     }
 
     /// Cache a font, reusing the persistent object cache when possible.

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -673,13 +673,21 @@ impl TextExtractor {
 
                             extracted_text.push_str(&decoded);
 
-                            // Get font info for accurate width calculation
+                            // Get font info for accurate width calculation.
+                            // Width comes from the char codes (`text_bytes`), not
+                            // the decoded Unicode: the Widths array is code-indexed
+                            // (issue #302).
                             let text_width = {
                                 let font_info = state
                                     .font_name
                                     .as_ref()
                                     .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width(&decoded, state.font_size, font_info)
+                                calculate_text_width_from_codes(
+                                    text_bytes,
+                                    &decoded,
+                                    state.font_size,
+                                    font_info,
+                                )
                             };
 
                             if self.options.preserve_layout {
@@ -718,7 +726,8 @@ impl TextExtractor {
                                                 .font_name
                                                 .as_ref()
                                                 .and_then(|name| self.font_cache.get(name));
-                                            calculate_text_width(
+                                            calculate_text_width_from_codes(
+                                                &text_bytes,
                                                 &decoded,
                                                 state.font_size,
                                                 font_info,
@@ -823,7 +832,12 @@ impl TextExtractor {
                                     .font_name
                                     .as_ref()
                                     .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width(&decoded, state.font_size, font_info)
+                                calculate_text_width_from_codes(
+                                    &text,
+                                    &decoded,
+                                    state.font_size,
+                                    font_info,
+                                )
                             };
 
                             if self.options.preserve_layout {
@@ -875,7 +889,12 @@ impl TextExtractor {
                                     .font_name
                                     .as_ref()
                                     .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width(&decoded, state.font_size, font_info)
+                                calculate_text_width_from_codes(
+                                    &text,
+                                    &decoded,
+                                    state.font_size,
+                                    font_info,
+                                )
                             };
 
                             if self.options.preserve_layout {
@@ -1750,6 +1769,75 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
     text.len() as f64 * font_size * 0.5
 }
 
+/// Compute advance width from the original character **codes**, not the decoded
+/// Unicode text.
+///
+/// A simple font's `Widths` array is indexed by character code (`first_char..=
+/// last_char`), i.e. the byte value in the content stream — not by the Unicode
+/// codepoint the code decodes to. [`calculate_text_width`] indexes by the decoded
+/// codepoint (`ch as u32`), which is correct only when code == codepoint (ASCII /
+/// WinAnsi fonts). For custom-encoded fonts (Type1 with `Differences`, embedded
+/// Computer Modern in LaTeX PDFs, ToUnicode remaps) the codepoint diverges from
+/// the code, so the wrong slot — or `missing_width` — is read, desyncing glyph
+/// advance and scrambling word order once fragments are sorted by position
+/// (issue #302).
+///
+/// `decoded` is the already-decoded text for this run; it is only consulted for
+/// composite (Type0) fonts, whose multi-byte codes cannot be indexed byte-wise
+/// and whose width path is unchanged here to avoid regressing CJK extraction.
+fn calculate_text_width_from_codes(
+    codes: &[u8],
+    decoded: &str,
+    font_size: f64,
+    font_info: Option<&FontInfo>,
+) -> f64 {
+    // Composite (Type0) fonts use multi-byte codes; a single byte is not a code,
+    // so byte-indexed width lookup is invalid. Preserve the existing decoded-based
+    // behavior for them.
+    let is_composite =
+        font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
+    if is_composite {
+        return calculate_text_width(decoded, font_size, font_info);
+    }
+
+    if let Some(font) = font_info {
+        if let Some(ref widths) = font.metrics.widths {
+            let first_char = font.metrics.first_char.unwrap_or(0);
+            let last_char = font.metrics.last_char.unwrap_or(255);
+            let missing_width = font.metrics.missing_width.unwrap_or(500.0);
+
+            let mut total_width = 0.0;
+            let mut iter = codes.iter().peekable();
+            while let Some(&byte) = iter.next() {
+                let code = byte as u32;
+                let width = if code >= first_char && code <= last_char {
+                    widths
+                        .get((code - first_char) as usize)
+                        .copied()
+                        .unwrap_or(missing_width)
+                } else {
+                    missing_width
+                };
+                total_width += width / 1000.0 * font_size;
+
+                // Kerning is keyed by code pair, consistent with code-based widths.
+                if let Some(ref kerning) = font.metrics.kerning {
+                    if let Some(&next_byte) = iter.peek() {
+                        if let Some(&kern_value) = kerning.get(&(code, *next_byte as u32)) {
+                            total_width += kern_value / 1000.0 * font_size;
+                        }
+                    }
+                }
+            }
+
+            return total_width;
+        }
+    }
+
+    // No metrics: one fallback width per code (byte), the simple-font glyph count.
+    codes.len() as f64 * font_size * 0.5
+}
+
 /// Sanitize extracted text by removing or replacing control characters.
 ///
 /// This function addresses Issue #116 where extracted text contains NUL bytes (`\0`)
@@ -2291,6 +2379,55 @@ mod tests {
         assert_ne!(
             width, simplified,
             "Metrics-based calculation should differ from simplified (30.0)"
+        );
+    }
+
+    #[test]
+    fn width_from_codes_uses_char_code_not_decoded_unicode() {
+        use crate::text::extraction_cmap::{FontInfo, FontMetrics};
+
+        // Simple Type1 font with a code-indexed Widths array: code 1 -> 1000,
+        // code 2 -> 100. A custom encoding decodes code 1 -> 'm' (U+006D) and
+        // code 2 -> 'i' (U+0069), so the decoded Unicode codepoints (109, 105)
+        // are far from the codes (1, 2). The advance width MUST come from the
+        // codes; indexing the Widths array by the decoded Unicode codepoint
+        // reads out-of-range -> missing_width, desyncing glyph advance on
+        // custom-encoded fonts (issue #302, Higgs/Computer-Modern scramble).
+        let font_info = FontInfo {
+            name: "F1".to_string(),
+            font_type: "Type1".to_string(),
+            encoding: None,
+            to_unicode: None,
+            differences: None,
+            descendant_font: None,
+            cid_to_gid_map: None,
+            cid_ordering: None,
+            metrics: FontMetrics {
+                first_char: Some(1),
+                last_char: Some(2),
+                widths: Some(vec![1000.0, 100.0]),
+                missing_width: Some(500.0),
+                kerning: None,
+            },
+            cid_encoding: None,
+        };
+
+        let codes = [1u8, 2u8];
+        let decoded = "mi"; // what decode_text produced for these codes
+        let width = calculate_text_width_from_codes(&codes, decoded, 10.0, Some(&font_info));
+        let expected = (1000.0 + 100.0) / 1000.0 * 10.0; // 11.0
+        assert!(
+            (width - expected).abs() < 1e-6,
+            "width must come from char codes: expected {expected}, got {width}"
+        );
+
+        // The decoded-Unicode-indexed path is the bug: 109 and 105 are outside
+        // [1,2] so both fall back to missing_width -> (500+500)/1000*10 = 10.0.
+        let buggy = calculate_text_width(decoded, 10.0, Some(&font_info));
+        assert_eq!(buggy, 10.0);
+        assert_ne!(
+            width, buggy,
+            "code-based width must differ from the Unicode-indexed bug"
         );
     }
 

--- a/oxidize-pdf-core/tests/issue_302_indirect_font_dict_test.rs
+++ b/oxidize-pdf-core/tests/issue_302_indirect_font_dict_test.rs
@@ -1,0 +1,76 @@
+//! Issue #302 (real root cause) — the text extractor silently loads no fonts
+//! when a page's `/Resources` dictionary references its `/Font` dictionary
+//! indirectly (`/Font 191 0 R`) instead of inlining it.
+//!
+//! The font loader matched only `PdfObject::Dictionary` for `resources.get("Font")`,
+//! so an indirect `/Font` reference (common in real PDFs — e.g. the ATLAS Higgs
+//! paper) fell through and the font cache stayed empty. With no font info, glyph
+//! advance widths fell back to a flat `0.5 * font_size`, over-advancing narrow
+//! glyphs so a column's last word overflowed into the next column and the
+//! position sort scrambled word order.
+//!
+//! This test pins font *loading* directly: the font carries a `/ToUnicode` CMap
+//! that maps code 0x41 to U+00E9 ('é'). The ToUnicode override is applied only
+//! when the font is loaded into the cache; if the indirect `/Font` dict is not
+//! resolved, decoding falls back to a base encoding and yields plain 'A'.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// ToUnicode CMap: code <41> -> U+00E9 ('é').
+const TOUNICODE: &[u8] = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\nbegincmap\n/CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n\
+1 begincodespacerange\n<00> <ff>\nendcodespacerange\n\
+1 beginbfchar\n<41> <00e9>\nendbfchar\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+/// Show code 0x41 ('A') under font /F1.
+const CONTENT: &[u8] = b"BT\n/F1 12 Tf\n100 700 Td\n(A) Tj\nET\n";
+
+/// `/Resources << /Font 5 0 R >>` — the Font dictionary is an INDIRECT reference
+/// (object 5), not an inline dictionary. Object 5 is the Font dictionary mapping
+/// /F1 to the font (object 6), whose /ToUnicode is object 7.
+fn build_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font 5 0 R >> \
+          /Contents 4 0 R /MediaBox [0 0 612 792] >>"
+            .to_vec(),
+        stream_obj("", CONTENT),
+        b"<< /F1 6 0 R >>".to_vec(),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /ToUnicode 7 0 R >>".to_vec(),
+        stream_obj("", TOUNICODE),
+    ];
+    assemble_pdf(&objects)
+}
+
+fn extract(pdf: Vec<u8>) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("fixture must be a readable PDF");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn indirect_font_dictionary_is_resolved_and_loaded() {
+    let text = extract(build_pdf());
+    assert!(
+        text.contains('é'),
+        "an indirectly-referenced /Font dict must be resolved so the font's \
+         ToUnicode CMap is applied (code 0x41 -> U+00E9); got {:?}",
+        text
+    );
+    assert!(
+        !text.contains('A'),
+        "ToUnicode override should replace 'A' entirely; got {:?}",
+        text
+    );
+}

--- a/oxidize-pdf-core/tests/issue_302_width_from_codes_test.rs
+++ b/oxidize-pdf-core/tests/issue_302_width_from_codes_test.rs
@@ -1,0 +1,85 @@
+//! Issue #302 symptom 1 — text extraction scrambles word order on custom-encoded
+//! simple fonts because glyph advance width is looked up by the decoded Unicode
+//! codepoint instead of the original character code.
+//!
+//! Reproduction: a Type1 font whose `/Encoding /Differences` + `/ToUnicode` map
+//! single-byte codes 1..4 to glyphs a/b/c/d (Unicode U+0061..U+0064). The
+//! `/Widths` array is code-indexed (`/FirstChar 1`), each glyph 250/1000 em.
+//! Indexing `/Widths` by the decoded codepoint (97..100) falls outside
+//! `[FirstChar, LastChar] = [1, 4]`, so the extractor reads `missing_width`
+//! (≈500) instead of 250 — over-advancing a relatively-positioned run until its
+//! trailing glyph overshoots an absolutely-positioned run on the same line. Once
+//! fragments are sorted by position, the words interleave: "abcd" -> "abdc".
+//!
+//! With width taken from the codes the advance is correct and order is preserved.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// ToUnicode CMap: code <01>..<04> -> U+0061..U+0064 ('a'..'d').
+const TOUNICODE: &[u8] = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Adobe-Identity-UCS def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<00> <ff>\nendcodespacerange\n\
+4 beginbfchar\n<01> <0061>\n<02> <0062>\n<03> <0063>\n<04> <0064>\nendbfchar\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+/// Two runs on the same baseline (y=700):
+///   Run A — relative, codes 1,2,3 ("abc") at the line origin x=100.
+///   Run B — absolute, code 4 ("d") at x=107.5, the x where run A *correctly*
+///           ends (100 + 3 * 250/1000 * 10 = 107.5).
+/// Correct widths (250) keep A within [100, 107.5) so order is a,b,c,d.
+/// Buggy widths (missing_width 500) push A's glyphs to 100/105/110, so the
+/// third glyph (110) overshoots B (107.5) and a sort by x yields a,b,d,c.
+const CONTENT: &[u8] = b"BT\n/F1 10 Tf\n100 700 Td\n[<01> <02> <03>] TJ\nET\n\
+BT\n/F1 10 Tf\n107.5 700 Td\n<04> Tj\nET\n";
+
+fn build_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 612 792] >>"
+            .to_vec(),
+        stream_obj("", CONTENT),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /CMR10 \
+          /FirstChar 1 /LastChar 4 /Widths [250 250 250 250] \
+          /Encoding << /Differences [1 /a /b /c /d] >> \
+          /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", TOUNICODE),
+    ];
+    assemble_pdf(&objects)
+}
+
+fn extract_layout(pdf: Vec<u8>) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("fixture must be a readable PDF");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..ExtractionOptions::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn custom_encoded_font_preserves_word_order() {
+    let text = extract_layout(build_pdf());
+    let letters: String = text.chars().filter(|c| c.is_ascii_alphabetic()).collect();
+    assert_eq!(
+        letters, "abcd",
+        "custom-encoded glyph advance must come from char codes, not decoded \
+         Unicode; got scrambled order in full text {:?}",
+        text
+    );
+}

--- a/oxidize-pdf-core/tests/ruling_table_partition_test.rs
+++ b/oxidize-pdf-core/tests/ruling_table_partition_test.rs
@@ -33,6 +33,11 @@ use oxidize_pdf::pipeline::Element;
 use oxidize_pdf::text::{ExtractionOptions, Table, TextExtractor};
 use oxidize_pdf::{Document, Page};
 
+/// Monotonic sequence so every `bordered_table_inputs` call gets a unique temp
+/// file. The old path `rt_{rows.len()}.pdf` collided across tests that happened
+/// to use the same row count, racing under the parallel test runner (flaky CI).
+static RT_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Build a 3-column bordered table PDF with the given rows; return (graphics, fragments).
 fn bordered_table_inputs(
     rows: &[[&str; 3]],
@@ -48,7 +53,12 @@ fn bordered_table_inputs(
     }
     page.add_table(&table).unwrap();
     doc.add_page(page);
-    let path = std::env::temp_dir().join(format!("rt_{}.pdf", rows.len()));
+    let path = std::env::temp_dir().join(format!(
+        "rt_{}_{}_{}.pdf",
+        rows.len(),
+        std::process::id(),
+        RT_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
     doc.save(&path).unwrap();
 
     let pdoc = PdfReader::open_document(&path).unwrap();


### PR DESCRIPTION
## What

Two text-extraction correctness fixes behind #302's dense-PDF scramble, each TDD'd with a reproduction test.

## 1. Resolve indirect `/Font` dictionaries (the main fix)

The font loader matched only an inline `PdfObject::Dictionary` for `resources.get("Font")`. A page whose `/Resources` references its `/Font` dictionary indirectly (`/Font 191 0 R` — common in real PDFs, e.g. the ATLAS Higgs paper) loaded **no fonts at all**: the font cache stayed empty, decoding lost the ToUnicode CMap, and glyph advance widths fell back to a flat `0.5 * font_size`. That over-advanced narrow glyphs so a column's last word overflowed into the next column, and the position sort interleaved the two columns.

- `cache_fonts_from_resources()` resolves `/Font` whether inline or an indirect reference; both resource-lookup branches share it.
- Test: a page with `/Font 5 0 R` applies the font's ToUnicode (`0x41` → `U+00E9`), proving the font loaded; previously it decoded to plain `A`.

## 2. Glyph advance width from char codes, not decoded Unicode

`calculate_text_width` indexed a simple font's `/Widths` array by the decoded Unicode codepoint (`ch as u32`). The array is indexed by character **code**. For custom-encoded fonts (Type1 `/Differences`, ToUnicode remaps) the codepoint diverges from the code, so the wrong slot / `missing_width` was read.

- `calculate_text_width_from_codes()` indexes `/Widths` by byte code for simple fonts; composite (Type0) fonts keep the decoded-based path. Wired into all four text-show call sites.
- Unit test (code ≠ codepoint) + integration test (custom-encoded Type1 PDF extracts `abcd`, not `abdc`).

## Effect on the ATLAS Higgs paper (page 5)

- **Before:** `wvietrhs ean invariant mass closest tZo tbhoeson mass`
- **After:** `with an invariant mass closest tZboso theon mass (mZ) in thequadrupletis`

The column-overflow scramble is gone; `"with an invariant mass closest"` extracts cleanly. Residual interleave on inline math notation is split out to #305; inter-word spacing and `U+FFFD` glyphs remain as the other #302 symptoms.

## Verification

- lib 6530/0
- t1_spec 22/0, t3_stress 22/0 (zero panics on stress corpus)
- All extraction integration tests green; clean single-column PDFs (BOE) unaffected.

Relates to #302. Residual tracked in #305.
