### PR TITLE
fix(extraction): #302 + #305 text fidelity — reorder, spaces, U+FFFD, sub-word backfill

### DIFF
--- a/oxidize-pdf-core/src/text/cmap.rs
+++ b/oxidize-pdf-core/src/text/cmap.rs
@@ -315,17 +315,14 @@ impl CMap {
 
     /// Map a character code to its destination
     pub fn map(&self, code: &[u8]) -> Option<Vec<u8>> {
-        // Check if code is in valid codespace
-        if !self.is_valid_code(code) {
-            return None;
-        }
-
-        // For predefined Identity CMaps
-        if let CMapType::Predefined(name) = &self.cmap_type {
-            if name.starts_with("Identity") {
-                return Some(code.to_vec());
-            }
-        }
+        // Explicit bfchar/bfrange mappings take precedence and are matched by
+        // their own key length, independent of the (frequently sloppy)
+        // codespacerange. Producers routinely declare the generic 2-byte
+        // Identity codespace <0000><FFFF> for a *simple* font whose ToUnicode
+        // entries are 1-byte bfchars; gating these behind a strict
+        // length-equal codespace check made `map` return None for every such
+        // code, blanking the whole stream and forcing a wrong base-encoding
+        // fallback that turned typographic glyphs into U+FFFD (#302 symptom 3).
 
         // Check single mappings first (cached)
         if let Some(dst) = self.single_mappings.get(code) {
@@ -359,6 +356,21 @@ impl CMap {
 
                     return Some(result);
                 }
+            }
+        }
+
+        // Codespace-gated passthroughs (Identity). These synthesise a result
+        // from the code itself rather than an explicit table, so they must
+        // stay constrained to the declared codespace to avoid swallowing
+        // out-of-range bytes.
+        if !self.is_valid_code(code) {
+            return None;
+        }
+
+        // For predefined Identity CMaps
+        if let CMapType::Predefined(name) = &self.cmap_type {
+            if name.starts_with("Identity") {
+                return Some(code.to_vec());
             }
         }
 
@@ -995,6 +1007,37 @@ endcmap
         assert_eq!(cmap.map(&[0x41]), Some(vec![0x00, 0x41])); // 'A'
         assert_eq!(cmap.map(&[0x7E]), Some(vec![0x00, 0x7E])); // '~'
         assert_eq!(cmap.map(&[0x7F]), None); // Out of range
+    }
+
+    #[test]
+    fn test_one_byte_bfchar_under_two_byte_codespace() {
+        // #302 symptom 3: producers frequently declare the generic Identity
+        // codespace <0000><FFFF> (2-byte) for a *simple* font whose ToUnicode
+        // entries are actually 1-byte bfchars. The strict length check in
+        // `CodeRange::contains` rejected every 1-byte code, so `map` returned
+        // None for the whole stream and the decoder fell back to the wrong
+        // base encoding — turning typographic glyphs (curly quotes, U+2019)
+        // into U+FFFD. A 1-byte code that has an explicit bfchar entry must
+        // decode regardless of the (sloppy) 2-byte codespace declaration.
+        let cmap_data = br#"/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+3 beginbfchar
+<2C> <002C>
+<92> <2019>
+<61> <0061>
+endbfchar
+endcmap
+"#;
+        let cmap = CMap::parse(cmap_data).unwrap();
+        assert_eq!(cmap.map(&[0x92]), Some(vec![0x20, 0x19]), "rsquo 0x92");
+        assert_eq!(cmap.map(&[0x2C]), Some(vec![0x00, 0x2C]), "comma 0x2C");
+        assert_eq!(cmap.map(&[0x61]), Some(vec![0x00, 0x61]), "'a' 0x61");
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -411,11 +411,12 @@ impl TextExtractor {
         // or random) order and only the X coordinate gives reading order.
         let is_tagged = fragments.iter().any(|f| f.mcid.is_some());
 
-        // Sort by (row_id asc, y desc, emission_idx/x asc).
-        // row_id primary keeps fragments from different visual rows in
-        // separate Y-bucket groups. Within a row, we sort by Y descending
-        // (so higher-on-page fragments come first) and then by emission index
-        // (tagged) or X coordinate (non-tagged).
+        // Sort for line GROUPING only: row_id, then Y descending, then X.
+        // row_id keeps fragments from different visual rows in separate
+        // Y-bucket groups; Y descending puts higher-on-page lines first. The
+        // X tie-break only makes same-line fragments adjacent for grouping —
+        // the authoritative reading order WITHIN each line is decided per line
+        // below (#302 symptom 1), so this grouping order is not the final order.
         let mut indexed: Vec<(u32, usize, &TextFragment)> = row_ids
             .iter()
             .copied()
@@ -425,34 +426,53 @@ impl TextExtractor {
         indexed.sort_by(|a, b| {
             a.0.cmp(&b.0)
                 .then(b.2.y.total_cmp(&a.2.y))
-                .then(if is_tagged {
-                    a.1.cmp(&b.1)
-                } else {
-                    a.2.x.total_cmp(&b.2.x)
-                })
+                .then(a.2.x.total_cmp(&b.2.x))
         });
 
-        let mut lines: Vec<Vec<&TextFragment>> = Vec::new();
+        // Group into visual lines, carrying each fragment's emission index so
+        // the per-line ordering decision below can restore emission order.
+        let mut lines: Vec<Vec<(usize, &TextFragment)>> = Vec::new();
         let mut last_seen_row_id: Option<u32> = None;
-        for (rid, _idx, frag) in indexed {
+        for (rid, idx, frag) in indexed {
             let same_batch = last_seen_row_id == Some(rid);
             let placed = same_batch
                 && lines.last_mut().is_some_and(|line| {
-                    let head = line[0];
+                    let head = line[0].1;
                     let tol = (head.height.min(frag.height)) * 0.2;
                     (head.y - frag.y).abs() < tol && head.mcid == frag.mcid
                 });
             if placed {
-                lines.last_mut().unwrap().push(frag);
+                lines.last_mut().unwrap().push((idx, frag));
             } else {
-                lines.push(vec![frag]);
+                lines.push(vec![(idx, frag)]);
                 last_seen_row_id = Some(rid);
             }
         }
 
+        // Decide reading order per visual line (#302 symptom 1).
+        //
+        // X-sort is wrong when one line mixes fonts whose glyph metrics differ
+        // (e.g. an italic particle symbol set in roman body text): the producer
+        // gives the font-switched run an x-origin that falls INSIDE the x-span
+        // of its neighbours, so sorting by x interleaves it
+        // ("to the Z boson" -> "tZboso theon"). The content stream still emits
+        // these runs in correct reading order, so when a line's emission order
+        // has no DISJOINT backward x-step (only span overlaps, or is already
+        // x-monotone) we keep emission order. A disjoint backward step signals
+        // a genuinely scrambled stream (right-to-left / random generators), for
+        // which x-order stays authoritative. Deciding per line — not per
+        // column — prevents one scrambled line from forcing x-sort on the rest.
         lines
             .into_iter()
-            .map(|line| build_line_fragment(line, self.options.space_threshold))
+            .map(|mut line| {
+                if is_tagged || line_prefers_emission_order(&line) {
+                    line.sort_by_key(|&(idx, _)| idx);
+                } else {
+                    line.sort_by(|a, b| a.1.x.total_cmp(&b.1.x));
+                }
+                let frags: Vec<&TextFragment> = line.into_iter().map(|(_, f)| f).collect();
+                build_line_fragment(frags, self.options.space_threshold)
+            })
             .collect()
     }
 
@@ -1988,6 +2008,38 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
     result
 }
 
+/// Decide whether a single visual line should be read in emission order.
+///
+/// `line` holds `(emission_index, fragment)` pairs for one visual line in any
+/// order. Returns `true` when, walked in emission order, the line has no
+/// DISJOINT backward x-step: every fragment either advances in x or only
+/// overlaps its predecessor's box (a font switch whose glyph box reaches back
+/// over the previous run — #302 symptom 1). A backward step to a non-
+/// overlapping x position means the emission order is not reading order
+/// (right-to-left / random generators), so x-order should be used instead.
+/// Lines that are already x-monotone in emission satisfy this trivially and
+/// decode identically under either policy.
+fn line_prefers_emission_order(line: &[(usize, &TextFragment)]) -> bool {
+    if line.len() < 2 {
+        return true;
+    }
+    let mut em: Vec<&(usize, &TextFragment)> = line.iter().collect();
+    em.sort_by_key(|&&(idx, _)| idx);
+    for pair in em.windows(2) {
+        let prev = pair[0].1;
+        let cur = pair[1].1;
+        if cur.x < prev.x {
+            let prev_end = prev.x + prev.width;
+            let cur_end = cur.x + cur.width;
+            let spans_overlap = cur.x < prev_end && cur_end > prev.x;
+            if !spans_overlap {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 fn build_line_fragment(line: Vec<&TextFragment>, space_threshold: f64) -> TextFragment {
     let head = line[0];
     let mut text = String::new();
@@ -2975,6 +3027,56 @@ mod tests {
         ];
         let lines = extractor.merge_into_lines(&tight);
         assert_eq!(lines[0].text, "ABCD", "tight gap must NOT insert space");
+    }
+
+    #[test]
+    fn merge_into_lines_keeps_emission_order_for_font_switch_overlap() {
+        // #302 symptom 1: a font-switched glyph (e.g. the italic particle
+        // symbol "Z" in "to the Z boson") is positioned by the producer with
+        // an x-origin that falls INSIDE the x-span of the preceding roman run
+        // ("to the"). The content stream still delivers it in correct reading
+        // order. Sorting a row purely by x-origin interleaves the overlapping
+        // fragment, yielding "Zto the" instead of "to theZ". When a row's only
+        // backward emission steps are span overlaps (not disjoint jumps),
+        // emission order is the authoritative reading order.
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        // emission order = reading order; "Z" overlaps "to t" + "he" in x.
+        let row = vec![
+            tf("to t", 455.5, 400.0, 12.0, 10.0), // 455.5 .. 467.5
+            tf("he", 467.5, 400.0, 10.0, 10.0),   // 467.5 .. 477.5
+            tf("Z", 455.3, 400.0, 23.0, 10.0),    // 455.3 .. 478.3 (overlaps both)
+        ];
+        let lines = extractor.merge_into_lines(&row);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(
+            lines[0].text, "to theZ",
+            "overlapping font-switch fragment must keep emission (reading) order"
+        );
+    }
+
+    #[test]
+    fn merge_into_lines_uses_x_order_for_disjoint_backward_jump() {
+        // Guard: a genuinely scrambled non-tagged stream (fragments emitted
+        // out of x-order at DISJOINT positions, e.g. right-to-left or random
+        // generators) must still be reordered by x. Here "the" is emitted
+        // after "boson" with no span overlap, so x-order is authoritative.
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        let row = vec![
+            tf("boson", 100.0, 400.0, 28.0, 10.0), // 100 .. 128
+            tf("the", 80.0, 400.0, 15.0, 10.0),    // 80 .. 95 (disjoint, left of boson)
+        ];
+        let lines = extractor.merge_into_lines(&row);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(
+            lines[0].text, "the boson",
+            "disjoint backward emission jump must be reordered by x"
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2090,30 +2090,34 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
 ///
 /// `line` holds `(emission_index, fragment)` pairs for one visual line in any
 /// order. Returns `true` when, walked in emission order, the line has no
-/// DISJOINT backward x-step: every fragment either advances in x or only
-/// overlaps its predecessor's box (a font switch whose glyph box reaches back
-/// over the previous run — #302 symptom 1). A backward step to a non-
-/// overlapping x position means the emission order is not reading order
-/// (right-to-left / random generators), so x-order should be used instead.
-/// Lines that are already x-monotone in emission satisfy this trivially and
-/// decode identically under either policy.
+/// DISJOINT backward x-step — i.e. no fragment lands entirely to the LEFT of
+/// everything emitted so far on the line. Such a left jump is the signature of
+/// a genuinely scrambled stream (right-to-left / random generators), for which
+/// x-order is authoritative.
+///
+/// The comparison is against the line's running left edge, not the immediately
+/// preceding fragment: dense bodies are split into sub-word glyph runs, so a
+/// run that legitimately backfills the line (a font-switched math symbol, or a
+/// word whose run starts left of the previous short run — #302 symptom 1 /
+/// #305) overlaps the *covered span* even when it does not overlap the single
+/// fragment right before it. As long as it does not jump past the line's left
+/// edge, emission order is preserved. Lines that are already x-monotone in
+/// emission satisfy this trivially and decode identically under either policy.
 fn line_prefers_emission_order(line: &[(usize, &TextFragment)]) -> bool {
     if line.len() < 2 {
         return true;
     }
     let mut em: Vec<&(usize, &TextFragment)> = line.iter().collect();
     em.sort_by_key(|&&(idx, _)| idx);
-    for pair in em.windows(2) {
-        let prev = pair[0].1;
-        let cur = pair[1].1;
-        if cur.x < prev.x {
-            let prev_end = prev.x + prev.width;
-            let cur_end = cur.x + cur.width;
-            let spans_overlap = cur.x < prev_end && cur_end > prev.x;
-            if !spans_overlap {
-                return false;
-            }
+    let mut min_start = em[0].1.x;
+    for &&(_, f) in &em[1..] {
+        let end = f.x + f.width;
+        // A fragment whose right edge is at or left of the leftmost glyph seen
+        // so far is a true backward jump — emission order is not reading order.
+        if end <= min_start {
+            return false;
         }
+        min_start = min_start.min(f.x);
     }
     true
 }
@@ -3149,6 +3153,33 @@ mod tests {
         assert_eq!(
             lines[0].text, "to theZ",
             "overlapping font-switch fragment must keep emission (reading) order"
+        );
+    }
+
+    #[test]
+    fn merge_into_lines_keeps_emission_when_run_backfills_covered_span() {
+        // #305: dense justified body text is split into sub-word fragments by
+        // the font's arbitrary glyph runs. A later word ("described", x 492..537)
+        // is emitted with a backward x-origin that lands INSIDE the span already
+        // covered by the line ("...selections", 479..521), but does NOT overlap
+        // the short immediately-preceding fragment ("s", 517..521). Emission is
+        // still the reading order, so the line must keep it — the overlap test
+        // has to consider the line's running extent, not just the previous
+        // fragment. (Real case: Higgs p5 "kinematic selections described in".)
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        let row = vec![
+            tf("selection", 479.0, 400.0, 38.0, 8.0), // 479..517
+            tf("s", 517.0, 400.0, 4.0, 8.0),          // 517..521  short predecessor
+            tf("d", 492.0, 400.0, 4.0, 8.0),          // 492..496  backfill, no overlap with "s"
+            tf("escribed", 496.0, 400.0, 41.0, 8.0),  // 496..537
+        ];
+        let lines = extractor.merge_into_lines(&row);
+        assert_eq!(
+            lines[0].text, "selectionsdescribed",
+            "a run that backfills the line's covered span must keep emission order"
         );
     }
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -471,9 +471,87 @@ impl TextExtractor {
                     line.sort_by(|a, b| a.1.x.total_cmp(&b.1.x));
                 }
                 let frags: Vec<&TextFragment> = line.into_iter().map(|(_, f)| f).collect();
-                build_line_fragment(frags, self.options.space_threshold)
+                self.build_line_fragment(frags)
             })
             .collect()
+    }
+
+    /// Space-glyph advance for `font_name` in text space (point units at
+    /// `font_size`), or `None` when unknown. Prefers the font's embedded
+    /// `/Widths` entry for code 32; falls back to the Adobe Core-14 AFM space
+    /// width for the standard base fonts (Times/Helvetica/Courier/Symbol/
+    /// ZapfDingbats), which ship no `/Widths` array (#302 symptom 2).
+    fn font_space_advance(&self, font_name: Option<&str>, font_size: f64) -> Option<f64> {
+        let info = self.font_cache.get(font_name?)?;
+        if let Some(ref widths) = info.metrics.widths {
+            let first = info.metrics.first_char.unwrap_or(0);
+            if first <= 32 {
+                if let Some(&w) = widths.get((32 - first) as usize) {
+                    if w > 0.0 {
+                        return Some(w / 1000.0 * font_size);
+                    }
+                }
+            }
+        }
+        standard_14_space_width(&info.name).map(|em| em / 1000.0 * font_size)
+    }
+
+    /// Minimum inter-fragment x-gap that counts as a word space for `frag`.
+    /// Anchored to the font's real space-glyph advance when known — word gaps
+    /// scale with the font's space metric, not with a fixed fraction of font
+    /// size — falling back to `space_threshold * font_size` otherwise. Tightly
+    /// set justified text (e.g. Standard-14 Times body) has word gaps near
+    /// 0.2em, far below the legacy 0.3*font_size, which dropped spaces
+    /// ("thequadrupletis"); a font with a 250-unit space then gets a 0.125em
+    /// threshold instead (#302 symptom 2).
+    fn space_gap_threshold(&self, frag: &TextFragment) -> f64 {
+        match self.font_space_advance(frag.font_name.as_deref(), frag.font_size) {
+            Some(adv) if adv > 0.0 => 0.5 * adv,
+            _ => self.options.space_threshold * frag.font_size,
+        }
+    }
+
+    /// Assemble one visual line's fragments into a single line `TextFragment`,
+    /// inserting a space between consecutive fragments whose x-gap exceeds the
+    /// font-anchored [`space_gap_threshold`](Self::space_gap_threshold).
+    fn build_line_fragment(&self, line: Vec<&TextFragment>) -> TextFragment {
+        let head = line[0];
+        let mut text = String::new();
+        let mut x_min = head.x;
+        let mut x_max = head.x + head.width;
+        let mut y_min = head.y;
+        let mut y_max = head.y + head.height;
+
+        for (i, frag) in line.iter().enumerate() {
+            if i > 0 {
+                let prev = line[i - 1];
+                let gap = frag.x - (prev.x + prev.width);
+                if gap > self.space_gap_threshold(frag) {
+                    text.push(' ');
+                }
+            }
+            text.push_str(&frag.text);
+            x_min = x_min.min(frag.x);
+            x_max = x_max.max(frag.x + frag.width);
+            y_min = y_min.min(frag.y);
+            y_max = y_max.max(frag.y + frag.height);
+        }
+
+        TextFragment {
+            text,
+            x: x_min,
+            y: y_min,
+            width: x_max - x_min,
+            height: y_max - y_min,
+            font_size: head.font_size,
+            font_name: head.font_name.clone(),
+            is_bold: head.is_bold,
+            is_italic: head.is_italic,
+            color: head.color,
+            space_decisions: Vec::new(),
+            mcid: head.mcid,
+            struct_tag: head.struct_tag.clone(),
+        }
     }
 
     /// Group consecutive lines into paragraphs based on vertical gap.
@@ -1340,8 +1418,8 @@ impl TextExtractor {
 
             if should_merge {
                 // Merge this fragment into current, preserving word boundaries
-                // when the gap exceeds the space threshold.
-                if x_gap > self.options.space_threshold * fragment.font_size {
+                // when the gap exceeds the font-anchored space threshold.
+                if x_gap > self.space_gap_threshold(fragment) {
                     current.text.push(' ');
                 }
                 current.text.push_str(&fragment.text);
@@ -2040,43 +2118,27 @@ fn line_prefers_emission_order(line: &[(usize, &TextFragment)]) -> bool {
     true
 }
 
-fn build_line_fragment(line: Vec<&TextFragment>, space_threshold: f64) -> TextFragment {
-    let head = line[0];
-    let mut text = String::new();
-    let mut x_min = head.x;
-    let mut x_max = head.x + head.width;
-    let mut y_min = head.y;
-    let mut y_max = head.y + head.height;
-
-    for (i, frag) in line.iter().enumerate() {
-        if i > 0 {
-            let prev = line[i - 1];
-            let gap = frag.x - (prev.x + prev.width);
-            if gap > space_threshold * frag.font_size {
-                text.push(' ');
-            }
-        }
-        text.push_str(&frag.text);
-        x_min = x_min.min(frag.x);
-        x_max = x_max.max(frag.x + frag.width);
-        y_min = y_min.min(frag.y);
-        y_max = y_max.max(frag.y + frag.height);
-    }
-
-    TextFragment {
-        text,
-        x: x_min,
-        y: y_min,
-        width: x_max - x_min,
-        height: y_max - y_min,
-        font_size: head.font_size,
-        font_name: head.font_name.clone(),
-        is_bold: head.is_bold,
-        is_italic: head.is_italic,
-        color: head.color,
-        space_decisions: Vec::new(),
-        mcid: head.mcid,
-        struct_tag: head.struct_tag.clone(),
+/// Space-glyph advance width (1000-em units) for the Adobe Core-14 base fonts,
+/// keyed by `/BaseFont`. Subset prefixes (`ABCDEF+`) are stripped; common
+/// substitute names (Arial→Helvetica, TimesNewRoman→Times, CourierNew→Courier)
+/// map to their metric-compatible base. Returns `None` for unknown fonts, which
+/// leaves the caller on its fixed-fraction fallback. These fonts legitimately
+/// ship no `/Widths` array, so their space metric is only available here.
+fn standard_14_space_width(base_font: &str) -> Option<f64> {
+    let name = base_font.rsplit('+').next().unwrap_or(base_font);
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("courier") {
+        Some(600.0)
+    } else if lower.contains("helvetica") || lower.contains("arial") {
+        Some(278.0)
+    } else if lower.contains("times") {
+        Some(250.0)
+    } else if lower == "symbol" {
+        Some(250.0)
+    } else if lower.contains("zapfdingbats") || lower.contains("dingbats") {
+        Some(278.0)
+    } else {
+        None
     }
 }
 
@@ -3027,6 +3089,39 @@ mod tests {
         ];
         let lines = extractor.merge_into_lines(&tight);
         assert_eq!(lines[0].text, "ABCD", "tight gap must NOT insert space");
+    }
+
+    #[test]
+    fn standard_14_space_width_maps_base_fonts_and_substitutes() {
+        // Adobe Core-14 AFM space advances, with subset prefixes stripped and
+        // metric-compatible substitutes folded in (#302 symptom 2).
+        assert_eq!(super::standard_14_space_width("Times-Roman"), Some(250.0));
+        assert_eq!(
+            super::standard_14_space_width("Times-BoldItalic"),
+            Some(250.0)
+        );
+        assert_eq!(super::standard_14_space_width("Helvetica"), Some(278.0));
+        assert_eq!(super::standard_14_space_width("Courier-Bold"), Some(600.0));
+        assert_eq!(super::standard_14_space_width("Symbol"), Some(250.0));
+        assert_eq!(super::standard_14_space_width("ZapfDingbats"), Some(278.0));
+        // subset prefix stripped
+        assert_eq!(
+            super::standard_14_space_width("ABCDEF+Times-Roman"),
+            Some(250.0)
+        );
+        // metric-compatible substitutes
+        assert_eq!(super::standard_14_space_width("Arial-BoldMT"), Some(278.0));
+        assert_eq!(
+            super::standard_14_space_width("TimesNewRomanPSMT"),
+            Some(250.0)
+        );
+        assert_eq!(
+            super::standard_14_space_width("CourierNewPSMT"),
+            Some(600.0)
+        );
+        // unknown / embedded fonts fall through to the caller's fallback
+        assert_eq!(super::standard_14_space_width("Poppins-Regular"), None);
+        assert_eq!(super::standard_14_space_width("VUNXGH+Calibri"), None);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -926,6 +926,44 @@ mod tests {
     }
 
     #[test]
+    fn simple_font_one_byte_tounicode_under_two_byte_codespace_decodes() {
+        // #302 symptom 3 end-to-end: a simple TrueType font whose ToUnicode
+        // declares the generic 2-byte codespace <0000><FFFF> but maps 1-byte
+        // codes. Before the fix `decode_with_cmap` returned "" for any string
+        // containing such a code, the result was rejected as garbage, and the
+        // wrong base-encoding fallback produced U+FFFD. The full decode chain
+        // must now recover the real characters (here U+2019 RIGHT SINGLE
+        // QUOTATION MARK for code 0x92, followed by a comma).
+        let cmap_src = br#"begincmap
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+2 beginbfchar
+<92> <2019>
+<2C> <002C>
+endbfchar
+endcmap
+"#;
+        let cmap = crate::text::cmap::CMap::parse(cmap_src).unwrap();
+        let font_info = FontInfo {
+            name: "VUNXGH+ArialMT".to_string(),
+            font_type: "TrueType".to_string(),
+            encoding: Some("WinAnsiEncoding".to_string()),
+            to_unicode: Some(cmap),
+            differences: None,
+            descendant_font: None,
+            cid_to_gid_map: None,
+            cid_ordering: None,
+            metrics: FontMetrics::default(),
+            cid_encoding: None,
+        };
+        let out = decode_text_with_font(&[0x92, 0x2C], &font_info).unwrap();
+        assert_eq!(out, "\u{2019},");
+    }
+
+    #[test]
     fn embedded_encoding_cmap_decodes_via_cid_table() {
         use crate::text::cid_to_unicode::CidCollection;
         use crate::text::encoding_cmap::{CidEncoding, EncodingCMap};

--- a/oxidize-pdf-core/tests/issue_302_extraction_fidelity_test.rs
+++ b/oxidize-pdf-core/tests/issue_302_extraction_fidelity_test.rs
@@ -64,6 +64,44 @@ fn symptom2_word_spaces_preserved_on_tight_justified_text() {
     );
 }
 
+/// Extract a given page with the partition options and return its joined text.
+fn higgs_page_text(page: u32) -> String {
+    let reader = PdfReader::open(HIGGS).expect("open Higgs fixture");
+    let doc = PdfDocument::new(reader);
+    let opts = ExtractionOptions {
+        preserve_layout: true,
+        reconstruct_paragraphs: true,
+        ..Default::default()
+    };
+    let mut ex = TextExtractor::with_options(opts);
+    let extracted = ex.extract_from_page(&doc, page).expect("extract");
+    extracted
+        .fragments
+        .iter()
+        .map(|f| f.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn issue_305_subword_backfill_run_not_reordered() {
+    // #305: dense justified body split into sub-word runs; "described" backfills
+    // the span of "...selections" and x-sort interleaved it into
+    // "sedleescctriiobnesd". Across the document the reading order must hold.
+    // (Higgs page 5 carries "...the kinematic selections described in...".)
+    let text = higgs_page_text(5);
+    assert!(
+        text.contains("selectionsdescribed") || text.contains("selections described"),
+        "sub-word backfill reorder: 'selections described' scrambled:\n{}",
+        snippet(&text, "kinematic")
+    );
+    assert!(
+        !text.contains("sedlee") && !text.contains("scctriio"),
+        "scramble 'sedleescctriiobnesd' present:\n{}",
+        snippet(&text, "kinematic")
+    );
+}
+
 fn snippet(text: &str, needle: &str) -> String {
     text.lines()
         .find(|l| l.contains(needle))

--- a/oxidize-pdf-core/tests/issue_302_extraction_fidelity_test.rs
+++ b/oxidize-pdf-core/tests/issue_302_extraction_fidelity_test.rs
@@ -1,0 +1,72 @@
+//! Integration tests for #302 — text-extraction fidelity on dense/scientific
+//! PDFs, exercised end-to-end through the partition extraction options used by
+//! `rag_chunks()`. Fixture: the ATLAS Higgs paper (arXiv 1207.7214), already
+//! committed for issue #272.
+//!
+//! - symptom 1: intra-line reorder of font-switched runs ("to the Z boson"
+//!   must NOT scramble into "tZboso theon").
+//! - symptom 2: word-boundary spaces dropped on tightly-set justified text
+//!   ("in the quadruplet is referred to" must NOT collapse into
+//!   "thequadrupletis referredto").
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+const HIGGS: &str = "tests/fixtures/issue_272_higgs_arxiv_1207_7214.pdf";
+
+/// Extract page 4 with the exact options `PdfDocument::partition()` uses.
+fn higgs_page4_text() -> String {
+    let reader = PdfReader::open(HIGGS).expect("open Higgs fixture");
+    let doc = PdfDocument::new(reader);
+    let opts = ExtractionOptions {
+        preserve_layout: true,
+        reconstruct_paragraphs: true,
+        ..Default::default()
+    };
+    let mut ex = TextExtractor::with_options(opts);
+    let extracted = ex.extract_from_page(&doc, 4).expect("extract page 4");
+    extracted
+        .fragments
+        .iter()
+        .map(|f| f.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn symptom1_font_switch_run_not_reordered() {
+    let text = higgs_page4_text();
+    // The right-column line reads "...closest to the Z boson mass (mZ)". The
+    // italic "Z" (math font) is positioned inside the roman run's x-span; an
+    // x-sort interleaved it into "tZboso theon".
+    assert!(
+        text.contains("closest to the"),
+        "expected correct reading order 'closest to the ...'; got fragments:\n{}",
+        snippet(&text, "closest")
+    );
+    assert!(
+        !text.contains("tZboso") && !text.contains("theon mass"),
+        "intra-line reorder regression: scramble 'tZboso theon' present:\n{}",
+        snippet(&text, "closest")
+    );
+}
+
+#[test]
+fn symptom2_word_spaces_preserved_on_tight_justified_text() {
+    let text = higgs_page4_text();
+    // Standard-14 Times-Roman body text, tightly justified: the word-boundary
+    // gaps are ~0.2em, below the fixed 0.3*font_size threshold, so spaces were
+    // dropped ("in thequadrupletis referredto as theleadingleptonpair").
+    assert!(
+        text.contains("in the quadruplet is referred to as the leading lepton pair"),
+        "word-boundary spaces dropped on tight justified text:\n{}",
+        snippet(&text, "quadruplet")
+    );
+}
+
+fn snippet(text: &str, needle: &str) -> String {
+    text.lines()
+        .find(|l| l.contains(needle))
+        .unwrap_or("<needle not found>")
+        .to_string()
+}


### PR DESCRIPTION
Resolves all three symptoms of #302 (dense/scientific-PDF text fidelity) plus the #305 residual, each root-caused by measuring the actual code path and fixed under TDD (failing test → fix → corpus). One commit per fix.

## Symptom 3 — `U+FFFD` for typographic glyphs (`e5eccb8`)
NCSC CAF rendered curly quotes / ellipsis / en-dash as `U+FFFD`. The producer's ToUnicode CMap maps them correctly (`<92> <2019>`), so the mapping was never the problem. The CMap declares the generic Identity codespace `<0000><FFFF>` (2-byte) for a **simple** TrueType font whose bfchar entries are **1-byte**. `CodeRange::contains` requires equal length, so `CMap::map` rejected every 1-byte code, blanked the whole decoded string, and the result fell back to the wrong base encoding (`PdfDocEncoding`) which yields `U+FFFD` for high-bit codes.

Fix: explicit bfchar/bfrange mappings now win **before** the codespace gate, matched by their own key length; the codespace still constrains the Identity passthroughs. NCSC `U+FFFD` count ~50+ → 8 (residual = glyphs with no ToUnicode and no encoding entry).

## Symptom 1 — intra-line reorder of font-switched runs (`f8619ca`)
`"...closest to the Z boson mass"` extracted as `"...closest tZboso theon mass"`. Non-tagged extraction ordered each line purely by x-origin; a font-switched run (the italic particle symbol `Z`, math font) is positioned with an x-origin **inside** the x-span of the surrounding roman run, so x-sort interleaves it. The content stream emits these runs in correct reading order.

Fix: `merge_into_lines` groups fragments into visual lines (carrying emission index) and decides reading order **per line**: a line whose emission order has no *disjoint* backward x-step keeps emission order; a disjoint backward step falls back to x-order for genuinely scrambled streams (RTL/random). Per-line, not per-column, so one scrambled line can't force x-sort on the rest. Higgs: `tZboso theon` → `to theZboson`.

## Symptom 2 — dropped word spaces on tight justified text (`41994dd`)
`"in the quadruplet is referred to"` collapsed into `"in thequadrupletis referredto"`. Space detection compared the x-gap against a fixed `0.3*font_size`; Higgs body is **Times-Roman (Standard-14, no `/Widths`)** with word gaps near 0.2em.

Fix: the threshold is anchored to the font's real space-glyph advance — embedded `/Widths[32]` when present, else the Adobe Core-14 AFM space width (Times 250, Helvetica 278, Courier 600, …) keyed by `/BaseFont`, else the legacy fallback. `build_line_fragment` becomes a method and `merge_close_fragments` shares the same `space_gap_threshold`. Higgs no-space runs (≥18 chars) 142 → 2; NCSC spurious-space count moves +2 (negligible).

## #305 — sub-word backfill reorder (`3b103a6`)
A deeper residual of symptom 1: `"...the kinematic selections described in"` scrambled into `"...kinematic sedleescctriiobnesd in"`. Dense bodies are split into **sub-word** glyph runs; `"described"` (x 492–537) backfills the span already covered by `"...selections"` (479–525) but does not overlap the single short fragment right before it (`"s"`, 517–521), so the adjacent-overlap test wrongly sent the line to x-sort. (This is why span-overlap clustering does not help — at char granularity the runs only touch.)

Fix: `line_prefers_emission_order` now compares against the line's **running left edge**, treating a fragment as a true backward jump only when its right edge lands at or left of the leftmost glyph seen so far (the signature of an actually reversed stream). Backfills within the covered span keep emission order. Subsumes the prior adjacent-overlap check; the font-switch and disjoint-jump guards are unchanged. Higgs: `sedleescctriiobnesd` → `selectionsdescribed`, `tZ-hmae ss` → `theZ-mass`.

## Known residuals (out of scope, pre-existing)
- The `"selectionsdescribed"` / `"theZ-mass"` cases have correct reading order but a missing inter-word space (the two runs overlap → negative gap), which belongs to the symptom-2 spacing nuance, not ordering.
- NCSC spurious-space direction (`Objectiv e`): its spurious gap (>1.21·space-width) is larger than Higgs's legitimate gap (0.8·space-width), so gap magnitude — even font-normalized — cannot separate the two directions. This PR fixes the dominant missing-space direction.

## Validation
- lib 6536/0, clippy `--lib -D warnings` clean
- integration `issue_302_extraction_fidelity_test` 3/3 (reorder + spaces + #305 backfill), `issue_265_line_interleaving_test` 4/4
- corpus t1_spec 22/0, t3_stress 22/0 (0 panics)
- rag_realworld 5/5 (1129 chunks); BOE single-column and BSI German verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
