### PR TITLE
fix(graphics): render real gradients — function/colorspace/sh operator (#297)

### DIFF
--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -238,6 +238,20 @@ impl GraphicsContext {
         self
     }
 
+    /// Paint a registered shading into the current clip region with the
+    /// `sh` operator (ISO 32000-1 §8.7.4.2, issue #297).
+    ///
+    /// `name` must match a shading registered on the page via
+    /// [`Page::add_shading`]; the writer emits it under
+    /// `/Resources/Shading/<name>`. `sh` fills the current clip (the whole
+    /// page if unclipped), so callers typically wrap it in `q … W n … Q`
+    /// with a clip path to bound the gradient.
+    pub fn paint_shading(&mut self, name: impl Into<String>) -> &mut Self {
+        self.apply_pending_extgstate().unwrap_or_default();
+        self.operations.push(ops::Op::PaintShading(name.into()));
+        self
+    }
+
     pub fn set_stroke_color(&mut self, color: Color) -> &mut Self {
         self.stroke_color = color;
         self
@@ -1183,6 +1197,18 @@ impl GraphicsContext {
     /// Create clipping path from current path using non-zero winding rule
     pub fn clip(&mut self) -> &mut Self {
         self.operations.push(ops::Op::ClipNonZero);
+        self
+    }
+
+    /// End the current path without filling or stroking (`n`).
+    ///
+    /// Required to terminate a clipping path: the canonical sequence is
+    /// `<path> W n` (ISO 32000-1 §8.5.4). Use after [`clip`](Self::clip)
+    /// before painting a shading into the clipped region.
+    pub fn end_path(&mut self) -> &mut Self {
+        // `n` is a path-painting (no-op) operator, not a colour-painting one,
+        // so no pending-ExtGState flush is needed here (matches `clip`).
+        self.operations.push(ops::Op::EndPath);
         self
     }
 

--- a/oxidize-pdf-core/src/graphics/ops.rs
+++ b/oxidize-pdf-core/src/graphics/ops.rs
@@ -136,6 +136,11 @@ pub(crate) enum Op {
     /// `mode Tr` — text rendering mode (`0`..=`7` per ISO 32000-1 §9.3.6)
     SetRenderingMode(u8),
 
+    // ── path painting (no-op) ──
+    /// `n` — end the path without filling or stroking. Required to
+    /// terminate a clipping path (`W n`) per ISO 32000-1 §8.5.4.
+    EndPath,
+
     // ── clipping ──
     /// `W` — modify current clipping path using the non-zero winding rule.
     ClipNonZero,
@@ -144,6 +149,12 @@ pub(crate) enum Op {
     /// `W S` — clip then stroke. Used by the `clip_stroke` builder for
     /// the common pattern of stroking the boundary of the clip region.
     ClipStroke,
+
+    // ── shading ──
+    /// `/name sh` — paint the named shading into the current clip region
+    /// (ISO 32000-1 §8.7.4.2). The shading must be registered in
+    /// `/Resources/Shading` under `name`.
+    PaintShading(String),
 
     // ── special ──
     /// `% comment` — a PDF comment line. Used for transparency-group
@@ -325,10 +336,18 @@ pub(crate) fn serialize_ops(out: &mut Vec<u8>, ops: &[Op]) {
                 writeln!(out, "{mode} Tr").expect("writing to Vec<u8> never fails");
             }
 
+            // ── path painting (no-op) ──
+            Op::EndPath => out.extend_from_slice(b"n\n"),
+
             // ── clipping ──
             Op::ClipNonZero => out.extend_from_slice(b"W\n"),
             Op::ClipEvenOdd => out.extend_from_slice(b"W*\n"),
             Op::ClipStroke => out.extend_from_slice(b"W S\n"),
+
+            // ── shading ──
+            Op::PaintShading(name) => {
+                writeln!(out, "/{name} sh").expect("writing to Vec<u8> never fails");
+            }
 
             // ── special ──
             Op::Comment(text) => {
@@ -438,5 +457,19 @@ mod tests {
     fn comment_emits_percent_prefix() {
         let ops = vec![Op::Comment("Begin Transparency Group".to_string())];
         assert_eq!(ops_to_string(&ops), "% Begin Transparency Group\n");
+    }
+
+    #[test]
+    fn paint_shading_emits_name_sh() {
+        // Issue #297 D: `/name sh` paints a registered shading (ISO 32000-1 §8.7.4.2).
+        let ops = vec![Op::PaintShading("Grad1".to_string())];
+        assert_eq!(ops_to_string(&ops), "/Grad1 sh\n");
+    }
+
+    #[test]
+    fn clip_end_path_emits_w_then_n() {
+        // ISO 32000-1 §8.5.4: a clip path is terminated by `W n`.
+        let ops = vec![Op::ClipNonZero, Op::EndPath];
+        assert_eq!(ops_to_string(&ops), "W\nn\n");
     }
 }

--- a/oxidize-pdf-core/src/graphics/shadings.rs
+++ b/oxidize-pdf-core/src/graphics/shadings.rs
@@ -49,6 +49,163 @@ impl ColorStop {
     }
 }
 
+/// Resolve the PDF colour space name for a set of stops.
+///
+/// A shading dictionary carries a single `/ColorSpace` (ISO 32000-1
+/// §8.7.4.3, Table 78), so all stops must share one space. If every stop
+/// is already in the same device space that space is kept; any mix is
+/// promoted to `DeviceRGB` (the lossless common denominator here, since
+/// `Color::to_rgb` converts Gray/CMYK exactly for our device spaces).
+fn resolve_color_space(stops: &[ColorStop]) -> &'static str {
+    match stops.first() {
+        Some(first) => {
+            let name = first.color.color_space_name();
+            if stops.iter().all(|s| s.color.color_space_name() == name) {
+                name
+            } else {
+                "DeviceRGB"
+            }
+        }
+        None => "DeviceRGB",
+    }
+}
+
+/// Component values of `color` expressed in the given device space.
+fn color_components(color: &Color, space: &str) -> Vec<f64> {
+    match space {
+        "DeviceGray" => vec![match color {
+            Color::Gray(g) => *g,
+            // `resolve_color_space` only yields "DeviceGray" when every stop
+            // is `Color::Gray`, so a non-Gray colour here is a logic bug, not
+            // a case to silently approximate.
+            other => {
+                unreachable!("color_components(DeviceGray) called with non-Gray color: {other:?}")
+            }
+        }],
+        "DeviceCMYK" => {
+            let (c, m, y, k) = color.cmyk_components();
+            vec![c, m, y, k]
+        }
+        // DeviceRGB (and any unexpected name) → exact RGB conversion.
+        _ => match color.to_rgb() {
+            Color::Rgb(r, g, b) => vec![r, g, b],
+            _ => unreachable!("to_rgb always yields Color::Rgb"),
+        },
+    }
+}
+
+/// Build a Type 2 (exponential interpolation) function dictionary mapping
+/// the parametric domain `[0 1]` linearly from `c0` to `c1`
+/// (ISO 32000-1 §7.10.3). Mirrors the Type 2 shape built by
+/// `separation_color::TintTransform::to_pdf_dict`, but over `Color` rather
+/// than raw component vectors.
+fn type2_function(c0: &Color, c1: &Color, space: &str) -> Dictionary {
+    let mut dict = Dictionary::new();
+    dict.set("FunctionType", Object::Integer(2));
+    dict.set(
+        "Domain",
+        Object::Array(vec![Object::Real(0.0), Object::Real(1.0)]),
+    );
+    dict.set(
+        "C0",
+        Object::Array(
+            color_components(c0, space)
+                .into_iter()
+                .map(Object::Real)
+                .collect(),
+        ),
+    );
+    dict.set(
+        "C1",
+        Object::Array(
+            color_components(c1, space)
+                .into_iter()
+                .map(Object::Real)
+                .collect(),
+        ),
+    );
+    dict.set("N", Object::Real(1.0));
+    dict
+}
+
+/// Build the colour-interpolation `/Function` for a gradient from its
+/// stops (ISO 32000-1 §7.10, Functions):
+/// - 1 stop  → a constant Type 2 (`C0 == C1`),
+/// - 2 stops → a single Type 2 (§7.10.3),
+/// - N stops → a Type 3 stitching function (§7.10.4) wrapping `N-1` Type 2
+///   subfunctions, with `/Bounds` at the interior stop positions and
+///   `/Encode` mapping each segment back onto `[0 1]`.
+fn build_color_function(stops: &[ColorStop], space: &str) -> Result<Dictionary> {
+    match stops {
+        [] => Err(PdfError::InvalidStructure(
+            "Shading must have at least one color stop".to_string(),
+        )),
+        [only] => Ok(type2_function(&only.color, &only.color, space)),
+        [a, b] => Ok(type2_function(&a.color, &b.color, space)),
+        _ => {
+            let subfunctions: Vec<Object> = stops
+                .windows(2)
+                .map(|w| Object::Dictionary(type2_function(&w[0].color, &w[1].color, space)))
+                .collect();
+
+            // Interior stop positions become the stitching bounds.
+            let bounds: Vec<Object> = stops[1..stops.len() - 1]
+                .iter()
+                .map(|s| Object::Real(s.position))
+                .collect();
+
+            // Each subfunction consumes the full [0 1] sub-domain.
+            let encode: Vec<Object> = (0..subfunctions.len())
+                .flat_map(|_| [Object::Real(0.0), Object::Real(1.0)])
+                .collect();
+
+            let mut dict = Dictionary::new();
+            dict.set("FunctionType", Object::Integer(3));
+            dict.set(
+                "Domain",
+                Object::Array(vec![Object::Real(0.0), Object::Real(1.0)]),
+            );
+            dict.set("Functions", Object::Array(subfunctions));
+            dict.set("Bounds", Object::Array(bounds));
+            dict.set("Encode", Object::Array(encode));
+            Ok(dict)
+        }
+    }
+}
+
+/// Assemble a complete axial/radial shading dictionary with a real,
+/// renderable `/Function` and the required `/ColorSpace`. The function is
+/// inlined here; the writer hoists it to an indirect object at emit time
+/// (issue #297 B) so the dictionary is also valid standalone.
+fn assemble_gradient_dict(
+    shading_type: ShadingType,
+    coords: Vec<Object>,
+    stops: &[ColorStop],
+    extend_start: bool,
+    extend_end: bool,
+) -> Result<Dictionary> {
+    let space = resolve_color_space(stops);
+    let function = build_color_function(stops, space)?;
+
+    let mut dict = Dictionary::new();
+    dict.set("ShadingType", Object::Integer(shading_type as i64));
+    dict.set("ColorSpace", Object::Name(space.to_string()));
+    dict.set("Coords", Object::Array(coords));
+    dict.set(
+        "Domain",
+        Object::Array(vec![Object::Real(0.0), Object::Real(1.0)]),
+    );
+    dict.set("Function", Object::Dictionary(function));
+    dict.set(
+        "Extend",
+        Object::Array(vec![
+            Object::Boolean(extend_start),
+            Object::Boolean(extend_end),
+        ]),
+    );
+    Ok(dict)
+}
+
 /// Coordinate point for shading definitions
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point {
@@ -121,34 +278,25 @@ impl AxialShading {
         Self::new(name, start_point, end_point, color_stops)
     }
 
-    /// Generate PDF shading dictionary
+    /// Generate PDF shading dictionary (ISO 32000-1 §8.7.4.3, Table 78).
+    ///
+    /// Emits a real `/Function` interpolating the `color_stops` and the
+    /// required `/ColorSpace`. The function is inlined; the writer hoists
+    /// it to an indirect object when emitting the page (issue #297).
     pub fn to_pdf_dictionary(&self) -> Result<Dictionary> {
-        let mut shading_dict = Dictionary::new();
-
-        // Basic shading properties
-        shading_dict.set("ShadingType", Object::Integer(ShadingType::Axial as i64));
-
-        // Coordinate array [x0 y0 x1 y1]
         let coords = vec![
             Object::Real(self.start_point.x),
             Object::Real(self.start_point.y),
             Object::Real(self.end_point.x),
             Object::Real(self.end_point.y),
         ];
-        shading_dict.set("Coords", Object::Array(coords));
-
-        // Function (simplified - would reference actual function object)
-        // In a real implementation, this would create a proper function dictionary
-        shading_dict.set("Function", Object::Integer(1)); // Placeholder
-
-        // Extend array
-        let extend = vec![
-            Object::Boolean(self.extend_start),
-            Object::Boolean(self.extend_end),
-        ];
-        shading_dict.set("Extend", Object::Array(extend));
-
-        Ok(shading_dict)
+        assemble_gradient_dict(
+            ShadingType::Axial,
+            coords,
+            &self.color_stops,
+            self.extend_start,
+            self.extend_end,
+        )
     }
 
     /// Validate axial shading parameters
@@ -248,14 +396,12 @@ impl RadialShading {
         Self::new(name, center, start_radius, center, end_radius, color_stops)
     }
 
-    /// Generate PDF shading dictionary
+    /// Generate PDF shading dictionary (ISO 32000-1 §8.7.4.4, Table 79).
+    ///
+    /// Emits a real `/Function` interpolating the `color_stops` and the
+    /// required `/ColorSpace`. The function is inlined; the writer hoists
+    /// it to an indirect object when emitting the page (issue #297).
     pub fn to_pdf_dictionary(&self) -> Result<Dictionary> {
-        let mut shading_dict = Dictionary::new();
-
-        // Basic shading properties
-        shading_dict.set("ShadingType", Object::Integer(ShadingType::Radial as i64));
-
-        // Coordinate array [x0 y0 r0 x1 y1 r1]
         let coords = vec![
             Object::Real(self.start_center.x),
             Object::Real(self.start_center.y),
@@ -264,19 +410,13 @@ impl RadialShading {
             Object::Real(self.end_center.y),
             Object::Real(self.end_radius),
         ];
-        shading_dict.set("Coords", Object::Array(coords));
-
-        // Function (simplified - would reference actual function object)
-        shading_dict.set("Function", Object::Integer(1)); // Placeholder
-
-        // Extend array
-        let extend = vec![
-            Object::Boolean(self.extend_start),
-            Object::Boolean(self.extend_end),
-        ];
-        shading_dict.set("Extend", Object::Array(extend));
-
-        Ok(shading_dict)
+        assemble_gradient_dict(
+            ShadingType::Radial,
+            coords,
+            &self.color_stops,
+            self.extend_start,
+            self.extend_end,
+        )
     }
 
     /// Validate radial shading parameters
@@ -448,7 +588,17 @@ impl ShadingPattern {
         self
     }
 
-    /// Generate PDF pattern dictionary for shading pattern
+    /// Generate PDF pattern dictionary for shading pattern.
+    ///
+    /// NOTE: `ShadingPattern` is not yet wired through `Page` → writer (there
+    /// is no `Page::add_shading_pattern` and the writer iterates only
+    /// `page.shadings()`), so this method is not exercised by the
+    /// serialisation pipeline today. The `sh` direct-paint path
+    /// ([`GraphicsContext::paint_shading`] over [`Page::add_shading`]) is the
+    /// wired, end-to-end gradient path. Because the inlined `/Shading` here
+    /// carries its `/Function` inline (the writer's indirect-hoist only
+    /// applies to `page.shadings()`), full PatternType-2 fill support remains
+    /// a follow-up.
     pub fn to_pdf_pattern_dictionary(&self) -> Result<Dictionary> {
         let mut pattern_dict = Dictionary::new();
 
@@ -456,8 +606,14 @@ impl ShadingPattern {
         pattern_dict.set("Type", Object::Name("Pattern".to_string()));
         pattern_dict.set("PatternType", Object::Integer(2)); // Shading pattern
 
-        // Shading reference (would be resolved during PDF generation)
-        pattern_dict.set("Shading", Object::Integer(1)); // Placeholder
+        // Inline the real shading dictionary (issue #297 C). A PatternType 2
+        // /Shading may be a dictionary or an indirect reference (ISO 32000-1
+        // §8.7.3.3, Table 76); inlining keeps the pattern self-contained and
+        // renderable instead of the old `Object::Integer(1)` placeholder.
+        pattern_dict.set(
+            "Shading",
+            Object::Dictionary(self.shading.to_pdf_dictionary()?),
+        );
 
         // Matrix (if specified)
         if let Some(matrix) = self.matrix {
@@ -1052,6 +1208,293 @@ mod tests {
                 assert!(!(*end_extend));
             }
         }
+    }
+
+    // ── Issue #297: real /Function, /ColorSpace and the `sh` paint path ──
+
+    /// Extract the C0/C1 arrays of a Type 2 function dictionary as f64 vecs.
+    fn type2_c0_c1(func: &Dictionary) -> (Vec<f64>, Vec<f64>) {
+        let extract = |key: &str| -> Vec<f64> {
+            match func.get(key) {
+                Some(Object::Array(a)) => a
+                    .iter()
+                    .map(|o| match o {
+                        Object::Real(v) => *v,
+                        Object::Integer(v) => *v as f64,
+                        _ => panic!("{key} component is not numeric"),
+                    })
+                    .collect(),
+                other => panic!("{key} is not an array: {other:?}"),
+            }
+        };
+        (extract("C0"), extract("C1"))
+    }
+
+    #[test]
+    fn test_axial_two_stops_emits_real_type2_function() {
+        // 2 stops red→blue must produce a Type 2 (exponential) function whose
+        // endpoints carry the actual stop colours, not a placeholder integer.
+        let shading = AxialShading::linear_gradient(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            Color::red(),
+            Color::blue(),
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+
+        // /ColorSpace is REQUIRED by ISO 32000-1 §8.7.4.3 Table 78 — was missing.
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceRGB".to_string())),
+            "axial shading must declare /ColorSpace"
+        );
+
+        // /Function must be a real function dictionary, not Object::Integer(1).
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        assert_eq!(func.get("FunctionType"), Some(&Object::Integer(2)));
+        let (c0, c1) = type2_c0_c1(func);
+        assert_eq!(c0, vec![1.0, 0.0, 0.0], "C0 must be red");
+        assert_eq!(c1, vec![0.0, 0.0, 1.0], "C1 must be blue");
+        assert_eq!(func.get("N"), Some(&Object::Real(1.0)));
+        assert_eq!(
+            func.get("Domain"),
+            Some(&Object::Array(vec![Object::Real(0.0), Object::Real(1.0)]))
+        );
+    }
+
+    #[test]
+    fn test_axial_three_stops_emits_type3_stitching() {
+        // 3 stops must produce a Type 3 stitching function wrapping 2 Type 2
+        // subfunctions, with /Bounds at the interior stop and /Encode [0 1 0 1].
+        let shading = AxialShading::new(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![
+                ColorStop::new(0.0, Color::red()),
+                ColorStop::new(0.5, Color::green()),
+                ColorStop::new(1.0, Color::blue()),
+            ],
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        assert_eq!(func.get("FunctionType"), Some(&Object::Integer(3)));
+        assert_eq!(
+            func.get("Bounds"),
+            Some(&Object::Array(vec![Object::Real(0.5)])),
+            "interior stop position is the only bound"
+        );
+        assert_eq!(
+            func.get("Encode"),
+            Some(&Object::Array(vec![
+                Object::Real(0.0),
+                Object::Real(1.0),
+                Object::Real(0.0),
+                Object::Real(1.0),
+            ]))
+        );
+        let subfuncs = match func.get("Functions") {
+            Some(Object::Array(a)) => a,
+            other => panic!("/Functions must be an array, got {other:?}"),
+        };
+        assert_eq!(subfuncs.len(), 2, "two segments for three stops");
+        // First subfunction red→green.
+        let f0 = match &subfuncs[0] {
+            Object::Dictionary(d) => d,
+            other => panic!("subfunction 0 not a dict: {other:?}"),
+        };
+        let (c0, c1) = type2_c0_c1(f0);
+        assert_eq!(c0, vec![1.0, 0.0, 0.0]);
+        assert_eq!(c1, vec![0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn test_axial_gray_stops_emit_devicegray_function() {
+        // Uniform Gray stops must keep DeviceGray (1 component), not promote to RGB.
+        let shading = AxialShading::linear_gradient(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Color::black(),
+            Color::white(),
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceGray".to_string()))
+        );
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        let (c0, c1) = type2_c0_c1(func);
+        assert_eq!(c0, vec![0.0], "black");
+        assert_eq!(c1, vec![1.0], "white");
+    }
+
+    #[test]
+    fn test_axial_cmyk_stops_emit_devicecmyk_function() {
+        // Uniform CMYK stops keep DeviceCMYK with 4-component C0/C1.
+        let shading = AxialShading::linear_gradient(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Color::Cmyk(1.0, 0.0, 0.0, 0.0),
+            Color::Cmyk(0.0, 1.0, 0.0, 0.0),
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceCMYK".to_string()))
+        );
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        let (c0, c1) = type2_c0_c1(func);
+        assert_eq!(c0, vec![1.0, 0.0, 0.0, 0.0], "C0 = cyan, 4 components");
+        assert_eq!(c1, vec![0.0, 1.0, 0.0, 0.0], "C1 = magenta, 4 components");
+    }
+
+    #[test]
+    fn test_axial_four_stops_type3_has_three_subfunctions_two_bounds() {
+        let shading = AxialShading::new(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![
+                ColorStop::new(0.0, Color::red()),
+                ColorStop::new(0.3, Color::green()),
+                ColorStop::new(0.7, Color::blue()),
+                ColorStop::new(1.0, Color::white()),
+            ],
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        assert_eq!(func.get("FunctionType"), Some(&Object::Integer(3)));
+        let subfuncs = match func.get("Functions") {
+            Some(Object::Array(a)) => a,
+            other => panic!("/Functions array expected, got {other:?}"),
+        };
+        assert_eq!(subfuncs.len(), 3, "4 stops → 3 segments");
+        assert_eq!(
+            func.get("Bounds"),
+            Some(&Object::Array(vec![Object::Real(0.3), Object::Real(0.7)])),
+            "two interior bounds at the middle stops"
+        );
+        assert_eq!(
+            func.get("Encode"),
+            Some(&Object::Array(vec![
+                Object::Real(0.0),
+                Object::Real(1.0),
+                Object::Real(0.0),
+                Object::Real(1.0),
+                Object::Real(0.0),
+                Object::Real(1.0),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_single_stop_emits_constant_type2() {
+        // A lone stop is valid (validate() only rejects empty) → constant colour.
+        let shading = AxialShading::new(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            vec![ColorStop::new(0.0, Color::Rgb(0.2, 0.4, 0.6))],
+        );
+        let func = match shading.to_pdf_dictionary().unwrap().get("Function") {
+            Some(Object::Dictionary(d)) => d.clone(),
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        assert_eq!(func.get("FunctionType"), Some(&Object::Integer(2)));
+        let (c0, c1) = type2_c0_c1(&func);
+        assert_eq!(c0, c1, "constant colour: C0 == C1");
+        assert_eq!(c0, vec![0.2, 0.4, 0.6]);
+    }
+
+    #[test]
+    fn test_mixed_color_spaces_promote_to_rgb() {
+        // Mixing Gray and RGB stops must promote the whole shading to DeviceRGB.
+        let shading = AxialShading::new(
+            "G".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            vec![
+                ColorStop::new(0.0, Color::Gray(0.5)),
+                ColorStop::new(1.0, Color::Rgb(1.0, 0.0, 0.0)),
+            ],
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceRGB".to_string()))
+        );
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        let (c0, c1) = type2_c0_c1(func);
+        assert_eq!(c0, vec![0.5, 0.5, 0.5], "gray 0.5 promoted to RGB");
+        assert_eq!(c1, vec![1.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_radial_emits_real_function_and_colorspace() {
+        let center = Point::new(50.0, 50.0);
+        let shading = RadialShading::radial_gradient(
+            "R".to_string(),
+            center,
+            0.0,
+            25.0,
+            Color::cyan(),
+            Color::magenta(),
+        );
+        let dict = shading.to_pdf_dictionary().unwrap();
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceRGB".to_string()))
+        );
+        let func = match dict.get("Function") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Function must be a dictionary, got {other:?}"),
+        };
+        assert_eq!(func.get("FunctionType"), Some(&Object::Integer(2)));
+    }
+
+    #[test]
+    fn test_shading_pattern_inlines_real_shading_not_placeholder() {
+        // Issue #297 C: /Shading must be the real shading dict, never Integer(1).
+        let axial = AxialShading::linear_gradient(
+            "P".to_string(),
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            Color::red(),
+            Color::blue(),
+        );
+        let pattern = ShadingPattern::new("SP1".to_string(), ShadingDefinition::Axial(axial));
+        let dict = pattern.to_pdf_pattern_dictionary().unwrap();
+        assert_eq!(dict.get("PatternType"), Some(&Object::Integer(2)));
+        let shading = match dict.get("Shading") {
+            Some(Object::Dictionary(d)) => d,
+            other => panic!("/Shading must be an inline dict, got {other:?}"),
+        };
+        assert_eq!(shading.get("ShadingType"), Some(&Object::Integer(2)));
+        assert!(
+            matches!(shading.get("Function"), Some(Object::Dictionary(_))),
+            "inlined shading must carry a real /Function"
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2672,8 +2672,19 @@ impl<W: Write> PdfWriter<W> {
                 page.shadings().iter().collect();
             entries.sort_by_key(|(name, _)| name.as_str());
             for (name, shading) in entries {
+                let mut shading_dict = shading.to_pdf_dictionary()?;
+                // Hoist the inline /Function to an indirect object (issue #297 B).
+                // ISO 32000-1 §8.7.4.5.2: functions are normally indirect. Only
+                // a dictionary value is hoisted; FunctionBased shadings carry an
+                // external function id (an Integer) which is left untouched.
+                if let Some(Object::Dictionary(_)) = shading_dict.get("Function") {
+                    if let Some(func_obj) = shading_dict.remove("Function") {
+                        let func_id = self.allocate_object_id();
+                        self.write_object(func_id, func_obj)?;
+                        shading_dict.set("Function", Object::Reference(func_id));
+                    }
+                }
                 let shading_id = self.allocate_object_id();
-                let shading_dict = shading.to_pdf_dictionary()?;
                 self.write_object(shading_id, Object::Dictionary(shading_dict))?;
                 sh_dict.set(name, Object::Reference(shading_id));
             }

--- a/oxidize-pdf-core/tests/page_shadings_test.rs
+++ b/oxidize-pdf-core/tests/page_shadings_test.rs
@@ -16,12 +16,13 @@
 //!     from `/Resources/Shading/<Name>`.
 
 use oxidize_pdf::graphics::{
-    AxialShading, Color, ColorStop, Point as ShadingPoint, ShadingDefinition,
+    AxialShading, Color, ColorStop, FunctionBasedShading, Point as ShadingPoint, RadialShading,
+    ShadingDefinition,
 };
 use oxidize_pdf::parser::objects::PdfObject;
-use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::{Document, Page};
-use std::io::Cursor;
+use std::io::{Cursor, Read, Seek};
 
 fn first_page_ref<R: std::io::Read + std::io::Seek>(reader: &mut PdfReader<R>) -> (u32, u16) {
     let pages = reader.pages().expect("/Pages").clone();
@@ -64,6 +65,63 @@ fn resolve_page0_shading_dict<R: std::io::Read + std::io::Seek>(
             .clone(),
         other => panic!("/Shading: unexpected {:?}", other),
     }
+}
+
+/// Decode the first page's content stream(s) to a UTF-8 string, applying
+/// FlateDecode (compression is a default feature).
+fn page0_content<R: Read + Seek>(reader: &mut PdfReader<R>) -> String {
+    let (page_n, page_g) = first_page_ref(reader);
+    let page = reader
+        .get_object(page_n, page_g)
+        .expect("page")
+        .clone()
+        .as_dict()
+        .expect("page dict")
+        .clone();
+    let opts = ParseOptions::default();
+    let refs: Vec<(u32, u16)> = match page.get("Contents").expect("/Contents") {
+        PdfObject::Reference(n, g) => vec![(*n, *g)],
+        PdfObject::Array(a) => {
+            a.0.iter()
+                .map(|el| el.as_reference().expect("/Contents element ref"))
+                .collect()
+        }
+        other => panic!("/Contents: unexpected {other:?}"),
+    };
+    let mut out = Vec::new();
+    for (n, g) in refs {
+        let obj = reader.get_object(n, g).expect("content object").clone();
+        let stream = obj.as_stream().expect("content stream");
+        out.extend(stream.decode(&opts).expect("decode content stream"));
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Resolve the indirect `/Function` of a shading dict and return it.
+fn resolve_function<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    shading: &oxidize_pdf::parser::objects::PdfDictionary,
+) -> oxidize_pdf::parser::objects::PdfDictionary {
+    let (n, g) = shading
+        .get("Function")
+        .and_then(|o| o.as_reference())
+        .expect("/Function must be an indirect reference (issue #297 B)");
+    reader
+        .get_object(n, g)
+        .expect("resolve /Function")
+        .clone()
+        .as_dict()
+        .expect("/Function dict")
+        .clone()
+}
+
+fn reals(obj: &PdfObject) -> Vec<f64> {
+    obj.as_array()
+        .expect("array")
+        .0
+        .iter()
+        .map(|o| o.as_real().expect("numeric component"))
+        .collect()
 }
 
 fn make_axial(name: &str) -> ShadingDefinition {
@@ -151,4 +209,194 @@ fn shadings_accessor_is_public_and_reflects_state() {
     let map = page.shadings();
     assert_eq!(map.len(), 1);
     assert!(map.contains_key("Sh1"));
+}
+
+// ── Issue #297: gradients must render (real /Function, /ColorSpace, `sh`) ──
+
+/// End-to-end: an axial shading's `/Function` resolves to an INDIRECT Type 2
+/// function whose `C0`/`C1` carry the actual stop colours, and the shading
+/// declares `/ColorSpace DeviceRGB`. Before the fix `/Function` was
+/// `Object::Integer(1)` and `/ColorSpace` was absent.
+#[test]
+fn axial_function_is_indirect_type2_with_real_colors() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_shading("Sh1", make_axial("Sh1"))
+        .expect("add_shading");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+    let (sn, sg) = sh
+        .get("Sh1")
+        .and_then(|o| o.as_reference())
+        .expect("/Sh1 indirect ref");
+    let shading = reader
+        .get_object(sn, sg)
+        .expect("resolve Sh1")
+        .clone()
+        .as_dict()
+        .expect("Sh1 dict")
+        .clone();
+
+    assert_eq!(
+        shading
+            .get("ColorSpace")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("DeviceRGB"),
+        "/ColorSpace is required (ISO 32000-1 §8.7.4.3, Table 78)"
+    );
+
+    let func = resolve_function(&mut reader, &shading);
+    assert_eq!(
+        func.get("FunctionType").and_then(|o| o.as_integer()),
+        Some(2),
+        "2 stops → Type 2 exponential function"
+    );
+    assert_eq!(
+        reals(func.get("C0").expect("/C0")),
+        vec![1.0, 0.0, 0.0],
+        "C0 = red"
+    );
+    assert_eq!(
+        reals(func.get("C1").expect("/C1")),
+        vec![0.0, 0.0, 1.0],
+        "C1 = blue"
+    );
+    assert_eq!(func.get("N").and_then(|o| o.as_real()), Some(1.0));
+}
+
+/// End-to-end: a 3-stop radial shading's `/Function` resolves to an indirect
+/// Type 3 stitching function wrapping two Type 2 subfunctions, with one
+/// interior `/Bounds` entry.
+#[test]
+fn radial_three_stops_function_is_type3_stitching() {
+    let radial = RadialShading::new(
+        "Rad".to_string(),
+        ShadingPoint::new(50.0, 50.0),
+        0.0,
+        ShadingPoint::new(50.0, 50.0),
+        40.0,
+        vec![
+            ColorStop::new(0.0, Color::Rgb(1.0, 0.0, 0.0)),
+            ColorStop::new(0.5, Color::Rgb(0.0, 1.0, 0.0)),
+            ColorStop::new(1.0, Color::Rgb(0.0, 0.0, 1.0)),
+        ],
+    );
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_shading("Rad", ShadingDefinition::Radial(radial))
+        .expect("add_shading");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+    let (sn, sg) = sh
+        .get("Rad")
+        .and_then(|o| o.as_reference())
+        .expect("/Rad ref");
+    let shading = reader
+        .get_object(sn, sg)
+        .expect("resolve Rad")
+        .clone()
+        .as_dict()
+        .expect("Rad dict")
+        .clone();
+    assert_eq!(
+        shading.get("ShadingType").and_then(|o| o.as_integer()),
+        Some(3),
+        "radial = ShadingType 3"
+    );
+    let coords = shading
+        .get("Coords")
+        .and_then(|o| o.as_array())
+        .expect("/Coords");
+    assert_eq!(coords.0.len(), 6, "radial /Coords = [x0 y0 r0 x1 y1 r1]");
+
+    let func = resolve_function(&mut reader, &shading);
+    assert_eq!(
+        func.get("FunctionType").and_then(|o| o.as_integer()),
+        Some(3),
+        "3 stops → Type 3 stitching function"
+    );
+    let subfns = func
+        .get("Functions")
+        .and_then(|o| o.as_array())
+        .expect("/Functions");
+    assert_eq!(subfns.0.len(), 2, "3 stops → 2 segments");
+    assert_eq!(
+        reals(func.get("Bounds").expect("/Bounds")),
+        vec![0.5],
+        "single interior bound at the middle stop"
+    );
+}
+
+/// Writer guard: a `FunctionBased` shading carries an external function id
+/// (an `Object::Integer`, not a dictionary). The function-hoisting logic
+/// must leave it untouched — only dictionary `/Function` values are hoisted
+/// to indirect objects (issue #297 B).
+#[test]
+fn function_based_shading_function_id_is_not_hoisted() {
+    let fb = FunctionBasedShading::new("FB".to_string(), [0.0, 1.0, 0.0, 1.0], 7);
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_shading("FB", ShadingDefinition::FunctionBased(fb))
+        .expect("add_shading");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+    let (sn, sg) = sh
+        .get("FB")
+        .and_then(|o| o.as_reference())
+        .expect("/FB ref");
+    let shading = reader
+        .get_object(sn, sg)
+        .expect("resolve FB")
+        .clone()
+        .as_dict()
+        .expect("FB dict")
+        .clone();
+    assert_eq!(
+        shading.get("ShadingType").and_then(|o| o.as_integer()),
+        Some(1),
+        "function-based = ShadingType 1"
+    );
+    assert_eq!(
+        shading.get("Function").and_then(|o| o.as_integer()),
+        Some(7),
+        "external function id stays an integer, not hoisted to a reference"
+    );
+}
+
+/// End-to-end: `GraphicsContext::paint_shading` emits `/name sh` into the
+/// page content stream (ISO 32000-1 §8.7.4.2) — the paint path that was
+/// entirely absent before issue #297.
+#[test]
+fn paint_shading_emits_sh_operator_in_content_stream() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_shading("Sh1", make_axial("Sh1"))
+        .expect("add_shading");
+    // Clip to a rectangle, then paint the gradient into it.
+    page.graphics()
+        .save_state()
+        .rectangle(50.0, 50.0, 200.0, 100.0)
+        .clip()
+        .end_path()
+        .paint_shading("Sh1")
+        .restore_state();
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let content = page0_content(&mut reader);
+    assert!(
+        content.contains("/Sh1 sh"),
+        "content stream must paint the shading with `/Sh1 sh`:\n{content}"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes the placeholder shading machinery reported in #297: axial/radial gradients now emit a real PDF `/Function`, the required `/ColorSpace`, and can be painted via the `sh` operator. Before this change the shading dict carried `/Function 1` (an integer), had no `/ColorSpace`, and there was no paint path — no viewer could render a registered gradient, and the real `color_stops` data was discarded.

## What changed

**A — real `/Function` from color stops** (`graphics/shadings.rs`)
- 2 stops → Type 2 (exponential interpolation), `C0`/`C1` = stop colours (ISO 32000-1 §7.10.3).
- >2 stops → Type 3 stitching (§7.10.4) wrapping N-1 Type 2 subfunctions, `/Bounds` at interior stop positions, `/Encode` per segment.
- 1 stop → constant Type 2 (`C0 == C1`).
- `/ColorSpace` now emitted (was missing; required by §8.7.4.3 Table 78). Uniform Gray/CMYK kept; mixed spaces promote to DeviceRGB. Axial and radial share one `assemble_gradient_dict` helper (no duplication).

**B — indirect `/Function`** (`writer/pdf_writer/mod.rs`)
- The shading block hoists the inlined function dictionary to an indirect object and references it. Only dictionary values are hoisted; `FunctionBased` shadings (external integer id) are left untouched.

**C — shading-pattern `/Shading`** (`graphics/shadings.rs`)
- `ShadingPattern::to_pdf_pattern_dictionary` inlines the real shading dict instead of the `Object::Integer(1)` placeholder.

**D — `sh` painting path** (`graphics/ops.rs`, `graphics/mod.rs`)
- `Op::PaintShading(name)` → `/name sh`; `GraphicsContext::paint_shading`.
- `Op::EndPath` → `n` and `GraphicsContext::end_path` so a clip path is terminated `W n` (§8.5.4) before painting the gradient.

## Scope note

The wired end-to-end gradient path is `sh` (`Page::add_shading` + `paint_shading`), which satisfies the issue's acceptance ("via `sh` and/or a PatternType-2 pattern … at least one of the two paths"). Full PatternType-2 fill via `scn` needs page-level `ShadingPattern` plumbing that does not exist yet (`Page` has no `add_shading_pattern`); the C placeholder is fixed at the method level and the gap is documented in-code as a follow-up.

## Tests (TDD, content-verifying — no smoke tests)

- 9 unit: Type 2/3 function shapes, DeviceGray/DeviceRGB/DeviceCMYK colour spaces, mixed-space promotion, single/constant stop, 4-stop stitching.
- 2 ops: `/name sh`, `W n`.
- 4 integration round-tripping the written PDF: indirect Type 2/3 function with real `C0`/`C1`, `/ColorSpace`, `Coords`, `sh` in the decoded content stream, and `FunctionBased` id not hoisted.

Verified: lib 6562/0, integration 11/11, clippy `-D warnings` clean, fmt OK, pre-commit green.

addresses #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
