### PR TITLE
chore: community health scaffolding (CoC, SECURITY, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report incorrect behavior in the oxidize-pdf Rust core
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please provide a minimal
+        reproduction and verify the actual behavior — not just a panic message.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: A short Rust snippet that reproduces the issue. Attach the input PDF if relevant.
+      render: rust
+      placeholder: |
+        use oxidize_pdf::parser::{PdfReader, PdfDocument};
+        // ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: oxidize-pdf version
+      description: The version from your `Cargo.toml` / `Cargo.lock`.
+      placeholder: "2.13.0"
+    validations:
+      required: true
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version`.
+      placeholder: "1.88.0"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Ubuntu 24.04 / macOS 14 / Windows 11"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/bzsanti/oxidizePdf/discussions
+    about: Ask questions and discuss ideas with the community.
+  - name: Security vulnerability
+    url: https://github.com/bzsanti/oxidizePdf/security/advisories/new
+    about: Report a security issue privately (do not open a public issue).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a new capability for the oxidize-pdf Rust core
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that you can't today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API
+      description: How would you like the Rust API to look? Include a usage sketch if you can.
+      render: rust
+    validations:
+      required: false
+  - type: dropdown
+    id: bindings
+    attributes:
+      label: Relevant bindings
+      description: Which downstream bindings should also expose this, if any?
+      multiple: true
+      options:
+        - Python (oxidize-pdf)
+        - .NET (OxidizePdf.NET)
+        - WASM
+        - Core only
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Changes
+
+<!-- Bullet the concrete changes. -->
+
+## Testing
+
+<!-- How did you verify this? Paste relevant test output. -->
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --all -- -D warnings` clean
+- [ ] `cargo fmt --all --check` clean
+- [ ] New behavior is covered by tests that assert real content (no smoke tests)
+
+## Checklist
+
+- [ ] Branch follows gitflow (targets `develop`)
+- [ ] CHANGELOG.md updated for user-facing changes
+- [ ] No breaking change to existing public APIs (or it is documented above)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at santiago.fernandez@belowzero.tech. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public issue.
+
+- Use GitHub's [private vulnerability reporting](https://github.com/bzsanti/oxidizePdf/security/advisories/new), or
+- Email **santiago.fernandez@belowzero.tech**.
+
+Include a description, reproduction steps (ideally a minimal crate or input PDF), the affected version, and the impact you observed.
+
+You can expect an initial response within 5 business days. Confirmed vulnerabilities are addressed in a patch release on crates.io, and you will be credited unless you ask to remain anonymous.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version on [crates.io](https://crates.io/crates/oxidize-pdf). Upgrade to the latest release before reporting.
+
+`oxidize-pdf` is the pure-Rust PDF engine that backs the Python (`oxidize-pdf`), .NET (`OxidizePdf.NET`), and WASM bindings. Vulnerabilities fixed here are propagated to the bindings in a coordinated release.
+
+## Scope
+
+Because this library parses untrusted PDF input, parser-level issues are in scope: out-of-bounds reads, unbounded memory/CPU on crafted input (decompression bombs, malformed cross-reference tables), and panics reachable from untrusted documents. Report these even if they are "only" a denial of service.


### PR DESCRIPTION
Adds the missing community-profile files, kept consistent with the Python and .NET binding repos (cross-repo health audit).

## Added
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (canonical text, contact set).
- `SECURITY.md` — private reporting via GitHub advisories + email; states that parser-level DoS on untrusted PDFs is in scope and fixes propagate to bindings.
- `.github/ISSUE_TEMPLATE/` — bug & feature forms + config (Discussions + private vuln links, blank issues disabled).
- `.github/PULL_REQUEST_TEMPLATE.md`.

`CONTRIBUTING.md`, Discussions, and per-tag GitHub Releases already exist here — this closes the remaining discrepancies with the binding repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)