### PR TITLE
fix(extraction): recover page text past a malformed content operator (#319)

### DIFF
--- a/oxidize-pdf-core/src/parser/content.rs
+++ b/oxidize-pdf-core/src/parser/content.rs
@@ -942,9 +942,21 @@ impl ContentParser {
         let mut tokenizer = ContentTokenizer::new(content);
         let mut tokens = Vec::new();
 
-        // Tokenize the entire stream
-        while let Some(token) = tokenizer.next_token()? {
-            tokens.push(token);
+        // Tokenize the entire stream. Best-effort recovery (issue #319):
+        // if the tokenizer hits an unrecoverable construct (e.g. an
+        // unterminated hex string), stop there but KEEP every token parsed
+        // so far instead of discarding the whole page. `next_token` already
+        // recovers internally from skippable garbage; a hard error here is
+        // the tail of the stream, and losing the tail beats losing the page.
+        loop {
+            match tokenizer.next_token() {
+                Ok(Some(token)) => tokens.push(token),
+                Ok(None) => break,
+                Err(_e) => {
+                    tracing::debug!("content tokenizer stopped early: {_e}");
+                    break;
+                }
+            }
         }
 
         let mut parser = Self {
@@ -965,8 +977,22 @@ impl ContentParser {
 
             match &token {
                 Token::Operator(op) => {
-                    let operator = self.parse_operator(op, &mut operand_stack)?;
-                    operators.push(operator);
+                    // Best-effort recovery (issue #319): a single malformed
+                    // operator must NOT discard the entire content stream.
+                    // Content streams are not safety-critical; an operand
+                    // mismatch on one operator (e.g. a `Td` missing its
+                    // numbers, common in some producers) previously aborted
+                    // the whole page via `?`, so the extractor dropped every
+                    // valid operator before it. Instead, skip the bad
+                    // operator, resync by clearing its pending operands, and
+                    // continue parsing the rest of the stream.
+                    match self.parse_operator(op, &mut operand_stack) {
+                        Ok(operator) => operators.push(operator),
+                        Err(_e) => {
+                            tracing::debug!("skipping malformed content operator '{op}': {_e}");
+                            operand_stack.clear();
+                        }
+                    }
                 }
                 _ => {
                     // Not an operator, push to operand stack
@@ -2158,16 +2184,30 @@ mod tests {
 
         #[test]
         fn test_error_handling_insufficient_operands() {
-            let content = b"100 Td"; // Missing y coordinate
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Best-effort recovery (issue #319): `Td` is missing its y
+            // coordinate. The malformed operator is skipped, but a following
+            // valid text operator must still be recovered — the page is NOT
+            // discarded wholesale.
+            let content = b"100 Td (kept) Tj";
+            let ops = ContentParser::parse(content).expect("recovers from bad Td");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "valid Tj after the malformed Td must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_error_handling_invalid_operator() {
-            let content = b"100 200 INVALID";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Unknown operator `INVALID` is skipped; the following valid
+            // MoveTo survives (issue #319 recovery contract).
+            let content = b"100 200 INVALID 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from unknown operator");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the unknown operator must survive: {ops:?}"
+            );
         }
 
         #[test]
@@ -2259,29 +2299,41 @@ mod tests {
 
         #[test]
         fn test_show_text_array_complex() {
-            // Test simple text array without complex syntax
-            let content = b"(Hello) TJ";
-            let result = ContentParser::parse(content);
-            // This should fail since TJ expects array, but test the error handling
-            assert!(result.is_err());
+            // `TJ` expects an array operand, not a plain string. The malformed
+            // operator is skipped; a following valid Tj is recovered
+            // (issue #319 recovery contract).
+            let content = b"(Hello) TJ (kept) Tj";
+            let ops = ContentParser::parse(content).expect("recovers from malformed TJ");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "valid Tj after the malformed TJ must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_dash_pattern_empty() {
-            // Test simple dash pattern without array syntax
-            let content = b"0 d";
-            let result = ContentParser::parse(content);
-            // This should fail since dash pattern needs array, but test the error handling
-            assert!(result.is_err());
+            // `d` needs an array operand; the malformed operator is skipped and
+            // a following valid MoveTo survives (issue #319 recovery contract).
+            let content = b"0 d 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from malformed d");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the malformed dash op must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_dash_pattern_complex() {
-            // Test simple dash pattern without complex array syntax
-            let content = b"2.5 d";
-            let result = ContentParser::parse(content);
-            // This should fail since dash pattern needs array, but test the error handling
-            assert!(result.is_err());
+            // Same recovery contract with a real-number operand before `d`.
+            let content = b"2.5 d 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from malformed d");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the malformed dash op must survive: {ops:?}"
+            );
         }
 
         #[test]
@@ -2694,20 +2746,32 @@ mod tests {
 
         #[test]
         fn test_parser_error_handling_invalid_operators() {
-            // Missing operands for move operator
-            let content = b"m";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Best-effort recovery contract (issue #319).
 
-            // Invalid hex string (no closing >)
-            let content = b"<ABC DEF BT";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Missing operands for `m`: the malformed operator is skipped but
+            // a following valid `l` is recovered.
+            let content = b"m 10 20 l";
+            let ops = ContentParser::parse(content).expect("recovers from operand-less m");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::LineTo(_, _))),
+                "valid LineTo after the operand-less m must survive: {ops:?}"
+            );
 
-            // Test that we can detect actual parsing errors
-            let content = b"100 200 300"; // Numbers without operator should parse ok
-            let result = ContentParser::parse(content);
-            assert!(result.is_ok()); // This should actually be ok since no operator is attempted
+            // Unterminated hex string: the tokenizer stops at the malformed
+            // tail but keeps every token before it, so valid text ahead of the
+            // bad hex is still extracted.
+            let content = b"(kept) Tj <ABC DEF";
+            let ops = ContentParser::parse(content).expect("recovers, keeping pre-error tokens");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "text before the unterminated hex must survive: {ops:?}"
+            );
+
+            // Numbers without an operator parse OK (no operator attempted).
+            let content = b"100 200 300";
+            assert!(ContentParser::parse(content).is_ok());
         }
 
         #[test]
@@ -2869,11 +2933,49 @@ mod tests {
 
         #[test]
         fn test_tokenizer_error_recovery() {
-            // Test that parser can handle malformed but recoverable content
+            // A comment carrying a stray binary byte sits between two valid
+            // path operators. The comment (and its binary) is skipped and
+            // BOTH operators are recovered (issue #319 recovery contract).
             let content = b"100 200 m % Comment with\xFFbinary\n150 250 l";
-            let result = ContentParser::parse(content);
-            // Should either parse successfully or fail gracefully
-            assert!(result.is_ok() || result.is_err());
+            let ops = ContentParser::parse(content).expect("recovers around binary comment");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "MoveTo before the comment must survive: {ops:?}"
+            );
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::LineTo(_, _))),
+                "LineTo after the comment must survive: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn malformed_operator_does_not_discard_surrounding_text() {
+            // Issue #319: a single malformed operator must NOT drop the whole
+            // page's content. Here a bare `Td` (missing its two operands)
+            // sits between two valid text-show operators. Before the fix,
+            // `parse_operators` propagated the operand error with `?`, so the
+            // entire stream returned Err and BOTH show-text ops were lost
+            // (the extractor then dropped the page). The parser must recover:
+            // skip the bad operator, keep the valid ones.
+            let content = b"BT /F1 12 Tf 72 700 Td (First line) Tj Td (Second line) Tj ET";
+            let ops = ContentParser::parse_content(content)
+                .expect("malformed operator must not fail the whole stream");
+            let shown: Vec<&Vec<u8>> = ops
+                .iter()
+                .filter_map(|op| match op {
+                    ContentOperation::ShowText(t) => Some(t),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                shown.len(),
+                2,
+                "both valid Tj operators must survive the malformed Td"
+            );
+            assert_eq!(shown[0], b"First line");
+            assert_eq!(shown[1], b"Second line");
         }
 
         #[test]

--- a/oxidize-pdf-core/src/streaming/text_streamer.rs
+++ b/oxidize-pdf-core/src/streaming/text_streamer.rs
@@ -773,10 +773,14 @@ mod tests {
         let content = b"BT /Times New Roman 14 Tf ET";
         let result = streamer.process_chunk(content);
 
-        // This should fail because "New" is treated as an unknown operator
-        assert!(result.is_err());
+        // Best-effort recovery (issue #319): "New"/"Roman" are unknown
+        // operators and the resulting `Tf` is missing its font-name operand.
+        // The malformed directives are skipped instead of aborting the chunk,
+        // so processing succeeds...
+        assert!(result.is_ok());
 
-        // The font and size should remain unchanged (default values)
+        // ...but the malformed font directive must NOT take effect: the font
+        // and size stay at their defaults.
         assert_eq!(streamer.current_font, None);
         assert_eq!(streamer.current_font_size, 12.0);
     }

--- a/oxidize-pdf-core/tests/issue_319_content_recovery_test.rs
+++ b/oxidize-pdf-core/tests/issue_319_content_recovery_test.rs
@@ -1,0 +1,116 @@
+//! Issue #319: text extraction dropped a whole page's content when that
+//! page's content stream contained a single malformed operator.
+//!
+//! Root cause (symptom level): `ContentParser::parse_operators` propagated
+//! an operand error with `?`, so one bad operator made `parse_content`
+//! return `Err`; the extractor's per-stream loop then `continue`d, dropping
+//! every valid operator on the page. A 3-page invoice produced by
+//! RML2PDF/pluscode lost its entire "charges in detail" page this way.
+//!
+//! These tests build a PDF whose page content stream interleaves valid
+//! text-show operators with a malformed one, then assert the valid text is
+//! still extracted (best-effort recovery). No smoke tests — exact strings
+//! are asserted.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Build a single-page PDF whose content stream is exactly `content_stream`,
+/// with a Helvetica font registered as /F1.
+fn build_pdf_with_content_stream(content_stream: &[u8]) -> Vec<u8> {
+    let stream_len = content_stream.len();
+    // Object bodies. Object 4 is the content stream (built separately so we
+    // can splice the raw bytes and a correct /Length).
+    let bodies: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        {
+            let mut s = format!("<< /Length {stream_len} >>\nstream\n").into_bytes();
+            s.extend_from_slice(content_stream);
+            s.extend_from_slice(b"\nendstream");
+            s
+        },
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (i, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = bodies.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+fn extract_page_text(pdf: &[u8]) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn malformed_operator_does_not_drop_page_text() {
+    // The second `Td` has no operands (its numbers are "missing"), which is
+    // exactly the class of defect that aborted the old parser. The two
+    // surrounding `Tj` strings must still be extracted.
+    let content =
+        b"BT /F1 12 Tf 72 700 Td (Supply number 1170000446615) Tj Td (Climate Change Levy) Tj ET";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(
+        text.contains("Supply number 1170000446615"),
+        "first line lost — page was dropped. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Climate Change Levy"),
+        "second line lost — page was dropped. Got: {text:?}"
+    );
+}
+
+#[test]
+fn well_formed_page_is_unaffected() {
+    // Regression guard: a clean content stream extracts exactly as before.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello) Tj 0 -14 Td (World) Tj ET";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(text.contains("Hello"), "got {text:?}");
+    assert!(text.contains("World"), "got {text:?}");
+}
+
+#[test]
+fn unterminated_tail_keeps_earlier_text() {
+    // A truncated/garbled tail (here an unterminated hex string) must not
+    // discard the valid text that precedes it.
+    let content = b"BT /F1 12 Tf 72 700 Td (Recovered before tail) Tj ET <ABC DEF";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(
+        text.contains("Recovered before tail"),
+        "text before the malformed tail lost. Got: {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary
A 3-page invoice (RML2PDF/pluscode producer) extracted with only two of its three pages: one page's entire content was absent even though the text is present (`pdftotext -layout` recovers it). Addresses #319.

## Root cause
`ContentParser::parse_operators` propagated an operand error with `?`, so a single malformed operator made `parse_content` return `Err`. The extractor's per-stream loop then `continue`d on that `Err`, discarding **every** valid operator on the page — the whole page vanished.

## Fix (best-effort recovery)
Content streams are not safety-critical; partial extraction beats losing the page:
- `parse_operators`: on a per-operator parse error, skip the bad operator, clear its pending operands to resync, and continue instead of aborting the stream.
- tokenization loop: on an unrecoverable tokenizer error (e.g. an unterminated hex string), stop there but **keep** every token parsed so far rather than discarding the page.

## Tests (content-verifying, no smoke tests)
- New `issue_319_content_recovery_test.rs`: hand-crafted PDF whose page content stream interleaves valid `Tj` with a malformed `Td` — both strings extracted; well-formed page unaffected; text before an unterminated tail survives.
- Unit test: malformed operator does not discard surrounding text.
- Rewrote 6 unit + 1 streaming test that previously asserted the whole-stream-abort behavior (they codified the bug) to the recovery contract with exact-content checks; improved the existing `test_tokenizer_error_recovery` smoke test.

## Verification note
Fixes the exact failure **class** (one bad operator/token drops a whole page). Not yet validated against the reporter's specific RML2PDF sample (not available); awaiting the file to confirm end-to-end.

## Verification
lib 6563/0, content parser 91/91, t1 22/0, t3 22/0 (0 panics/timeouts), extraction e2e/265/tj/hang suites green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)