### PR TITLE
feat(forms): synthesize /AP appearance streams in IncrementalFormFiller

### DIFF
--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -17,13 +17,18 @@
 //! 1. Parse the base PDF, resolve the `/AcroForm` field tree (handling
 //!    `/Kids` and hierarchical names via `/Parent`).
 //! 2. Clone the affected field dictionaries, set `/V`, and set
-//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2 — compliant
-//!    viewers regenerate the appearance stream; `/AP` generation is a
-//!    documented follow-up).
-//! 3. Emit ONLY the modified objects (each reusing its existing object id),
-//!    a PARTIAL incremental cross-reference section covering only the
-//!    changed ids, and a trailer chaining `/Prev` to the previous
-//!    `startxref`, reusing the base `/Root` and `/ID`.
+//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2).
+//! 3. Synthesize the visual appearance so non-compliant viewers and
+//!    flatten/print pipelines (which never regenerate from `/V`) still show
+//!    the value: text fields (`/FT /Tx`) get a freshly-built `/AP /N` Form
+//!    XObject; button fields (`/FT /Btn`) get `/AS` set to the selected
+//!    state, activating their pre-authored `/AP`. `NeedAppearances` stays
+//!    true — the two are complementary, not in conflict.
+//! 4. Emit the modified objects (each reusing its existing object id), the
+//!    newly-allocated appearance streams (ids from the base `/Size`), a
+//!    PARTIAL incremental cross-reference section covering only the changed
+//!    ids, and a trailer chaining `/Prev` to the previous `startxref`,
+//!    reusing the base `/Root` and `/ID`.
 //!
 //! The original bytes are emitted verbatim as the prefix of the output, so
 //! every untouched object, page, font and content stream is preserved
@@ -32,6 +37,7 @@
 use crate::error::{PdfError, Result};
 use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
 use crate::parser::PdfReader;
+use crate::text::TextEncoding;
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -238,8 +244,50 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
         }
     }
 
-    // Flag NeedAppearances so viewers regenerate the appearance stream.
+    // Keep NeedAppearances true: our synthesized /AP serves non-compliant
+    // viewers and flatten/print pipelines, while compliant viewers may still
+    // regenerate from /V. The two are not in conflict.
     acro_dict.insert("NeedAppearances".to_string(), PdfObject::Boolean(true));
+
+    // Synthesize /AP appearance streams. New stream objects take fresh ids
+    // starting at base_size (the next free object number); the field/widget
+    // dicts are mutated to reference them. The AcroForm-level /DA is the
+    // fallback font selector when a field carries none.
+    let acro_da = da_of(&acro_dict);
+    let widgets_by_parent = collect_widgets_by_parent(&mut reader);
+    let mut new_streams: Vec<(u32, Vec<u8>, [f64; 4], Vec<u8>)> = Vec::new();
+    let mut extra_widgets: Vec<(u32, u16, PdfDictionary)> = Vec::new();
+    let mut next_id = base_size;
+    for (num, gen, dict) in modified.iter_mut() {
+        let ft = dict
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.clone());
+        match ft.as_deref() {
+            Some("Tx") => {
+                synthesize_text_field_ap(
+                    (*num, *gen),
+                    dict,
+                    &acro_da,
+                    &mut reader,
+                    &widgets_by_parent,
+                    &mut next_id,
+                    &mut new_streams,
+                    &mut extra_widgets,
+                )?;
+            }
+            Some("Btn") => {
+                // Buttons (checkbox/radio) carry pre-authored /AP states; the
+                // visible state is selected by /AS, not a synthesized stream.
+                if let Some(PdfObject::String(v)) = dict.get("V").cloned() {
+                    let state = String::from_utf8_lossy(v.as_bytes()).into_owned();
+                    dict.insert("AS".to_string(), PdfObject::Name(PdfName(state)));
+                }
+            }
+            _ => {}
+        }
+    }
+    let total_size = next_id;
 
     // ----- assemble appended bytes -----
     let mut out = Vec::with_capacity(base_bytes.len() + 1024);
@@ -253,10 +301,24 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
         changed.push((*num, *gen, offset));
     }
 
+    // Widget annotations rewritten to carry /AP (separate-widget /Kids layout).
+    for (num, gen, dict) in &extra_widgets {
+        let offset = out.len() as u64;
+        write_indirect_object(&mut out, *num, *gen, dict)?;
+        changed.push((*num, *gen, offset));
+    }
+
     // AcroForm object.
     let acro_offset = out.len() as u64;
     write_indirect_object(&mut out, acro_ref.0, acro_ref.1, &acro_dict)?;
     changed.push((acro_ref.0, acro_ref.1, acro_offset));
+
+    // Appearance-stream Form XObjects (new objects).
+    for (id, content, bbox, resources) in &new_streams {
+        let offset = out.len() as u64;
+        write_indirect_stream_object(&mut out, *id, 0, content, *bbox, resources)?;
+        changed.push((*id, 0, offset));
+    }
 
     let xref_pos = out.len() as u64;
     // Keep the permanent first /ID element; regenerate the second so the
@@ -270,7 +332,7 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     out.extend_from_slice(&write_incremental_trailer(
         base_startxref,
         base_root,
-        base_size,
+        total_size,
         xref_pos,
         id_pair,
     ));
@@ -318,6 +380,369 @@ fn first_id_bytes(id: Option<&PdfObject>) -> Option<Vec<u8>> {
 // ---------------------------------------------------------------------------
 // Low-level serialization (Vec<u8>, no PdfWriter state)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Appearance-stream (/AP /N) synthesis
+//
+// The filler operates on parser-side `PdfObject`s with NO `Document` / font
+// registry, so it CANNOT drive the writer-side `forms::appearance` generator
+// (which needs a resolved `Font` handle for the Type0/CID path). The two
+// genuinely shareable, correctness-critical pieces are reused directly:
+// WinAnsi strict encoding (`TextEncoding::WinAnsiEncoding`) and PDF literal
+// escaping (`write_literal_string`). The remaining BT/Tf/Td/Tj/ET scaffold is
+// PDF wire syntax, not algorithm — replicating it here is simpler and lower
+// risk than bridging the writer object model. Scope is therefore built-in
+// non-symbolic Type1 fonts (the dominant `/DA` case: Helv/Cour/Times).
+// ---------------------------------------------------------------------------
+
+/// Map a `/DA` font resource name to a Standard-14 `/BaseFont`. AcroForm `/DR`
+/// commonly aliases the base-14 fonts (Acrobat's `Helv`, `HeBo`, `Cour`,
+/// `TiRo`, …). Unknown names pass through verbatim — they may already be a
+/// real base font (e.g. `Helvetica-Bold`).
+fn da_font_to_base_font(name: &str) -> &str {
+    match name {
+        "Helv" => "Helvetica",
+        "HeBO" | "HeBo" => "Helvetica-Bold",
+        "HeOb" => "Helvetica-Oblique",
+        "Cour" => "Courier",
+        "CoBO" | "CoBo" => "Courier-Bold",
+        "TiRo" => "Times-Roman",
+        "TiBo" => "Times-Bold",
+        "TiIt" => "Times-Italic",
+        "Symb" => "Symbol",
+        "ZaDb" => "ZapfDingbats",
+        other => other,
+    }
+}
+
+/// Read a 4-number `/Rect` ([llx lly urx ury]) as `[f64; 4]`, accepting
+/// integer or real components.
+fn rect_of(dict: &PdfDictionary) -> Option<[f64; 4]> {
+    let arr = dict.get("Rect").and_then(|o| o.as_array())?;
+    if arr.0.len() != 4 {
+        return None;
+    }
+    let mut r = [0.0f64; 4];
+    for (i, slot) in r.iter_mut().enumerate() {
+        *slot = arr.0[i].as_real()?;
+    }
+    Some(r)
+}
+
+/// Extract a `/DA` string value from a dictionary entry, if present and a
+/// string object.
+fn da_of(dict: &PdfDictionary) -> Option<String> {
+    dict.get("DA")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+}
+
+/// Build the `/AP /N` content stream for a single-line text widget: a
+/// `q … BT /Font size Tf x y Td (value) Tj ET … Q` sequence in the widget's
+/// local (BBox) coordinate space. Returns the content bytes, the BBox and the
+/// serialized `/Resources` dict. Fails (rather than emitting `?`) when the
+/// value carries a codepoint WinAnsiEncoding cannot represent — matching the
+/// writer-side generator's strict contract.
+fn build_text_ap(
+    value: &str,
+    da_font_name: &str,
+    da_font_size: f64,
+    rect: [f64; 4],
+) -> Result<(Vec<u8>, [f64; 4], Vec<u8>)> {
+    let width = (rect[2] - rect[0]).abs();
+    let height = (rect[3] - rect[1]).abs();
+    // Size 0 is "auto"; with no glyph metrics here, pick a sane concrete size.
+    let font_size = if da_font_size > 0.0 {
+        da_font_size
+    } else {
+        12.0
+    };
+
+    let encoded = TextEncoding::WinAnsiEncoding
+        .encode_strict(value)
+        .map_err(|ch| {
+            PdfError::EncodingError(format!(
+                "form value contains character {:?} (U+{:04X}) not representable in \
+                 WinAnsiEncoding used by built-in font {:?}; an embedded Type0 font \
+                 would be required (not yet supported on the incremental fill path)",
+                ch, ch as u32, da_font_name,
+            ))
+        })?;
+
+    // Vertical centring identical to forms::appearance::TextFieldAppearance.
+    let pad = 2.0;
+    let text_y = (height - font_size) / 2.0 + font_size * 0.3;
+
+    let mut content = Vec::new();
+    content.extend_from_slice(b"q\n");
+    content.extend_from_slice(b"BT\n");
+    content
+        .extend_from_slice(format!("/{da_font_name} {} Tf\n", format_real(font_size)).as_bytes());
+    content.extend_from_slice(b"0 g\n");
+    content
+        .extend_from_slice(format!("{} {} Td\n", format_real(pad), format_real(text_y)).as_bytes());
+    write_literal_string(&mut content, &encoded);
+    content.extend_from_slice(b" Tj\n");
+    content.extend_from_slice(b"ET\n");
+    content.extend_from_slice(b"Q");
+
+    // /Resources << /Font << /{da_font_name} << /Type /Font /Subtype /Type1
+    //                        /BaseFont /{base} >> >> >>
+    let mut font_entry = PdfDictionary::new();
+    font_entry.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Font".to_string())),
+    );
+    font_entry.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("Type1".to_string())),
+    );
+    font_entry.insert(
+        "BaseFont".to_string(),
+        PdfObject::Name(PdfName(da_font_to_base_font(da_font_name).to_string())),
+    );
+    let mut font_dict = PdfDictionary::new();
+    font_dict.insert(da_font_name.to_string(), PdfObject::Dictionary(font_entry));
+    let mut resources = PdfDictionary::new();
+    resources.insert("Font".to_string(), PdfObject::Dictionary(font_dict));
+    let mut resources_bytes = Vec::new();
+    write_dict(&mut resources_bytes, &resources)?;
+
+    Ok((content, [0.0, 0.0, width, height], resources_bytes))
+}
+
+/// Resolve the effective `(font_name, size)` for a widget from its own `/DA`,
+/// then the field's `/DA`, then the AcroForm `/DA`, defaulting to Helvetica 12.
+fn resolve_da(
+    widget_da: Option<&str>,
+    field_da: Option<&str>,
+    acro_da: Option<&str>,
+) -> (String, f64) {
+    widget_da
+        .and_then(parse_da_string)
+        .or_else(|| field_da.and_then(parse_da_string))
+        .or_else(|| acro_da.and_then(parse_da_string))
+        .unwrap_or_else(|| ("Helv".to_string(), 12.0))
+}
+
+/// Map each field object id to the widget annotation ids that reference it via
+/// `/Parent`, by walking the page tree and scanning every page's `/Annots`.
+/// This recovers the widget(s) for the common layout where a single-widget
+/// field omits `/Kids` and is linked only by the widget's `/Parent`
+/// back-reference (ISO 32000-1 §12.7.3.1 NOTE).
+fn collect_widgets_by_parent(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> HashMap<(u32, u16), Vec<(u32, u16)>> {
+    let mut map: HashMap<(u32, u16), Vec<(u32, u16)>> = HashMap::new();
+    let root = match reader.pages() {
+        Ok(p) => p.clone(),
+        Err(_) => return map,
+    };
+    // Iterative page-tree walk with a visited set + bound (defensive against
+    // cyclic or pathological /Kids).
+    let mut stack: Vec<(u32, u16)> = match root.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    let mut visited: std::collections::HashSet<(u32, u16)> = std::collections::HashSet::new();
+    let mut budget = 100_000u32;
+    while let Some(node_ref) = stack.pop() {
+        if budget == 0 || !visited.insert(node_ref) {
+            continue;
+        }
+        budget -= 1;
+        let node = match reader
+            .get_object(node_ref.0, node_ref.1)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+        {
+            Some(d) => d,
+            None => continue,
+        };
+        // Intermediate Pages node: descend.
+        if let Some(PdfObject::Array(kids)) = node.get("Kids") {
+            let is_pages = node
+                .get("Type")
+                .and_then(|o| o.as_name())
+                .map(|n| n.0 == "Pages")
+                .unwrap_or(false);
+            if is_pages || node.get("Count").is_some() {
+                for k in &kids.0 {
+                    if let Some(r) = k.as_reference() {
+                        stack.push(r);
+                    }
+                }
+                continue;
+            }
+        }
+        // Leaf page: scan /Annots for widgets carrying a /Parent reference.
+        if let Some(PdfObject::Array(annots)) = node.get("Annots") {
+            let annot_refs: Vec<(u32, u16)> =
+                annots.0.iter().filter_map(|o| o.as_reference()).collect();
+            for (an, ag) in annot_refs {
+                if let Some(annot) = reader
+                    .get_object(an, ag)
+                    .ok()
+                    .and_then(|o| o.as_dict().cloned())
+                {
+                    if let Some(parent) = annot.get("Parent").and_then(|o| o.as_reference()) {
+                        map.entry(parent).or_default().push((an, ag));
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
+/// Synthesize the `/AP /N` stream(s) for one text field, mutating the field
+/// (merged layout) or its widget annotations (separate-widget layouts) to
+/// reference a freshly-allocated appearance object. New stream descriptors go
+/// to `new_streams`; rewritten widgets go to `extra_widgets`.
+///
+/// Three layouts (ISO 32000-1 §12.7.3.1 / §12.5.6.19):
+/// - field dict carries `/Rect` → merged field+widget; `/AP` on the field.
+/// - field dict has `/Kids` widget annotations → `/AP` on each kid.
+/// - field has neither, widgets linked only by `/Parent` → resolved via
+///   `widgets_by_parent`.
+fn synthesize_text_field_ap(
+    field_id: (u32, u16),
+    field_dict: &mut PdfDictionary,
+    acro_da: &Option<String>,
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    widgets_by_parent: &HashMap<(u32, u16), Vec<(u32, u16)>>,
+    next_id: &mut u32,
+    new_streams: &mut Vec<(u32, Vec<u8>, [f64; 4], Vec<u8>)>,
+    extra_widgets: &mut Vec<(u32, u16, PdfDictionary)>,
+) -> Result<()> {
+    let value = match field_dict.get("V") {
+        Some(PdfObject::String(s)) => String::from_utf8_lossy(s.as_bytes()).into_owned(),
+        _ => return Ok(()),
+    };
+    let field_da = da_of(field_dict);
+
+    // Merged field+widget: the field dict itself has the /Rect.
+    if let Some(rect) = rect_of(field_dict) {
+        let (font_name, font_size) =
+            resolve_da(field_da.as_deref(), field_da.as_deref(), acro_da.as_deref());
+        let (content, bbox, resources) = build_text_ap(&value, &font_name, font_size, rect)?;
+        let ap_id = *next_id;
+        *next_id += 1;
+        new_streams.push((ap_id, content, bbox, resources));
+        let mut ap = PdfDictionary::new();
+        ap.insert("N".to_string(), PdfObject::Reference(ap_id, 0));
+        field_dict.insert("AP".to_string(), PdfObject::Dictionary(ap));
+        return Ok(());
+    }
+
+    // Separate-widget layouts: widget refs from /Kids, else from the
+    // /Parent reverse map.
+    let mut widget_refs: Vec<(u32, u16)> = match field_dict.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    if widget_refs.is_empty() {
+        if let Some(refs) = widgets_by_parent.get(&field_id) {
+            widget_refs = refs.clone();
+        }
+    }
+    for (kn, kg) in widget_refs {
+        let mut kid = match reader
+            .get_object(kn, kg)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+        {
+            Some(d) => d,
+            None => continue,
+        };
+        let is_widget = kid
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0 == "Widget")
+            .unwrap_or(false);
+        let rect = match rect_of(&kid) {
+            Some(r) if is_widget => r,
+            _ => continue,
+        };
+        let widget_da = da_of(&kid);
+        let (font_name, font_size) = resolve_da(
+            widget_da.as_deref(),
+            field_da.as_deref(),
+            acro_da.as_deref(),
+        );
+        let (content, bbox, resources) = build_text_ap(&value, &font_name, font_size, rect)?;
+        let ap_id = *next_id;
+        *next_id += 1;
+        new_streams.push((ap_id, content, bbox, resources));
+        let mut ap = PdfDictionary::new();
+        ap.insert("N".to_string(), PdfObject::Reference(ap_id, 0));
+        kid.insert("AP".to_string(), PdfObject::Dictionary(ap));
+        extra_widgets.push((kn, kg, kid));
+    }
+    Ok(())
+}
+
+/// Parse a `/DA` (default appearance) string, returning the selected font
+/// resource name (without the leading `/`) and size in points.
+///
+/// A `/DA` value is a content-stream fragment whose font selector is
+/// `/{name} {size} Tf` (ISO 32000-1 §12.7.3.3), optionally preceded by colour
+/// operators (`g`, `rg`, `k`). The scanner finds the `Tf` operator and takes
+/// the two tokens immediately before it. A size of `0` is the auto-size
+/// sentinel (the viewer chooses) and is preserved verbatim. Returns `None`
+/// when no well-formed font selector is present.
+fn parse_da_string(da: &str) -> Option<(String, f64)> {
+    let tokens: Vec<&str> = da.split_whitespace().collect();
+    let tf_idx = tokens.iter().position(|t| *t == "Tf")?;
+    if tf_idx < 2 {
+        return None;
+    }
+    let name_tok = tokens[tf_idx - 2];
+    let size_tok = tokens[tf_idx - 1];
+    let name = name_tok.strip_prefix('/')?;
+    if name.is_empty() {
+        return None;
+    }
+    let size: f64 = size_tok.parse().ok()?;
+    Some((name.to_string(), size))
+}
+
+/// Write a Form XObject appearance-stream object
+/// `{num} {gen} obj\n<< /Type /XObject /Subtype /Form /BBox [...] /Length L
+/// /Resources ... >>\nstream\n{content}\nendstream\nendobj\n`.
+///
+/// The content is emitted UNCOMPRESSED, so `/Length` is exactly the raw byte
+/// count — no filter, no two-pass buffering. `resources_snippet` is a
+/// pre-serialized `<< ... >>` dictionary (built by the caller via the
+/// module's `write_dict`) inlined as the `/Resources` value.
+fn write_indirect_stream_object(
+    out: &mut Vec<u8>,
+    num: u32,
+    gen: u16,
+    content: &[u8],
+    bbox: [f64; 4],
+    resources_snippet: &[u8],
+) -> Result<()> {
+    out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
+    out.extend_from_slice(b"<< /Type /XObject /Subtype /Form /BBox [");
+    out.extend_from_slice(
+        format!(
+            "{} {} {} {}",
+            format_real(bbox[0]),
+            format_real(bbox[1]),
+            format_real(bbox[2]),
+            format_real(bbox[3])
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(b"] /Resources ");
+    out.extend_from_slice(resources_snippet);
+    out.extend_from_slice(format!(" /Length {} >>\n", content.len()).as_bytes());
+    out.extend_from_slice(b"stream\n");
+    out.extend_from_slice(content);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    Ok(())
+}
 
 /// Write `{num} {gen} obj\n<dict>\nendobj\n` into `out`.
 fn write_indirect_object(
@@ -588,5 +1013,72 @@ mod tests {
         let mut out = Vec::new();
         write_literal_string(&mut out, b"a(b)c\\d");
         assert_eq!(out, b"(a\\(b\\)c\\\\d)");
+    }
+
+    // ----- Cycle 1: /DA string parsing -----
+
+    #[test]
+    fn parse_da_string_extracts_font_and_size() {
+        assert_eq!(
+            parse_da_string("/Helv 12 Tf 0 g"),
+            Some(("Helv".to_string(), 12.0))
+        );
+        assert_eq!(
+            parse_da_string("/Helvetica-Bold 9.5 Tf 0 g"),
+            Some(("Helvetica-Bold".to_string(), 9.5))
+        );
+        // Color operators before Tf must not confuse the scanner.
+        assert_eq!(
+            parse_da_string("0 0 1 rg /Cour 8 Tf"),
+            Some(("Cour".to_string(), 8.0))
+        );
+        // Size 0 is the auto-size sentinel (viewer chooses); preserved as 0.0.
+        assert_eq!(parse_da_string("/F1 0 Tf"), Some(("F1".to_string(), 0.0)));
+        assert_eq!(parse_da_string(""), None);
+        assert_eq!(parse_da_string("garbage"), None);
+        // A Tf with no preceding name/size is not a valid font selector.
+        assert_eq!(parse_da_string("Tf"), None);
+    }
+
+    // ----- Cycle 2: appearance stream object serialization -----
+
+    #[test]
+    fn write_indirect_stream_object_produces_valid_form_xobject() {
+        let content = b"q BT /Helv 12 Tf 2 5 Td (Hi) Tj ET Q";
+        let mut resources = Vec::new();
+        resources.extend_from_slice(b"<< /Font << /Helv << /Type /Font >> >> >>");
+        let mut out = Vec::new();
+        write_indirect_stream_object(&mut out, 9, 0, content, [0.0, 0.0, 200.0, 20.0], &resources)
+            .unwrap();
+        let s = String::from_utf8(out.clone()).unwrap();
+
+        assert!(s.starts_with("9 0 obj\n<<"), "object header: {s}");
+        assert!(s.contains("/Type /XObject"), "must be XObject: {s}");
+        assert!(s.contains("/Subtype /Form"), "must be Form: {s}");
+        assert!(s.contains("/BBox [0 0 200 20]"), "bbox: {s}");
+        assert!(
+            s.contains(&format!("/Length {}", content.len())),
+            "length must equal raw content byte count: {s}"
+        );
+        assert!(s.contains("/Resources << /Font"), "resources inlined: {s}");
+        // Exact stream framing around the verbatim content.
+        let marker = format!(
+            "stream\n{}\nendstream\nendobj\n",
+            String::from_utf8_lossy(content)
+        );
+        assert!(s.ends_with(&marker), "stream framing: {s}");
+
+        // Deterministic.
+        let mut out2 = Vec::new();
+        write_indirect_stream_object(
+            &mut out2,
+            9,
+            0,
+            content,
+            [0.0, 0.0, 200.0, 20.0],
+            &resources,
+        )
+        .unwrap();
+        assert_eq!(out, out2, "serialization must be deterministic");
     }
 }

--- a/oxidize-pdf-core/tests/incremental_form_fill_ap_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_ap_test.rs
@@ -1,0 +1,471 @@
+//! Integration tests for `/AP` appearance-stream regeneration in
+//! `IncrementalFormFiller` (follow-up to issue #318).
+//!
+//! `fill_*` sets `/V` and flags `NeedAppearances true`. Non-compliant viewers
+//! and flatten/print pipelines never regenerate from `/V`, so they need a real
+//! `/AP /N` Form XObject. These tests verify that the filler synthesizes that
+//! stream for text fields and sets `/AS` for button fields — asserting decoded
+//! content, not status codes (no smoke tests).
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+mod common;
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Single-page PDF with merged field+widget text fields (the FormManager
+/// layout: each field dict carries `/Subtype /Widget`, `/Rect` and `/DA`).
+fn build_base_pdf_with_fields(names: &[&str]) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let mut y = 700.0;
+    for name in names {
+        let rect = Rectangle::new(Point::new(100.0, y), Point::new(300.0, y + 20.0));
+        let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+        let field = TextField::new(*name);
+        let field_ref = fm
+            .add_text_field(field, widget.clone(), None)
+            .expect("add_text_field");
+        page.add_form_widget_with_ref(widget, field_ref)
+            .expect("add_form_widget_with_ref");
+        y -= 40.0;
+    }
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    doc.to_bytes().expect("serialize base document")
+}
+
+// ---------------------------------------------------------------------------
+// /AP/N resolution + content inspection
+// ---------------------------------------------------------------------------
+
+/// Resolve the `/AP/N` stream bytes (decoded) of a specific object id.
+fn ap_n_bytes_of_object(pdf: &[u8], num: u32, gen: u16) -> Option<Vec<u8>> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    let ap = dict.get("AP").and_then(|o| o.as_dict())?.clone();
+    let normal = ap.get("N")?.clone();
+    match normal {
+        PdfObject::Reference(n, g) => {
+            let xobj = reader.get_object(n, g).ok()?.clone();
+            let stream = xobj.as_stream()?;
+            stream.decode(reader.options()).ok()
+        }
+        PdfObject::Stream(ref s) => s.decode(reader.options()).ok(),
+        _ => None,
+    }
+}
+
+/// The `/AP/N` stream dict of a specific object id (for /Type, /BBox checks).
+fn ap_n_stream_dict(
+    pdf: &[u8],
+    num: u32,
+    gen: u16,
+) -> Option<oxidize_pdf::parser::objects::PdfDictionary> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    let ap = dict.get("AP").and_then(|o| o.as_dict())?.clone();
+    match ap.get("N")?.clone() {
+        PdfObject::Reference(n, g) => {
+            let xobj = reader.get_object(n, g).ok()?.clone();
+            xobj.as_stream().map(|s| s.dict.clone())
+        }
+        PdfObject::Stream(ref s) => Some(s.dict.clone()),
+        _ => None,
+    }
+}
+
+/// Object id of the first widget annotation on the first page. Appearance
+/// streams are read by viewers from the annotation, so this is the
+/// layout-agnostic place to look (merged field+widget OR separate widget).
+fn first_widget_annot_id(pdf: &[u8]) -> Option<(u32, u16)> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let pages = reader.pages().ok()?.clone();
+    let kids = pages.get("Kids").and_then(|o| o.as_array())?;
+    let (pn, pg) = kids.0[0].as_reference()?;
+    let page = reader.get_object(pn, pg).ok()?.as_dict()?.clone();
+    let annots = page.get("Annots").and_then(|o| o.as_array())?;
+    annots.0[0].as_reference()
+}
+
+/// Object id of a terminal field by fully-qualified name.
+#[allow(dead_code)]
+fn field_object_id(pdf: &[u8], name: &str) -> Option<(u32, u16)> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog.get("AcroForm")?.as_reference()?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let fields: Vec<(u32, u16)> = match acro.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => return None,
+    };
+    for r in fields {
+        if let Some(found) = walk_for_id(&mut reader, r, "", name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn walk_for_id(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    prefix: &str,
+    target: &str,
+) -> Option<(u32, u16)> {
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+    let full = match (&partial, prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{prefix}.{t}"),
+        (None, _) => prefix.to_string(),
+    };
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    let kids_are_subfields = kids.iter().any(|(n, g)| {
+        reader
+            .get_object(*n, *g)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+            .map(|d| d.contains_key("T"))
+            .unwrap_or(false)
+    });
+    if kids.is_empty() || !kids_are_subfields {
+        if partial.is_some() && full == target {
+            return Some(node_ref);
+        }
+        None
+    } else {
+        for kid in kids {
+            if let Some(found) = walk_for_id(reader, kid, &full, target) {
+                return Some(found);
+            }
+        }
+        None
+    }
+}
+
+fn needappearances(pdf: &[u8]) -> Option<bool> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog.get("AcroForm")?.as_reference()?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    match acro.get("NeedAppearances") {
+        Some(PdfObject::Boolean(b)) => Some(*b),
+        _ => None,
+    }
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 3 — text field, merged field+widget layout
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_text_field_ap_n_stream_contains_value() {
+    let base = build_base_pdf_with_fields(&["name"]);
+    let output = IncrementalFormFiller::new(&base)
+        .fill("name", "Alice")
+        .expect("fill");
+
+    // Base bytes preserved verbatim.
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (num, gen) = first_widget_annot_id(&output).expect("resolve widget annot id");
+
+    let content = ap_n_bytes_of_object(&output, num, gen)
+        .expect("widget must carry an /AP/N stream after fill");
+
+    assert!(
+        contains(&content, b"BT"),
+        "content begins text: {content:?}"
+    );
+    assert!(contains(&content, b"Tf"), "content selects a font");
+    assert!(contains(&content, b"Td"), "content positions text");
+    assert!(contains(&content, b"Alice"), "value text present in Tj");
+    assert!(contains(&content, b"ET"), "content ends text");
+
+    let sdict = ap_n_stream_dict(&output, num, gen).expect("stream dict");
+    assert_eq!(
+        sdict
+            .get("Type")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("XObject"),
+        "AP/N must be an XObject"
+    );
+    assert_eq!(
+        sdict
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("Form"),
+        "AP/N must be a Form XObject"
+    );
+    assert!(sdict.contains_key("BBox"), "AP/N must carry /BBox");
+
+    assert_eq!(
+        needappearances(&output),
+        Some(true),
+        "NeedAppearances stays true (additive, viewers may still regenerate)"
+    );
+
+    // Full round-trip parse succeeds.
+    assert!(
+        PdfReader::new(Cursor::new(&output)).is_ok(),
+        "output must re-parse"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 4 — button field: set /AS, preserve pre-authored /AP
+// ---------------------------------------------------------------------------
+
+/// A checkbox (merged field+widget) carrying pre-authored `/AP` on/off states.
+fn build_checkbox_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] >>".to_vec(),
+        b"<< /FT /Btn /T (agree) /Type /Annot /Subtype /Widget /Rect [100 700 120 720] \
+           /AP << /N << /Yes 6 0 R /Off 7 0 R >> >> /AS /Off >>"
+            .to_vec(),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 20 20]",
+            b"q 1 0 0 RG Q",
+        ),
+        stream_obj("/Type /XObject /Subtype /Form /BBox [0 0 20 20]", b"q Q"),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_button_field_sets_as_to_on_state() {
+    let base = build_checkbox_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("agree", "Yes")
+        .expect("fill checkbox");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse output");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+
+    assert_eq!(
+        field
+            .get("AS")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("Yes"),
+        "/AS must select the on-state so the pre-authored /AP/N/Yes shows"
+    );
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str())
+            .or_else(|| field.get("V").and_then(|o| o.as_string()).map(|_| "Yes")),
+        Some("Yes"),
+        "/V must record the selected state"
+    );
+    // Pre-authored /AP preserved: /N still maps the two appearance states.
+    let ap = field
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("AP preserved");
+    let n = ap
+        .get("N")
+        .and_then(|o| o.as_dict())
+        .expect("AP/N dict preserved");
+    assert!(
+        n.contains_key("Yes") && n.contains_key("Off"),
+        "states preserved"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5 — text field, separate widget via /Kids
+// ---------------------------------------------------------------------------
+
+fn build_kids_text_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [6 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] /DA (/Helv 12 Tf 0 g) >>".to_vec(),
+        b"<< /FT /Tx /T (city) /DA (/Helv 12 Tf 0 g) /Kids [6 0 R] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [100 700 300 720] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_text_field_kids_layout_ap_on_widget() {
+    let base = build_kids_text_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("city", "Berlin")
+        .expect("fill kids-layout text field");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_string())
+            .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()),
+        Some("Berlin".to_string()),
+        "field carries /V"
+    );
+    assert!(
+        !field.contains_key("AP"),
+        "field with no /Rect must not bear /AP"
+    );
+
+    // The widget (obj 6) carries the synthesized /AP/N.
+    let content =
+        ap_n_bytes_of_object(&output, 6, 0).expect("widget kid must carry /AP/N after fill");
+    assert!(contains(&content, b"BT"), "text begins");
+    assert!(contains(&content, b"Berlin"), "value present");
+    assert!(contains(&content, b"ET"), "text ends");
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 6 — multi-field, mixed layouts in one incremental update
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_many_ap_merged_and_kids() {
+    let base = build_base_pdf_with_fields(&["alpha", "beta"]);
+    let output = IncrementalFormFiller::new(&base)
+        .fill_many(&[("alpha", "Foo"), ("beta", "Bar")])
+        .expect("fill_many");
+
+    // Both widgets (page annotations) carry an /AP/N with their own value.
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let pages = reader.pages().expect("pages").clone();
+    let (pn, pg) = pages.get("Kids").and_then(|o| o.as_array()).unwrap().0[0]
+        .as_reference()
+        .unwrap();
+    let page = reader
+        .get_object(pn, pg)
+        .expect("page")
+        .as_dict()
+        .unwrap()
+        .clone();
+    let annots: Vec<(u32, u16)> = page
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .unwrap()
+        .0
+        .iter()
+        .filter_map(|o| o.as_reference())
+        .collect();
+    assert_eq!(annots.len(), 2, "two widgets");
+
+    let mut seen = Vec::new();
+    for (n, g) in annots {
+        let c = ap_n_bytes_of_object(&output, n, g).expect("each widget has /AP/N");
+        if contains(&c, b"Foo") {
+            seen.push("Foo");
+        }
+        if contains(&c, b"Bar") {
+            seen.push("Bar");
+        }
+    }
+    seen.sort_unstable();
+    assert_eq!(
+        seen,
+        vec!["Bar", "Foo"],
+        "both values rendered in distinct APs"
+    );
+
+    assert_eq!(
+        needappearances(&output),
+        Some(true),
+        "NeedAppearances retained"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 7 — unknown /FT: set /V, no /AP, no error
+// ---------------------------------------------------------------------------
+
+fn build_sig_field_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] >>".to_vec(),
+        b"<< /FT /Sig /T (sig) /Type /Annot /Subtype /Widget /Rect [100 700 300 720] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_unknown_ft_sets_v_without_ap() {
+    let base = build_sig_field_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("sig", "ignored")
+        .expect("unknown FT must not error");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_string())
+            .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()),
+        Some("ignored".to_string()),
+        "/V set even for unhandled field types"
+    );
+    assert!(
+        !field.contains_key("AP"),
+        "no /AP synthesized for unknown FT"
+    );
+}

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -156,6 +156,37 @@ fn base_startxref(bytes: &[u8]) -> u64 {
     reader.trailer().xref_offset
 }
 
+/// Base trailer `/Size` (= the first object id a fresh appearance stream takes).
+fn base_size(bytes: &[u8]) -> u32 {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    reader.trailer().size().expect("base /Size") as u32
+}
+
+/// Object ids of the first page's widget annotations (the bearers of /AP after
+/// a fill in the separate-widget layouts).
+fn page_widget_ids(bytes: &[u8]) -> Vec<u32> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let pages = reader.pages().expect("pages").clone();
+    let (pn, pg) = match pages.get("Kids").and_then(|o| o.as_array()) {
+        Some(arr) => arr.0[0].as_reference().expect("page ref"),
+        None => return Vec::new(),
+    };
+    let page = reader
+        .get_object(pn, pg)
+        .expect("page")
+        .as_dict()
+        .expect("page dict")
+        .clone();
+    match page.get("Annots") {
+        Some(PdfObject::Array(arr)) => arr
+            .0
+            .iter()
+            .filter_map(|o| o.as_reference().map(|(n, _)| n))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Read `/Prev` from an appended incremental trailer (text form).
 fn appended_prev(appended: &[u8]) -> u64 {
     let s = String::from_utf8_lossy(appended);
@@ -220,15 +251,20 @@ fn fill_single_field_incremental_roundtrip() {
         "/AcroForm/NeedAppearances must be true"
     );
 
-    // 4) Appended xref lists exactly the changed objects: field + AcroForm.
+    // 4) Appended xref lists the changed objects: field + its widget + AcroForm
+    //    + one synthesized /AP appearance stream (the new follow-up behaviour).
     let appended = &output[base.len()..];
     let mut ids = appended_xref_object_numbers(appended);
     ids.sort_unstable();
-    let mut expected = vec![field_id_after.0, acro_id.0];
+    let widget_ids = page_widget_ids(&base);
+    let ap_stream_id = base_size(&base); // single text field -> single new stream
+    let mut expected = vec![field_id_after.0, acro_id.0, ap_stream_id];
+    expected.extend(widget_ids);
     expected.sort_unstable();
+    expected.dedup();
     assert_eq!(
         ids, expected,
-        "appended xref must list exactly the field and AcroForm objects"
+        "appended xref must list the field, its widget, the AcroForm and the new /AP stream"
     );
 
     // 5) /Prev chains to the base startxref.
@@ -264,9 +300,13 @@ fn fill_many_fields_incremental_roundtrip() {
         Some(true)
     );
 
-    // Appended xref: two field objects + one AcroForm object = 3 distinct ids.
+    // Appended xref: 2 fields + 2 widgets + AcroForm + 2 /AP streams = 7 ids.
     let ids = appended_xref_object_numbers(&output[base.len()..]);
-    assert_eq!(ids.len(), 3, "two fields + AcroForm, got {ids:?}");
+    assert_eq!(
+        ids.len(),
+        7,
+        "two fields + two widgets + AcroForm + two /AP streams, got {ids:?}"
+    );
 }
 
 #[test]
@@ -422,8 +462,18 @@ fn fill_field_with_widget_kids() {
         Some("user@example.com"),
         "/V must be set on the terminal field object (5), not lost in widget recursion"
     );
-    // Only the field (5) + AcroForm (4) change — the widget (6) is untouched.
+    // Field (5) gets /V, AcroForm (4) gets NeedAppearances, the widget (6) is
+    // rewritten with /AP, and one new appearance stream (7) is appended.
     let mut ids = appended_xref_object_numbers(&output[base.len()..]);
     ids.sort_unstable();
-    assert_eq!(ids, vec![4, 5]);
+    assert_eq!(ids, vec![4, 5, 6, 7]);
+    // The widget (6) now carries a synthesized /AP/N showing the value.
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let widget = reader
+        .get_object(6, 0)
+        .expect("widget 6")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert!(widget.contains_key("AP"), "widget gains /AP");
 }


### PR DESCRIPTION
## Summary

Addresses the documented #318 follow-up. `IncrementalFormFiller::fill_*` set `/V` and `/AcroForm/NeedAppearances true` but did **not** synthesize the visual appearance (`/AP /N`). Non-compliant viewers and flatten/print pipelines never regenerate from `/V`, so filled fields rendered **blank** for them. This adds real appearance synthesis.

## What it does

- **Text fields (`/FT /Tx`)**: builds a real `/AP /N` Form XObject content stream (`q BT /Font size Tf 0 g x y Td (value) Tj ET Q`) from the widget `/Rect` and resolved `/DA` (widget → field → AcroForm, default `Helv 12`). Reuses the correctness-critical WinAnsi strict encoding so output matches the writer-side generator.
- **Button fields (`/FT /Btn`)**: sets `/AS` to the selected state, activating the **pre-authored** `/AP` on/off appearances — no glyph synthesis.
- **Three widget layouts** handled: merged field+widget (`/Rect` on field), explicit `/Kids` widget annotations, and single-widget fields linked only by `/Parent` (recovered by scanning page `/Annots`).
- New uncompressed stream objects take fresh ids from the base `/Size`; the partial xref and trailer `/Size` are extended. `NeedAppearances` stays **true** (additive; compliant viewers may still regenerate — the two are complementary).

## Scope / honest limits

The parser-side filler has no `Document`/font registry, so it cannot drive the writer-side Type0/CID path. Scope is **built-in non-symbolic Type1 fonts** (the dominant `/DA` case: Helv/Cour/Times). Values with codepoints WinAnsi can't represent fail loudly rather than emitting `?`.

## Tests

- 5 integration cycles (`incremental_form_fill_ap_test`) asserting **decoded** `/AP/N` content (BT/Tf/Td/value/ET), stream dict (`/Type /XObject`, `/Subtype /Form`, `/BBox`), `/AS` state, multi-field, and unknown-FT passthrough — no smoke tests.
- 2 unit tests (`/DA` parse, stream serialization with exact `/Length`).
- Existing `incremental_form_fill_test` xref-set assertions updated for the new object set.
- `lib 6571/0`, 0 warnings, clippy clean. End-to-end verified: a `Tessera (RAG) — café` fill produces correct WinAnsi (`—`→`\227`, `é`→`\351`, parens escaped).

Addresses #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)