### PR TITLE
Release 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [2.15.0] - 2026-06-11
+
+### Added
+
+- `IncrementalFormFiller` (`oxidize_pdf::writer`): fill AcroForm fields on an
+  existing, already-serialized PDF and recover the value via a form reader.
+  It appends a conformant ISO 32000-1 §7.5.6 incremental update — the original
+  bytes are preserved verbatim, only the modified field objects and the
+  `/AcroForm` dict are rewritten (with a partial cross-reference section, a
+  chained `/Prev`, and a regenerated `/ID`). Resolves hierarchical field names
+  (`/Kids` + `/Parent`) and terminal fields whose `/Kids` are widget
+  annotations. Sets `/V` and `/AcroForm/NeedAppearances` (`/AP` regeneration is
+  a follow-up). `PdfReader::trailer()` accessor added (#318).
+
+### Fixed
+
+- Text extraction dropped a whole page's content when that page's content
+  stream contained a single malformed operator: the parser propagated the
+  error and the extractor discarded every operator on the page. Parsing is now
+  best-effort — a malformed operator is skipped and surrounding valid operators
+  are kept; an unrecoverable tokenizer error keeps the tokens parsed so far
+  instead of discarding the page (#319).
+- Text drawn inside a Form XObject (invoked with `Do`) was never extracted.
+  Producers such as RML2PDF/pluscode embed the page body as a Form XObject
+  ("inclPDF"), so only the page's direct content was returned and the body went
+  missing. The extractor now recurses into Form XObjects — composing their
+  `/Matrix` onto the CTM, scoping their `/Resources` fonts, and handling nested
+  XObjects with a depth guard. Validated across the full 9051-PDF corpus: zero
+  regressions, 277 files recover previously-dropped text (#319).
+
 ## [2.14.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.14.0"
+version = "2.15.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/examples/fill_existing_form.rs
+++ b/oxidize-pdf-core/examples/fill_existing_form.rs
@@ -1,0 +1,93 @@
+//! Fill AcroForm fields on an EXISTING (already-serialized) PDF via an
+//! ISO 32000-1 §7.5.6 incremental update — issue #318.
+//!
+//! This is the standard "fill a form template" use case: take a PDF that
+//! already contains AcroForm fields and set their values so a form reader
+//! recovers them, without rewriting the original document.
+//!
+//! Run with: `cargo run --example fill_existing_form`
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --- Produce a base form PDF (stands in for a template from Acrobat) ---
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+    let rect = Rectangle::new(Point::new(100.0, 700.0), Point::new(320.0, 720.0));
+    let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+    fm.add_text_field(TextField::new("full_name"), widget.clone(), None)
+        .and_then(|field_ref| page.add_form_widget_with_ref(widget, field_ref))?;
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    let base_pdf: Vec<u8> = doc.to_bytes()?;
+
+    // --- Fill the existing field on the parsed bytes (incremental update) ---
+    let filled: Vec<u8> =
+        IncrementalFormFiller::new(&base_pdf).fill("full_name", "Ada Lovelace")?;
+
+    // The base bytes are preserved verbatim; the value lives in the appended
+    // section. A form reader recovers /V after re-parsing.
+    assert_eq!(&filled[..base_pdf.len()], &base_pdf[..]);
+
+    let recovered = read_field_value(&filled, "full_name")?;
+    println!("Base PDF: {} bytes", base_pdf.len());
+    println!(
+        "Filled PDF: {} bytes (+{} appended)",
+        filled.len(),
+        filled.len() - base_pdf.len()
+    );
+    println!("Recovered /V for 'full_name': {recovered:?}");
+
+    std::fs::write("filled_form.pdf", &filled)?;
+    println!("Wrote filled_form.pdf");
+    Ok(())
+}
+
+/// Walk /AcroForm/Fields and return the `/V` string of a terminal field.
+fn read_field_value(
+    bytes: &[u8],
+    name: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))?;
+    let catalog = reader.catalog()?.clone();
+    let acro_ref = catalog
+        .get("AcroForm")
+        .and_then(|o| o.as_reference())
+        .ok_or("no /AcroForm")?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)?
+        .as_dict()
+        .cloned()
+        .ok_or("AcroForm not dict")?;
+    let fields = match acro.get("Fields") {
+        Some(PdfObject::Array(a)) => a.0.clone(),
+        _ => Vec::new(),
+    };
+    for f in fields {
+        if let Some((n, g)) = f.as_reference() {
+            let dict = reader
+                .get_object(n, g)?
+                .as_dict()
+                .cloned()
+                .ok_or("field not dict")?;
+            let t = dict
+                .get("T")
+                .and_then(|o| o.as_string())
+                .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+            if t.as_deref() == Some(name) {
+                return Ok(dict
+                    .get("V")
+                    .and_then(|o| o.as_string())
+                    .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/oxidize-pdf-core/src/parser/content.rs
+++ b/oxidize-pdf-core/src/parser/content.rs
@@ -942,9 +942,21 @@ impl ContentParser {
         let mut tokenizer = ContentTokenizer::new(content);
         let mut tokens = Vec::new();
 
-        // Tokenize the entire stream
-        while let Some(token) = tokenizer.next_token()? {
-            tokens.push(token);
+        // Tokenize the entire stream. Best-effort recovery (issue #319):
+        // if the tokenizer hits an unrecoverable construct (e.g. an
+        // unterminated hex string), stop there but KEEP every token parsed
+        // so far instead of discarding the whole page. `next_token` already
+        // recovers internally from skippable garbage; a hard error here is
+        // the tail of the stream, and losing the tail beats losing the page.
+        loop {
+            match tokenizer.next_token() {
+                Ok(Some(token)) => tokens.push(token),
+                Ok(None) => break,
+                Err(_e) => {
+                    tracing::debug!("content tokenizer stopped early: {_e}");
+                    break;
+                }
+            }
         }
 
         let mut parser = Self {
@@ -965,8 +977,22 @@ impl ContentParser {
 
             match &token {
                 Token::Operator(op) => {
-                    let operator = self.parse_operator(op, &mut operand_stack)?;
-                    operators.push(operator);
+                    // Best-effort recovery (issue #319): a single malformed
+                    // operator must NOT discard the entire content stream.
+                    // Content streams are not safety-critical; an operand
+                    // mismatch on one operator (e.g. a `Td` missing its
+                    // numbers, common in some producers) previously aborted
+                    // the whole page via `?`, so the extractor dropped every
+                    // valid operator before it. Instead, skip the bad
+                    // operator, resync by clearing its pending operands, and
+                    // continue parsing the rest of the stream.
+                    match self.parse_operator(op, &mut operand_stack) {
+                        Ok(operator) => operators.push(operator),
+                        Err(_e) => {
+                            tracing::debug!("skipping malformed content operator '{op}': {_e}");
+                            operand_stack.clear();
+                        }
+                    }
                 }
                 _ => {
                     // Not an operator, push to operand stack
@@ -2158,16 +2184,30 @@ mod tests {
 
         #[test]
         fn test_error_handling_insufficient_operands() {
-            let content = b"100 Td"; // Missing y coordinate
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Best-effort recovery (issue #319): `Td` is missing its y
+            // coordinate. The malformed operator is skipped, but a following
+            // valid text operator must still be recovered — the page is NOT
+            // discarded wholesale.
+            let content = b"100 Td (kept) Tj";
+            let ops = ContentParser::parse(content).expect("recovers from bad Td");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "valid Tj after the malformed Td must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_error_handling_invalid_operator() {
-            let content = b"100 200 INVALID";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Unknown operator `INVALID` is skipped; the following valid
+            // MoveTo survives (issue #319 recovery contract).
+            let content = b"100 200 INVALID 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from unknown operator");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the unknown operator must survive: {ops:?}"
+            );
         }
 
         #[test]
@@ -2259,29 +2299,41 @@ mod tests {
 
         #[test]
         fn test_show_text_array_complex() {
-            // Test simple text array without complex syntax
-            let content = b"(Hello) TJ";
-            let result = ContentParser::parse(content);
-            // This should fail since TJ expects array, but test the error handling
-            assert!(result.is_err());
+            // `TJ` expects an array operand, not a plain string. The malformed
+            // operator is skipped; a following valid Tj is recovered
+            // (issue #319 recovery contract).
+            let content = b"(Hello) TJ (kept) Tj";
+            let ops = ContentParser::parse(content).expect("recovers from malformed TJ");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "valid Tj after the malformed TJ must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_dash_pattern_empty() {
-            // Test simple dash pattern without array syntax
-            let content = b"0 d";
-            let result = ContentParser::parse(content);
-            // This should fail since dash pattern needs array, but test the error handling
-            assert!(result.is_err());
+            // `d` needs an array operand; the malformed operator is skipped and
+            // a following valid MoveTo survives (issue #319 recovery contract).
+            let content = b"0 d 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from malformed d");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the malformed dash op must survive: {ops:?}"
+            );
         }
 
         #[test]
         fn test_dash_pattern_complex() {
-            // Test simple dash pattern without complex array syntax
-            let content = b"2.5 d";
-            let result = ContentParser::parse(content);
-            // This should fail since dash pattern needs array, but test the error handling
-            assert!(result.is_err());
+            // Same recovery contract with a real-number operand before `d`.
+            let content = b"2.5 d 10 20 m";
+            let ops = ContentParser::parse(content).expect("recovers from malformed d");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "valid MoveTo after the malformed dash op must survive: {ops:?}"
+            );
         }
 
         #[test]
@@ -2694,20 +2746,32 @@ mod tests {
 
         #[test]
         fn test_parser_error_handling_invalid_operators() {
-            // Missing operands for move operator
-            let content = b"m";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Best-effort recovery contract (issue #319).
 
-            // Invalid hex string (no closing >)
-            let content = b"<ABC DEF BT";
-            let result = ContentParser::parse(content);
-            assert!(result.is_err());
+            // Missing operands for `m`: the malformed operator is skipped but
+            // a following valid `l` is recovered.
+            let content = b"m 10 20 l";
+            let ops = ContentParser::parse(content).expect("recovers from operand-less m");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::LineTo(_, _))),
+                "valid LineTo after the operand-less m must survive: {ops:?}"
+            );
 
-            // Test that we can detect actual parsing errors
-            let content = b"100 200 300"; // Numbers without operator should parse ok
-            let result = ContentParser::parse(content);
-            assert!(result.is_ok()); // This should actually be ok since no operator is attempted
+            // Unterminated hex string: the tokenizer stops at the malformed
+            // tail but keeps every token before it, so valid text ahead of the
+            // bad hex is still extracted.
+            let content = b"(kept) Tj <ABC DEF";
+            let ops = ContentParser::parse(content).expect("recovers, keeping pre-error tokens");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::ShowText(t) if t == b"kept")),
+                "text before the unterminated hex must survive: {ops:?}"
+            );
+
+            // Numbers without an operator parse OK (no operator attempted).
+            let content = b"100 200 300";
+            assert!(ContentParser::parse(content).is_ok());
         }
 
         #[test]
@@ -2869,11 +2933,49 @@ mod tests {
 
         #[test]
         fn test_tokenizer_error_recovery() {
-            // Test that parser can handle malformed but recoverable content
+            // A comment carrying a stray binary byte sits between two valid
+            // path operators. The comment (and its binary) is skipped and
+            // BOTH operators are recovered (issue #319 recovery contract).
             let content = b"100 200 m % Comment with\xFFbinary\n150 250 l";
-            let result = ContentParser::parse(content);
-            // Should either parse successfully or fail gracefully
-            assert!(result.is_ok() || result.is_err());
+            let ops = ContentParser::parse(content).expect("recovers around binary comment");
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::MoveTo(_, _))),
+                "MoveTo before the comment must survive: {ops:?}"
+            );
+            assert!(
+                ops.iter()
+                    .any(|op| matches!(op, ContentOperation::LineTo(_, _))),
+                "LineTo after the comment must survive: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn malformed_operator_does_not_discard_surrounding_text() {
+            // Issue #319: a single malformed operator must NOT drop the whole
+            // page's content. Here a bare `Td` (missing its two operands)
+            // sits between two valid text-show operators. Before the fix,
+            // `parse_operators` propagated the operand error with `?`, so the
+            // entire stream returned Err and BOTH show-text ops were lost
+            // (the extractor then dropped the page). The parser must recover:
+            // skip the bad operator, keep the valid ones.
+            let content = b"BT /F1 12 Tf 72 700 Td (First line) Tj Td (Second line) Tj ET";
+            let ops = ContentParser::parse_content(content)
+                .expect("malformed operator must not fail the whole stream");
+            let shown: Vec<&Vec<u8>> = ops
+                .iter()
+                .filter_map(|op| match op {
+                    ContentOperation::ShowText(t) => Some(t),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                shown.len(),
+                2,
+                "both valid Tj operators must survive the malformed Td"
+            );
+            assert_eq!(shown[0], b"First line");
+            assert_eq!(shown[1], b"Second line");
         }
 
         #[test]

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -71,6 +71,17 @@ impl<R: Read + Seek> PdfReader<R> {
         self.encryption_handler.is_some()
     }
 
+    /// Access the parsed document trailer.
+    ///
+    /// Exposes the already-parsed [`PdfTrailer`], which carries the base
+    /// `startxref` offset (`xref_offset`), and the `/Root`, `/Info`, `/ID`
+    /// and `/Size` entries. Required to build a conformant ISO 32000-1
+    /// §7.5.6 incremental update (the appended trailer must chain its
+    /// `/Prev` to this offset and reuse the base `/Root` and `/ID`).
+    pub fn trailer(&self) -> &PdfTrailer {
+        &self.trailer
+    }
+
     /// Check if the PDF is unlocked (can read encrypted content)
     pub fn is_unlocked(&self) -> bool {
         match &self.encryption_handler {

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -708,21 +708,25 @@ impl XRefTable {
 
         let mut lines = content.pdf_lines();
 
-        // Find startxref line - need to iterate forward after finding it
+        // Find the LAST startxref in the tail window. An incremental update
+        // (ISO 32000-1 §7.5.6) appends a new `startxref`/`%%EOF` after the
+        // original; the most recent one points at the newest cross-reference
+        // section and MUST take precedence (earlier ones are reached via the
+        // `/Prev` chain). Returning the first occurrence would read the base
+        // PDF and silently ignore every appended update.
+        let mut last_offset = None;
         while let Some(line) = lines.next() {
             if line.trim() == "startxref" {
                 // The offset should be on the next line
                 if let Some(offset_line) = lines.next() {
-                    let offset = offset_line
-                        .trim()
-                        .parse::<u64>()
-                        .map_err(|_| ParseError::InvalidXRef)?;
-                    return Ok(offset);
+                    if let Ok(offset) = offset_line.trim().parse::<u64>() {
+                        last_offset = Some(offset);
+                    }
                 }
             }
         }
 
-        Err(ParseError::InvalidXRef)
+        last_offset.ok_or(ParseError::InvalidXRef)
     }
 
     /// Scan PDF for objects not present in XRef and add them (for hybrid files)

--- a/oxidize-pdf-core/src/streaming/text_streamer.rs
+++ b/oxidize-pdf-core/src/streaming/text_streamer.rs
@@ -773,10 +773,14 @@ mod tests {
         let content = b"BT /Times New Roman 14 Tf ET";
         let result = streamer.process_chunk(content);
 
-        // This should fail because "New" is treated as an unknown operator
-        assert!(result.is_err());
+        // Best-effort recovery (issue #319): "New"/"Roman" are unknown
+        // operators and the resulting `Tf` is missing its font-name operand.
+        // The malformed directives are skipped instead of aborting the chunk,
+        // so processing succeeds...
+        assert!(result.is_ok());
 
-        // The font and size should remain unchanged (default values)
+        // ...but the malformed font directive must NOT take effect: the font
+        // and size stay at their defaults.
         assert_eq!(streamer.current_font, None);
         assert_eq!(streamer.current_font_size, 12.0);
     }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -255,6 +255,19 @@ struct SavedGraphicsState {
     fill_color: Option<Color>,
 }
 
+/// Mutable accumulator threaded through `process_operations` so the op loop
+/// can be driven recursively (page content stream → Form XObjects) while
+/// carrying text state, position, and accumulated output. Bundled into one
+/// struct so the op match moves verbatim into the recursive method (#319).
+struct OpRunState {
+    state: TextState,
+    in_text_object: bool,
+    last_x: f64,
+    last_y: f64,
+    extracted_text: String,
+    fragments: Vec<TextFragment>,
+}
+
 impl Default for TextState {
     fn default() -> Self {
         Self {
@@ -659,22 +672,33 @@ impl TextExtractor {
             page.content_streams_with_document(document)?
         };
 
-        let mut extracted_text = String::new();
-        let mut fragments = Vec::new();
-        let mut state = TextState::default();
-        let mut in_text_object = false;
-        let mut last_x = 0.0;
-        let mut last_y = 0.0;
+        let extracted_text = String::new();
+        let fragments = Vec::new();
+        let state = TextState::default();
+        let in_text_object = false;
+        let last_x = 0.0;
+        let last_y = 0.0;
 
-        // Issue #269 Phase 1: resolve /Properties resource dictionary for BDC
-        // resource-ref operands (e.g. `/Span /PropsName BDC`). Optional — most
-        // PDFs use inline dicts.
-        let page_properties: Option<&crate::parser::objects::PdfDictionary> = page
-            .get_resources()
-            .and_then(|res| match res.get("Properties") {
-                Some(crate::parser::objects::PdfObject::Dictionary(d)) => Some(d),
-                _ => None,
-            });
+        // Page resources (owned) for XObject + /Properties lookup during
+        // recursive Form XObject extraction (issue #319).
+        let page_resources: Option<crate::parser::objects::PdfDictionary> =
+            if let Some(rr) = page.dict.get("Resources").and_then(|o| o.as_reference()) {
+                document
+                    .get_object(rr.0, rr.1)
+                    .ok()
+                    .and_then(|o| o.as_dict().cloned())
+            } else {
+                page.get_resources().cloned()
+            };
+
+        let mut run = OpRunState {
+            state,
+            in_text_object,
+            last_x,
+            last_y,
+            extracted_text,
+            fragments,
+        };
 
         // Process each content stream
         for (stream_idx, stream_data) in streams.iter().enumerate() {
@@ -708,483 +732,21 @@ impl TextExtractor {
                 }
             };
 
-            let _ops_span = tracing::info_span!("text_ops_loop").entered();
-            for op in operations {
-                match op {
-                    ContentOperation::BeginText => {
-                        in_text_object = true;
-                        // Reset text matrix to identity
-                        state.text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
-                        state.text_line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
-                    }
-
-                    ContentOperation::EndText => {
-                        in_text_object = false;
-                    }
-
-                    ContentOperation::SetTextMatrix(a, b, c, d, e, f) => {
-                        state.text_matrix =
-                            [a as f64, b as f64, c as f64, d as f64, e as f64, f as f64];
-                        state.text_line_matrix =
-                            [a as f64, b as f64, c as f64, d as f64, e as f64, f as f64];
-                    }
-
-                    ContentOperation::MoveText(tx, ty) => {
-                        // Update text matrix by translation
-                        let new_matrix = multiply_matrix(
-                            &[1.0, 0.0, 0.0, 1.0, tx as f64, ty as f64],
-                            &state.text_line_matrix,
-                        );
-                        state.text_matrix = new_matrix;
-                        state.text_line_matrix = new_matrix;
-                    }
-
-                    ContentOperation::NextLine => {
-                        // Move to next line using current leading
-                        let new_matrix = multiply_matrix(
-                            &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
-                            &state.text_line_matrix,
-                        );
-                        state.text_matrix = new_matrix;
-                        state.text_line_matrix = new_matrix;
-                    }
-
-                    ContentOperation::ShowText(text) => {
-                        if in_text_object {
-                            let text_bytes = &text;
-                            let decoded = self.decode_text(text_bytes, &state)?;
-
-                            // Pen origin in user space = (CTM × text_matrix)(0, 0).
-                            let (x, y) = text_origin(&state);
-
-                            // Add spacing based on position change
-                            if !extracted_text.is_empty() {
-                                let dx = x - last_x;
-                                let dy = (y - last_y).abs();
-
-                                if dy > self.options.newline_threshold {
-                                    extracted_text.push('\n');
-                                } else if dx > self.options.space_threshold * state.font_size {
-                                    extracted_text.push(' ');
-                                }
-                            }
-
-                            extracted_text.push_str(&decoded);
-
-                            // Get font info for accurate width calculation.
-                            // Width comes from the char codes (`text_bytes`), not
-                            // the decoded Unicode: the Widths array is code-indexed
-                            // (issue #302).
-                            let text_width = {
-                                let font_info = state
-                                    .font_name
-                                    .as_ref()
-                                    .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width_from_codes(
-                                    text_bytes,
-                                    &decoded,
-                                    state.font_size,
-                                    font_info,
-                                )
-                            };
-
-                            if self.options.preserve_layout {
-                                emit_text_fragment(
-                                    &mut fragments,
-                                    &decoded,
-                                    text_width,
-                                    x,
-                                    y,
-                                    &mut state,
-                                    self.options.include_artifacts,
-                                );
-                            }
-
-                            // Update position for next text
-                            last_x = x + text_width;
-                            last_y = y;
-
-                            // Update text matrix for next show operation
-                            let tx = text_width * state.horizontal_scale / 100.0;
-                            state.text_matrix =
-                                multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
-                        }
-                    }
-
-                    ContentOperation::ShowTextArray(array) => {
-                        if in_text_object {
-                            for item in array {
-                                match item {
-                                    TextElement::Text(text_bytes) => {
-                                        let decoded = self.decode_text(&text_bytes, &state)?;
-                                        extracted_text.push_str(&decoded);
-
-                                        let text_width = {
-                                            let font_info = state
-                                                .font_name
-                                                .as_ref()
-                                                .and_then(|name| self.font_cache.get(name));
-                                            calculate_text_width_from_codes(
-                                                &text_bytes,
-                                                &decoded,
-                                                state.font_size,
-                                                font_info,
-                                            )
-                                        };
-
-                                        if self.options.preserve_layout {
-                                            let (x, y) = text_origin(&state);
-                                            emit_text_fragment(
-                                                &mut fragments,
-                                                &decoded,
-                                                text_width,
-                                                x,
-                                                y,
-                                                &mut state,
-                                                self.options.include_artifacts,
-                                            );
-                                        }
-
-                                        let tx = text_width * state.horizontal_scale / 100.0;
-                                        state.text_matrix = multiply_matrix(
-                                            &[1.0, 0.0, 0.0, 1.0, tx, 0.0],
-                                            &state.text_matrix,
-                                        );
-                                    }
-                                    TextElement::Spacing(adjustment) => {
-                                        // Text position adjustment (negative = move left,
-                                        // i.e. shifts the pen forward). When the synthesised
-                                        // forward advance exceeds `tj_space_threshold * font_size`
-                                        // we treat the kern as an implicit `U+0020` (issue #272):
-                                        // many PDFs encode word breaks purely as wide negative
-                                        // kerns and never emit a literal space byte.
-                                        let tx = -(adjustment as f64) / 1000.0 * state.font_size;
-
-                                        if tx > self.options.tj_space_threshold * state.font_size
-                                            && !extracted_text.is_empty()
-                                            && !extracted_text.ends_with(' ')
-                                        {
-                                            extracted_text.push(' ');
-
-                                            // Skip the fragment-level emission while an
-                                            // ActualText scope is pending: the synthesised
-                                            // space is a heuristic, not real content, and
-                                            // emitting it would call `emit_text_fragment`
-                                            // whose ActualText short-circuit would inflate
-                                            // `pending.width` and set `pending.populated`
-                                            // even though no real `Tj` has fired yet. The
-                                            // EMC flush will supply the canonical fragment
-                                            // text from the override (Phase 1 #269 contract).
-                                            if self.options.preserve_layout
-                                                && state.pending_actualtext.is_none()
-                                            {
-                                                // Emit a synthetic single-space fragment at the
-                                                // current pen origin so downstream layout merges
-                                                // (e.g. `merge_close_fragments`) see the gap as
-                                                // explicit content rather than as a sub-threshold
-                                                // x-jump. Width = the kern advance so the next
-                                                // text fragment begins flush against it.
-                                                let (sx, sy) = text_origin(&state);
-                                                emit_text_fragment(
-                                                    &mut fragments,
-                                                    " ",
-                                                    tx,
-                                                    sx,
-                                                    sy,
-                                                    &mut state,
-                                                    self.options.include_artifacts,
-                                                );
-                                            }
-                                        }
-
-                                        state.text_matrix = multiply_matrix(
-                                            &[1.0, 0.0, 0.0, 1.0, tx, 0.0],
-                                            &state.text_matrix,
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    ContentOperation::NextLineShowText(text) => {
-                        if in_text_object {
-                            // ' = T* then Tj string. Advance line matrix by -leading.
-                            let new_matrix = multiply_matrix(
-                                &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
-                                &state.text_line_matrix,
-                            );
-                            state.text_matrix = new_matrix;
-                            state.text_line_matrix = new_matrix;
-
-                            let decoded = self.decode_text(&text, &state)?;
-                            let (x, y) = text_origin(&state);
-
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
-                            }
-                            extracted_text.push_str(&decoded);
-
-                            let text_width = {
-                                let font_info = state
-                                    .font_name
-                                    .as_ref()
-                                    .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width_from_codes(
-                                    &text,
-                                    &decoded,
-                                    state.font_size,
-                                    font_info,
-                                )
-                            };
-
-                            if self.options.preserve_layout {
-                                emit_text_fragment(
-                                    &mut fragments,
-                                    &decoded,
-                                    text_width,
-                                    x,
-                                    y,
-                                    &mut state,
-                                    self.options.include_artifacts,
-                                );
-                            }
-
-                            last_x = x + text_width;
-                            last_y = y;
-
-                            let tx = text_width * state.horizontal_scale / 100.0;
-                            state.text_matrix =
-                                multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
-                        }
-                    }
-
-                    ContentOperation::SetSpacingNextLineShowText(word_space, char_space, text) => {
-                        if in_text_object {
-                            // " = aw Tw, ac Tc, then ' string. ISO 32000-1 §9.4.3.
-                            // The variant fields mirror the spec field names:
-                            // (word_spacing, char_spacing, text).
-                            state.word_space = word_space as f64;
-                            state.char_space = char_space as f64;
-
-                            let new_matrix = multiply_matrix(
-                                &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
-                                &state.text_line_matrix,
-                            );
-                            state.text_matrix = new_matrix;
-                            state.text_line_matrix = new_matrix;
-
-                            let decoded = self.decode_text(&text, &state)?;
-                            let (x, y) = text_origin(&state);
-
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
-                            }
-                            extracted_text.push_str(&decoded);
-
-                            let text_width = {
-                                let font_info = state
-                                    .font_name
-                                    .as_ref()
-                                    .and_then(|name| self.font_cache.get(name));
-                                calculate_text_width_from_codes(
-                                    &text,
-                                    &decoded,
-                                    state.font_size,
-                                    font_info,
-                                )
-                            };
-
-                            if self.options.preserve_layout {
-                                emit_text_fragment(
-                                    &mut fragments,
-                                    &decoded,
-                                    text_width,
-                                    x,
-                                    y,
-                                    &mut state,
-                                    self.options.include_artifacts,
-                                );
-                            }
-
-                            last_x = x + text_width;
-                            last_y = y;
-
-                            let tx = text_width * state.horizontal_scale / 100.0;
-                            state.text_matrix =
-                                multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
-                        }
-                    }
-
-                    ContentOperation::SetFont(name, size) => {
-                        state.font_name = Some(name);
-                        state.font_size = size as f64;
-                    }
-
-                    ContentOperation::SetLeading(leading) => {
-                        state.leading = leading as f64;
-                    }
-
-                    ContentOperation::SetCharSpacing(spacing) => {
-                        state.char_space = spacing as f64;
-                    }
-
-                    ContentOperation::SetWordSpacing(spacing) => {
-                        state.word_space = spacing as f64;
-                    }
-
-                    ContentOperation::SetHorizontalScaling(scale) => {
-                        state.horizontal_scale = scale as f64;
-                    }
-
-                    ContentOperation::SetTextRise(rise) => {
-                        state.text_rise = rise as f64;
-                    }
-
-                    ContentOperation::SetTextRenderMode(mode) => {
-                        state.render_mode = mode as u8;
-                    }
-
-                    ContentOperation::SetTransformMatrix(a, b, c, d, e, f) => {
-                        // Update CTM: new_ctm = concat_matrix * current_ctm
-                        let [a0, b0, c0, d0, e0, f0] = state.ctm;
-                        let a = a as f64;
-                        let b = b as f64;
-                        let c = c as f64;
-                        let d = d as f64;
-                        let e = e as f64;
-                        let f = f as f64;
-                        state.ctm = [
-                            a * a0 + b * c0,
-                            a * b0 + b * d0,
-                            c * a0 + d * c0,
-                            c * b0 + d * d0,
-                            e * a0 + f * c0 + e0,
-                            e * b0 + f * d0 + f0,
-                        ];
-                    }
-
-                    // Graphics state stack (issue #262). `q` snapshots the
-                    // current CTM and fill_color; `Q` restores the most recent
-                    // snapshot. Without these, every `cm` accumulates onto the
-                    // CTM forever, producing absurd page-space coordinates and
-                    // wrong font_size scaling on PDFs that nest graphics state.
-                    ContentOperation::SaveGraphicsState => {
-                        state.saved_states.push(SavedGraphicsState {
-                            ctm: state.ctm,
-                            fill_color: state.fill_color,
-                        });
-                    }
-                    ContentOperation::RestoreGraphicsState => {
-                        if let Some(saved) = state.saved_states.pop() {
-                            state.ctm = saved.ctm;
-                            state.fill_color = saved.fill_color;
-                        }
-                        // Unbalanced Q (pop on empty stack) is silently ignored
-                        // to keep extraction robust to malformed PDFs.
-                    }
-
-                    // Color operations (Phase 4: Color extraction)
-                    ContentOperation::SetNonStrokingGray(gray) => {
-                        state.fill_color = Some(Color::gray(gray as f64));
-                    }
-
-                    ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                        state.fill_color = Some(Color::rgb(r as f64, g as f64, b as f64));
-                    }
-
-                    ContentOperation::SetNonStrokingCMYK(c, m, y, k) => {
-                        state.fill_color =
-                            Some(Color::cmyk(c as f64, m as f64, y as f64, k as f64));
-                    }
-
-                    // Issue #269 Phase 1: marked-content operators
-                    ContentOperation::BeginMarkedContent(tag) => {
-                        let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
-                        state.mc_stack.push(MarkedContentEntry {
-                            is_artifact: tag == "Artifact" || parent_artifact,
-                            tag,
-                            mcid: None,
-                            actual_text: None,
-                        });
-                    }
-
-                    ContentOperation::BeginMarkedContentWithProps(tag, props) => {
-                        let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
-                        let (mcid, actual_text) = resolve_props(&props, page_properties);
-
-                        // If this scope declares ActualText, open a pending run that will be
-                        // flushed on the matching EMC. Suppresses per-Tj emission inside the
-                        // scope (innermost-ActualText-wins per spec §4).
-                        if let Some(ref text) = actual_text {
-                            state.pending_actualtext = Some(PendingActualText {
-                                text: text.clone(),
-                                first_x: 0.0,
-                                first_y: 0.0,
-                                width: 0.0,
-                                font_size: state.font_size,
-                                font_name: state.font_name.clone(),
-                                is_bold: false, // overwritten on first Tj
-                                is_italic: false,
-                                color: state.fill_color,
-                                stack_depth: state.mc_stack.len(), // BEFORE the push below
-                                populated: false,
-                            });
-                        }
-
-                        state.mc_stack.push(MarkedContentEntry {
-                            is_artifact: tag == "Artifact" || parent_artifact,
-                            tag,
-                            mcid,
-                            actual_text,
-                        });
-                    }
-
-                    ContentOperation::EndMarkedContent => {
-                        let popped_depth = state.mc_stack.len();
-                        if state.mc_stack.pop().is_none() {
-                            // Unbalanced EMC — log and ignore. Real PDFs occasionally emit
-                            // dangling EMC (e.g. from incremental updates). We must not panic.
-                            tracing::debug!(
-                                "extraction: EMC with empty marked-content stack on page {}",
-                                page_index + 1
-                            );
-                        } else if let Some(pending) = state.pending_actualtext.as_ref() {
-                            // If we just closed the scope that opened the pending run, flush it.
-                            if pending.stack_depth + 1 == popped_depth {
-                                let run = state.pending_actualtext.take().unwrap();
-                                if run.populated && self.options.preserve_layout {
-                                    let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
-                                    let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
-                                    if !in_artifact || self.options.include_artifacts {
-                                        fragments.push(TextFragment {
-                                            text: run.text,
-                                            x: run.first_x,
-                                            y: run.first_y,
-                                            width: run.width,
-                                            height: run.font_size,
-                                            font_size: run.font_size,
-                                            font_name: run.font_name,
-                                            is_bold: run.is_bold,
-                                            is_italic: run.is_italic,
-                                            color: run.color,
-                                            space_decisions: Vec::new(),
-                                            mcid,
-                                            struct_tag,
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    _ => {
-                        // Other operations don't affect text extraction
-                    }
-                }
-            }
+            run = self.process_operations(
+                operations,
+                document,
+                page_resources.as_ref(),
+                run,
+                page_index,
+                0,
+            )?;
         }
 
+        let OpRunState {
+            mut extracted_text,
+            mut fragments,
+            ..
+        } = run;
         {
             let _span = tracing::info_span!("layout_finalize").entered();
 
@@ -1224,6 +786,645 @@ impl TextExtractor {
             text: extracted_text,
             fragments,
         })
+    }
+
+    /// Run a content-stream operation list, recursing into Form XObjects so
+    /// text drawn inside a `Do`-painted Form XObject is extracted (issue #319).
+    #[allow(clippy::too_many_arguments)]
+    fn process_operations<R: Read + Seek>(
+        &mut self,
+        operations: Vec<ContentOperation>,
+        document: &PdfDocument<R>,
+        resources: Option<&crate::parser::objects::PdfDictionary>,
+        run: OpRunState,
+        page_index: u32,
+        depth: u8,
+    ) -> ParseResult<OpRunState> {
+        let OpRunState {
+            mut state,
+            mut in_text_object,
+            mut last_x,
+            mut last_y,
+            mut extracted_text,
+            mut fragments,
+        } = run;
+
+        let page_properties: Option<&crate::parser::objects::PdfDictionary> =
+            resources.and_then(|res| match res.get("Properties") {
+                Some(crate::parser::objects::PdfObject::Dictionary(d)) => Some(d),
+                _ => None,
+            });
+
+        let _ops_span = tracing::info_span!("text_ops_loop").entered();
+        for op in operations {
+            match op {
+                ContentOperation::BeginText => {
+                    in_text_object = true;
+                    // Reset text matrix to identity
+                    state.text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                    state.text_line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                }
+
+                ContentOperation::EndText => {
+                    in_text_object = false;
+                }
+
+                ContentOperation::SetTextMatrix(a, b, c, d, e, f) => {
+                    state.text_matrix =
+                        [a as f64, b as f64, c as f64, d as f64, e as f64, f as f64];
+                    state.text_line_matrix =
+                        [a as f64, b as f64, c as f64, d as f64, e as f64, f as f64];
+                }
+
+                ContentOperation::MoveText(tx, ty) => {
+                    // Update text matrix by translation
+                    let new_matrix = multiply_matrix(
+                        &[1.0, 0.0, 0.0, 1.0, tx as f64, ty as f64],
+                        &state.text_line_matrix,
+                    );
+                    state.text_matrix = new_matrix;
+                    state.text_line_matrix = new_matrix;
+                }
+
+                ContentOperation::NextLine => {
+                    // Move to next line using current leading
+                    let new_matrix = multiply_matrix(
+                        &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
+                        &state.text_line_matrix,
+                    );
+                    state.text_matrix = new_matrix;
+                    state.text_line_matrix = new_matrix;
+                }
+
+                ContentOperation::ShowText(text) => {
+                    if in_text_object {
+                        let text_bytes = &text;
+                        let decoded = self.decode_text(text_bytes, &state)?;
+
+                        // Pen origin in user space = (CTM × text_matrix)(0, 0).
+                        let (x, y) = text_origin(&state);
+
+                        // Add spacing based on position change
+                        if !extracted_text.is_empty() {
+                            let dx = x - last_x;
+                            let dy = (y - last_y).abs();
+
+                            if dy > self.options.newline_threshold {
+                                extracted_text.push('\n');
+                            } else if dx > self.options.space_threshold * state.font_size {
+                                extracted_text.push(' ');
+                            }
+                        }
+
+                        extracted_text.push_str(&decoded);
+
+                        // Get font info for accurate width calculation.
+                        // Width comes from the char codes (`text_bytes`), not
+                        // the decoded Unicode: the Widths array is code-indexed
+                        // (issue #302).
+                        let text_width = {
+                            let font_info = state
+                                .font_name
+                                .as_ref()
+                                .and_then(|name| self.font_cache.get(name));
+                            calculate_text_width_from_codes(
+                                text_bytes,
+                                &decoded,
+                                state.font_size,
+                                font_info,
+                            )
+                        };
+
+                        if self.options.preserve_layout {
+                            emit_text_fragment(
+                                &mut fragments,
+                                &decoded,
+                                text_width,
+                                x,
+                                y,
+                                &mut state,
+                                self.options.include_artifacts,
+                            );
+                        }
+
+                        // Update position for next text
+                        last_x = x + text_width;
+                        last_y = y;
+
+                        // Update text matrix for next show operation
+                        let tx = text_width * state.horizontal_scale / 100.0;
+                        state.text_matrix =
+                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
+                    }
+                }
+
+                ContentOperation::ShowTextArray(array) => {
+                    if in_text_object {
+                        for item in array {
+                            match item {
+                                TextElement::Text(text_bytes) => {
+                                    let decoded = self.decode_text(&text_bytes, &state)?;
+                                    extracted_text.push_str(&decoded);
+
+                                    let text_width = {
+                                        let font_info = state
+                                            .font_name
+                                            .as_ref()
+                                            .and_then(|name| self.font_cache.get(name));
+                                        calculate_text_width_from_codes(
+                                            &text_bytes,
+                                            &decoded,
+                                            state.font_size,
+                                            font_info,
+                                        )
+                                    };
+
+                                    if self.options.preserve_layout {
+                                        let (x, y) = text_origin(&state);
+                                        emit_text_fragment(
+                                            &mut fragments,
+                                            &decoded,
+                                            text_width,
+                                            x,
+                                            y,
+                                            &mut state,
+                                            self.options.include_artifacts,
+                                        );
+                                    }
+
+                                    let tx = text_width * state.horizontal_scale / 100.0;
+                                    state.text_matrix = multiply_matrix(
+                                        &[1.0, 0.0, 0.0, 1.0, tx, 0.0],
+                                        &state.text_matrix,
+                                    );
+                                }
+                                TextElement::Spacing(adjustment) => {
+                                    // Text position adjustment (negative = move left,
+                                    // i.e. shifts the pen forward). When the synthesised
+                                    // forward advance exceeds `tj_space_threshold * font_size`
+                                    // we treat the kern as an implicit `U+0020` (issue #272):
+                                    // many PDFs encode word breaks purely as wide negative
+                                    // kerns and never emit a literal space byte.
+                                    let tx = -(adjustment as f64) / 1000.0 * state.font_size;
+
+                                    if tx > self.options.tj_space_threshold * state.font_size
+                                        && !extracted_text.is_empty()
+                                        && !extracted_text.ends_with(' ')
+                                    {
+                                        extracted_text.push(' ');
+
+                                        // Skip the fragment-level emission while an
+                                        // ActualText scope is pending: the synthesised
+                                        // space is a heuristic, not real content, and
+                                        // emitting it would call `emit_text_fragment`
+                                        // whose ActualText short-circuit would inflate
+                                        // `pending.width` and set `pending.populated`
+                                        // even though no real `Tj` has fired yet. The
+                                        // EMC flush will supply the canonical fragment
+                                        // text from the override (Phase 1 #269 contract).
+                                        if self.options.preserve_layout
+                                            && state.pending_actualtext.is_none()
+                                        {
+                                            // Emit a synthetic single-space fragment at the
+                                            // current pen origin so downstream layout merges
+                                            // (e.g. `merge_close_fragments`) see the gap as
+                                            // explicit content rather than as a sub-threshold
+                                            // x-jump. Width = the kern advance so the next
+                                            // text fragment begins flush against it.
+                                            let (sx, sy) = text_origin(&state);
+                                            emit_text_fragment(
+                                                &mut fragments,
+                                                " ",
+                                                tx,
+                                                sx,
+                                                sy,
+                                                &mut state,
+                                                self.options.include_artifacts,
+                                            );
+                                        }
+                                    }
+
+                                    state.text_matrix = multiply_matrix(
+                                        &[1.0, 0.0, 0.0, 1.0, tx, 0.0],
+                                        &state.text_matrix,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                ContentOperation::NextLineShowText(text) => {
+                    if in_text_object {
+                        // ' = T* then Tj string. Advance line matrix by -leading.
+                        let new_matrix = multiply_matrix(
+                            &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
+                            &state.text_line_matrix,
+                        );
+                        state.text_matrix = new_matrix;
+                        state.text_line_matrix = new_matrix;
+
+                        let decoded = self.decode_text(&text, &state)?;
+                        let (x, y) = text_origin(&state);
+
+                        if !extracted_text.is_empty() {
+                            extracted_text.push('\n');
+                        }
+                        extracted_text.push_str(&decoded);
+
+                        let text_width = {
+                            let font_info = state
+                                .font_name
+                                .as_ref()
+                                .and_then(|name| self.font_cache.get(name));
+                            calculate_text_width_from_codes(
+                                &text,
+                                &decoded,
+                                state.font_size,
+                                font_info,
+                            )
+                        };
+
+                        if self.options.preserve_layout {
+                            emit_text_fragment(
+                                &mut fragments,
+                                &decoded,
+                                text_width,
+                                x,
+                                y,
+                                &mut state,
+                                self.options.include_artifacts,
+                            );
+                        }
+
+                        last_x = x + text_width;
+                        last_y = y;
+
+                        let tx = text_width * state.horizontal_scale / 100.0;
+                        state.text_matrix =
+                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
+                    }
+                }
+
+                ContentOperation::SetSpacingNextLineShowText(word_space, char_space, text) => {
+                    if in_text_object {
+                        // " = aw Tw, ac Tc, then ' string. ISO 32000-1 §9.4.3.
+                        // The variant fields mirror the spec field names:
+                        // (word_spacing, char_spacing, text).
+                        state.word_space = word_space as f64;
+                        state.char_space = char_space as f64;
+
+                        let new_matrix = multiply_matrix(
+                            &[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading],
+                            &state.text_line_matrix,
+                        );
+                        state.text_matrix = new_matrix;
+                        state.text_line_matrix = new_matrix;
+
+                        let decoded = self.decode_text(&text, &state)?;
+                        let (x, y) = text_origin(&state);
+
+                        if !extracted_text.is_empty() {
+                            extracted_text.push('\n');
+                        }
+                        extracted_text.push_str(&decoded);
+
+                        let text_width = {
+                            let font_info = state
+                                .font_name
+                                .as_ref()
+                                .and_then(|name| self.font_cache.get(name));
+                            calculate_text_width_from_codes(
+                                &text,
+                                &decoded,
+                                state.font_size,
+                                font_info,
+                            )
+                        };
+
+                        if self.options.preserve_layout {
+                            emit_text_fragment(
+                                &mut fragments,
+                                &decoded,
+                                text_width,
+                                x,
+                                y,
+                                &mut state,
+                                self.options.include_artifacts,
+                            );
+                        }
+
+                        last_x = x + text_width;
+                        last_y = y;
+
+                        let tx = text_width * state.horizontal_scale / 100.0;
+                        state.text_matrix =
+                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
+                    }
+                }
+
+                ContentOperation::SetFont(name, size) => {
+                    state.font_name = Some(name);
+                    state.font_size = size as f64;
+                }
+
+                ContentOperation::SetLeading(leading) => {
+                    state.leading = leading as f64;
+                }
+
+                ContentOperation::SetCharSpacing(spacing) => {
+                    state.char_space = spacing as f64;
+                }
+
+                ContentOperation::SetWordSpacing(spacing) => {
+                    state.word_space = spacing as f64;
+                }
+
+                ContentOperation::SetHorizontalScaling(scale) => {
+                    state.horizontal_scale = scale as f64;
+                }
+
+                ContentOperation::SetTextRise(rise) => {
+                    state.text_rise = rise as f64;
+                }
+
+                ContentOperation::SetTextRenderMode(mode) => {
+                    state.render_mode = mode as u8;
+                }
+
+                ContentOperation::SetTransformMatrix(a, b, c, d, e, f) => {
+                    // Update CTM: new_ctm = concat_matrix * current_ctm
+                    let [a0, b0, c0, d0, e0, f0] = state.ctm;
+                    let a = a as f64;
+                    let b = b as f64;
+                    let c = c as f64;
+                    let d = d as f64;
+                    let e = e as f64;
+                    let f = f as f64;
+                    state.ctm = [
+                        a * a0 + b * c0,
+                        a * b0 + b * d0,
+                        c * a0 + d * c0,
+                        c * b0 + d * d0,
+                        e * a0 + f * c0 + e0,
+                        e * b0 + f * d0 + f0,
+                    ];
+                }
+
+                // Graphics state stack (issue #262). `q` snapshots the
+                // current CTM and fill_color; `Q` restores the most recent
+                // snapshot. Without these, every `cm` accumulates onto the
+                // CTM forever, producing absurd page-space coordinates and
+                // wrong font_size scaling on PDFs that nest graphics state.
+                ContentOperation::SaveGraphicsState => {
+                    state.saved_states.push(SavedGraphicsState {
+                        ctm: state.ctm,
+                        fill_color: state.fill_color,
+                    });
+                }
+                ContentOperation::RestoreGraphicsState => {
+                    if let Some(saved) = state.saved_states.pop() {
+                        state.ctm = saved.ctm;
+                        state.fill_color = saved.fill_color;
+                    }
+                    // Unbalanced Q (pop on empty stack) is silently ignored
+                    // to keep extraction robust to malformed PDFs.
+                }
+
+                // Color operations (Phase 4: Color extraction)
+                ContentOperation::SetNonStrokingGray(gray) => {
+                    state.fill_color = Some(Color::gray(gray as f64));
+                }
+
+                ContentOperation::SetNonStrokingRGB(r, g, b) => {
+                    state.fill_color = Some(Color::rgb(r as f64, g as f64, b as f64));
+                }
+
+                ContentOperation::SetNonStrokingCMYK(c, m, y, k) => {
+                    state.fill_color = Some(Color::cmyk(c as f64, m as f64, y as f64, k as f64));
+                }
+
+                // Issue #269 Phase 1: marked-content operators
+                ContentOperation::BeginMarkedContent(tag) => {
+                    let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
+                    state.mc_stack.push(MarkedContentEntry {
+                        is_artifact: tag == "Artifact" || parent_artifact,
+                        tag,
+                        mcid: None,
+                        actual_text: None,
+                    });
+                }
+
+                ContentOperation::BeginMarkedContentWithProps(tag, props) => {
+                    let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
+                    let (mcid, actual_text) = resolve_props(&props, page_properties);
+
+                    // If this scope declares ActualText, open a pending run that will be
+                    // flushed on the matching EMC. Suppresses per-Tj emission inside the
+                    // scope (innermost-ActualText-wins per spec §4).
+                    if let Some(ref text) = actual_text {
+                        state.pending_actualtext = Some(PendingActualText {
+                            text: text.clone(),
+                            first_x: 0.0,
+                            first_y: 0.0,
+                            width: 0.0,
+                            font_size: state.font_size,
+                            font_name: state.font_name.clone(),
+                            is_bold: false, // overwritten on first Tj
+                            is_italic: false,
+                            color: state.fill_color,
+                            stack_depth: state.mc_stack.len(), // BEFORE the push below
+                            populated: false,
+                        });
+                    }
+
+                    state.mc_stack.push(MarkedContentEntry {
+                        is_artifact: tag == "Artifact" || parent_artifact,
+                        tag,
+                        mcid,
+                        actual_text,
+                    });
+                }
+
+                ContentOperation::EndMarkedContent => {
+                    let popped_depth = state.mc_stack.len();
+                    if state.mc_stack.pop().is_none() {
+                        // Unbalanced EMC — log and ignore. Real PDFs occasionally emit
+                        // dangling EMC (e.g. from incremental updates). We must not panic.
+                        tracing::debug!(
+                            "extraction: EMC with empty marked-content stack on page {}",
+                            page_index + 1
+                        );
+                    } else if let Some(pending) = state.pending_actualtext.as_ref() {
+                        // If we just closed the scope that opened the pending run, flush it.
+                        if pending.stack_depth + 1 == popped_depth {
+                            let run = state.pending_actualtext.take().unwrap();
+                            if run.populated && self.options.preserve_layout {
+                                let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
+                                let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
+                                if !in_artifact || self.options.include_artifacts {
+                                    fragments.push(TextFragment {
+                                        text: run.text,
+                                        x: run.first_x,
+                                        y: run.first_y,
+                                        width: run.width,
+                                        height: run.font_size,
+                                        font_size: run.font_size,
+                                        font_name: run.font_name,
+                                        is_bold: run.is_bold,
+                                        is_italic: run.is_italic,
+                                        color: run.color,
+                                        space_decisions: Vec::new(),
+                                        mcid,
+                                        struct_tag,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+
+                ContentOperation::PaintXObject(name) => {
+                    // Issue #319: recurse into Form XObjects. `Do` paints a
+                    // Form XObject in an implicit q/Q, with the XObject's
+                    // /Matrix composed onto the CTM and its own /Resources
+                    // fonts in scope. Without this, text drawn inside the
+                    // XObject (the page body, for RML2PDF "inclPDF" output)
+                    // is never extracted.
+                    const MAX_XOBJECT_DEPTH: u8 = 12;
+                    if depth < MAX_XOBJECT_DEPTH {
+                        if let Some((xobj_ops, xobj_res, matrix)) =
+                            self.load_form_xobject(resources, &name, document)
+                        {
+                            let saved_ctm = state.ctm;
+                            let saved_fill = state.fill_color;
+                            let saved_stack = state.saved_states.len();
+                            let saved_fonts = self.font_cache.clone();
+
+                            if let Some(m) = matrix {
+                                let [a0, b0, c0, d0, e0, f0] = state.ctm;
+                                let [a, b, c, d, e, f] = m;
+                                state.ctm = [
+                                    a * a0 + b * c0,
+                                    a * b0 + b * d0,
+                                    c * a0 + d * c0,
+                                    c * b0 + d * d0,
+                                    e * a0 + f * c0 + e0,
+                                    e * b0 + f * d0 + f0,
+                                ];
+                            }
+                            if let Some(ref xr) = xobj_res {
+                                self.cache_fonts_from_resources::<R>(xr, document);
+                            }
+
+                            let sub = OpRunState {
+                                state,
+                                in_text_object: false,
+                                last_x,
+                                last_y,
+                                extracted_text,
+                                fragments,
+                            };
+                            let mut out = self.process_operations(
+                                xobj_ops,
+                                document,
+                                xobj_res.as_ref(),
+                                sub,
+                                page_index,
+                                depth + 1,
+                            )?;
+
+                            out.state.ctm = saved_ctm;
+                            out.state.fill_color = saved_fill;
+                            out.state.saved_states.truncate(saved_stack);
+                            self.font_cache = saved_fonts;
+
+                            state = out.state;
+                            last_x = out.last_x;
+                            last_y = out.last_y;
+                            extracted_text = out.extracted_text;
+                            fragments = out.fragments;
+                        }
+                    }
+                }
+                _ => {
+                    // Other operations don't affect text extraction
+                }
+            }
+        }
+
+        Ok(OpRunState {
+            state,
+            in_text_object,
+            last_x,
+            last_y,
+            extracted_text,
+            fragments,
+        })
+    }
+
+    /// Load a Form XObject by name: parsed operations, resolved /Resources,
+    /// and optional /Matrix. None for image XObjects or anything unparseable.
+    fn load_form_xobject<R: Read + Seek>(
+        &self,
+        resources: Option<&crate::parser::objects::PdfDictionary>,
+        name: &str,
+        document: &PdfDocument<R>,
+    ) -> Option<(
+        Vec<ContentOperation>,
+        Option<crate::parser::objects::PdfDictionary>,
+        Option<[f64; 6]>,
+    )> {
+        use crate::parser::objects::PdfObject;
+        let res = resources?;
+        let xobjects = match res.get("XObject")? {
+            PdfObject::Dictionary(d) => d.clone(),
+            PdfObject::Reference(n, g) => match document.get_object(*n, *g).ok()? {
+                PdfObject::Dictionary(d) => d,
+                _ => return None,
+            },
+            _ => return None,
+        };
+        let (n, g) = xobjects.get(name)?.as_reference()?;
+        let obj = document.get_object(n, g).ok()?;
+        let stream = obj.as_stream()?;
+        if stream
+            .dict
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|nm| nm.0.as_str())
+            != Some("Form")
+        {
+            return None;
+        }
+        let data = stream.decode(&Default::default()).ok()?;
+        let ops = ContentParser::parse_content(&data).ok()?;
+        let xobj_res = match stream.dict.get("Resources") {
+            Some(PdfObject::Dictionary(d)) => Some(d.clone()),
+            Some(PdfObject::Reference(rn, rg)) => document
+                .get_object(*rn, *rg)
+                .ok()
+                .and_then(|o| o.as_dict().cloned()),
+            _ => None,
+        };
+        let matrix = stream
+            .dict
+            .get("Matrix")
+            .and_then(|o| o.as_array())
+            .and_then(|a| {
+                if a.0.len() == 6 {
+                    let mut m = [0.0f64; 6];
+                    for (i, slot) in m.iter_mut().enumerate() {
+                        *slot = a.0[i]
+                            .as_real()
+                            .or_else(|| a.0[i].as_integer().map(|x| x as f64))?;
+                    }
+                    Some(m)
+                } else {
+                    None
+                }
+            });
+        Some((ops, xobj_res, matrix))
     }
 
     /// Sort text fragments by position and merge them appropriately

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -69,12 +69,12 @@ impl<'a> IncrementalFormFiller<'a> {
 /// or cyclic `/Kids` structures).
 const MAX_FIELD_DEPTH: u8 = 32;
 
-/// Resolve every terminal/named AcroForm field of `bytes` to its object id,
-/// keyed by fully-qualified name (ISO 32000-1 §12.7.3.1).
-fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> {
-    let mut reader = PdfReader::new(Cursor::new(bytes))
-        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
-
+/// Resolve every terminal/named AcroForm field to its object id, keyed by
+/// fully-qualified name (ISO 32000-1 §12.7.3.1). Reuses the caller's reader
+/// (the base PDF is parsed once per fill).
+fn resolve_acroform_fields(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> Result<HashMap<String, (u32, u16)>> {
     let acroform_dict = {
         let catalog = reader
             .catalog()
@@ -105,7 +105,7 @@ fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> 
 
     let mut out = HashMap::new();
     for (n, g) in field_refs {
-        collect_fields(&mut reader, (n, g), "", &mut out, 0)?;
+        collect_fields(reader, (n, g), "", &mut out, 0)?;
     }
     Ok(out)
 }
@@ -151,7 +151,22 @@ fn collect_fields(
         _ => Vec::new(),
     };
 
-    if kids.is_empty() {
+    // A non-empty `/Kids` does NOT imply an intermediate field. Per ISO
+    // 32000-1 §12.7.3.1 a single terminal field may carry `/T`/`/FT`/`/V`
+    // AND a `/Kids` array whose elements are its WIDGET annotations
+    // (`/Subtype /Widget`, no `/T`) — the dominant Acrobat layout. Only
+    // recurse when at least one kid is itself a field (has `/T`); otherwise
+    // the kids are widgets and THIS node is the terminal field.
+    let kids_are_subfields = kids.iter().any(|(n, g)| {
+        reader
+            .get_object(*n, *g)
+            .ok()
+            .and_then(|o| o.as_dict())
+            .map(|d| d.contains_key("T"))
+            .unwrap_or(false)
+    });
+
+    if kids.is_empty() || !kids_are_subfields {
         // Terminal field — record it under its full name (if it has one).
         if partial.is_some() {
             out.insert(full_name, node_ref);
@@ -193,10 +208,12 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     // Resolve the AcroForm dict object id and its current contents.
     let (acro_ref, mut acro_dict) = resolve_acroform_object(&mut reader)?;
 
-    // Resolve field name -> object id.
-    let field_map = resolve_acroform_fields(base_bytes)?;
+    // Resolve field name -> object id (reusing the open reader, no second parse).
+    let field_map = resolve_acroform_fields(&mut reader)?;
 
-    // Build the set of modified objects.
+    // Build the set of modified objects. Duplicate field names (or distinct
+    // names resolving to the same object id) collapse to a single rewrite
+    // with the LAST value, so we never emit two objects for one id.
     let mut modified: Vec<(u32, u16, PdfDictionary)> = Vec::new();
     for (name, value) in fields {
         let (num, gen) = field_map
@@ -215,7 +232,10 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
             "V".to_string(),
             PdfObject::String(PdfString(value.as_bytes().to_vec())),
         );
-        modified.push((num, gen, field_dict));
+        match modified.iter_mut().find(|(n, g, _)| *n == num && *g == gen) {
+            Some(slot) => slot.2 = field_dict,
+            None => modified.push((num, gen, field_dict)),
+        }
     }
 
     // Flag NeedAppearances so viewers regenerate the appearance stream.
@@ -239,13 +259,20 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     changed.push((acro_ref.0, acro_ref.1, acro_offset));
 
     let xref_pos = out.len() as u64;
+    // Keep the permanent first /ID element; regenerate the second so the
+    // revision is distinguishable (§14.4). Omit /ID entirely if the base had
+    // none.
+    let id_pair = base_id_first.map(|first| {
+        let second = derive_revision_id(&first, fields, xref_pos);
+        (first, second)
+    });
     out.extend_from_slice(&write_partial_xref_section(&changed));
     out.extend_from_slice(&write_incremental_trailer(
         base_startxref,
         base_root,
         base_size,
         xref_pos,
-        base_id_first,
+        id_pair,
     ));
 
     Ok(out)
@@ -394,7 +421,13 @@ fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
 
 /// Format a PDF real without scientific notation, trimming trailing zeros.
 fn format_real(f: f64) -> String {
-    if f == f.trunc() && f.is_finite() {
+    // PDF has no token for NaN/Infinity; emit a benign 0 rather than a
+    // malformed numeric. Field dicts essentially never carry such values,
+    // but the serializer must stay total.
+    if !f.is_finite() {
+        return "0".to_string();
+    }
+    if f == f.trunc() {
         return format!("{}", f as i64);
     }
     let mut s = format!("{f:.6}");
@@ -439,28 +472,48 @@ fn write_partial_xref_section(changed: &[(u32, u16, u64)]) -> Vec<u8> {
 }
 
 /// Build the incremental-update trailer chaining `/Prev` and reusing the
-/// base `/Root`, `/Size` and `/ID`.
+/// base `/Root` and `/Size`. The `/ID` array, when present, keeps the
+/// permanent first element and carries a fresh second element that changes
+/// with this revision (ISO 32000-1 Table 15 / §14.4 — signature validators
+/// rely on the second element changing per update).
 fn write_incremental_trailer(
     base_prev_xref: u64,
     base_root: (u32, u16),
     base_size: u32,
     new_xref_pos: u64,
-    base_id_first: Option<Vec<u8>>,
+    id_pair: Option<(Vec<u8>, Vec<u8>)>,
 ) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(b"trailer\n<< ");
     out.extend_from_slice(format!("/Size {base_size} ").as_bytes());
     out.extend_from_slice(format!("/Root {} {} R ", base_root.0, base_root.1).as_bytes());
     out.extend_from_slice(format!("/Prev {base_prev_xref} ").as_bytes());
-    if let Some(id) = base_id_first {
-        let hex: String = id.iter().map(|b| format!("{b:02X}")).collect();
-        out.extend_from_slice(format!("/ID [<{hex}> <{hex}>] ").as_bytes());
+    if let Some((first, second)) = id_pair {
+        let hex = |bytes: &[u8]| -> String { bytes.iter().map(|b| format!("{b:02X}")).collect() };
+        out.extend_from_slice(format!("/ID [<{}> <{}>] ", hex(&first), hex(&second)).as_bytes());
     }
     out.extend_from_slice(b">>\n");
     out.extend_from_slice(b"startxref\n");
     out.extend_from_slice(format!("{new_xref_pos}\n").as_bytes());
     out.extend_from_slice(b"%%EOF\n");
     out
+}
+
+/// Derive a fresh 16-byte `/ID` second element bound to this revision's
+/// content (permanent id + the values written + the new xref position).
+/// Deterministic so a given fill reproduces byte-for-byte (testable), while
+/// still differing from the base second element and from other revisions.
+fn derive_revision_id(first: &[u8], fields: &[(&str, &str)], xref_pos: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(first);
+    for (name, value) in fields {
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(value.as_bytes());
+        buf.push(0);
+    }
+    buf.extend_from_slice(&xref_pos.to_le_bytes());
+    md5::compute(&buf).0.to_vec()
 }
 
 #[cfg(test)]
@@ -501,10 +554,33 @@ mod tests {
     }
 
     #[test]
-    fn incremental_trailer_emits_id_when_present() {
-        let bytes = write_incremental_trailer(10, (2, 0), 5, 99, Some(vec![0xDE, 0xAD]));
+    fn incremental_trailer_emits_distinct_id_pair() {
+        // The first element is preserved; the second changes with the
+        // revision (§14.4). They must NOT be identical.
+        let bytes = write_incremental_trailer(
+            10,
+            (2, 0),
+            5,
+            99,
+            Some((vec![0xDE, 0xAD], vec![0xBE, 0xEF])),
+        );
         let s = String::from_utf8(bytes).unwrap();
-        assert!(s.contains("/ID [<DEAD> <DEAD>]"), "id reused: {s}");
+        assert!(s.contains("/ID [<DEAD> <BEEF>]"), "distinct id pair: {s}");
+    }
+
+    #[test]
+    fn revision_id_differs_from_permanent_and_is_deterministic() {
+        let first = vec![1u8, 2, 3, 4];
+        let a = derive_revision_id(&first, &[("name", "Ada")], 100);
+        let b = derive_revision_id(&first, &[("name", "Ada")], 100);
+        let c = derive_revision_id(&first, &[("name", "Grace")], 100);
+        assert_eq!(a, b, "same inputs -> same id (reproducible)");
+        assert_ne!(
+            a, first,
+            "second element must differ from the permanent one"
+        );
+        assert_ne!(a, c, "different content -> different revision id");
+        assert_eq!(a.len(), 16, "PDF /ID elements are 16 bytes");
     }
 
     #[test]

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -1,0 +1,516 @@
+//! Writable AcroForm field filling on an existing (parsed) PDF via a real
+//! ISO 32000-1 §7.5.6 incremental update (issue #318).
+//!
+//! The writer-side [`crate::Document`] can only fill fields that were built
+//! in the current process through a [`crate::forms::FormManager`]. There is
+//! no way to set `/V` on the fields of a PDF produced elsewhere (Acrobat,
+//! pdftk, another library) so a form reader recovers the value after a
+//! re-serialize. [`IncrementalFormFiller`] closes that gap.
+//!
+//! # Approach (non-lossy)
+//!
+//! Rather than rehydrating a full writable `Document` (which cannot
+//! faithfully represent an arbitrary parsed PDF and would corrupt complex
+//! documents on round-trip), this appends a true incremental update to the
+//! original bytes:
+//!
+//! 1. Parse the base PDF, resolve the `/AcroForm` field tree (handling
+//!    `/Kids` and hierarchical names via `/Parent`).
+//! 2. Clone the affected field dictionaries, set `/V`, and set
+//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2 — compliant
+//!    viewers regenerate the appearance stream; `/AP` generation is a
+//!    documented follow-up).
+//! 3. Emit ONLY the modified objects (each reusing its existing object id),
+//!    a PARTIAL incremental cross-reference section covering only the
+//!    changed ids, and a trailer chaining `/Prev` to the previous
+//!    `startxref`, reusing the base `/Root` and `/ID`.
+//!
+//! The original bytes are emitted verbatim as the prefix of the output, so
+//! every untouched object, page, font and content stream is preserved
+//! byte-for-byte.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::PdfReader;
+use std::collections::HashMap;
+use std::io::Cursor;
+
+/// Fills AcroForm fields on an existing parsed PDF by appending an
+/// ISO 32000-1 §7.5.6 incremental update. See the module docs.
+pub struct IncrementalFormFiller<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalFormFiller<'a> {
+    /// Create a filler over the bytes of an existing PDF.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Fill a single field by its fully-qualified name, returning the
+    /// updated PDF bytes (base bytes + appended incremental update).
+    pub fn fill(&self, field_name: &str, value: &str) -> Result<Vec<u8>> {
+        self.fill_many(&[(field_name, value)])
+    }
+
+    /// Fill multiple fields in a single incremental update (one parse, one
+    /// appended section). Field names are fully qualified
+    /// (e.g. `"address.street"`).
+    pub fn fill_many(&self, fields: &[(&str, &str)]) -> Result<Vec<u8>> {
+        fill_many_impl(self.base_bytes, fields)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field-tree resolution
+// ---------------------------------------------------------------------------
+
+/// Maximum field-tree recursion depth (defensive guard against pathological
+/// or cyclic `/Kids` structures).
+const MAX_FIELD_DEPTH: u8 = 32;
+
+/// Resolve every terminal/named AcroForm field of `bytes` to its object id,
+/// keyed by fully-qualified name (ISO 32000-1 §12.7.3.1).
+fn resolve_acroform_fields(bytes: &[u8]) -> Result<HashMap<String, (u32, u16)>> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+
+    let acroform_dict = {
+        let catalog = reader
+            .catalog()
+            .map_err(|e| PdfError::InvalidStructure(format!("read catalog: {e}")))?
+            .clone();
+        match catalog.get("AcroForm") {
+            Some(PdfObject::Reference(n, g)) => reader
+                .get_object(*n, *g)
+                .map_err(|e| PdfError::InvalidStructure(format!("resolve /AcroForm: {e}")))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| {
+                    PdfError::InvalidStructure("/AcroForm is not a dictionary".to_string())
+                })?,
+            Some(PdfObject::Dictionary(d)) => d.clone(),
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "document has no /AcroForm".to_string(),
+                ))
+            }
+        }
+    };
+
+    let field_refs: Vec<(u32, u16)> = match acroform_dict.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+
+    let mut out = HashMap::new();
+    for (n, g) in field_refs {
+        collect_fields(&mut reader, (n, g), "", &mut out, 0)?;
+    }
+    Ok(out)
+}
+
+/// Recursively walk a field node, accumulating fully-qualified names. A node
+/// is named if it carries `/T`; nodes with `/Kids` are intermediate (their
+/// `/T` prefixes the children's names).
+fn collect_fields(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    parent_prefix: &str,
+    out: &mut HashMap<String, (u32, u16)>,
+    depth: u8,
+) -> Result<()> {
+    if depth >= MAX_FIELD_DEPTH {
+        return Err(PdfError::InvalidStructure(
+            "AcroForm field tree exceeds maximum depth".to_string(),
+        ));
+    }
+
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .map_err(|e| PdfError::InvalidStructure(format!("resolve field object: {e}")))?
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| {
+            PdfError::InvalidStructure("field object is not a dictionary".to_string())
+        })?;
+
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+
+    let full_name = match (&partial, parent_prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{parent_prefix}.{t}"),
+        (None, _) => parent_prefix.to_string(),
+    };
+
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+
+    if kids.is_empty() {
+        // Terminal field — record it under its full name (if it has one).
+        if partial.is_some() {
+            out.insert(full_name, node_ref);
+        }
+    } else {
+        for kid in kids {
+            collect_fields(reader, kid, &full_name, out, depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Incremental update assembly
+// ---------------------------------------------------------------------------
+
+fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>> {
+    let mut reader = PdfReader::new(Cursor::new(base_bytes))
+        .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "incremental form fill is not supported on encrypted PDFs".to_string(),
+        ));
+    }
+
+    // Base trailer facts needed for the appended trailer.
+    let base_startxref = reader.trailer().xref_offset;
+    let base_root = reader
+        .trailer()
+        .root()
+        .map_err(|e| PdfError::InvalidStructure(format!("base /Root: {e}")))?;
+    let base_size = reader
+        .trailer()
+        .size()
+        .map_err(|e| PdfError::InvalidStructure(format!("base /Size: {e}")))?;
+    let base_id_first: Option<Vec<u8>> = first_id_bytes(reader.trailer().id());
+
+    // Resolve the AcroForm dict object id and its current contents.
+    let (acro_ref, mut acro_dict) = resolve_acroform_object(&mut reader)?;
+
+    // Resolve field name -> object id.
+    let field_map = resolve_acroform_fields(base_bytes)?;
+
+    // Build the set of modified objects.
+    let mut modified: Vec<(u32, u16, PdfDictionary)> = Vec::new();
+    for (name, value) in fields {
+        let (num, gen) = field_map
+            .get(*name)
+            .copied()
+            .ok_or_else(|| PdfError::FieldNotFound((*name).to_string()))?;
+        let mut field_dict = reader
+            .get_object(num, gen)
+            .map_err(|e| PdfError::InvalidStructure(format!("resolve field {name}: {e}")))?
+            .as_dict()
+            .cloned()
+            .ok_or_else(|| {
+                PdfError::InvalidStructure(format!("field {name} is not a dictionary"))
+            })?;
+        field_dict.insert(
+            "V".to_string(),
+            PdfObject::String(PdfString(value.as_bytes().to_vec())),
+        );
+        modified.push((num, gen, field_dict));
+    }
+
+    // Flag NeedAppearances so viewers regenerate the appearance stream.
+    acro_dict.insert("NeedAppearances".to_string(), PdfObject::Boolean(true));
+
+    // ----- assemble appended bytes -----
+    let mut out = Vec::with_capacity(base_bytes.len() + 1024);
+    out.extend_from_slice(base_bytes);
+
+    let mut changed: Vec<(u32, u16, u64)> = Vec::new();
+
+    for (num, gen, dict) in &modified {
+        let offset = out.len() as u64;
+        write_indirect_object(&mut out, *num, *gen, dict)?;
+        changed.push((*num, *gen, offset));
+    }
+
+    // AcroForm object.
+    let acro_offset = out.len() as u64;
+    write_indirect_object(&mut out, acro_ref.0, acro_ref.1, &acro_dict)?;
+    changed.push((acro_ref.0, acro_ref.1, acro_offset));
+
+    let xref_pos = out.len() as u64;
+    out.extend_from_slice(&write_partial_xref_section(&changed));
+    out.extend_from_slice(&write_incremental_trailer(
+        base_startxref,
+        base_root,
+        base_size,
+        xref_pos,
+        base_id_first,
+    ));
+
+    Ok(out)
+}
+
+/// Resolve the `/AcroForm` indirect object id and a clone of its dict.
+fn resolve_acroform_object(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> Result<((u32, u16), PdfDictionary)> {
+    let catalog = reader
+        .catalog()
+        .map_err(|e| PdfError::InvalidStructure(format!("read catalog: {e}")))?
+        .clone();
+    match catalog.get("AcroForm") {
+        Some(PdfObject::Reference(n, g)) => {
+            let dict = reader
+                .get_object(*n, *g)
+                .map_err(|e| PdfError::InvalidStructure(format!("resolve /AcroForm: {e}")))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| {
+                    PdfError::InvalidStructure("/AcroForm is not a dictionary".to_string())
+                })?;
+            Ok(((*n, *g), dict))
+        }
+        _ => Err(PdfError::InvalidStructure(
+            "/AcroForm must be an indirect reference for incremental fill".to_string(),
+        )),
+    }
+}
+
+fn first_id_bytes(id: Option<&PdfObject>) -> Option<Vec<u8>> {
+    match id {
+        Some(PdfObject::Array(arr)) => arr
+            .0
+            .first()
+            .and_then(|o| o.as_string())
+            .map(|s| s.as_bytes().to_vec()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level serialization (Vec<u8>, no PdfWriter state)
+// ---------------------------------------------------------------------------
+
+/// Write `{num} {gen} obj\n<dict>\nendobj\n` into `out`.
+fn write_indirect_object(
+    out: &mut Vec<u8>,
+    num: u32,
+    gen: u16,
+    dict: &PdfDictionary,
+) -> Result<()> {
+    out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
+    write_object_value(out, &PdfObject::Dictionary(dict.clone()))?;
+    out.extend_from_slice(b"\nendobj\n");
+    Ok(())
+}
+
+/// Serialize a parser [`PdfObject`] to PDF wire bytes. Streams are rejected:
+/// AcroForm field and form dictionaries never carry an embedded stream, and
+/// emitting one without a fresh `/Length` would corrupt the file.
+fn write_object_value(out: &mut Vec<u8>, obj: &PdfObject) -> Result<()> {
+    match obj {
+        PdfObject::Null => out.extend_from_slice(b"null"),
+        PdfObject::Boolean(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
+        PdfObject::Integer(i) => out.extend_from_slice(i.to_string().as_bytes()),
+        PdfObject::Real(f) => out.extend_from_slice(format_real(*f).as_bytes()),
+        PdfObject::String(s) => write_literal_string(out, s.as_bytes()),
+        PdfObject::Name(n) => write_name(out, n),
+        PdfObject::Reference(num, gen) => {
+            out.extend_from_slice(format!("{num} {gen} R").as_bytes())
+        }
+        PdfObject::Array(arr) => {
+            out.extend_from_slice(b"[");
+            for (i, item) in arr.0.iter().enumerate() {
+                if i > 0 {
+                    out.extend_from_slice(b" ");
+                }
+                write_object_value(out, item)?;
+            }
+            out.extend_from_slice(b"]");
+        }
+        PdfObject::Dictionary(d) => write_dict(out, d)?,
+        PdfObject::Stream(_) => {
+            return Err(PdfError::InvalidStructure(
+                "unexpected stream object in AcroForm field dictionary".to_string(),
+            ))
+        }
+    }
+    Ok(())
+}
+
+fn write_dict(out: &mut Vec<u8>, dict: &PdfDictionary) -> Result<()> {
+    out.extend_from_slice(b"<< ");
+    // Deterministic key order: keeps output stable and tests reproducible.
+    let mut keys: Vec<&PdfName> = dict.0.keys().collect();
+    keys.sort_by(|a, b| a.0.cmp(&b.0));
+    for key in keys {
+        write_name(out, key);
+        out.extend_from_slice(b" ");
+        // Safe: key came from the dict.
+        write_object_value(out, &dict.0[key])?;
+        out.extend_from_slice(b" ");
+    }
+    out.extend_from_slice(b">>");
+    Ok(())
+}
+
+fn write_name(out: &mut Vec<u8>, name: &PdfName) {
+    out.extend_from_slice(b"/");
+    for &b in name.0.as_bytes() {
+        // Regular characters pass through; everything else is #XX-escaped
+        // (ISO 32000-1 §7.3.5).
+        if b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
+            )
+        {
+            out.push(b);
+        } else {
+            out.extend_from_slice(format!("#{b:02X}").as_bytes());
+        }
+    }
+}
+
+/// Serialize a PDF literal string `(...)`, escaping the reserved bytes and
+/// emitting non-printable bytes as `\ddd` octal (ISO 32000-1 §7.3.4.2).
+fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.push(b'(');
+    for &b in bytes {
+        match b {
+            b'(' => out.extend_from_slice(b"\\("),
+            b')' => out.extend_from_slice(b"\\)"),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            0x20..=0x7E => out.push(b),
+            _ => out.extend_from_slice(format!("\\{b:03o}").as_bytes()),
+        }
+    }
+    out.push(b')');
+}
+
+/// Format a PDF real without scientific notation, trimming trailing zeros.
+fn format_real(f: f64) -> String {
+    if f == f.trunc() && f.is_finite() {
+        return format!("{}", f as i64);
+    }
+    let mut s = format!("{f:.6}");
+    while s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Partial incremental xref + trailer
+// ---------------------------------------------------------------------------
+
+/// Build a partial cross-reference section listing ONLY the changed objects,
+/// grouped into contiguous subsections (ISO 32000-1 §7.5.4).
+fn write_partial_xref_section(changed: &[(u32, u16, u64)]) -> Vec<u8> {
+    let mut entries = changed.to_vec();
+    entries.sort_by_key(|(num, _, _)| *num);
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"xref\n");
+
+    let mut i = 0;
+    while i < entries.len() {
+        let start = entries[i].0;
+        let mut j = i;
+        // Extend the subsection while object numbers stay contiguous.
+        while j + 1 < entries.len() && entries[j + 1].0 == entries[j].0 + 1 {
+            j += 1;
+        }
+        let count = j - i + 1;
+        out.extend_from_slice(format!("{start} {count}\n").as_bytes());
+        for entry in &entries[i..=j] {
+            out.extend_from_slice(format!("{:010} {:05} n \n", entry.2, entry.1).as_bytes());
+        }
+        i = j + 1;
+    }
+    out
+}
+
+/// Build the incremental-update trailer chaining `/Prev` and reusing the
+/// base `/Root`, `/Size` and `/ID`.
+fn write_incremental_trailer(
+    base_prev_xref: u64,
+    base_root: (u32, u16),
+    base_size: u32,
+    new_xref_pos: u64,
+    base_id_first: Option<Vec<u8>>,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"trailer\n<< ");
+    out.extend_from_slice(format!("/Size {base_size} ").as_bytes());
+    out.extend_from_slice(format!("/Root {} {} R ", base_root.0, base_root.1).as_bytes());
+    out.extend_from_slice(format!("/Prev {base_prev_xref} ").as_bytes());
+    if let Some(id) = base_id_first {
+        let hex: String = id.iter().map(|b| format!("{b:02X}")).collect();
+        out.extend_from_slice(format!("/ID [<{hex}> <{hex}>] ").as_bytes());
+    }
+    out.extend_from_slice(b">>\n");
+    out.extend_from_slice(b"startxref\n");
+    out.extend_from_slice(format!("{new_xref_pos}\n").as_bytes());
+    out.extend_from_slice(b"%%EOF\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_xref_groups_contiguous_subsections() {
+        let bytes = write_partial_xref_section(&[(5, 0, 1024), (7, 0, 2048)]);
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.starts_with("xref\n"), "must start with xref keyword");
+        assert!(s.contains("5 1\n0000001024 00000 n \n"), "obj 5 subsection");
+        assert!(s.contains("7 1\n0000002048 00000 n \n"), "obj 7 subsection");
+        assert!(!s.contains("\n6 "), "gap object 6 must not appear");
+    }
+
+    #[test]
+    fn partial_xref_merges_adjacent_ids() {
+        let bytes = write_partial_xref_section(&[(7, 0, 2048), (5, 0, 1024), (6, 0, 1536)]);
+        let s = String::from_utf8(bytes).unwrap();
+        // 5,6,7 are contiguous -> one subsection "5 3".
+        assert!(
+            s.contains("5 3\n"),
+            "contiguous ids form one subsection: {s}"
+        );
+        assert!(s.contains("0000001024 00000 n \n0000001536 00000 n \n0000002048 00000 n \n"));
+    }
+
+    #[test]
+    fn incremental_trailer_carries_root_prev_size() {
+        let bytes = write_incremental_trailer(312, (1, 0), 8, 5000, None);
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.contains("/Prev 312"), "must chain /Prev: {s}");
+        assert!(s.contains("/Root 1 0 R"), "must reuse base /Root");
+        assert!(s.contains("/Size 8"), "must carry /Size");
+        assert!(s.ends_with("startxref\n5000\n%%EOF\n"), "suffix: {s}");
+        assert!(!s.contains("/Info"), "no /Info in incremental trailer");
+    }
+
+    #[test]
+    fn incremental_trailer_emits_id_when_present() {
+        let bytes = write_incremental_trailer(10, (2, 0), 5, 99, Some(vec![0xDE, 0xAD]));
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.contains("/ID [<DEAD> <DEAD>]"), "id reused: {s}");
+    }
+
+    #[test]
+    fn literal_string_escapes_reserved_bytes() {
+        let mut out = Vec::new();
+        write_literal_string(&mut out, b"a(b)c\\d");
+        assert_eq!(out, b"(a\\(b\\)c\\\\d)");
+    }
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -1,6 +1,7 @@
 //! PDF writing functionality
 
 mod content_stream_utils;
+mod incremental_form_fill;
 mod object_streams;
 mod pdf_writer;
 mod signature;
@@ -8,6 +9,7 @@ mod xref_stream_writer;
 
 // Phase 2 utilities for font preservation
 pub(crate) use content_stream_utils::{rename_preserved_fonts, rewrite_font_references};
+pub use incremental_form_fill::IncrementalFormFiller;
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};
 pub(crate) use signature::{Edition, PdfSignature};

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -353,3 +353,77 @@ fn fill_hierarchical_field_incremental() {
     ids.sort_unstable();
     assert_eq!(ids, vec![4, 6], "only street kid + AcroForm rewritten");
 }
+
+// ---------------------------------------------------------------------------
+// Terminal field whose /Kids are WIDGET annotations (not sub-fields)
+// ---------------------------------------------------------------------------
+
+/// Read `/V` of a specific object id directly (bypasses the field-tree walk,
+/// so it works regardless of widget-vs-subfield kid classification).
+fn object_v(bytes: &[u8], num: u32, gen: u16) -> Option<String> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    dict.get("V")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+}
+
+/// The most common real-world layout (Acrobat): a single terminal field
+/// dict that carries `/T`/`/FT` AND a `/Kids` array whose elements are
+/// widget annotation dicts (`/Subtype /Widget`, NO `/T`). The field
+/// resolver must treat this node as terminal — recursing into the widgets
+/// (which have no `/T`) would lose the field entirely.
+fn build_widget_kids_form_pdf() -> Vec<u8> {
+    // 1 Catalog  2 Pages  3 Page  4 AcroForm
+    // 5 terminal field "email" with widget kid 6
+    // 6 widget annotation (no /T)
+    let objects: Vec<String> = vec![
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [6 0 R] >>".to_string(),
+        "<< /Fields [5 0 R] >>".to_string(),
+        "<< /FT /Tx /T (email) /Kids [6 0 R] >>".to_string(),
+        "<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [100 700 300 720] >>".to_string(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = objects.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn fill_field_with_widget_kids() {
+    let base = build_widget_kids_form_pdf();
+    // The terminal field is object 5; before fill it has no value.
+    assert!(object_v(&base, 5, 0).is_none(), "field starts empty");
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("email", "user@example.com")
+        .expect("must resolve a terminal field whose kids are widgets");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+    assert_eq!(
+        object_v(&output, 5, 0).as_deref(),
+        Some("user@example.com"),
+        "/V must be set on the terminal field object (5), not lost in widget recursion"
+    );
+    // Only the field (5) + AcroForm (4) change — the widget (6) is untouched.
+    let mut ids = appended_xref_object_numbers(&output[base.len()..]);
+    ids.sort_unstable();
+    assert_eq!(ids, vec![4, 5]);
+}

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -1,0 +1,355 @@
+//! Integration tests for issue #318: filling AcroForm fields on an existing
+//! (parsed) PDF via an ISO 32000-1 §7.5.6 incremental update.
+//!
+//! Every assertion verifies real wire content after a full
+//! parse -> fill -> serialize -> parse round-trip — no smoke tests.
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Build a single-page PDF carrying AcroForm text fields with the given
+/// names (no values set), serialized to bytes through the public writer.
+fn build_base_pdf_with_fields(names: &[&str]) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let mut y = 700.0;
+    for name in names {
+        let rect = Rectangle::new(Point::new(100.0, y), Point::new(300.0, y + 20.0));
+        let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+        let field = TextField::new(*name);
+        let field_ref = fm
+            .add_text_field(field, widget.clone(), None)
+            .expect("add_text_field");
+        page.add_form_widget_with_ref(widget, field_ref)
+            .expect("add_form_widget_with_ref");
+        y -= 40.0;
+    }
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    doc.to_bytes().expect("serialize base document")
+}
+
+/// Resolve `/AcroForm` -> (object id, dict clone) from PDF bytes.
+fn acroform_object(bytes: &[u8]) -> ((u32, u16), oxidize_pdf::parser::objects::PdfDictionary) {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog
+        .get("AcroForm")
+        .expect("/AcroForm present")
+        .as_reference()
+        .expect("/AcroForm indirect");
+    let dict = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .expect("resolve AcroForm")
+        .as_dict()
+        .expect("AcroForm dict")
+        .clone();
+    (acro_ref, dict)
+}
+
+/// Recover a terminal field's object id and `/V` string by fully-qualified
+/// name from PDF bytes (walks /Fields and /Kids).
+fn field_value(bytes: &[u8], name: &str) -> Option<((u32, u16), Option<String>)> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let (_, acro) = acroform_object(bytes);
+    let field_refs: Vec<(u32, u16)> = match acro.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    for r in field_refs {
+        if let Some(found) = walk_field(&mut reader, r, "", name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn walk_field(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    prefix: &str,
+    target: &str,
+) -> Option<((u32, u16), Option<String>)> {
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+    let full = match (&partial, prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{prefix}.{t}"),
+        (None, _) => prefix.to_string(),
+    };
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    if kids.is_empty() {
+        if partial.is_some() && full == target {
+            let v = node
+                .get("V")
+                .and_then(|o| o.as_string())
+                .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+            return Some((node_ref, v));
+        }
+        None
+    } else {
+        for kid in kids {
+            if let Some(found) = walk_field(reader, kid, &full, target) {
+                return Some(found);
+            }
+        }
+        None
+    }
+}
+
+/// Parse the object numbers listed in an appended xref section (raw text
+/// `xref` format), returning every object number across all subsections.
+fn appended_xref_object_numbers(appended: &[u8]) -> Vec<u32> {
+    let s = String::from_utf8_lossy(appended);
+    let xref_pos = s.find("xref").expect("appended bytes must contain xref");
+    let after = &s[xref_pos + 4..];
+    let mut nums = Vec::new();
+    let mut lines = after.lines().filter(|l| !l.trim().is_empty());
+    while let Some(header) = lines.next() {
+        let header = header.trim();
+        if header.starts_with("trailer") {
+            break;
+        }
+        let parts: Vec<&str> = header.split_whitespace().collect();
+        if parts.len() != 2 {
+            break;
+        }
+        let (start, count): (u32, u32) = match (parts[0].parse(), parts[1].parse()) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => break,
+        };
+        for i in 0..count {
+            // consume one entry line per object
+            if lines.next().is_some() {
+                nums.push(start + i);
+            }
+        }
+    }
+    nums
+}
+
+/// Read the base PDF's most-recent startxref offset.
+fn base_startxref(bytes: &[u8]) -> u64 {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    reader.trailer().xref_offset
+}
+
+/// Read `/Prev` from an appended incremental trailer (text form).
+fn appended_prev(appended: &[u8]) -> u64 {
+    let s = String::from_utf8_lossy(appended);
+    let pos = s.find("/Prev").expect("appended trailer must carry /Prev");
+    let after = &s[pos + 5..];
+    after
+        .split_whitespace()
+        .next()
+        .expect("number after /Prev")
+        .parse()
+        .expect("/Prev integer")
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 4: single-field round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_single_field_incremental_roundtrip() {
+    let base = build_base_pdf_with_fields(&["email"]);
+
+    // The fixture must parse and the field must start without a value.
+    let (field_id_before, v_before) = field_value(&base, "email").expect("field present in base");
+    assert!(
+        v_before.is_none() || v_before.as_deref() == Some(""),
+        "base field must start empty, got {v_before:?}"
+    );
+
+    let prev_offset = base_startxref(&base);
+    let (acro_id, _) = acroform_object(&base);
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("email", "hello@test.com")
+        .expect("fill must succeed");
+
+    // 1) Base bytes are a verbatim prefix (true incremental update).
+    assert_eq!(
+        &output[..base.len()],
+        &base[..],
+        "incremental update must preserve base bytes verbatim"
+    );
+    assert!(output.len() > base.len(), "must append an update section");
+
+    // 2) Re-parse and recover the exact /V.
+    let (field_id_after, v_after) = field_value(&output, "email").expect("field present in output");
+    assert_eq!(
+        v_after.as_deref(),
+        Some("hello@test.com"),
+        "recovered /V must equal the filled value"
+    );
+    // Same object id reused (incremental, not a new field object).
+    assert_eq!(
+        field_id_before, field_id_after,
+        "field object id must be reused"
+    );
+
+    // 3) NeedAppearances flipped true.
+    let (_, acro_after) = acroform_object(&output);
+    assert_eq!(
+        acro_after.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true),
+        "/AcroForm/NeedAppearances must be true"
+    );
+
+    // 4) Appended xref lists exactly the changed objects: field + AcroForm.
+    let appended = &output[base.len()..];
+    let mut ids = appended_xref_object_numbers(appended);
+    ids.sort_unstable();
+    let mut expected = vec![field_id_after.0, acro_id.0];
+    expected.sort_unstable();
+    assert_eq!(
+        ids, expected,
+        "appended xref must list exactly the field and AcroForm objects"
+    );
+
+    // 5) /Prev chains to the base startxref.
+    assert_eq!(
+        appended_prev(appended),
+        prev_offset,
+        "/Prev must equal the base startxref offset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5a: multi-field fill
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_many_fields_incremental_roundtrip() {
+    let base = build_base_pdf_with_fields(&["first_name", "last_name"]);
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill_many(&[("first_name", "Jane"), ("last_name", "Doe")])
+        .expect("fill_many must succeed");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (_, first) = field_value(&output, "first_name").expect("first_name present");
+    let (_, last) = field_value(&output, "last_name").expect("last_name present");
+    assert_eq!(first.as_deref(), Some("Jane"));
+    assert_eq!(last.as_deref(), Some("Doe"));
+
+    let (_, acro_after) = acroform_object(&output);
+    assert_eq!(
+        acro_after.get("NeedAppearances").and_then(|o| o.as_bool()),
+        Some(true)
+    );
+
+    // Appended xref: two field objects + one AcroForm object = 3 distinct ids.
+    let ids = appended_xref_object_numbers(&output[base.len()..]);
+    assert_eq!(ids.len(), 3, "two fields + AcroForm, got {ids:?}");
+}
+
+#[test]
+fn fill_unknown_field_errors() {
+    let base = build_base_pdf_with_fields(&["email"]);
+    let err = IncrementalFormFiller::new(&base).fill("does_not_exist", "x");
+    assert!(err.is_err(), "filling a missing field must error");
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5b: genuine hierarchical field tree (/Kids + /Parent)
+// ---------------------------------------------------------------------------
+
+/// Hand-craft a minimal valid PDF whose AcroForm has a parent field
+/// (`T = "address"`) with two terminal kids (`street`, `city`), exercising
+/// the recursive field-tree walk and fully-qualified naming.
+fn build_hierarchical_form_pdf() -> Vec<u8> {
+    // Object layout:
+    //  1: Catalog  2: Pages  3: Page  4: AcroForm
+    //  5: parent field "address"  6: kid "street"  7: kid "city"
+    let objects: Vec<String> = vec![
+        // 1 Catalog
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_string(),
+        // 2 Pages
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        // 3 Page
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>".to_string(),
+        // 4 AcroForm
+        "<< /Fields [5 0 R] >>".to_string(),
+        // 5 parent field
+        "<< /T (address) /Kids [6 0 R 7 0 R] >>".to_string(),
+        // 6 kid street
+        "<< /FT /Tx /T (street) /Parent 5 0 R >>".to_string(),
+        // 7 kid city
+        "<< /FT /Tx /T (city) /Parent 5 0 R >>".to_string(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = objects.len() + 1; // +1 for free object 0
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn fill_hierarchical_field_incremental() {
+    let base = build_hierarchical_form_pdf();
+
+    // Sanity: the hand-crafted base parses and the qualified name resolves.
+    let (street_id, v_before) =
+        field_value(&base, "address.street").expect("address.street must resolve in base");
+    assert!(v_before.is_none(), "kid starts empty");
+
+    let output = IncrementalFormFiller::new(&base)
+        .fill("address.street", "221B Baker St")
+        .expect("fill hierarchical field");
+
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (street_id_after, v_after) =
+        field_value(&output, "address.street").expect("resolve after fill");
+    assert_eq!(v_after.as_deref(), Some("221B Baker St"));
+    assert_eq!(street_id, street_id_after, "kid object id reused");
+
+    // The other kid is untouched.
+    let (_, city_v) = field_value(&output, "address.city").expect("city still resolvable");
+    assert!(city_v.is_none(), "untouched kid keeps no value");
+
+    // Only the street kid (obj 6) + AcroForm (obj 4) change.
+    let mut ids = appended_xref_object_numbers(&output[base.len()..]);
+    ids.sort_unstable();
+    assert_eq!(ids, vec![4, 6], "only street kid + AcroForm rewritten");
+}

--- a/oxidize-pdf-core/tests/issue_319_content_recovery_test.rs
+++ b/oxidize-pdf-core/tests/issue_319_content_recovery_test.rs
@@ -1,0 +1,116 @@
+//! Issue #319: text extraction dropped a whole page's content when that
+//! page's content stream contained a single malformed operator.
+//!
+//! Root cause (symptom level): `ContentParser::parse_operators` propagated
+//! an operand error with `?`, so one bad operator made `parse_content`
+//! return `Err`; the extractor's per-stream loop then `continue`d, dropping
+//! every valid operator on the page. A 3-page invoice produced by
+//! RML2PDF/pluscode lost its entire "charges in detail" page this way.
+//!
+//! These tests build a PDF whose page content stream interleaves valid
+//! text-show operators with a malformed one, then assert the valid text is
+//! still extracted (best-effort recovery). No smoke tests — exact strings
+//! are asserted.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Build a single-page PDF whose content stream is exactly `content_stream`,
+/// with a Helvetica font registered as /F1.
+fn build_pdf_with_content_stream(content_stream: &[u8]) -> Vec<u8> {
+    let stream_len = content_stream.len();
+    // Object bodies. Object 4 is the content stream (built separately so we
+    // can splice the raw bytes and a correct /Length).
+    let bodies: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        {
+            let mut s = format!("<< /Length {stream_len} >>\nstream\n").into_bytes();
+            s.extend_from_slice(content_stream);
+            s.extend_from_slice(b"\nendstream");
+            s
+        },
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (i, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = bodies.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+fn extract_page_text(pdf: &[u8]) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn malformed_operator_does_not_drop_page_text() {
+    // The second `Td` has no operands (its numbers are "missing"), which is
+    // exactly the class of defect that aborted the old parser. The two
+    // surrounding `Tj` strings must still be extracted.
+    let content =
+        b"BT /F1 12 Tf 72 700 Td (Supply number 1170000446615) Tj Td (Climate Change Levy) Tj ET";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(
+        text.contains("Supply number 1170000446615"),
+        "first line lost — page was dropped. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Climate Change Levy"),
+        "second line lost — page was dropped. Got: {text:?}"
+    );
+}
+
+#[test]
+fn well_formed_page_is_unaffected() {
+    // Regression guard: a clean content stream extracts exactly as before.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello) Tj 0 -14 Td (World) Tj ET";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(text.contains("Hello"), "got {text:?}");
+    assert!(text.contains("World"), "got {text:?}");
+}
+
+#[test]
+fn unterminated_tail_keeps_earlier_text() {
+    // A truncated/garbled tail (here an unterminated hex string) must not
+    // discard the valid text that precedes it.
+    let content = b"BT /F1 12 Tf 72 700 Td (Recovered before tail) Tj ET <ABC DEF";
+    let pdf = build_pdf_with_content_stream(content);
+
+    let text = extract_page_text(&pdf);
+    assert!(
+        text.contains("Recovered before tail"),
+        "text before the malformed tail lost. Got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_319_form_xobject_test.rs
+++ b/oxidize-pdf-core/tests/issue_319_form_xobject_test.rs
@@ -1,0 +1,178 @@
+//! Issue #319 (real root cause for the good-energy invoice): text drawn
+//! inside a Form XObject (invoked with `Do`) was never extracted. The
+//! producer (RML2PDF/pluscode) embeds the page body as a Form XObject
+//! ("inclPDF"); only the page's direct content (a footer) was extracted,
+//! so the "charges in detail" body went missing.
+//!
+//! These tests build PDFs whose text lives inside a Form XObject (flat,
+//! nested, and translated via /Matrix) and assert it is extracted. Content
+//! is asserted exactly — no smoke tests.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Build a single-page PDF from raw object bodies (object 1 = catalog).
+/// `streams` maps an object index (1-based) to raw stream bytes that get a
+/// correct `/Length` and `stream`/`endstream` wrapper appended to the body.
+fn build_pdf(bodies: &[(&str, Option<&[u8]>)]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (i, (dict_body, stream)) in bodies.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+        match stream {
+            Some(data) => {
+                pdf.extend_from_slice(
+                    format!("<< {} /Length {} >>\nstream\n", dict_body, data.len()).as_bytes(),
+                );
+                pdf.extend_from_slice(data);
+                pdf.extend_from_slice(b"\nendstream");
+            }
+            None => pdf.extend_from_slice(format!("<< {dict_body} >>").as_bytes()),
+        }
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = bodies.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+fn extract(pdf: &[u8]) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn text_inside_form_xobject_is_extracted() {
+    // Page content: paint a Form XObject, then draw a direct footer.
+    let page_content = b"q /Fx Do Q BT /F1 12 Tf 72 60 Td (Direct footer) Tj ET";
+    // XObject content: the "body" text.
+    let xobj_content = b"BT /F1 12 Tf 72 500 Td (Inside the form xobject) Tj ET";
+
+    let pdf = build_pdf(&[
+        // 1 catalog
+        ("/Type /Catalog /Pages 2 0 R", None),
+        // 2 pages
+        ("/Type /Pages /Kids [3 0 R] /Count 1", None),
+        // 3 page
+        (
+            "/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> /Contents 4 0 R",
+            None,
+        ),
+        // 4 page content
+        ("", Some(page_content)),
+        // 5 font
+        (
+            "/Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding",
+            None,
+        ),
+        // 6 Form XObject
+        (
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            Some(xobj_content),
+        ),
+    ]);
+
+    let text = extract(&pdf);
+    assert!(
+        text.contains("Direct footer"),
+        "direct page content must extract: {text:?}"
+    );
+    assert!(
+        text.contains("Inside the form xobject"),
+        "text inside the Form XObject must be extracted: {text:?}"
+    );
+}
+
+#[test]
+fn nested_form_xobjects_are_extracted() {
+    // Page -> Fx (outer) -> Fy (inner). Inner text must surface.
+    let page_content = b"/Fx Do";
+    let outer = b"BT /F1 12 Tf 72 600 Td (Outer body) Tj ET /Fy Do";
+    let inner = b"BT /F1 12 Tf 72 400 Td (Inner nested body) Tj ET";
+
+    let pdf = build_pdf(&[
+        ("/Type /Catalog /Pages 2 0 R", None),
+        ("/Type /Pages /Kids [3 0 R] /Count 1", None),
+        (
+            "/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> /Contents 4 0 R",
+            None,
+        ),
+        ("", Some(page_content)),
+        (
+            "/Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding",
+            None,
+        ),
+        // 6 outer XObject references inner /Fy
+        (
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fy 7 0 R >> >>",
+            Some(outer),
+        ),
+        // 7 inner XObject
+        (
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            Some(inner),
+        ),
+    ]);
+
+    let text = extract(&pdf);
+    assert!(text.contains("Outer body"), "outer XObject text: {text:?}");
+    assert!(
+        text.contains("Inner nested body"),
+        "nested XObject text must be extracted: {text:?}"
+    );
+}
+
+#[test]
+fn form_xobject_matrix_offsets_position_without_losing_text() {
+    // The XObject is painted with a /Matrix translation. The text must still
+    // be extracted (position composes through the matrix; we assert content).
+    let page_content = b"q 1 0 0 1 100 200 cm /Fx Do Q";
+    let xobj_content = b"BT /F1 12 Tf 0 0 Td (Matrixed body) Tj ET";
+
+    let pdf = build_pdf(&[
+        ("/Type /Catalog /Pages 2 0 R", None),
+        ("/Type /Pages /Kids [3 0 R] /Count 1", None),
+        (
+            "/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> /Contents 4 0 R",
+            None,
+        ),
+        ("", Some(page_content)),
+        (
+            "/Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding",
+            None,
+        ),
+        (
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 0 0] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            Some(xobj_content),
+        ),
+    ]);
+
+    let text = extract(&pdf);
+    assert!(
+        text.contains("Matrixed body"),
+        "text in a matrixed XObject must be extracted: {text:?}"
+    );
+}


### PR DESCRIPTION
Minor release (additive public API, no breaking changes). Brings to `main` the three fixes merged to `develop` since 2.14.0.

## Included
- **#318** — `IncrementalFormFiller` (`oxidize_pdf::writer`): fill AcroForm fields on an existing/parsed PDF via an ISO 32000-1 §7.5.6 incremental update (base bytes preserved verbatim; partial xref; chained `/Prev`; regenerated `/ID`). Handles hierarchical names and widget-kid terminal fields. `PdfReader::trailer()` accessor.
- **#319** — content-stream best-effort recovery: a malformed operator/token no longer drops the whole page.
- **#319** — Form XObject text recursion: text embedded in `Do`-painted Form XObjects (RML2PDF "inclPDF" page bodies) is now extracted (`/Matrix`→CTM, scoped fonts, nested, depth-guarded).

## Validation
- Full 9051-PDF corpus before/after extraction sweep: **0 regressions, 0 status changes, 277 files recover text (+880k chars), 0 panics/timeouts**.
- Reporter's invoice (`good-energy`) extracts all previously-missing content, including exact charge lines.
- lib 6569/0, t1 22/0, t3 22/0, rag_realworld 5/5, clippy clean.

## SemVer
MINOR: new public API (`IncrementalFormFiller`, `PdfReader::trailer`) is additive; extraction changes are behavioural improvements, no signatures removed/changed.

## Release steps after merge
Tag `v2.15.0` on `main` and push → `release.yml` publishes to crates.io. Then back-merge `main` → `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)