### PR TITLE
feat(rag): ChunkMetadata enrichment — citation anchor, language reliability, table dims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional per-chunk language detection behind the existing
   `language-detection` feature: `pipeline::detect_language(text)` returns the
   dominant ISO 639-3 code (via `whatlang`), and `ChunkMetadata::language` is
-  populated when the feature is enabled.
+  populated when the feature is enabled. `ChunkMetadata::language_confidence`
+  and `language_reliable` surface `whatlang`'s confidence and reliability so
+  consumers can gate language-based routing.
+- Citation anchor on `ChunkMetadata`: `page_span: Option<(u32, u32)>` and
+  `page_regions: Vec<PageRegion>` (the union bounding box of the chunk's
+  elements per page), giving RAG consumers an exact region of the source PDF to
+  cite back to. New `pipeline::PageRegion { page, bbox }`.
+- Table dimensions on `ChunkMetadata`: `table_rows`/`table_cols` (largest table
+  in the chunk) for table-aware retrieval.
 
 ## [2.15.0] - 2026-06-11
 

--- a/oxidize-pdf-core/examples/rag_realworld.rs
+++ b/oxidize-pdf-core/examples/rag_realworld.rs
@@ -209,6 +209,22 @@ pub fn jsonl_line(
     entry_url: &str,
     chunk: &RagChunk,
 ) -> String {
+    let m = &chunk.metadata;
+    // Citation anchor: where in the source PDF this chunk lives (the RAG
+    // coordinate-fidelity differentiator).
+    let page_regions: Vec<_> = m
+        .page_regions
+        .iter()
+        .map(|r| {
+            json!({
+                "page": r.page,
+                "x": r.bbox.x,
+                "y": r.bbox.y,
+                "width": r.bbox.width,
+                "height": r.bbox.height,
+            })
+        })
+        .collect();
     let value = json!({
         "id": format!("{}-{:04}", entry_slug, chunk.chunk_index),
         "text": chunk.text,
@@ -219,9 +235,25 @@ pub fn jsonl_line(
             "language": entry_language,
             "page_numbers": chunk.page_numbers,
             "heading_context": chunk.heading_context,
+            "heading_path": m.heading_path,
             "element_types": chunk.element_types,
             "token_estimate": chunk.token_estimate,
             "is_oversized": chunk.is_oversized,
+            "chunk_id": m.chunk_id,
+            "prev_chunk_id": m.prev_chunk_id,
+            "next_chunk_id": m.next_chunk_id,
+            "page_span": m.page_span,
+            "page_regions": page_regions,
+            "char_count": m.char_count,
+            "word_count": m.word_count,
+            "content_types": {
+                "has_table": m.content_types.has_table,
+                "has_list": m.content_types.has_list,
+                "has_code": m.content_types.has_code,
+                "heading_only": m.content_types.heading_only,
+            },
+            "table_rows": m.table_rows,
+            "table_cols": m.table_cols,
         }
     });
     value.to_string()

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -159,8 +159,15 @@ pub struct ChunkMetadata {
     /// Sentence count (uses the chunker's sentence splitter).
     pub sentence_count: usize,
     /// Detected language code (ISO 639-3, via `whatlang`); `None` if the
-    /// `lang-detect` feature is off or detection is inconclusive.
+    /// `language-detection` feature is off or detection is inconclusive.
     pub language: Option<String>,
+    /// Detection confidence in `(0, 1]` for [`language`](Self::language);
+    /// `None` when no language was detected.
+    pub language_confidence: Option<f32>,
+    /// Whether `whatlang` considered the [`language`](Self::language)
+    /// detection reliable. Consumers should gate language-based routing on
+    /// this; `None` when no language was detected.
+    pub language_reliable: Option<bool>,
     /// Deterministic, stable identifier for this chunk.
     pub chunk_id: String,
     /// Identifier of the previous chunk in the document, if any.
@@ -197,6 +204,18 @@ impl ChunkMetadata {
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
         let (page_span, page_regions) = page_anchor(elements);
+        // Detect once; fill code + confidence + reliability together.
+        #[cfg(feature = "language-detection")]
+        let (language, language_confidence, language_reliable) = match detect_language_full(text) {
+            Some((code, conf, reliable)) => (Some(code), Some(conf), Some(reliable)),
+            None => (None, None, None),
+        };
+        #[cfg(not(feature = "language-detection"))]
+        let (language, language_confidence, language_reliable): (
+            Option<String>,
+            Option<f32>,
+            Option<bool>,
+        ) = (None, None, None);
         ChunkMetadata {
             heading_path,
             dominant_font: agg.dominant_font,
@@ -208,10 +227,9 @@ impl ChunkMetadata {
             char_count: char_count(text),
             word_count: word_count(text),
             sentence_count: sentence_count(text),
-            #[cfg(feature = "language-detection")]
-            language: detect_language(text),
-            #[cfg(not(feature = "language-detection"))]
-            language: None,
+            language,
+            language_confidence,
+            language_reliable,
             chunk_id: content_chunk_id(doc_hash, chunk_index, full_text),
             prev_chunk_id: None,
             next_chunk_id: None,
@@ -277,10 +295,25 @@ pub(crate) fn link_chunks(chunks: &mut [crate::pipeline::RagChunk]) {
 /// Requires the `language-detection` feature.
 #[cfg(feature = "language-detection")]
 pub fn detect_language(text: &str) -> Option<String> {
+    detect_language_full(text).map(|(code, _, _)| code)
+}
+
+/// Run `whatlang` once and return `(code, confidence, reliable)`; `None` for
+/// empty/whitespace-only input or when no detection is produced. Single call
+/// site so [`ChunkMetadata`] can fill code + confidence + reliability without
+/// detecting twice.
+#[cfg(feature = "language-detection")]
+pub(crate) fn detect_language_full(text: &str) -> Option<(String, f32, bool)> {
     if text.trim().is_empty() {
         return None;
     }
-    whatlang::detect(text).map(|info| info.lang().code().to_string())
+    whatlang::detect(text).map(|info| {
+        (
+            info.lang().code().to_string(),
+            info.confidence() as f32,
+            info.is_reliable(),
+        )
+    })
 }
 
 /// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
@@ -517,5 +550,36 @@ mod tests {
         let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
         assert_eq!(m.page_span, None);
         assert!(m.page_regions.is_empty());
+    }
+
+    #[cfg(feature = "language-detection")]
+    #[test]
+    fn language_reliability_populated_alongside_code() {
+        let els = vec![para("x", "F", 10.0, false, 1.0)];
+        let text =
+            "The annual report summarizes the financial performance of the company over the year.";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+        assert_eq!(m.language.as_deref(), Some("eng"));
+        let conf = m
+            .language_confidence
+            .expect("confidence present when a language is detected");
+        assert!(
+            conf > 0.0 && conf <= 1.0,
+            "confidence must be in (0, 1], got {conf}"
+        );
+        assert_eq!(
+            m.language_reliable,
+            Some(true),
+            "a full English sentence must be a reliable detection"
+        );
+    }
+
+    #[cfg(feature = "language-detection")]
+    #[test]
+    fn language_reliability_none_for_empty_text() {
+        let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
+        assert_eq!(m.language, None);
+        assert_eq!(m.language_confidence, None);
+        assert_eq!(m.language_reliable, None);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -182,6 +182,12 @@ pub struct ChunkMetadata {
     /// Per-page citation regions (union bbox of the chunk's elements on each
     /// page), sorted ascending by page. Empty when the chunk has no elements.
     pub page_regions: Vec<PageRegion>,
+    /// Row count of the chunk's largest table (by row count), or `None` if the
+    /// chunk has no table. Lets a consumer filter/route table-bearing chunks.
+    pub table_rows: Option<usize>,
+    /// Column count (widest row) of the same table reported by
+    /// [`table_rows`](Self::table_rows); `None` when the chunk has no table.
+    pub table_cols: Option<usize>,
 }
 
 use sha2::{Digest, Sha256};
@@ -204,6 +210,7 @@ impl ChunkMetadata {
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
         let (page_span, page_regions) = page_anchor(elements);
+        let (table_rows, table_cols) = table_dims(elements);
         // Detect once; fill code + confidence + reliability together.
         #[cfg(feature = "language-detection")]
         let (language, language_confidence, language_reliable) = match detect_language_full(text) {
@@ -236,8 +243,27 @@ impl ChunkMetadata {
             source: None,
             page_span,
             page_regions,
+            table_rows,
+            table_cols,
         }
     }
+}
+
+/// Dimensions of the chunk's largest table (by row count): `(rows, widest row)`.
+/// `(None, None)` when the chunk contains no table element.
+fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
+    elements
+        .iter()
+        .filter_map(|e| match e {
+            Element::Table(t) => Some(&t.rows),
+            _ => None,
+        })
+        .max_by_key(|rows| rows.len())
+        .map(|rows| {
+            let cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+            (Some(rows.len()), Some(cols))
+        })
+        .unwrap_or((None, None))
 }
 
 /// Union of two axis-aligned bounding boxes.
@@ -465,8 +491,14 @@ mod tests {
         assert!(!m.content_types.has_table);
         assert_eq!(m.char_count, 0);
         assert_eq!(m.language, None);
+        assert_eq!(m.language_confidence, None);
+        assert_eq!(m.language_reliable, None);
         assert_eq!(m.chunk_id, "");
         assert!(m.source.is_none());
+        assert_eq!(m.page_span, None);
+        assert!(m.page_regions.is_empty());
+        assert_eq!(m.table_rows, None);
+        assert_eq!(m.table_cols, None);
     }
 
     #[test]
@@ -581,5 +613,43 @@ mod tests {
         assert_eq!(m.language, None);
         assert_eq!(m.language_confidence, None);
         assert_eq!(m.language_reliable, None);
+    }
+
+    fn table_with(rows: Vec<Vec<&str>>) -> Element {
+        Element::Table(crate::pipeline::element::TableElementData {
+            rows: rows
+                .into_iter()
+                .map(|r| r.into_iter().map(String::from).collect())
+                .collect(),
+            metadata: ElementMetadata::default(),
+        })
+    }
+
+    #[test]
+    fn table_dims_from_largest_table() {
+        let small = table_with(vec![vec!["a", "b"]]); // 1 row x 2 cols
+        let big = table_with(vec![vec!["a"], vec!["b"], vec!["c"]]); // 3 rows x 1 col
+        let els = vec![para("x", "F", 10.0, false, 1.0), small, big];
+        let text = "x";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+        // Largest by row count wins.
+        assert_eq!(m.table_rows, Some(3));
+        assert_eq!(m.table_cols, Some(1));
+    }
+
+    #[test]
+    fn table_cols_uses_widest_row() {
+        let ragged = table_with(vec![vec!["a", "b"], vec!["c", "d", "e", "f"]]);
+        let m = ChunkMetadata::from_elements(&[ragged], "t", "t", 0, None);
+        assert_eq!(m.table_rows, Some(2));
+        assert_eq!(m.table_cols, Some(4));
+    }
+
+    #[test]
+    fn table_dims_none_without_table() {
+        let els = vec![para("just prose", "F", 10.0, false, 1.0)];
+        let m = ChunkMetadata::from_elements(&els, "just prose", "just prose", 0, None);
+        assert_eq!(m.table_rows, None);
+        assert_eq!(m.table_cols, None);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -7,7 +7,7 @@
 #[cfg(feature = "semantic")]
 use serde::{Deserialize, Serialize};
 
-use crate::pipeline::element::Element;
+use crate::pipeline::element::{Element, ElementBBox};
 use crate::pipeline::hybrid_chunking::split_into_sentences;
 
 /// Char-weighted aggregates over a chunk's elements.
@@ -120,6 +120,19 @@ impl DocumentSource {
     }
 }
 
+/// Citation anchor for a chunk on a single page: the axis-aligned union of all
+/// the chunk's element bounding boxes that fall on that page. Lets a RAG
+/// consumer cite back to an exact region of the source PDF.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct PageRegion {
+    /// Page the region is on (as stored on the elements).
+    pub page: u32,
+    /// Union bounding box of the chunk's elements on this page.
+    pub bbox: ElementBBox,
+}
+
 /// Per-chunk metadata attached to every [`RagChunk`](crate::pipeline::RagChunk).
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
@@ -156,6 +169,12 @@ pub struct ChunkMetadata {
     pub next_chunk_id: Option<String>,
     /// Source-document metadata, if available.
     pub source: Option<DocumentSource>,
+    /// First and last page the chunk's elements touch (inclusive), or `None`
+    /// when the chunk has no positioned elements.
+    pub page_span: Option<(u32, u32)>,
+    /// Per-page citation regions (union bbox of the chunk's elements on each
+    /// page), sorted ascending by page. Empty when the chunk has no elements.
+    pub page_regions: Vec<PageRegion>,
 }
 
 use sha2::{Digest, Sha256};
@@ -177,6 +196,7 @@ impl ChunkMetadata {
             .first()
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
+        let (page_span, page_regions) = page_anchor(elements);
         ChunkMetadata {
             heading_path,
             dominant_font: agg.dominant_font,
@@ -196,8 +216,44 @@ impl ChunkMetadata {
             prev_chunk_id: None,
             next_chunk_id: None,
             source: None,
+            page_span,
+            page_regions,
         }
     }
+}
+
+/// Union of two axis-aligned bounding boxes.
+fn union_bbox(a: ElementBBox, b: ElementBBox) -> ElementBBox {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let right = a.right().max(b.right());
+    let top = a.top().max(b.top());
+    ElementBBox::new(x, y, right - x, top - y)
+}
+
+/// Compute the chunk's citation anchor: `(page_span, page_regions)`. Groups the
+/// elements by page, unions their bboxes per page, and sorts the regions by
+/// page ascending. Returns `(None, vec![])` for an element-less chunk.
+fn page_anchor(elements: &[Element]) -> (Option<(u32, u32)>, Vec<PageRegion>) {
+    let mut by_page: Vec<(u32, ElementBBox)> = Vec::new();
+    for e in elements {
+        let page = e.metadata().page;
+        let bbox = *e.bbox();
+        match by_page.iter_mut().find(|(p, _)| *p == page) {
+            Some(slot) => slot.1 = union_bbox(slot.1, bbox),
+            None => by_page.push((page, bbox)),
+        }
+    }
+    if by_page.is_empty() {
+        return (None, Vec::new());
+    }
+    by_page.sort_by_key(|(p, _)| *p);
+    let span = (by_page.first().unwrap().0, by_page.last().unwrap().0);
+    let regions = by_page
+        .into_iter()
+        .map(|(page, bbox)| PageRegion { page, bbox })
+        .collect();
+    (Some(span), regions)
 }
 
 /// Fill `prev_chunk_id` / `next_chunk_id` on each chunk from its neighbours' ids.
@@ -413,5 +469,53 @@ mod tests {
         // the chunk text (the exact code is whatlang's call, not asserted here).
         #[cfg(not(feature = "language-detection"))]
         assert_eq!(m.language, None);
+    }
+
+    fn el_at(text: &str, page: u32, x: f64, y: f64, w: f64, h: f64) -> Element {
+        Element::Paragraph(ElementData {
+            text: text.to_string(),
+            metadata: ElementMetadata {
+                page,
+                bbox: crate::pipeline::element::ElementBBox::new(x, y, w, h),
+                ..ElementMetadata::default()
+            },
+        })
+    }
+
+    #[test]
+    fn citation_anchor_page_span_and_per_page_union_bbox() {
+        let els = vec![
+            el_at("a", 1, 10.0, 700.0, 100.0, 20.0), // page1: x[10,110] y[700,720]
+            el_at("b", 1, 50.0, 600.0, 200.0, 10.0), // page1: x[50,250] y[600,610]
+            el_at("c", 2, 30.0, 500.0, 40.0, 40.0),  // page2: x[30,70]  y[500,540]
+        ];
+        let text = "a\nb\nc";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+
+        assert_eq!(m.page_span, Some((1, 2)));
+        assert_eq!(m.page_regions.len(), 2);
+        // Sorted ascending by page.
+        assert_eq!(m.page_regions[0].page, 1);
+        assert_eq!(m.page_regions[1].page, 2);
+
+        // Page 1 region = union of its two element bboxes.
+        let p1 = &m.page_regions[0].bbox;
+        assert_eq!(p1.x, 10.0);
+        assert_eq!(p1.y, 600.0);
+        assert_eq!(p1.right(), 250.0);
+        assert_eq!(p1.top(), 720.0);
+
+        // Page 2 region = the single element's bbox.
+        let p2 = &m.page_regions[1].bbox;
+        assert_eq!(p2.x, 30.0);
+        assert_eq!(p2.right(), 70.0);
+        assert_eq!(p2.top(), 540.0);
+    }
+
+    #[test]
+    fn citation_anchor_empty_for_no_elements() {
+        let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
+        assert_eq!(m.page_span, None);
+        assert!(m.page_regions.is_empty());
     }
 }

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -11,7 +11,7 @@ pub mod semantic_chunking;
 
 #[cfg(feature = "language-detection")]
 pub use chunk_metadata::detect_language;
-pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource};
+pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource, PageRegion};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,
     KeyValueElementData, TableElementData,

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -340,6 +340,77 @@ fn rag_chunk_metadata_json_roundtrip() {
         back.metadata.char_count, chunks[0].metadata.char_count,
         "char_count must survive the round-trip"
     );
+    // Enrichment fields survive serialization too.
+    assert!(json.contains("\"page_span\""), "json must carry page_span");
+    assert!(
+        json.contains("\"page_regions\""),
+        "json must carry page_regions"
+    );
+    assert_eq!(
+        back.metadata.page_span, chunks[0].metadata.page_span,
+        "page_span must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.page_regions, chunks[0].metadata.page_regions,
+        "page_regions must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.table_rows, chunks[0].metadata.table_rows,
+        "table_rows must survive the round-trip"
+    );
+}
+
+/// Enrichment end-to-end: the citation anchor (page_span + page_regions) is
+/// populated through the real `rag_chunks` pipeline, with regions that fall
+/// inside the A4 page box. Content-verifying, not mere presence.
+#[test]
+fn citation_anchor_populated_through_rag_chunks() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Anchored Section")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 720.0)
+        .write("Body paragraph positioned on the page so the chunk has a real bounding box.")
+        .unwrap();
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+
+    let m = &chunks[0].metadata;
+    // Page numbers follow the pipeline's own indexing (0-based here); assert
+    // the span is well-ordered rather than assuming a base.
+    let (first, last) = m.page_span.expect("page_span must be populated");
+    assert!(
+        last >= first,
+        "page_span must be well-ordered: ({first},{last})"
+    );
+    // Single-page document → exactly one region.
+    assert_eq!(
+        m.page_regions.len(),
+        1,
+        "single-page chunk must have exactly one citation region"
+    );
+    assert_eq!(m.page_regions[0].page, first, "region page must match span");
+    for region in &m.page_regions {
+        let b = &region.bbox;
+        // A4 is ~595x842 pt; the region must sit within a generous page box.
+        assert!(
+            b.x >= 0.0 && b.y >= 0.0 && b.right() <= 700.0 && b.top() <= 900.0,
+            "region bbox must fall inside the A4 page, got {b:?}"
+        );
+        assert!(
+            b.width > 0.0 && b.height > 0.0,
+            "region bbox must be non-degenerate, got {b:?}"
+        );
+    }
 }
 
 /// #2: `rag_chunks_with_source_and_config` both stamps the source metadata and


### PR DESCRIPTION
## Summary

Three additive, pure-Rust enrichments to `ChunkMetadata` (on top of PR #325), strengthening RAG retrieval quality and citation fidelity. All `#[non_exhaustive]` fields — no breaking change. Built with strict TDD (red→green→commit per feature).

## What's added

- **Citation anchor (RAG coordinate fidelity — the strategic differentiator).** `ChunkMetadata::page_span: Option<(u32,u32)>` (first/last page touched) and `page_regions: Vec<PageRegion>` — the axis-aligned union of the chunk's element bounding boxes on each page, sorted ascending. New `pipeline::PageRegion { page, bbox }`. Lets a consumer cite back to an exact region of the source PDF. Page numbers follow the pipeline's 0-based indexing (consistent with `RagChunk.page_numbers`).
- **Language reliability.** `language_confidence: Option<f32>` + `language_reliable: Option<bool>` from `whatlang::Info`, which the RAG path previously discarded. A consumer can now gate language-based routing on the reliability flag instead of trusting a code that may be random on short text. Detection runs once via `detect_language_full`; `detect_language` delegates (single whatlang call site).
- **Table dimensions.** `table_rows`/`table_cols` of the chunk's largest table (by row count, widest row for cols), for table-aware retrieval. `None` when the chunk has no table.

## Showcase

The `rag_realworld` example's bespoke JSONL writer only emitted a subset of fields, leaving the headline coordinate-fidelity signal invisible. It now serializes the citation anchor, chunk_id + prev/next links, heading_path, counts, content_types, and table dims. Verified against the real corpus: e.g. an `ens` chunk emits `{page:0, x:28.35, y:753.39, w:538.58, h:20.68}` and a 3×1 table chunk reports `table_rows=3/table_cols=1`.

## Tests

Content-verifying (no smoke tests):
- Unit (`from_elements`): multi-page span + exact per-page union bbox corners; empty chunk → `(None, [])`; language confidence ∈ (0,1] + `reliable=true` for a full English sentence; largest-table selection, ragged-row width, no-table → `(None, None)`.
- Integration (real `rag_chunks` pipeline): citation anchor populated with an in-page, non-degenerate bbox; JSON round-trip of `page_span`/`page_regions`/`table_rows` under `semantic`.
- `default-is-empty` extended to pin every new field's default.

Verified: lib 6588/0; clippy clean (default + `language-detection`); 14/14 `chunk_metadata` unit + 8/8 integration across `semantic language-detection multilingual-fixtures`; corpus `rag_realworld` 5/5, 1129 chunks (unchanged — additive).

## Not in this PR

Version bump / release (CHANGELOG entry under `[Unreleased]`; bump belongs to the release flow → target 2.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)