### PR TITLE
feat(forms): fill AcroForm fields on existing PDFs via incremental update (#318)

### DIFF
--- a/oxidize-pdf-core/examples/fill_existing_form.rs
+++ b/oxidize-pdf-core/examples/fill_existing_form.rs
@@ -1,0 +1,93 @@
+//! Fill AcroForm fields on an EXISTING (already-serialized) PDF via an
+//! ISO 32000-1 §7.5.6 incremental update — issue #318.
+//!
+//! This is the standard "fill a form template" use case: take a PDF that
+//! already contains AcroForm fields and set their values so a form reader
+//! recovers them, without rewriting the original document.
+//!
+//! Run with: `cargo run --example fill_existing_form`
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --- Produce a base form PDF (stands in for a template from Acrobat) ---
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(320.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    fm.add_text_field(TextField::new("full_name"), widget.clone(), None)
+        .and_then(|field_ref| page.add_form_widget_with_ref(widget, field_ref))?;
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    let base_pdf: Vec<u8> = doc.to_bytes()?;
+
+    // --- Fill the existing field on the parsed bytes (incremental update) ---
+    let filled: Vec<u8> =
+        IncrementalFormFiller::new(&base_pdf).fill("full_name", "Ada Lovelace")?;
+
+    // The base bytes are preserved verbatim; the value lives in the appended
+    // section. A form reader recovers /V after re-parsing.
+    assert_eq!(&filled[..base_pdf.len()], &base_pdf[..]);
+
+    let recovered = read_field_value(&filled, "full_name")?;
+    println!("Base PDF: {} bytes", base_pdf.len());
+    println!(
+        "Filled PDF: {} bytes (+{} appended)",
+        filled.len(),
+        filled.len() - base_pdf.len()
+    );
+    println!("Recovered /V for 'full_name': {recovered:?}");
+
+    std::fs::write("filled_form.pdf", &filled)?;
+    println!("Wrote filled_form.pdf");
+    Ok(())
+}
+
+/// Walk /AcroForm/Fields and return the `/V` string of a terminal field.
+fn read_field_value(
+    bytes: &[u8],
+    name: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))?;
+    let catalog = reader.catalog()?.clone();
+    let acro_ref = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .ok_or("no /AcroForm")?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)?
+        .as_dict()
+        .cloned()
+        .ok_or("AcroForm not dict")?;
+    let fields = match acro.get("Fields") {
+        Some(PdfObject::Array(a)) => a.0.clone(),
+        _ => Vec::new(),
+    };
+    for f in fields {
+        if let Some((n, g)) = f.as_reference() {
+            let dict = reader
+                .get_object(n, g)?
+                .as_dict()
+                .cloned()
+                .ok_or("field not dict")?;
+            let t = dict
+                .get("T")
+                .and_then(|o| o.as_string())
+                .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+            if t.as_deref() == Some(name) {
+                return Ok(dict
+                    .get("V")
+                    .and_then(|o| o.as_string())
+                    .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -71,6 +71,17 @@ impl<R: Read + Seek> PdfReader<R> {
         self.encryption_handler.is_some()
     }
 
+    /// Access the parsed document trailer.
+    ///
+    /// Exposes the already-parsed [`PdfTrailer`], which carries the base
+    /// `startxref` offset (`xref_offset`), and the `/Root`, `/Info`, `/ID`
+    /// and `/Size` entries. Required to build a conformant ISO 32000-1
+    /// §7.5.6 incremental update (the appended trailer must chain its
+    /// `/Prev` to this offset and reuse the base `/Root` and `/ID`).
+    pub fn trailer(&self) -> &PdfTrailer {
+        &self.trailer
+    }
+
     /// Check if the PDF is unlocked (can read encrypted content)
     pub fn is_unlocked(&self) -> bool {
         match &self.encryption_handler {

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -708,21 +708,25 @@ impl XRefTable {
 
         let mut lines = content.pdf_lines();
 
-        // Find startxref line - need to iterate forward after finding it
+        // Find the LAST startxref in the tail window. An incremental update
+        // (ISO 32000-1 §7.5.6) appends a new `startxref`/`%%EOF` after the
+        // original; the most recent one points at the newest cross-reference
+        // section and MUST take precedence (earlier ones are reached via the
+        // `/Prev` chain). Returning the first occurrence would read the base
+        // PDF and silently ignore every appended update.
+        let mut last_offset = None;
         while let Some(line) = lines.next() {
             if line.trim() == "startxref" {
                 // The offset should be on the next line
                 if let Some(offset_line) = lines.next() {
-                    let offset = offset_line
-                        .trim()
-                        .parse::<u64>()
-                        .map_err(|_| ParseError::InvalidXRef)?;
-                    return Ok(offset);
+                    if let Ok(offset) = offset_line.trim().parse::<u64>() {
+                        last_offset = Some(offset);
+                    }
                 }
             }
         }
 
-        Err(ParseError::InvalidXRef)
+        last_offset.ok_or(ParseError::InvalidXRef)
     }
 
     /// Scan PDF for objects not present in XRef and add them (for hybrid files)

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -69,12 +69,12 @@ impl<'a> IncrementalFormFiller<'a> {
 /// or cyclic `/Kids` structures).
 const MAX_FIELD_DEPTH: u8 = 32;
 
-/// Resolve every terminal/named AcroForm field of `bytes` to its object id,
-/// keyed by fully-qualified name (ISO 32000-1 §12.7.3.1).
-fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> {
-    let mut reader = PdfReader::new(Cursor::new(bytes))
-        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
-
+/// Resolve every terminal/named AcroForm field to its object id, keyed by
+/// fully-qualified name (ISO 32000-1 §12.7.3.1). Reuses the caller's reader
+/// (the base PDF is parsed once per fill).
+fn resolve_acroform_fields(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> Result<HashMap<String, (u32, u16)>> {
     let acroform_dict = {
         let catalog = reader
             .catalog()
@@ -105,7 +105,7 @@ fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> 
 
     let mut out = HashMap::new();
     for (n, g) in field_refs {
-        collect_fields(&mut reader, (n, g), "", &mut out, 0)?;
+        collect_fields(reader, (n, g), "", &mut out, 0)?;
     }
     Ok(out)
 }
@@ -151,7 +151,22 @@ fn collect_fields(
         _ => Vec::new(),
     };
 
-    if kids.is_empty() {
+    // A non-empty `/Kids` does NOT imply an intermediate field. Per ISO
+    // 32000-1 §12.7.3.1 a single terminal field may carry `/T`/`/FT`/`/V`
+    // AND a `/Kids` array whose elements are its WIDGET annotations
+    // (`/Subtype /Widget`, no `/T`) — the dominant Acrobat layout. Only
+    // recurse when at least one kid is itself a field (has `/T`); otherwise
+    // the kids are widgets and THIS node is the terminal field.
+    let kids_are_subfields = kids.iter().any(|(n, g)| {
+        reader
+            .get_object(*n, *g)
+            .ok()
+            .and_then(|o| o.as_dict())
+            .map(|d| d.contains_key("T"))
+            .unwrap_or(false)
+    });
+
+    if kids.is_empty() || !kids_are_subfields {
         // Terminal field — record it under its full name (if it has one).
         if partial.is_some() {
             out.insert(full_name, node_ref);
@@ -193,10 +208,12 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     // Resolve the AcroForm dict object id and its current contents.
     let (acro_ref, mut acro_dict) = resolve_acroform_object(&mut reader)?;
 
-    // Resolve field name -> object id.
-    let field_map = resolve_acroform_fields(base_bytes)?;
+    // Resolve field name -> object id (reusing the open reader, no second parse).
+    let field_map = resolve_acroform_fields(&mut reader)?;
 
-    // Build the set of modified objects.
+    // Build the set of modified objects. Duplicate field names (or distinct
+    // names resolving to the same object id) collapse to a single rewrite
+    // with the LAST value, so we never emit two objects for one id.
     let mut modified: Vec<(u32, u16, PdfDictionary)> = Vec::new();
     for (name, value) in fields {
         let (num, gen) = field_map
@@ -215,7 +232,10 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
             "V".to_string(),
             PdfObject::String(PdfString(value.as_bytes().to_vec())),
         );
-        modified.push((num, gen, field_dict));
+        match modified.iter_mut().find(|(n, g, _)| *n == num && *g == gen) {
+            Some(slot) => slot.2 = field_dict,
+            None => modified.push((num, gen, field_dict)),
+        }
     }
 
     // Flag NeedAppearances so viewers regenerate the appearance stream.
@@ -239,13 +259,20 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     changed.push((acro_ref.0, acro_ref.1, acro_offset));
 
     let xref_pos = out.len() as u64;
+    // Keep the permanent first /ID element; regenerate the second so the
+    // revision is distinguishable (§14.4). Omit /ID entirely if the base had
+    // none.
+    let id_pair = base_id_first.map(|first| {
+        let second = derive_revision_id(&first, fields, xref_pos);
+        (first, second)
+    });
     out.extend_from_slice(&write_partial_xref_section(&changed));
     out.extend_from_slice(&write_incremental_trailer(
         base_startxref,
         base_root,
         base_size,
         xref_pos,
-        base_id_first,
+        id_pair,
     ));
 
     Ok(out)
@@ -394,7 +421,13 @@ fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
 
 /// Format a PDF real without scientific notation, trimming trailing zeros.
 fn format_real(f: f64) -> String {
-    if f == f.trunc() && f.is_finite() {
+    // PDF has no token for NaN/Infinity; emit a benign 0 rather than a
+    // malformed numeric. Field dicts essentially never carry such values,
+    // but the serializer must stay total.
+    if !f.is_finite() {
+        return "0".to_string();
+    }
+    if f == f.trunc() {
         return format!("{}", f as i64);
     }
     let mut s = format!("{f:.6}");
@@ -439,28 +472,48 @@ fn write_partial_xref_section(changed: &[(u32, u16, u64)]) -> Vec<u8> {
 }
 
 /// Build the incremental-update trailer chaining `/Prev` and reusing the
-/// base `/Root`, `/Size` and `/ID`.
+/// base `/Root` and `/Size`. The `/ID` array, when present, keeps the
+/// permanent first element and carries a fresh second element that changes
+/// with this revision (ISO 32000-1 Table 15 / §14.4 — signature validators
+/// rely on the second element changing per update).
 fn write_incremental_trailer(
     base_prev_xref: u64,
     base_root: (u32, u16),
     base_size: u32,
     new_xref_pos: u64,
-    base_id_first: Option<Vec<u8>>,
+    id_pair: Option<(Vec<u8>, Vec<u8>)>,
 ) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(b"trailer\n<< ");
     out.extend_from_slice(format!("/Size {base_size} ").as_bytes());
     out.extend_from_slice(format!("/Root {} {} R ", base_root.0, base_root.1).as_bytes());
     out.extend_from_slice(format!("/Prev {base_prev_xref} ").as_bytes());
-    if let Some(id) = base_id_first {
-        let hex: String = id.iter().map(|b| format!("{b:02X}")).collect();
-        out.extend_from_slice(format!("/ID [<{hex}> <{hex}>] ").as_bytes());
+    if let Some((first, second)) = id_pair {
+        let hex = |bytes: &[u8]| -> String { bytes.iter().map(|b| format!("{b:02X}")).collect() };
+        out.extend_from_slice(format!("/ID [<{}> <{}>] ", hex(&first), hex(&second)).as_bytes());
     }
     out.extend_from_slice(b">>\n");
     out.extend_from_slice(b"startxref\n");
     out.extend_from_slice(format!("{new_xref_pos}\n").as_bytes());
     out.extend_from_slice(b"%%EOF\n");
     out
+}
+
+/// Derive a fresh 16-byte `/ID` second element bound to this revision's
+/// content (permanent id + the values written + the new xref position).
+/// Deterministic so a given fill reproduces byte-for-byte (testable), while
+/// still differing from the base second element and from other revisions.
+fn derive_revision_id(first: &[u8], fields: &[(&str, &str)], xref_pos: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(first);
+    for (name, value) in fields {
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(value.as_bytes());
+        buf.push(0);
+    }
+    buf.extend_from_slice(&xref_pos.to_le_bytes());
+    md5::compute(&buf).0.to_vec()
 }
 
 #[cfg(test)]
@@ -501,10 +554,33 @@ mod tests {
     }
 
     #[test]
-    fn incremental_trailer_emits_id_when_present() {
-        let bytes = write_incremental_trailer(10, (2, 0), 5, 99, Some(vec![0xDE, 0xAD]));
+    fn incremental_trailer_emits_distinct_id_pair() {
+        // The first element is preserved; the second changes with the
+        // revision (§14.4). They must NOT be identical.
+        let bytes = write_incremental_trailer(
+            10,
+            (2, 0),
+            5,
+            99,
+            Some((vec![0xDE, 0xAD], vec![0xBE, 0xEF])),
+        );
         let s = String::from_utf8(bytes).unwrap();
-        assert!(s.contains("/ID [<DEAD> <DEAD>]"), "id reused: {s}");
+        assert!(s.contains("/ID [<DEAD> <BEEF>]"), "distinct id pair: {s}");
+    }
+
+    #[test]
+    fn revision_id_differs_from_permanent_and_is_deterministic() {
+        let first = vec![1u8, 2, 3, 4];
+        let a = derive_revision_id(&first, &[("name", "Ada")], 100);
+        let b = derive_revision_id(&first, &[("name", "Ada")], 100);
+        let c = derive_revision_id(&first, &[("name", "Grace")], 100);
+        assert_eq!(a, b, "same inputs -> same id (reproducible)");
+        assert_ne!(
+            a, first,
+            "second element must differ from the permanent one"
+        );
+        assert_ne!(a, c, "different content -> different revision id");
+        assert_eq!(a.len(), 16, "PDF /ID elements are 16 bytes");
     }
 
     #[test]

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -1,0 +1,516 @@
+//! Writable AcroForm field filling on an existing (parsed) PDF via a real
+//! ISO 32000-1 §7.5.6 incremental update (issue #318).
+//!
+//! The writer-side [`crate::Document`] can only fill fields that were built
+//! in the current process through a [`crate::forms::FormManager`]. There is
+//! no way to set `/V` on the fields of a PDF produced elsewhere (Acrobat,
+//! pdftk, another library) so a form reader recovers the value after a
+//! re-serialize. [`IncrementalFormFiller`] closes that gap.
+//!
+//! # Approach (non-lossy)
+//!
+//! Rather than rehydrating a full writable `Document` (which cannot
+//! faithfully represent an arbitrary parsed PDF and would corrupt complex
+//! documents on round-trip), this appends a true incremental update to the
+//! original bytes:
+//!
+//! 1. Parse the base PDF, resolve the `/AcroForm` field tree (handling
+//!    `/Kids` and hierarchical names via `/Parent`).
+//! 2. Clone the affected field dictionaries, set `/V`, and set
+//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2 — compliant
+//!    viewers regenerate the appearance stream; `/AP` generation is a
+//!    documented follow-up).
+//! 3. Emit ONLY the modified objects (each reusing its existing object id),
+//!    a PARTIAL incremental cross-reference section covering only the
+//!    changed ids, and a trailer chaining `/Prev` to the previous
+//!    `startxref`, reusing the base `/Root` and `/ID`.
+//!
+//! The original bytes are emitted verbatim as the prefix of the output, so
+//! every untouched object, page, font and content stream is preserved
+//! byte-for-byte.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::PdfReader;
+use std::collections::HashMap;
+use std::io::Cursor;
+
+/// Fills AcroForm fields on an existing parsed PDF by appending an
+/// ISO 32000-1 §7.5.6 incremental update. See the module docs.
+pub struct IncrementalFormFiller<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalFormFiller<'a> {
+    /// Create a filler over the bytes of an existing PDF.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Fill a single field by its fully-qualified name, returning the
+    /// updated PDF bytes (base bytes + appended incremental update).
+    pub fn fill(&self, field_name: &str, value: &str) -> Result<Vec<u8>> {
+        self.fill_many(&[(field_name, value)])
+    }
+
+    /// Fill multiple fields in a single incremental update (one parse, one
+    /// appended section). Field names are fully qualified
+    /// (e.g. `"address.street"`).
+    pub fn fill_many(&self, fields: &[(&str, &str)]) -> Result<Vec<u8>> {
+        fill_many_impl(self.base_bytes, fields)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field-tree resolution
+// ---------------------------------------------------------------------------
+
+/// Maximum field-tree recursion depth (defensive guard against pathological
+/// or cyclic `/Kids` structures).
+const MAX_FIELD_DEPTH: u8 = 32;
+
+/// Resolve every terminal/named AcroForm field of `bytes` to its object id,
+/// keyed by fully-qualified name (ISO 32000-1 §12.7.3.1).
+fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+
+    let acroform_dict = {
+        let catalog = reader
+            .catalog()
+            .map_err(|e| PdfError::InvalidStructure(format!("read catalog: {e}")))?
+            .clone();
+        match catalog.get("AcroForm") {
+            Some(PdfObject::Reference(n, g)) => reader
+                .get_object(*n, *g)
+                .map_err(|e| PdfError::InvalidStructure(format!("resolve /AcroForm: {e}")))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| {
+                    PdfError::InvalidStructure("/AcroForm is not a dictionary".to_string())
+                })?,
+            Some(PdfObject::Dictionary(d)) => d.clone(),
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "document has no /AcroForm".to_string(),
+                ))
+            }
+        }
+    };
+
+    let field_refs: Vec<(u32, u16)> = match acroform_dict.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+
+    let mut out = HashMap::new();
+    for (n, g) in field_refs {
+        collect_fields(&mut reader, (n, g), "", &mut out, 0)?;
+    }
+    Ok(out)
+}
+
+/// Recursively walk a field node, accumulating fully-qualified names. A node
+/// is named if it carries `/T`; nodes with `/Kids` are intermediate (their
+/// `/T` prefixes the children's names).
+fn collect_fields(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    parent_prefix: &str,
+    out: &mut HashMap<String, (u32, u16)>,
+    depth: u8,
+) -> Result<()> {
+    if depth >= MAX_FIELD_DEPTH {
+        return Err(PdfError::InvalidStructure(
+            "AcroForm field tree exceeds maximum depth".to_string(),
+        ));
+    }
+
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .map_err(|e| PdfError::InvalidStructure(format!("resolve field object: {e}")))?
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| {
+            PdfError::InvalidStructure("field object is not a dictionary".to_string())
+        })?;
+
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+
+    let full_name = match (&partial, parent_prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{parent_prefix}.{t}"),
+        (None, _) => parent_prefix.to_string(),
+    };
+
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+
+    if kids.is_empty() {
+        // Terminal field — record it under its full name (if it has one).
+        if partial.is_some() {
+            out.insert(full_name, node_ref);
+        }
+    } else {
+        for kid in kids {
+            collect_fields(reader, kid, &full_name, out, depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Incremental update assembly
+// ---------------------------------------------------------------------------
+
+fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>> {
+    let mut reader = PdfReader::new(Cursor::new(base_bytes))
+        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "incremental form fill is not supported on encrypted PDFs".to_string(),
+        ));
+    }
+
+    // Base trailer facts needed for the appended trailer.
+    let base_startxref = reader.trailer().xref_offset;
+    let base_root = reader
+        .trailer()
+        .root()
+        .map_err(|e| PdfError::InvalidStructure(format!("base /Root: {e}")))?;
+    let base_size = reader
+        .trailer()
+        .size()
+        .map_err(|e| PdfError::InvalidStructure(format!("base /Size: {e}")))?;
+    let base_id_first: Option<Vec<u8>> = first_id_bytes(reader.trailer().id());
+
+    // Resolve the AcroForm dict object id and its current contents.
+    let (acro_ref, mut acro_dict) = resolve_acroform_object(&mut reader)?;
+
+    // Resolve field name -> object id.
+    let field_map = resolve_acroform_fields(base_bytes)?;
+
+    // Build the set of modified objects.
+    let mut modified: Vec<(u32, u16, PdfDictionary)> = Vec::new();
+    for (name, value) in fields {
+        let (num, gen) = field_map
+            .get(*name)
+            .copied()
+            .ok_or_else(|| PdfError::FieldNotFound((*name).to_string()))?;
+        let mut field_dict = reader
+            .get_object(num, gen)
+            .map_err(|e| PdfError::InvalidStructure(format!("resolve field {name}: {e}")))?
+            .as_dict()
+            .cloned()
+            .ok_or_else(|| {
+                PdfError::InvalidStructure(format!("field {name} is not a dictionary"))
+            })?;
+        field_dict.insert(
+            "V".to_string(),
+            PdfObject::String(PdfString(value.as_bytes().to_vec())),
+        );
+        modified.push((num, gen, field_dict));
+    }
+
+    // Flag NeedAppearances so viewers regenerate the appearance stream.
+    acro_dict.insert("NeedAppearances".to_string(), PdfObject::Boolean(true));
+
+    // ----- assemble appended bytes -----
+    let mut out = Vec::with_capacity(base_bytes.len() + 1024);
+    out.extend_from_slice(base_bytes);
+
+    let mut changed: Vec<(u32, u16, u64)> = Vec::new();
+
+    for (num, gen, dict) in &modified {
+        let offset = out.len() as u64;
+        write_indirect_object(&mut out, *num, *gen, dict)?;
+        changed.push((*num, *gen, offset));
+    }
+
+    // AcroForm object.
+    let acro_offset = out.len() as u64;
+    write_indirect_object(&mut out, acro_ref.0, acro_ref.1, &acro_dict)?;
+    changed.push((acro_ref.0, acro_ref.1, acro_offset));
+
+    let xref_pos = out.len() as u64;
+    out.extend_from_slice(&write_partial_xref_section(&changed));
+    out.extend_from_slice(&write_incremental_trailer(
+        base_startxref,
+        base_root,
+        base_size,
+        xref_pos,
+        base_id_first,
+    ));
+
+    Ok(out)
+}
+
+/// Resolve the `/AcroForm` indirect object id and a clone of its dict.
+fn resolve_acroform_object(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> Result<((u32, u16), PdfDictionary)> {
+    let catalog = reader
+        .catalog()
+        .map_err(|e| PdfError::InvalidStructure(format!("read catalog: {e}")))?
+        .clone();
+    match catalog.get("AcroForm") {
+        Some(PdfObject::Reference(n, g)) => {
+            let dict = reader
+                .get_object(*n, *g)
+                .map_err(|e| PdfError::InvalidStructure(format!("resolve /AcroForm: {e}")))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| {
+                    PdfError::InvalidStructure("/AcroForm is not a dictionary".to_string())
+                })?;
+            Ok(((*n, *g), dict))
+        }
+        _ => Err(PdfError::InvalidStructure(
+            "/AcroForm must be an indirect reference for incremental fill".to_string(),
+        )),
+    }
+}
+
+fn first_id_bytes(id: Option<&PdfObject>) -> Option<Vec<u8>> {
+    match id {
+        Some(PdfObject::Array(arr)) => arr
+            .0
+            .first()
+            .and_then(|o| o.as_string())
+            .map(|s| s.as_bytes().to_vec()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level serialization (Vec<u8>, no PdfWriter state)
+// ---------------------------------------------------------------------------
+
+/// Write `{num} {gen} obj\n<dict>\nendobj\n` into `out`.
+fn write_indirect_object(
+    out: &mut Vec<u8>,
+    num: u32,
+    gen: u16,
+    dict: &PdfDictionary,
+) -> Result<()> {
+    out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
+    write_object_value(out, &PdfObject::Dictionary(dict.clone()))?;
+    out.extend_from_slice(b"\nendobj\n");
+    Ok(())
+}
+
+/// Serialize a parser [`PdfObject`] to PDF wire bytes. Streams are rejected:
+/// AcroForm field and form dictionaries never carry an embedded stream, and
+/// emitting one without a fresh `/Length` would corrupt the file.
+fn write_object_value(out: &mut Vec<u8>, obj: &PdfObject) -> Result<()> {
+    match obj {
+        PdfObject::Null => out.extend_from_slice(b"null"),
+        PdfObject::Boolean(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
+        PdfObject::Integer(i) => out.extend_from_slice(i.to_string().as_bytes()),
+        PdfObject::Real(f) => out.extend_from_slice(format_real(*f).as_bytes()),
+        PdfObject::String(s) => write_literal_string(out, s.as_bytes()),
+        PdfObject::Name(n) => write_name(out, n),
+        PdfObject::Reference(num, gen) => {
+            out.extend_from_slice(format!("{num} {gen} R").as_bytes())
+        }
+        PdfObject::Array(arr) => {
+            out.extend_from_slice(b"[");
+            for (i, item) in arr.0.iter().enumerate() {
+                if i > 0 {
+                    out.extend_from_slice(b" ");
+                }
+                write_object_value(out, item)?;
+            }
+            out.extend_from_slice(b"]");
+        }
+        PdfObject::Dictionary(d) => write_dict(out, d)?,
+        PdfObject::Stream(_) => {
+            return Err(PdfError::InvalidStructure(
+                "unexpected stream object in AcroForm field dictionary".to_string(),
+            ))
+        }
+    }
+    Ok(())
+}
+
+fn write_dict(out: &mut Vec<u8>, dict: &PdfDictionary) -> Result<()> {
+    out.extend_from_slice(b"<< ");
+    // Deterministic key order: keeps output stable and tests reproducible.
+    let mut keys: Vec<&PdfName> = dict.0.keys().collect();
+    keys.sort_by(|a, b| a.0.cmp(&b.0));
+    for key in keys {
+        write_name(out, key);
+        out.extend_from_slice(b" ");
+        // Safe: key came from the dict.
+        write_object_value(out, &dict.0[key])?;
+        out.extend_from_slice(b" ");
+    }
+    out.extend_from_slice(b">>");
+    Ok(())
+}
+
+fn write_name(out: &mut Vec<u8>, name: &PdfName) {
+    out.extend_from_slice(b"/");
+    for &b in name.0.as_bytes() {
+        // Regular characters pass through; everything else is #XX-escaped
+        // (ISO 32000-1 §7.3.5).
+        if b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
+            )
+        {
+            out.push(b);
+        } else {
+            out.extend_from_slice(format!("#{b:02X}").as_bytes());
+        }
+    }
+}
+
+/// Serialize a PDF literal string `(...)`, escaping the reserved bytes and
+/// emitting non-printable bytes as `\ddd` octal (ISO 32000-1 §7.3.4.2).
+fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.push(b'(');
+    for &b in bytes {
+        match b {
+            b'(' => out.extend_from_slice(b"\\("),
+            b')' => out.extend_from_slice(b"\\)"),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            0x20..=0x7E => out.push(b),
+            _ => out.extend_from_slice(format!("\\{b:03o}").as_bytes()),
+        }
+    }
+    out.push(b')');
+}
+
+/// Format a PDF real without scientific notation, trimming trailing zeros.
+fn format_real(f: f64) -> String {
+    if f == f.trunc() && f.is_finite() {
+        return format!("{}", f as i64);
+    }
+    let mut s = format!("{f:.6}");
+    while s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Partial incremental xref + trailer
+// ---------------------------------------------------------------------------
+
+/// Build a partial cross-reference section listing ONLY the changed objects,
+/// grouped into contiguous subsections (ISO 32000-1 §7.5.4).
+fn write_partial_xref_section(changed: &[(u32, u16, u64)]) -> Vec<u8> {
+    let mut entries = changed.to_vec();
+    entries.sort_by_key(|(num, _, _)| *num);
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"xref\n");
+
+    let mut i = 0;
+    while i < entries.len() {
+        let start = entries[i].0;
+        let mut j = i;
+        // Extend the subsection while object numbers stay contiguous.
+        while j + 1 < entries.len() && entries[j + 1].0 == entries[j].0 + 1 {
+            j += 1;
+        }
+        let count = j - i + 1;
+        out.extend_from_slice(format!("{start} {count}\n").as_bytes());
+        for entry in &entries[i..=j] {
+            out.extend_from_slice(format!("{:010} {:05} n \n", entry.2, entry.1).as_bytes());
+        }
+        i = j + 1;
+    }
+    out
+}
+
+/// Build the incremental-update trailer chaining `/Prev` and reusing the
+/// base `/Root`, `/Size` and `/ID`.
+fn write_incremental_trailer(
+    base_prev_xref: u64,
+    base_root: (u32, u16),
+    base_size: u32,
+    new_xref_pos: u64,
+    base_id_first: Option<Vec<u8>>,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"trailer\n<< ");
+    out.extend_from_slice(format!("/Size {base_size} ").as_bytes());
+    out.extend_from_slice(format!("/Root {} {} R ", base_root.0, base_root.1).as_bytes());
+    out.extend_from_slice(format!("/Prev {base_prev_xref} ").as_bytes());
+    if let Some(id) = base_id_first {
+        let hex: String = id.iter().map(|b| format!("{b:02X}")).collect();
+        out.extend_from_slice(format!("/ID [<{hex}> <{hex}>] ").as_bytes());
+    }
+    out.extend_from_slice(b">>\n");
+    out.extend_from_slice(b"startxref\n");
+    out.extend_from_slice(format!("{new_xref_pos}\n").as_bytes());
+    out.extend_from_slice(b"%%EOF\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_xref_groups_contiguous_subsections() {
+        let bytes = write_partial_xref_section(&[(5, 0, 1024), (7, 0, 2048)]);
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.starts_with("xref\n"), "must start with xref keyword");
+        assert!(s.contains("5 1\n0000001024 00000 n \n"), "obj 5 subsection");
+        assert!(s.contains("7 1\n0000002048 00000 n \n"), "obj 7 subsection");
+        assert!(!s.contains("\n6 "), "gap object 6 must not appear");
+    }
+
+    #[test]
+    fn partial_xref_merges_adjacent_ids() {
+        let bytes = write_partial_xref_section(&[(7, 0, 2048), (5, 0, 1024), (6, 0, 1536)]);
+        let s = String::from_utf8(bytes).unwrap();
+        // 5,6,7 are contiguous -> one subsection "5 3".
+        assert!(
+            s.contains("5 3\n"),
+            "contiguous ids form one subsection: {s}"
+        );
+        assert!(s.contains("0000001024 00000 n \n0000001536 00000 n \n0000002048 00000 n \n"));
+    }
+
+    #[test]
+    fn incremental_trailer_carries_root_prev_size() {
+        let bytes = write_incremental_trailer(312, (1, 0), 8, 5000, None);
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.contains("/Prev 312"), "must chain /Prev: {s}");
+        assert!(s.contains("/Root 1 0 R"), "must reuse base /Root");
+        assert!(s.contains("/Size 8"), "must carry /Size");
+        assert!(s.ends_with("startxref\n5000\n%%EOF\n"), "suffix: {s}");
+        assert!(!s.contains("/Info"), "no /Info in incremental trailer");
+    }
+
+    #[test]
+    fn incremental_trailer_emits_id_when_present() {
+        let bytes = write_incremental_trailer(10, (2, 0), 5, 99, Some(vec![0xDE, 0xAD]));
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.contains("/ID [<DEAD> <DEAD>]"), "id reused: {s}");
+    }
+
+    #[test]
+    fn literal_string_escapes_reserved_bytes() {
+        let mut out = Vec::new();
+        write_literal_string(&mut out, b"a(b)c\\d");
+        assert_eq!(out, b"(a\\(b\\)c\\\\d)");
+    }
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -1,6 +1,7 @@
 //! PDF writing functionality
 
 mod content_stream_utils;
+mod incremental_form_fill;
 mod object_streams;
 mod pdf_writer;
 mod signature;
@@ -8,6 +9,7 @@ mod xref_stream_writer;
 
 // Phase 2 utilities for font preservation
 pub(crate) use content_stream_utils::{rename_preserved_fonts, rewrite_font_references};
+pub use incremental_form_fill::IncrementalFormFiller;
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};
 pub(crate) use signature::{Edition, PdfSignature};

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -353,3 +353,77 @@ fn fill_hierarchical_field_incremental() {
     ids.sort_unstable();
     assert_eq!(ids, vec![4, 6], "only street kid + AcroForm rewritten");
 }
+
+// ---------------------------------------------------------------------------
+// Terminal field whose /Kids are WIDGET annotations (not sub-fields)
+// ---------------------------------------------------------------------------
+
+/// Read `/V` of a specific object id directly (bypasses the field-tree walk,
+/// so it works regardless of widget-vs-subfield kid classification).
+fn object_v(bytes: &[u8], num: u32, gen: u16) -> Option<String> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    dict.get("V")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+}
+
+/// The most common real-world layout (Acrobat): a single terminal field
+/// dict that carries `/T`/`/FT` AND a `/Kids` array whose elements are
+/// widget annotation dicts (`/Subtype /Widget`, NO `/T`). The field
+/// resolver must treat this node as terminal — recursing into the widgets
+/// (which have no `/T`) would lose the field entirely.
+fn build_widget_kids_form_pdf() -> Vec<u8> {
+    // 1 Catalog  2 Pages  3 Page  4 AcroForm
+    // 5 terminal field "email" with widget kid 6
+    // 6 widget annotation (no /T)
+    let objects: Vec<String> = vec![
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [6 0 R] >>".to_string(),
+        "<< /Fields [5 0 R] >>".to_string(),
+        "<< /FT /Tx /T (email) /Kids [6 0 R] >>".to_string(),
+        "<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [100 700 300 720] >>".to_string(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = objects.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn fill_field_with_widget_kids() {
+    let base = build_widget_kids_form_pdf();
+    // The terminal field is object 5; before fill it has no value.
+    assert!(object_v(&base, 5, 0).is_none(), "field starts empty");
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("email", "user@example.com")
+        .expect("must resolve a terminal field whose kids are widgets");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+    assert_eq!(
+        object_v(&output, 5, 0).as_deref(),
+        Some("user@example.com"),
+        "/V must be set on the terminal field object (5), not lost in widget recursion"
+    );
+    // Only the field (5) + AcroForm (4) change — the widget (6) is untouched.
+    let mut ids = appended_xref_object_numbers(&output[base.len()..]);
+    ids.sort_unstable();
+    assert_eq!(ids, vec![4, 5]);
+}

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -1,0 +1,355 @@
+//! Integration tests for issue #318: filling AcroForm fields on an existing
+//! (parsed) PDF via an ISO 32000-1 §7.5.6 incremental update.
+//!
+//! Every assertion verifies real wire content after a full
+//! parse -> fill -> serialize -> parse round-trip — no smoke tests.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Build a single-page PDF carrying AcroForm text fields with the given
+/// names (no values set), serialized to bytes through the public writer.
+fn build_base_pdf_with_fields(names: &[&str]) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let mut y = 700.0;
+    for name in names {
+        let rect = Rectangle::new(Point::new(100.0, y), Point::new(300.0, y + 20.0));
+        let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+        let field = TextField::new(*name);
+        let field_ref = fm
+            .add_text_field(field, widget.clone(), None)
+            .expect("add_text_field");
+        page.add_form_widget_with_ref(widget, field_ref)
+            .expect("add_form_widget_with_ref");
+        y -= 40.0;
+    }
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    doc.to_bytes().expect("serialize base document")
+}
+
+/// Resolve `/AcroForm` -> (object id, dict clone) from PDF bytes.
+fn acroform_object(bytes: &[u8]) -> ((u32, u16), oxidize_pdf::parser::objects::PdfDictionary) {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog
+        .get("AcroForm")
+        .expect("/AcroForm present")
+        .as_reference()
+        .expect("/AcroForm indirect");
+    let dict = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .expect("resolve AcroForm")
+        .as_dict()
+        .expect("AcroForm dict")
+        .clone();
+    (acro_ref, dict)
+}
+
+/// Recover a terminal field's object id and `/V` string by fully-qualified
+/// name from PDF bytes (walks /Fields and /Kids).
+fn field_value(bytes: &[u8], name: &str) -> Option<((u32, u16), Option<String>)> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let (_, acro) = acroform_object(bytes);
+    let field_refs: Vec<(u32, u16)> = match acro.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    for r in field_refs {
+        if let Some(found) = walk_field(&mut reader, r, "", name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn walk_field(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    prefix: &str,
+    target: &str,
+) -> Option<((u32, u16), Option<String>)> {
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+    let full = match (&partial, prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{prefix}.{t}"),
+        (None, _) => prefix.to_string(),
+    };
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    if kids.is_empty() {
+        if partial.is_some() && full == target {
+            let v = node
+                .get("V")
+                .and_then(|o| o.as_string())
+                .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+            return Some((node_ref, v));
+        }
+        None
+    } else {
+        for kid in kids {
+            if let Some(found) = walk_field(reader, kid, &full, target) {
+                return Some(found);
+            }
+        }
+        None
+    }
+}
+
+/// Parse the object numbers listed in an appended xref section (raw text
+/// `xref` format), returning every object number across all subsections.
+fn appended_xref_object_numbers(appended: &[u8]) -> Vec<u32> {
+    let s = String::from_utf8_lossy(appended);
+    let xref_pos = s.find("xref").expect("appended bytes must contain xref");
+    let after = &s[xref_pos + 4..];
+    let mut nums = Vec::new();
+    let mut lines = after.lines().filter(|l| !l.trim().is_empty());
+    while let Some(header) = lines.next() {
+        let header = header.trim();
+        if header.starts_with("trailer") {
+            break;
+        }
+        let parts: Vec<&str> = header.split_whitespace().collect();
+        if parts.len() != 2 {
+            break;
+        }
+        let (start, count): (u32, u32) = match (parts[0].parse(), parts[1].parse()) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => break,
+        };
+        for i in 0..count {
+            // consume one entry line per object
+            if lines.next().is_some() {
+                nums.push(start + i);
+            }
+        }
+    }
+    nums
+}
+
+/// Read the base PDF's most-recent startxref offset.
+fn base_startxref(bytes: &[u8]) -> u64 {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    reader.trailer().xref_offset
+}
+
+/// Read `/Prev` from an appended incremental trailer (text form).
+fn appended_prev(appended: &[u8]) -> u64 {
+    let s = String::from_utf8_lossy(appended);
+    let pos = s.find("/Prev").expect("appended trailer must carry /Prev");
+    let after = &s[pos + 5..];
+    after
+        .split_whitespace()
+        .next()
+        .expect("number after /Prev")
+        .parse()
+        .expect("/Prev integer")
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 4: single-field round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_single_field_incremental_roundtrip() {
+    let base = build_base_pdf_with_fields(&["email"]);
+
+    // The fixture must parse and the field must start without a value.
+    let (field_id_before, v_before) = field_value(&base, "email").expect("field present in base");
+    assert!(
+        v_before.is_none() || v_before.as_deref() == Some(""),
+        "base field must start empty, got {v_before:?}"
+    );
+
+    let prev_offset = base_startxref(&base);
+    let (acro_id, _) = acroform_object(&base);
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("email", "hello@test.com")
+        .expect("fill must succeed");
+
+    // 1) Base bytes are a verbatim prefix (true incremental update).
+    assert_eq!(
+        &output[..base.len()],
+        &base[..],
+        "incremental update must preserve base bytes verbatim"
+    );
+    assert!(output.len() > base.len(), "must append an update section");
+
+    // 2) Re-parse and recover the exact /V.
+    let (field_id_after, v_after) = field_value(&output, "email").expect("field present in output");
+    assert_eq!(
+        v_after.as_deref(),
+        Some("hello@test.com"),
+        "recovered /V must equal the filled value"
+    );
+    // Same object id reused (incremental, not a new field object).
+    assert_eq!(
+        field_id_before, field_id_after,
+        "field object id must be reused"
+    );
+
+    // 3) NeedAppearances flipped true.
+    let (_, acro_after) = acroform_object(&output);
+    assert_eq!(
+        acro_after.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true),
+        "/AcroForm/NeedAppearances must be true"
+    );
+
+    // 4) Appended xref lists exactly the changed objects: field + AcroForm.
+    let appended = &output[base.len()..];
+    let mut ids = appended_xref_object_numbers(appended);
+    ids.sort_unstable();
+    let mut expected = vec![field_id_after.0, acro_id.0];
+    expected.sort_unstable();
+    assert_eq!(
+        ids, expected,
+        "appended xref must list exactly the field and AcroForm objects"
+    );
+
+    // 5) /Prev chains to the base startxref.
+    assert_eq!(
+        appended_prev(appended),
+        prev_offset,
+        "/Prev must equal the base startxref offset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5a: multi-field fill
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_many_fields_incremental_roundtrip() {
+    let base = build_base_pdf_with_fields(&["first_name", "last_name"]);
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill_many(&[("first_name", "Jane"), ("last_name", "Doe")])
+        .expect("fill_many must succeed");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (_, first) = field_value(&output, "first_name").expect("first_name present");
+    let (_, last) = field_value(&output, "last_name").expect("last_name present");
+    assert_eq!(first.as_deref(), Some("Jane"));
+    assert_eq!(last.as_deref(), Some("Doe"));
+
+    let (_, acro_after) = acroform_object(&output);
+    assert_eq!(
+        acro_after.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true)
+    );
+
+    // Appended xref: two field objects + one AcroForm object = 3 distinct ids.
+    let ids = appended_xref_object_numbers(&output[base.len()..]);
+    assert_eq!(ids.len(), 3, "two fields + AcroForm, got {ids:?}");
+}
+
+#[test]
+fn fill_unknown_field_errors() {
+    let base = build_base_pdf_with_fields(&["email"]);
+    let err = IncrementalFormFiller::new(&base).fill("does_not_exist", "x");
+    assert!(err.is_err(), "filling a missing field must error");
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5b: genuine hierarchical field tree (/Kids + /Parent)
+// ---------------------------------------------------------------------------
+
+/// Hand-craft a minimal valid PDF whose AcroForm has a parent field
+/// (`T = "address"`) with two terminal kids (`street`, `city`), exercising
+/// the recursive field-tree walk and fully-qualified naming.
+fn build_hierarchical_form_pdf() -> Vec<u8> {
+    // Object layout:
+    //  1: Catalog  2: Pages  3: Page  4: AcroForm
+    //  5: parent field "address"  6: kid "street"  7: kid "city"
+    let objects: Vec<String> = vec![
+        // 1 Catalog
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_string(),
+        // 2 Pages
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        // 3 Page
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>".to_string(),
+        // 4 AcroForm
+        "<< /Fields [5 0 R] >>".to_string(),
+        // 5 parent field
+        "<< /T (address) /Kids [6 0 R 7 0 R] >>".to_string(),
+        // 6 kid street
+        "<< /FT /Tx /T (street) /Parent 5 0 R >>".to_string(),
+        // 7 kid city
+        "<< /FT /Tx /T (city) /Parent 5 0 R >>".to_string(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = objects.len() + 1; // +1 for free object 0
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn fill_hierarchical_field_incremental() {
+    let base = build_hierarchical_form_pdf();
+
+    // Sanity: the hand-crafted base parses and the qualified name resolves.
+    let (street_id, v_before) =
+        field_value(&base, "address.street").expect("address.street must resolve in base");
+    assert!(v_before.is_none(), "kid starts empty");
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("address.street", "221B Baker St")
+        .expect("fill hierarchical field");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (street_id_after, v_after) =
+        field_value(&output, "address.street").expect("resolve after fill");
+    assert_eq!(v_after.as_deref(), Some("221B Baker St"));
+    assert_eq!(street_id, street_id_after, "kid object id reused");
+
+    // The other kid is untouched.
+    let (_, city_v) = field_value(&output, "address.city").expect("city still resolvable");
+    assert!(city_v.is_none(), "untouched kid keeps no value");
+
+    // Only the street kid (obj 6) + AcroForm (obj 4) change.
+    let mut ids = appended_xref_object_numbers(&output[base.len()..]);
+    ids.sort_unstable();
+    assert_eq!(ids, vec![4, 6], "only street kid + AcroForm rewritten");
+}


### PR DESCRIPTION
## Summary
Adds `IncrementalFormFiller` — the first supported path to set `/V` on the AcroForm fields of an **already-serialized** PDF so a form reader recovers the value after re-parsing. Addresses #318.

`Document::fill_field` only worked on in-process `FormManager`-built documents; `PdfReader::into_document` returns a read-only wrapper. Filling a form template (the most common forms use case) was impossible.

## Approach (ISO 32000-1 §7.5.6 incremental update, non-lossy)
Rejected full `Document` rehydration (lossy for arbitrary PDFs). Instead:
- Parse the base PDF, resolve the `/AcroForm` field tree (`/Kids` + hierarchical `/Parent` names per §12.7.3.1; a terminal field whose `/Kids` are widget annotations is handled correctly).
- Clone affected field dicts, set `/V`, set `/AcroForm/NeedAppearances true` (§12.7.2 — viewers regenerate the appearance; `/AP` generation is a documented follow-up).
- Emit ONLY the modified objects reusing their existing ids, a PARTIAL incremental xref section, trailer reusing the base `/Root`, chaining `/Prev`, and regenerating the `/ID` second element. Base bytes are preserved **verbatim** as the prefix.

## Parser fix (prerequisite)
`find_xref_offset` returned the **first** `startxref` in the tail window instead of the **last**, so any appended incremental update was silently ignored on re-parse. Now returns the most recent; older sections via the `/Prev` chain. Also affected overlay/page-replacement re-reads.

Adds `PdfReader::trailer()` accessor.

## API
`oxidize_pdf::writer::IncrementalFormFiller::{new, fill, fill_many}`. Example: `examples/fill_existing_form.rs`.

## Tests (content-verifying, no smoke tests)
Round-trip recovers exact `/V`; field object id reused; base bytes verbatim prefix; appended xref lists exactly the changed ids; `/Prev` = base startxref; `NeedAppearances` true; hierarchical `/Kids`+`/Parent` tree; terminal-field-with-widget-kids (Acrobat layout); distinct `/ID` pair; unknown-field error. Plus unit tests for partial xref, trailer, string escaping, revision id.

A quality-rust review caught one MAJOR (widget-kids field resolution) + two MINOR (`/ID` duplication, non-finite real formatting); all fixed with tests in the second commit.

## Verification
lib 6568/0, incremental_form_fill suite 5/5 + 6 unit, t1 22/0, t3 22/0 (0 panics/timeouts), overlay/incremental suites green, examples gate green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)