### PR TITLE
Release v2.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
 
+      # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
+      # enricher/extra bag), so the default test step above never compiles its
+      # tests. Exercise the SPI feature matrix on Linux/stable (spec §10.6).
+      - name: Run analysis SPI tests (unstable-spi)
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: cargo test -p oxidize-pdf --features "internal-testing,unstable-spi" --verbose
+
+      - name: Run analysis SPI tests (unstable-spi + semantic)
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: cargo test -p oxidize-pdf --features "internal-testing,unstable-spi,semantic" --verbose
+
       - name: Build documentation
         run: cargo doc --all --no-deps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Added
+
+- Rich chunk metadata for RAG: every `RagChunk` now carries a nested
+  `ChunkMetadata` (`oxidize_pdf::pipeline`) with the section breadcrumb
+  (`heading_path`), char-weighted dominant font/size and bold/italic flags,
+  the lowest element confidence (`min_confidence`), content-type flags
+  (`has_table`/`has_list`/`has_code`/`heading_only`), char/word/sentence
+  counts, a deterministic `chunk_id`, and prev/next chunk links. `RagChunk`
+  and the new metadata types are `#[non_exhaustive]`.
+- `PdfDocument::rag_chunks_with_source(DocumentSource)`: builds chunks stamped
+  with source-document metadata. Auto-fills `title`/`author`/`creation_date`/
+  `total_pages` from the info dictionary (caller values win); the caller's
+  `doc_hash` becomes the stable `chunk_id` prefix.
+- Optional per-chunk language detection behind the existing
+  `language-detection` feature: `pipeline::detect_language(text)` returns the
+  dominant ISO 639-3 code (via `whatlang`), and `ChunkMetadata::language` is
+  populated when the feature is enabled.
+
 ## [2.15.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`has_table`/`has_list`/`has_code`/`heading_only`), char/word/sentence
   counts, a deterministic `chunk_id`, and prev/next chunk links. `RagChunk`
   and the new metadata types are `#[non_exhaustive]`.
-- `PdfDocument::rag_chunks_with_source(DocumentSource)`: builds chunks stamped
-  with source-document metadata. Auto-fills `title`/`author`/`creation_date`/
-  `total_pages` from the info dictionary (caller values win); the caller's
-  `doc_hash` becomes the stable `chunk_id` prefix.
+- `PdfDocument::rag_chunks_with_source(DocumentSource)` and
+  `rag_chunks_with_source_and_config(DocumentSource, HybridChunkConfig)`: build
+  chunks stamped with source-document metadata, the latter also honouring a
+  custom token budget. Auto-fill `title`/`author`/`creation_date`/`total_pages`
+  from the info dictionary (caller values win); the caller's `doc_hash` becomes
+  the stable `chunk_id` prefix. `DocumentSource::with_file(filename, doc_hash)`
+  is the ergonomic constructor for the two caller-supplied fields.
 - Optional per-chunk language detection behind the existing
   `language-detection` feature: `pipeline::detect_language(text)` returns the
   dominant ISO 639-3 code (via `whatlang`), and `ChunkMetadata::language` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cite back to. New `pipeline::PageRegion { page, bbox }`.
 - Table dimensions on `ChunkMetadata`: `table_rows`/`table_cols` (largest table
   in the chunk) for table-aware retrieval.
+- **Analysis SPI** (unstable, behind the new `unstable-spi` feature): extension
+  points that let a closed crate plug custom analysis into the RAG pipeline
+  without forking the MIT core. The trait surface is exempt from semver while
+  experimental.
+  - `ChunkingStrategy` (`pipeline::ChunkingStrategy`) + `ChunkGroup`: decide how
+    elements group into chunks; the pipeline still owns `chunk_id`, prev/next
+    links, `oversized`, and `ChunkMetadata`. `HybridChunker` is the default impl
+    (`impl ChunkingStrategy for HybridChunker`), so a custom strategy can wrap it
+    and refine.
+  - `ElementClassifier` (`pipeline::ElementClassifier`) + `ClassLabel` +
+    `ClassifyContext`: assign an open string label to each element before
+    chunking, stored on the new `ElementMetadata::class_label`. A chunking
+    strategy may read it to drive boundaries.
+  - `MetadataEnricher` (`pipeline::MetadataEnricher`) + `EnrichContext` (both
+    additionally behind `semantic`): write provider-specific fields into a
+    chunk's open `extra` bag after metadata is derived; enrichers run in
+    registration order.
+  - `ChunkMetadata::extra: BTreeMap<String, serde_json::Value>` (behind
+    `semantic`): open, namespaced metadata bag, serialized nested under `extra`
+    and omitted when empty (no output change unless populated).
+  - `AnalysisPipeline` builder + `PdfDocument::rag_chunks_with_pipeline`:
+    run a strategy/classifier/enrichers over a document. `AnalysisPipeline::new()`
+    reproduces `rag_chunks()` exactly (verified by a parity test). Every existing
+    `rag_chunks*` entry point is unchanged.
 
 ## [2.15.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [2.16.0] - 2026-06-14
+
 ### Added
 
 - Rich chunk metadata for RAG: every `RagChunk` now carries a nested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional per-chunk language detection behind the existing
   `language-detection` feature: `pipeline::detect_language(text)` returns the
   dominant ISO 639-3 code (via `whatlang`), and `ChunkMetadata::language` is
-  populated when the feature is enabled.
+  populated when the feature is enabled. `ChunkMetadata::language_confidence`
+  and `language_reliable` surface `whatlang`'s confidence and reliability so
+  consumers can gate language-based routing.
+- Citation anchor on `ChunkMetadata`: `page_span: Option<(u32, u32)>` and
+  `page_regions: Vec<PageRegion>` (the union bounding box of the chunk's
+  elements per page), giving RAG consumers an exact region of the source PDF to
+  cite back to. New `pipeline::PageRegion { page, bbox }`.
+- Table dimensions on `ChunkMetadata`: `table_rows`/`table_cols` (largest table
+  in the chunk) for table-aware retrieval.
 
 ## [2.15.0] - 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.15.0"
+version = "2.16.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/docs/superpowers/plans/2026-06-13-analysis-spi.md
+++ b/docs/superpowers/plans/2026-06-13-analysis-spi.md
@@ -1,0 +1,781 @@
+# Analysis SPI (v1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `ChunkingStrategy` SPI + an open `extra` metadata bag so a closed crate can plug in custom chunking and surface domain fields, without forking the MIT core.
+
+**Architecture:** A new `ChunkingStrategy` trait returns `ChunkGroup`s (element groupings); the pipeline owns everything downstream (RagChunk, ids, links, metadata). `HybridChunker` becomes the default impl. A new `AnalysisPipeline` builder + `PdfDocument::rag_chunks_with_pipeline` entry point run a strategy and reuse the existing `build_rag_chunks` machinery. `ChunkMetadata` gains an open `extra: BTreeMap<String, serde_json::Value>` bag. All SPI items are behind `unstable-spi`; `extra` is behind `semantic`. Every existing entry point is unchanged.
+
+**Tech Stack:** Rust (MSRV 1.88), `serde_json` (already a dep under `semantic`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-analysis-spi-design.md`
+
+## Prerequisites / sequencing
+
+- This plan targets `develop`. It modifies `chunk_metadata.rs`, `rag.rs`,
+  `hybrid_chunking.rs`, `parser/document.rs`, `pipeline/mod.rs`, `Cargo.toml`.
+- PR #326 (`feature/chunk-metadata-enrichment`) also modifies `chunk_metadata.rs`
+  and `rag.rs`. **Merge #326 to develop first, then rebase this branch onto it**
+  so the SPI, the enrichment, and the bridge work ship together (per spec §9) and
+  to avoid conflicts in the metadata struct.
+- Branch for this work: `feature/analysis-spi` (already created).
+
+## File Structure
+
+- **Create** `oxidize-pdf-core/src/pipeline/spi.rs` — `ChunkGroup`, `ChunkingStrategy`, `AnalysisPipeline`. One responsibility: the SPI surface. All `#[cfg(feature = "unstable-spi")]`.
+- **Create** `oxidize-pdf-core/tests/analysis_spi_test.rs` — integration tests (custom strategy, decorator, parity, source stamping). Gated `#![cfg(feature = "unstable-spi")]`.
+- **Modify** `oxidize-pdf-core/Cargo.toml` — add `unstable-spi = []`.
+- **Modify** `oxidize-pdf-core/src/pipeline/mod.rs` — `mod spi;` + cfg-gated re-exports.
+- **Modify** `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs` — `HybridChunk::into_group`, `HybridChunk::from_group`, `impl ChunkingStrategy for HybridChunker`.
+- **Modify** `oxidize-pdf-core/src/pipeline/chunk_metadata.rs` — `extra` field + construction + unit tests.
+- **Modify** `oxidize-pdf-core/src/parser/document.rs` — `autofill_source` helper + `rag_chunks_with_pipeline`.
+
+---
+
+### Task 1: `ChunkGroup` + `ChunkingStrategy` trait (feature + module)
+
+**Files:**
+- Modify: `oxidize-pdf-core/Cargo.toml`
+- Create: `oxidize-pdf-core/src/pipeline/spi.rs`
+- Modify: `oxidize-pdf-core/src/pipeline/mod.rs`
+- Test: `oxidize-pdf-core/tests/analysis_spi_test.rs`
+
+- [ ] **Step 1: Add the feature**
+
+In `oxidize-pdf-core/Cargo.toml`, under `[features]`, add:
+
+```toml
+# Unstable analysis SPI (ChunkingStrategy + AnalysisPipeline). Exempt from
+# semver while experimental; may change until promoted to a stable feature.
+unstable-spi = []
+```
+
+- [ ] **Step 2: Create the SPI module**
+
+Create `oxidize-pdf-core/src/pipeline/spi.rs`:
+
+```rust
+//! Unstable analysis SPI — extension points for the chunking pipeline.
+//!
+//! Behind the `unstable-spi` feature. The trait surface is exempt from semver
+//! while experimental and may change until promoted.
+
+use crate::pipeline::element::Element;
+
+/// A grouping of elements destined to become one chunk. The chunking strategy
+/// decides the boundaries; the pipeline owns everything downstream (RagChunk,
+/// chunk_id, links, metadata).
+#[non_exhaustive]
+pub struct ChunkGroup {
+    /// The elements that form this chunk, in order.
+    pub elements: Vec<Element>,
+    /// Optional heading context to prepend for embedding.
+    pub heading_context: Option<String>,
+}
+
+impl ChunkGroup {
+    /// Construct a group from elements and an optional heading context.
+    pub fn new(elements: Vec<Element>, heading_context: Option<String>) -> Self {
+        Self {
+            elements,
+            heading_context,
+        }
+    }
+}
+
+/// Decides which elements group into a chunk. Implement this in a (possibly
+/// closed) crate to override how the pipeline forms chunks. The pipeline
+/// computes `oversized`, `chunk_id`, prev/next links, and `ChunkMetadata`.
+pub trait ChunkingStrategy: Send + Sync {
+    /// Group `elements` into chunks. Called once per document.
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
+}
+```
+
+- [ ] **Step 3: Wire the module + re-exports**
+
+In `oxidize-pdf-core/src/pipeline/mod.rs`, after the existing `pub mod ...` lines, add:
+
+```rust
+#[cfg(feature = "unstable-spi")]
+pub mod spi;
+```
+
+And after the existing `pub use ...` block, add:
+
+```rust
+#[cfg(feature = "unstable-spi")]
+pub use spi::{ChunkGroup, ChunkingStrategy};
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `oxidize-pdf-core/tests/analysis_spi_test.rs`:
+
+```rust
+//! Integration tests for the unstable analysis SPI.
+#![cfg(feature = "unstable-spi")]
+
+use oxidize_pdf::pipeline::{ChunkGroup, ChunkingStrategy};
+use oxidize_pdf::pipeline::{Element, ElementData, ElementMetadata};
+
+/// A strategy that emits exactly one chunk per element.
+struct OnePerElement;
+
+impl ChunkingStrategy for OnePerElement {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+        elements
+            .iter()
+            .map(|e| ChunkGroup::new(vec![e.clone()], None))
+            .collect()
+    }
+}
+
+fn para(text: &str) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })
+}
+
+#[test]
+fn custom_strategy_is_object_safe_and_groups_per_element() {
+    let strategy: Box<dyn ChunkingStrategy> = Box::new(OnePerElement);
+    let elements = vec![para("alpha"), para("bravo"), para("charlie")];
+    let groups = strategy.chunk(&elements);
+    assert_eq!(groups.len(), 3, "one chunk per element");
+    assert_eq!(groups[0].elements.len(), 1);
+    assert_eq!(groups[0].elements[0].text(), "alpha");
+    assert_eq!(groups[2].elements[0].text(), "charlie");
+}
+```
+
+> Note: `Element::text()` is the accessor used elsewhere in tests; confirm it exists in `pipeline/element.rs` (it does — used by `chunk_metadata` tests). If the variant constructor differs, mirror the `para` helper in `tests/rag_chunk_test.rs`.
+
+- [ ] **Step 5: Run the test**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test custom_strategy_is_object_safe_and_groups_per_element`
+Expected: PASS (the trait + type are defined; the test exercises object-safety via `Box<dyn>`).
+
+- [ ] **Step 6: Verify the default build is unaffected**
+
+Run: `cargo build -p oxidize-pdf`
+Expected: success; `spi` module not compiled (no feature).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add oxidize-pdf-core/Cargo.toml oxidize-pdf-core/src/pipeline/spi.rs oxidize-pdf-core/src/pipeline/mod.rs oxidize-pdf-core/tests/analysis_spi_test.rs
+git commit -m "feat(spi): ChunkingStrategy trait + ChunkGroup behind unstable-spi"
+```
+
+---
+
+### Task 2: `HybridChunker` as the default `ChunkingStrategy`
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs`
+- Test: `oxidize-pdf-core/tests/analysis_spi_test.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `oxidize-pdf-core/tests/analysis_spi_test.rs`:
+
+```rust
+use oxidize_pdf::pipeline::{HybridChunkConfig, HybridChunker, MergePolicy};
+
+#[test]
+fn hybrid_chunker_is_the_default_strategy() {
+    let elements = vec![para("alpha one two three"), para("bravo four five six")];
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 4,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+
+    // Inherent API: Vec<HybridChunk>.
+    let hybrid = HybridChunker::chunk(&chunker, &elements);
+    // Trait API: Vec<ChunkGroup>, same grouping.
+    let groups = ChunkingStrategy::chunk(&chunker, &elements);
+
+    assert_eq!(groups.len(), hybrid.len(), "same number of chunks");
+    for (g, h) in groups.iter().zip(hybrid.iter()) {
+        let g_text: Vec<&str> = g.elements.iter().map(|e| e.text()).collect();
+        let h_text: Vec<&str> = h.elements().iter().map(|e| e.text()).collect();
+        assert_eq!(g_text, h_text, "same element grouping");
+        assert_eq!(g.heading_context, h.heading_context);
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test hybrid_chunker_is_the_default_strategy`
+Expected: FAIL — `HybridChunker` does not implement `ChunkingStrategy` (trait method `chunk` not found via `ChunkingStrategy::chunk`).
+
+- [ ] **Step 3: Implement `into_group` + the trait impl**
+
+In `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs`, inside `impl HybridChunk { ... }` (the block starting near the `pub fn elements` accessor), add:
+
+```rust
+    /// Convert into a [`ChunkGroup`](crate::pipeline::spi::ChunkGroup),
+    /// dropping the derived `oversized` flag (the pipeline recomputes it).
+    #[cfg(feature = "unstable-spi")]
+    pub(crate) fn into_group(self) -> crate::pipeline::spi::ChunkGroup {
+        crate::pipeline::spi::ChunkGroup {
+            elements: self.elements,
+            heading_context: self.heading_context,
+        }
+    }
+```
+
+At the end of the file (module scope), add the trait impl:
+
+```rust
+#[cfg(feature = "unstable-spi")]
+impl crate::pipeline::spi::ChunkingStrategy for HybridChunker {
+    fn chunk(&self, elements: &[Element]) -> Vec<crate::pipeline::spi::ChunkGroup> {
+        // Call the inherent method explicitly to avoid recursing into this impl.
+        HybridChunker::chunk(self, elements)
+            .into_iter()
+            .map(HybridChunk::into_group)
+            .collect()
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test hybrid_chunker_is_the_default_strategy`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/hybrid_chunking.rs oxidize-pdf-core/tests/analysis_spi_test.rs
+git commit -m "feat(spi): HybridChunker implements ChunkingStrategy (default impl)"
+```
+
+---
+
+### Task 3: `HybridChunk::from_group` (ChunkGroup → HybridChunk)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs`, find the `#[cfg(test)] mod tests { ... }` block and add (inside it):
+
+```rust
+    #[cfg(feature = "unstable-spi")]
+    #[test]
+    fn from_group_recomputes_oversized_and_preserves_content() {
+        use crate::pipeline::spi::ChunkGroup;
+
+        let big = Element::Paragraph(ElementData {
+            text: "one two three four five six seven eight".to_string(),
+            metadata: ElementMetadata::default(),
+        });
+        // Budget far below the token count → oversized.
+        let group = ChunkGroup::new(vec![big.clone()], Some("H".to_string()));
+        let hc = HybridChunk::from_group(group, 2);
+        assert!(hc.is_oversized(), "8-word chunk over a 2-token budget is oversized");
+        assert_eq!(hc.heading_context.as_deref(), Some("H"));
+        assert_eq!(hc.elements().len(), 1);
+
+        // Generous budget → not oversized.
+        let group2 = ChunkGroup::new(vec![big], None);
+        let hc2 = HybridChunk::from_group(group2, 100);
+        assert!(!hc2.is_oversized());
+    }
+```
+
+> Note: confirm the test module already imports `Element`, `ElementData`, `ElementMetadata`. If not, add `use crate::pipeline::element::{Element, ElementData, ElementMetadata};` at the top of the `tests` module.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --lib hybrid_chunking::tests::from_group_recomputes_oversized_and_preserves_content`
+Expected: FAIL — `HybridChunk::from_group` not found.
+
+- [ ] **Step 3: Implement `from_group`**
+
+In `oxidize-pdf-core/src/pipeline/hybrid_chunking.rs`, inside `impl HybridChunk { ... }`, add:
+
+```rust
+    /// Build a chunk from a [`ChunkGroup`](crate::pipeline::spi::ChunkGroup),
+    /// recomputing `oversized` against `max_tokens`. Used by the pipeline when a
+    /// custom strategy produced the grouping.
+    #[cfg(feature = "unstable-spi")]
+    pub(crate) fn from_group(
+        group: crate::pipeline::spi::ChunkGroup,
+        max_tokens: usize,
+    ) -> Self {
+        let text = group
+            .elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let oversized = estimate_tokens(&text) > max_tokens;
+        HybridChunk {
+            elements: group.elements,
+            heading_context: group.heading_context,
+            oversized,
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --lib hybrid_chunking::tests::from_group_recomputes_oversized_and_preserves_content`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+git commit -m "feat(spi): HybridChunk::from_group recomputes oversized vs budget"
+```
+
+---
+
+### Task 4: `ChunkMetadata::extra` open bag
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/chunk_metadata.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `oxidize-pdf-core/src/pipeline/chunk_metadata.rs`, inside `#[cfg(test)] mod tests { ... }`, add:
+
+```rust
+    #[cfg(feature = "semantic")]
+    #[test]
+    fn extra_bag_defaults_empty_and_roundtrips() {
+        let mut m = ChunkMetadata::default();
+        assert!(m.extra.is_empty(), "extra defaults to empty");
+
+        // Empty extra is omitted from the serialized output.
+        let json_empty = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json_empty.contains("\"extra\""),
+            "empty extra must be skipped in JSON"
+        );
+
+        // Populated extra survives a deterministic round-trip.
+        m.extra
+            .insert("legal.clause_number".to_string(), serde_json::json!("3.2"));
+        m.extra.insert(
+            "legal.defined_terms".to_string(),
+            serde_json::json!(["Party", "Agreement"]),
+        );
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("\"extra\""));
+        let back: ChunkMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.extra, m.extra, "extra survives round-trip");
+        assert_eq!(
+            back.extra.get("legal.clause_number").unwrap(),
+            &serde_json::json!("3.2")
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --features semantic --lib chunk_metadata::tests::extra_bag_defaults_empty_and_roundtrips`
+Expected: FAIL — no field `extra` on `ChunkMetadata`.
+
+- [ ] **Step 3: Add the `use` for `BTreeMap`**
+
+At the top of `oxidize-pdf-core/src/pipeline/chunk_metadata.rs`, after the existing `use` lines, add:
+
+```rust
+#[cfg(feature = "semantic")]
+use std::collections::BTreeMap;
+```
+
+- [ ] **Step 4: Add the field to `ChunkMetadata`**
+
+In the `pub struct ChunkMetadata { ... }` definition, add as the last field (after `source`):
+
+```rust
+    /// Open extension bag for provider-supplied fields (e.g. a closed analyzer
+    /// stamping `legal.clause_number`). Namespacing keys by provider avoids
+    /// collisions. Serializes nested under `"extra"`; omitted when empty.
+    #[cfg(feature = "semantic")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+```
+
+- [ ] **Step 5: Fill the field in `from_elements`**
+
+In `ChunkMetadata::from_elements`, in the returned `ChunkMetadata { ... }` literal, add as the last field (after `source: None,`):
+
+```rust
+            #[cfg(feature = "semantic")]
+            extra: BTreeMap::new(),
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p oxidize-pdf --features semantic --lib chunk_metadata::tests::extra_bag_defaults_empty_and_roundtrips`
+Expected: PASS.
+
+- [ ] **Step 7: Verify default (no-feature) build still compiles**
+
+Run: `cargo build -p oxidize-pdf`
+Expected: success (the `extra` field is cfg-gated out without `semantic`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+git commit -m "feat(spi): open ChunkMetadata.extra bag under semantic"
+```
+
+---
+
+### Task 5: `AnalysisPipeline` + `rag_chunks_with_pipeline`
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/spi.rs`
+- Modify: `oxidize-pdf-core/src/pipeline/mod.rs`
+- Modify: `oxidize-pdf-core/src/parser/document.rs`
+- Test: `oxidize-pdf-core/tests/analysis_spi_test.rs`
+
+- [ ] **Step 1: Add `AnalysisPipeline` to the SPI module**
+
+Append to `oxidize-pdf-core/src/pipeline/spi.rs`:
+
+```rust
+use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
+use crate::pipeline::DocumentSource;
+
+/// Configures the analysis pipeline: which chunking strategy to run, the token
+/// budget used to flag oversized chunks, and optional source-document metadata.
+pub struct AnalysisPipeline {
+    pub(crate) chunking: Box<dyn ChunkingStrategy>,
+    pub(crate) max_tokens: usize,
+    pub(crate) source: Option<DocumentSource>,
+}
+
+impl Default for AnalysisPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisPipeline {
+    /// Default pipeline: the built-in `HybridChunker`, default token budget, no
+    /// source. Reproduces `PdfDocument::rag_chunks()` exactly.
+    pub fn new() -> Self {
+        let config = HybridChunkConfig::default();
+        Self {
+            max_tokens: config.max_tokens,
+            chunking: Box::new(HybridChunker::new(config)),
+            source: None,
+        }
+    }
+
+    /// Replace the chunking strategy.
+    pub fn with_chunking(mut self, strategy: Box<dyn ChunkingStrategy>) -> Self {
+        self.chunking = strategy;
+        self
+    }
+
+    /// Set the token budget used to flag oversized chunks.
+    pub fn with_max_tokens(mut self, max_tokens: usize) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Stamp source-document metadata onto every chunk.
+    pub fn with_source(mut self, source: DocumentSource) -> Self {
+        self.source = Some(source);
+        self
+    }
+}
+```
+
+- [ ] **Step 2: Re-export `AnalysisPipeline`**
+
+In `oxidize-pdf-core/src/pipeline/mod.rs`, update the cfg-gated re-export to:
+
+```rust
+#[cfg(feature = "unstable-spi")]
+pub use spi::{AnalysisPipeline, ChunkGroup, ChunkingStrategy};
+```
+
+- [ ] **Step 3: Write the failing integration test**
+
+Append to `oxidize-pdf-core/tests/analysis_spi_test.rs`:
+
+```rust
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::AnalysisPipeline;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn build_two_section_doc() -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Section One")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 730.0)
+        .write("First body paragraph with enough words to chunk on its own line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 700.0)
+        .write("Second body paragraph also with several words to fill a bucket.")
+        .unwrap();
+    doc.add_page(page);
+    doc.to_bytes().expect("pdf generation")
+}
+
+#[test]
+fn default_pipeline_matches_rag_chunks() {
+    let bytes = build_two_section_doc();
+
+    let parsed_a = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let baseline = parsed_a.rag_chunks().expect("rag_chunks");
+
+    let parsed_b = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let via_pipeline = parsed_b
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("rag_chunks_with_pipeline");
+
+    assert_eq!(
+        via_pipeline.len(),
+        baseline.len(),
+        "default pipeline produces the same chunk count"
+    );
+    for (p, b) in via_pipeline.iter().zip(baseline.iter()) {
+        assert_eq!(p.text, b.text, "same chunk text");
+        assert_eq!(p.metadata.chunk_id, b.metadata.chunk_id, "same chunk_id");
+        assert_eq!(p.is_oversized, b.is_oversized, "same oversized flag");
+        assert_eq!(
+            p.metadata.prev_chunk_id, b.metadata.prev_chunk_id,
+            "same prev link"
+        );
+    }
+}
+
+#[test]
+fn custom_strategy_drives_chunk_count_and_pipeline_owns_ids() {
+    let bytes = build_two_section_doc();
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+
+    let pipeline = AnalysisPipeline::new().with_chunking(Box::new(OnePerElement));
+    let chunks = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+
+    // One element per chunk → at least as many chunks as the default merge.
+    assert!(chunks.len() >= 3, "one-per-element yields >= 3 chunks");
+    // The pipeline (not the strategy) derived ids and links.
+    assert!(chunks[0].metadata.prev_chunk_id.is_none());
+    assert_eq!(
+        chunks[0].metadata.next_chunk_id.as_deref(),
+        Some(chunks[1].metadata.chunk_id.as_str()),
+        "pipeline wired prev/next"
+    );
+    for c in &chunks {
+        assert!(!c.metadata.chunk_id.is_empty());
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test default_pipeline_matches_rag_chunks`
+Expected: FAIL — no method `rag_chunks_with_pipeline`.
+
+- [ ] **Step 5: Extract the source auto-fill helper (DRY)**
+
+In `oxidize-pdf-core/src/parser/document.rs`, locate `rag_chunks_with_source_and_config`. It contains an `if let Ok(meta) = self.metadata() { ... }` block plus a `total_pages` fallback. Extract that into a private method on the same `impl` block:
+
+```rust
+    /// Fill `title`/`author`/`creation_date`/`total_pages` from the info
+    /// dictionary where the caller left them `None`.
+    fn autofill_source(&self, source: &mut crate::pipeline::DocumentSource) {
+        if let Ok(meta) = self.metadata() {
+            source.title = source.title.take().or(meta.title);
+            source.author = source.author.take().or(meta.author);
+            source.creation_date = source.creation_date.take().or(meta.creation_date);
+            source.total_pages = source.total_pages.or(meta.page_count);
+        }
+        if source.total_pages.is_none() {
+            source.total_pages = self.page_count().ok();
+        }
+    }
+```
+
+Then replace the inlined block in `rag_chunks_with_source_and_config` with a call:
+
+```rust
+        self.autofill_source(&mut source);
+```
+
+(keep the rest of `rag_chunks_with_source_and_config` unchanged).
+
+- [ ] **Step 6: Add `rag_chunks_with_pipeline`**
+
+In `oxidize-pdf-core/src/parser/document.rs`, in the same `impl<R: Read + Seek> PdfDocument<R>` block (near the other `rag_chunks*` methods), add:
+
+```rust
+    /// Run a custom [`AnalysisPipeline`](crate::pipeline::AnalysisPipeline):
+    /// partition, apply the pipeline's chunking strategy, then build linked
+    /// `RagChunk`s (ids, prev/next, metadata, optional source) exactly as the
+    /// other `rag_chunks*` entry points do.
+    ///
+    /// `AnalysisPipeline::new()` reproduces [`rag_chunks`](Self::rag_chunks).
+    #[cfg(feature = "unstable-spi")]
+    pub fn rag_chunks_with_pipeline(
+        &self,
+        pipeline: &crate::pipeline::AnalysisPipeline,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let mut source = pipeline.source.clone();
+        if let Some(src) = source.as_mut() {
+            self.autofill_source(src);
+        }
+        let elements = self.partition()?;
+        let groups = pipeline.chunking.chunk(&elements);
+        let hybrid: Vec<crate::pipeline::HybridChunk> = groups
+            .into_iter()
+            .map(|g| {
+                crate::pipeline::HybridChunk::from_group(g, pipeline.max_tokens)
+            })
+            .collect();
+        Ok(self.build_rag_chunks(&hybrid, source))
+    }
+```
+
+> Note: `from_group` is `pub(crate)`, so it is callable from `parser/document.rs` (same crate). `build_rag_chunks` already maps `&[HybridChunk]` + `Option<DocumentSource>` → linked `Vec<RagChunk>` (it handles `from_hybrid_chunk` / `from_hybrid_chunk_with_source` + `link_chunks`). Confirm `HybridChunk` is re-exported from `crate::pipeline` (it is, via `hybrid_chunking::HybridChunk`).
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test`
+Expected: PASS (all four tests: object-safety, default-strategy, parity, custom-strategy).
+
+Run the source-stamping regression too:
+Run: `cargo test -p oxidize-pdf --features "unstable-spi semantic" --test rag_chunk_metadata_test`
+Expected: PASS (the `autofill_source` extraction didn't change `rag_chunks_with_source*` behavior).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/spi.rs oxidize-pdf-core/src/pipeline/mod.rs oxidize-pdf-core/src/parser/document.rs oxidize-pdf-core/tests/analysis_spi_test.rs
+git commit -m "feat(spi): AnalysisPipeline + rag_chunks_with_pipeline (default = rag_chunks)"
+```
+
+---
+
+### Task 6: Decorator test, feature matrix, and gate
+
+**Files:**
+- Test: `oxidize-pdf-core/tests/analysis_spi_test.rs`
+
+- [ ] **Step 1: Write the decorator test**
+
+Append to `oxidize-pdf-core/tests/analysis_spi_test.rs`:
+
+```rust
+/// A strategy that delegates to the default and then merges every pair of
+/// adjacent groups — proving "delegate to the default and refine".
+struct PairMerger {
+    inner: HybridChunker,
+}
+
+impl ChunkingStrategy for PairMerger {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+        let base = ChunkingStrategy::chunk(&self.inner, elements);
+        let mut out = Vec::new();
+        let mut iter = base.into_iter();
+        while let Some(mut a) = iter.next() {
+            if let Some(b) = iter.next() {
+                a.elements.extend(b.elements);
+            }
+            out.push(a);
+        }
+        out
+    }
+}
+
+#[test]
+fn decorator_wraps_default_and_refines() {
+    let elements = vec![para("alpha"), para("bravo"), para("charlie"), para("delta")];
+
+    let inner = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 1, // force one element per group from the default
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let base_count = ChunkingStrategy::chunk(&inner, &elements).len();
+    assert_eq!(base_count, 4, "default emits one group per element here");
+
+    let decorated = PairMerger { inner };
+    let groups = decorated.chunk(&elements);
+    assert_eq!(groups.len(), 2, "pairs merged: 4 groups -> 2");
+    assert_eq!(groups[0].elements.len(), 2);
+    assert_eq!(groups[1].elements.len(), 2);
+}
+```
+
+- [ ] **Step 2: Run the full SPI test suite**
+
+Run: `cargo test -p oxidize-pdf --features unstable-spi --test analysis_spi_test`
+Expected: PASS (all tests including the decorator).
+
+- [ ] **Step 3: Run the feature matrix**
+
+Run each and confirm success / no warnings:
+
+```bash
+cargo build -p oxidize-pdf
+cargo build -p oxidize-pdf --features unstable-spi
+cargo build -p oxidize-pdf --features "unstable-spi semantic"
+cargo clippy -p oxidize-pdf --features "unstable-spi semantic" --all-targets -- -D warnings
+cargo test -p oxidize-pdf --lib
+cargo test -p oxidize-pdf --features "unstable-spi semantic" --test analysis_spi_test
+```
+
+Expected: all succeed; clippy clean on the touched files (`spi.rs`, `hybrid_chunking.rs`, `chunk_metadata.rs`, `parser/document.rs`). Pre-existing `--all-targets` clippy debt in unrelated test files is out of scope (see project notes).
+
+- [ ] **Step 4: Format**
+
+Run: `cargo fmt --all && cargo fmt --all -- --check`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/tests/analysis_spi_test.rs
+git commit -m "test(spi): decorator wrapping the default strategy; feature matrix verified"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - §4 ChunkingStrategy + ChunkGroup → Task 1; HybridChunker default impl → Task 2; ChunkGroup→HybridChunk → Task 3.
+  - §5 `extra` bag → Task 4.
+  - §6 AnalysisPipeline + `rag_chunks_with_pipeline` + backward-compat + parity → Task 5 (+ DRY `autofill_source`).
+  - §8 feature-gating (`unstable-spi`/`semantic`) → all tasks gate accordingly; matrix in Task 6.
+  - §10 testing: parity (Task 5), custom strategy (Task 5), decorator (Task 6), `extra` round-trip + skip-empty (Task 4), oversized ownership (Task 3 + Task 5 parity), feature matrix (Task 6).
+  - §7 documented-not-built seams (ElementClassifier/MetadataEnricher) → intentionally no tasks (out of v1 scope).
+  - §9 bridges → intentionally no tasks (separate repos / release-wave work).
+- **Type consistency:** `ChunkGroup { elements, heading_context }`, `ChunkingStrategy::chunk(&self, &[Element]) -> Vec<ChunkGroup>`, `HybridChunk::into_group`/`from_group`, `AnalysisPipeline::{new,with_chunking,with_max_tokens,with_source}`, `rag_chunks_with_pipeline(&AnalysisPipeline)`, `autofill_source(&mut DocumentSource)` — used identically across tasks.
+- **No placeholders:** every code step shows complete code; commands have expected output.

--- a/docs/superpowers/specs/2026-06-13-analysis-spi-design.md
+++ b/docs/superpowers/specs/2026-06-13-analysis-spi-design.md
@@ -1,0 +1,331 @@
+# Analysis SPI — Design Spec
+
+**Date:** 2026-06-13
+**Status:** Approved design, pending implementation plan
+**Target crate:** `oxidize-pdf-core` (published as `oxidize-pdf`), MIT
+**Feature gate:** `unstable-spi` (+ `semantic` for the `extra` bag)
+**Version impact:** additive MINOR; no new dependencies; MSRV 1.88 preserved
+
+## 1. Purpose
+
+Expose a **Service Provider Interface (SPI)** in the analysis pipeline so that a
+closed, proprietary crate (e.g. `oxidize-legal`) can plug in its own chunking —
+and, in later phases, classification and metadata enrichment — **without
+forking the core and without releasing its IP**.
+
+The MIT core is permissive (not copyleft), so a crate that depends on
+`oxidize-pdf` may already be fully proprietary. The SPI is therefore **not a
+licensing mechanism** — it is the *technical* seam that lets a closed crate hook
+into a pipeline whose classifier and chunker are concrete/hardcoded today
+(`Partitioner`, `HybridChunker`). It also becomes a product feature in its own
+right: the audience for the Tessera funnel is organizations with proprietary
+domain logic; an extension surface that keeps their IP private removes a real
+adoption barrier.
+
+### Guiding rule — "the socket, not the device"
+
+Only **anemic, generic** interfaces live in the MIT core. Domain semantics
+(what a clause is, how a defined term is linked) live in the closed crate. The
+core's contract types carry opaque containers (`ClassLabel(String)`,
+`extra: Map<String, Value>`), never legal-domain types.
+
+## 2. Scope
+
+### v1 — built
+
+- `trait ChunkingStrategy` + `struct ChunkGroup`.
+- `struct AnalysisPipeline` (builder) + `PdfDocument::rag_chunks_with_pipeline`.
+- `HybridChunker` becomes the default `ChunkingStrategy` impl.
+- `ChunkMetadata::extra: BTreeMap<String, serde_json::Value>` (open bag, under `semantic`).
+- All behind `unstable-spi`; `extra` additionally under `semantic`.
+- Full backward compatibility: every existing `rag_chunks*` entry point is unchanged.
+
+### v1 — documented, NOT built
+
+- `trait ElementClassifier` + `ClassLabel` + `ElementMetadata.class_label`.
+- `trait MetadataEnricher` + `EnrichContext`.
+- The complete `AnalysisPipeline` (classifier + enrichers fields).
+- Bridge story: surfacing `ChunkMetadata` (incl. `extra`) in the Python and
+  .NET bridges, and the closed "pro build" that selects a strategy by name.
+
+## 3. Architecture and boundary
+
+Three extension points, in pipeline order:
+
+```
+fragments ──▶ [ElementClassifier] ──▶ elements
+elements  ──▶ [ChunkingStrategy]   ──▶ ChunkGroup[] ──▶ RagChunk + ChunkMetadata
+RagChunk  ──▶ [MetadataEnricher]   ──▶ ChunkMetadata.extra enriched
+```
+
+License boundary:
+
+| Layer | Lives in | License | Content |
+|---|---|---|---|
+| The socket (traits + contract types) | `oxidize-pdf-core` | MIT | Anemic interfaces, no domain semantics |
+| The default impl (`HybridChunker`, current classifier) | `oxidize-pdf-core` | MIT | The "basic plugin" — current tuned pipeline |
+| The device (legal chunking, defined-terms, citations) | `oxidize-legal` (private repo) | proprietary | All valuable IP |
+
+`oxidize-legal` depends on `oxidize-pdf` as a normal dependency (crates.io/git),
+**outside this workspace** (all workspace members are MIT). It enables
+`unstable-spi` + `semantic`.
+
+## 4. ChunkingStrategy contract (v1)
+
+```rust
+/// Decides which elements group into a chunk. The pipeline owns everything
+/// downstream (HybridChunk wrapping, RagChunk, chunk_id, link_chunks,
+/// ChunkMetadata, extra).
+pub trait ChunkingStrategy: Send + Sync {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
+}
+
+/// A grouping of elements destined to become one chunk.
+#[non_exhaustive]
+pub struct ChunkGroup {
+    pub elements: Vec<Element>,
+    pub heading_context: Option<String>,
+}
+```
+
+- **Object-safe + `Send + Sync`** (like `OcrProvider`): no generics, no
+  `Self`-returning methods → `Box<dyn ChunkingStrategy>` works; usable in
+  batch/concurrent contexts. **Synchronous** (chunking is CPU-bound; no async).
+- **`ChunkGroup` is the only new contract type**, anemic and `#[non_exhaustive]`.
+  The strategy supplies grouping + optional `heading_context`. The pipeline
+  computes `oversized` (vs the token budget), `chunk_id`, prev/next links,
+  `ChunkMetadata`, and `extra`. The strategy therefore **cannot corrupt**
+  ids/metadata, and `HybridChunk`'s internals stay private (a third party never
+  constructs `HybridChunk`, only `ChunkGroup`).
+- **`HybridChunker` becomes the default impl**: `impl ChunkingStrategy for
+  HybridChunker`. Its grouping step is extracted to produce `ChunkGroup`s; its
+  current public method `chunk() -> Vec<HybridChunk>` is **kept** (backward
+  compat). Internally the pipeline converts `ChunkGroup → HybridChunk` via a
+  `pub(crate) fn` (no new public API) and reuses `from_hybrid_chunk`.
+- **Decorator-ready**: because `HybridChunker` is public and implements the
+  trait, a closed strategy holds one, calls `.chunk()` for base groups, and
+  refines/re-groups ("delegate to default and refine").
+- **`oversized` ownership**: the pipeline computes it from the budget, not the
+  strategy. A legal strategy that ignores token limits still produces valid
+  groups; the pipeline flags `oversized`.
+
+## 5. The `extra` bag on `ChunkMetadata` (v1)
+
+```rust
+// additive field on ChunkMetadata (#[non_exhaustive] already permits it)
+#[cfg(feature = "semantic")]
+#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+pub extra: BTreeMap<String, serde_json::Value>,
+```
+
+- **Gated on `semantic`** (forced by the type): `serde_json::Value` only exists
+  under `semantic` (`semantic = ["dep:serde_json"]`). Coherent: the bag exists
+  to flow into serialized RAG output, which requires `semantic` anyway. Same cfg
+  pattern as the `language` field. `oxidize-legal` builds with `semantic`.
+- **`BTreeMap`, not `HashMap`**: deterministic key ordering → stable, diffable
+  JSONL and reproducible tests.
+- **Serializes nested** inside `metadata` as `"extra": { ... }`, with
+  `skip_serializing_if = is_empty` → when no enrichment happens, the output is
+  byte-identical to today (no corpus regression).
+- **Who writes it in v1**: the field is `pub` and mutable (mutating fields of a
+  `#[non_exhaustive]` struct is permitted). The consumer calls
+  `rag_chunks_with_pipeline(...)`, gets `Vec<RagChunk>`, and **mutates
+  `chunk.metadata.extra` directly** before serialization. The `MetadataEnricher`
+  trait (§7) only formalizes this hook later; it is NOT needed in v1.
+- **Key discipline (convention, not code)**: providers namespace their keys
+  (`legal.clause_number`, `legal.defined_terms`) to avoid collisions between
+  enrichers. Documented; not enforced (YAGNI).
+
+## 6. Pipeline wiring (v1)
+
+```rust
+pub struct AnalysisPipeline {
+    chunking: Box<dyn ChunkingStrategy>,   // default: HybridChunker::default()
+    max_tokens: usize,                     // budget for `oversized`; default = HybridChunkConfig::default().max_tokens (512)
+    source: Option<DocumentSource>,        // reuses existing source-stamping
+    // documented-for-later (NOT in v1):
+    // classifier: Option<Box<dyn ElementClassifier>>,
+    // enrichers: Vec<Box<dyn MetadataEnricher>>,
+}
+
+impl AnalysisPipeline {
+    pub fn new() -> Self;                                       // = current behavior
+    pub fn with_chunking(self, s: Box<dyn ChunkingStrategy>) -> Self;
+    pub fn with_max_tokens(self, n: usize) -> Self;
+    pub fn with_source(self, src: DocumentSource) -> Self;
+}
+
+impl PdfDocument {
+    pub fn rag_chunks_with_pipeline(&self, p: &AnalysisPipeline)
+        -> ParseResult<Vec<RagChunk>>;
+}
+```
+
+Flow inside `rag_chunks_with_pipeline`:
+
+1. `let elements = self.partition()?;` (v1: default partition — the classifier seam is documented-later).
+2. `let groups = p.chunking.chunk(&elements);`
+3. `groups → RagChunks`: per group, wrap into `HybridChunk` (via `pub(crate) fn`),
+   compute `oversized` vs `p.max_tokens`, derive `ChunkMetadata`, stamp `source`.
+   Reuses `build_rag_chunks` logic generalized to `ChunkGroup`.
+4. `link_chunks` (prev/next).
+5. *(documented-later: run enrichers → `extra`)*.
+
+Decisions:
+
+- **Total backward compatibility**: `rag_chunks`, `rag_chunks_with`,
+  `rag_chunks_with_source[_and_config]`, `rag_chunks_with_profile*` keep their
+  signatures. They MAY delegate internally to
+  `rag_chunks_with_pipeline(AnalysisPipeline::new()...)` for DRY, but this is not
+  required in v1.
+- **`AnalysisPipeline::new()` reproduces current behavior byte-for-byte** → the
+  5-doc corpus yields exactly 1129 chunks (parity check, as validated for
+  #325/#326).
+- **`oversized` decoupled from the strategy** (see §4).
+- **Partition/profile**: v1 uses the default partition. A profile-aware
+  `AnalysisPipeline` (reading order, XYCut) is a documented follow-up, not v1.
+
+## 7. Documented-but-not-built seams
+
+Both `Send + Sync`, gated on `unstable-spi` (the enricher also on `semantic`).
+
+### ElementClassifier — in `partition`, before chunking
+
+```rust
+pub trait ElementClassifier: Send + Sync {
+    /// Return an open class label, or None to leave the core classification as-is.
+    fn classify(&self, element: &Element, ctx: &ClassifyContext) -> Option<ClassLabel>;
+}
+pub struct ClassLabel(pub std::borrow::Cow<'static, str>);  // OPEN: "clause", "definition"... are strings
+```
+
+- **Open label (string), not a closed enum**: legal classes (`Clause`,
+  `Definition`, `Party`) never live in MIT — the core only transports the
+  string. Stored in a new `ElementMetadata.class_label: Option<String>`
+  (orthogonal to the core-owned `Element` enum).
+- The chunker/strategy then **reads** the label to make boundary decisions (a
+  legal strategy splits on `clause`).
+- **Decorator**: the legal classifier wraps the default — runs it, then refines
+  (default says nothing → legal says `"clause-heading"`).
+
+### MetadataEnricher — after metadata derivation, writes `extra`
+
+```rust
+pub trait MetadataEnricher: Send + Sync {
+    fn enrich(&self, ctx: &EnrichContext, meta: &mut ChunkMetadata);
+}
+```
+
+- `EnrichContext` gives read access to the chunk's text/elements/`heading_path`;
+  the enricher writes `meta.extra` (e.g. `legal.clause_number`,
+  `legal.defined_terms`). Formalizes the v1 "mutate `extra` directly" hook.
+- Multiple enrichers run in order (`Vec<Box<dyn MetadataEnricher>>` in
+  `AnalysisPipeline`). Wiring: after `link_chunks`,
+  `for enricher { for chunk { enricher.enrich(ctx, &mut chunk.metadata) } }`.
+
+### Complete AnalysisPipeline (target)
+
+The two commented fields in §6 become active, with `with_classifier()` /
+`with_enricher()` builder methods.
+
+## 8. Feature-gating and stability posture
+
+```toml
+[features]
+unstable-spi = []   # traits + AnalysisPipeline + entry point
+# `extra` already lives under `semantic` (forced by serde_json::Value)
+```
+
+- Under `unstable-spi`: `ChunkingStrategy`, `ChunkGroup`, `AnalysisPipeline`,
+  `rag_chunks_with_pipeline`, and `impl ChunkingStrategy for HybridChunker` are
+  `pub`. Without the feature, none of it compiles → zero impact on the default
+  build, MSRV (1.88, **no new deps**), or the bridges.
+- The `extra` bag stays under `semantic`. `oxidize-legal` enables **both**.
+
+**Posture: experimental-first (validate before freezing).**
+
+- The `unstable-` prefix is a Rust convention: **unstable APIs are exempt from
+  semver**, so the contract can iterate without breaking anyone on
+  `develop`/releases while `oxidize-legal` validates the shape. This is what
+  avoids designing the extension API in a vacuum.
+- **Exit criterion** (explicit): once `oxidize-legal` has implemented its
+  `ChunkingStrategy` and its output flows end-to-end through `extra` over a real
+  legal corpus, the contract is considered validated → a later MINOR release
+  **promotes** `unstable-spi` to a stable feature (or default).
+
+**Semver discipline once stable:**
+
+- `ChunkGroup` is `#[non_exhaustive]` (future fields without breaking).
+- The **trait** stays minimal; future methods are added **with default impls**
+  (adding a non-default method to a public trait is breaking). Documented as the
+  SPI evolution rule.
+- Sealed-trait pattern where applicable, if controlling what a third party may
+  implement becomes necessary.
+
+## 9. Bridges (Python + .NET)
+
+Current state (verified): both bridges expose the RAG producer
+(`rag_chunks()` in Python `parser.rs`; `PdfExtractor.RagChunksAsync` in .NET) but
+their chunk models surface only the **legacy flat fields** (chunk_index, text,
+full_text, page_numbers, element_types, heading_context, token_estimate,
+is_oversized). **Neither exposes `RagChunk.metadata`** — the rich
+`ChunkMetadata` (and therefore `extra`) is invisible to Python and .NET today.
+
+Impact and plan (same release wave as the SPI + metadata enrichment):
+
+- **Surface `ChunkMetadata` in both bridges**: Python adds a `metadata`
+  accessor on `PyRagChunk` (a `PyChunkMetadata` class or a dict); .NET adds
+  `Metadata` to `RagChunk.cs` + the native FFI DTO. The `extra` bag maps to a
+  Python `dict` / .NET `Dictionary<string, object>` (or `JsonElement`). This is
+  the prerequisite for any enrichment to reach bridge consumers.
+- **The SPI is Rust-native, compile-time.** A Python/C# class cannot implement a
+  Rust trait across FFI. Cross-FFI strategy *implementation* (callbacks +
+  marshaling every `Element` across the boundary) is **out of scope** — costly,
+  loses zero-copy, and unnecessary (legal logic is Rust).
+- **Delivering legal chunking to Python/.NET**: a closed **"pro build"** of the
+  bridge statically links `oxidize-legal` and selects the strategy **by name**
+  (`doc.rag_chunks(strategy="legal")`). Cheap FFI (one string), zero IP leak (IP
+  compiled into the binary), no element marshaling.
+
+> The exact .NET binding mechanism (C-ABI `native/` cdylib + C# P/Invoke) is
+> confirmed; the precise native RAG DTO mapping must be re-read before
+> implementing the .NET metadata surface.
+
+## 10. Testing and validation (v1)
+
+All content-verifying (no smoke tests).
+
+1. **Corpus parity (regression guard)**: `AnalysisPipeline::new()` must produce
+   byte-identical chunks to current `rag_chunks()` (rag_realworld baseline vs SPI
+   path → same 1129 chunks, same content). Proves the
+   `HybridChunker → ChunkGroup → RagChunk` refactor doesn't regress.
+2. **Custom strategy (unit)**: a toy `ChunkingStrategy` in the test (e.g. "one
+   chunk per element" or "split on a marker") asserting the pipeline produces the
+   expected grouping **with chunk_id/links/metadata derived by the pipeline** —
+   proving the strategy only controls boundaries.
+3. **Decorator**: a strategy wrapping `HybridChunker::default()`, calling it and
+   post-processing (e.g. merging two adjacent groups); assert the result differs
+   from default exactly there.
+4. **`extra` round-trip (semantic)**: mutate `metadata.extra` with namespaced
+   keys, serialize, assert `"extra"` appears nested, survives a deterministic
+   round-trip (BTreeMap order), and that empty `extra` is omitted.
+5. **`oversized` ownership**: a strategy emitting an over-budget group → the
+   pipeline marks `is_oversized` regardless.
+6. **Feature matrix in CI**: build/test with `unstable-spi`, `unstable-spi
+   semantic`, and neither → no cfg breakage across combos. Default build
+   unchanged.
+
+Documented-later seams carry their test plans (classifier-decorator,
+multi-enricher ordering) for when they land; 0 tests in v1.
+
+Bridge tests live in the bridge repos (assert `chunk.metadata` surfaces the rich
+fields incl. `extra` as a dict/Dictionary); referenced here, not built here.
+
+## 11. Out of scope (explicit)
+
+- Cross-FFI strategy implementation in Python/C#.
+- Dynamic runtime plugin loading (`.so`/`.dll`): Rust has no stable ABI; the
+  consumer profile (developers who compile their app) does not need it.
+- Monetization/licensing of `oxidize-legal` itself (a separate product decision;
+  the revenue is captured downstream in the sellable product/Tessera).
+- Profile-aware `AnalysisPipeline` (reading order/XYCut) — documented follow-up.

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -471,6 +471,10 @@ signatures = [
 # Semantic marking (Community level - basic tagging)
 semantic = ["dep:serde_json"]
 
+# Unstable analysis SPI (ChunkingStrategy + AnalysisPipeline). Exempt from
+# semver while experimental; may change until promoted to a stable feature.
+unstable-spi = []
+
 # Language detection for RAG chunks (opt-in: pulls pure-Rust `whatlang`)
 language-detection = ["dep:whatlang"]
 

--- a/oxidize-pdf-core/examples/analysis_spi_custom_chunking.rs
+++ b/oxidize-pdf-core/examples/analysis_spi_custom_chunking.rs
@@ -1,0 +1,137 @@
+//! Analysis SPI — plugging a custom `ChunkingStrategy`.
+//!
+//! The SPI (behind the `unstable-spi` feature) lets you decide how elements
+//! group into chunks while the pipeline keeps ownership of everything
+//! downstream: chunk ids, prev/next links, the `oversized` flag, and the full
+//! `ChunkMetadata`. A custom strategy therefore cannot corrupt ids or metadata —
+//! it only controls boundaries.
+//!
+//! Run with:
+//!   cargo run --example analysis_spi_custom_chunking --features unstable-spi
+//!
+//! This example is self-contained: it generates a small PDF in memory, then
+//! chunks it two ways (the built-in `HybridChunker` vs a custom strategy) to
+//! show the difference.
+
+#[cfg(feature = "unstable-spi")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    use oxidize_pdf::pipeline::{
+        AnalysisPipeline, ChunkGroup, ChunkingStrategy, Element, HybridChunker,
+    };
+    use oxidize_pdf::text::Font;
+    use oxidize_pdf::{Document, Page};
+    use std::io::Cursor;
+
+    // 1. Build a throwaway PDF with a heading and a few paragraphs.
+    let pdf_bytes = {
+        let mut doc = Document::new();
+        let mut page = Page::a4();
+        let lines = [
+            (770.0, 18.0, Font::HelveticaBold, "Quarterly Report"),
+            (
+                740.0,
+                11.0,
+                Font::Helvetica,
+                "Revenue grew across every region this quarter.",
+            ),
+            (
+                715.0,
+                11.0,
+                Font::Helvetica,
+                "Operating costs stayed flat versus last quarter.",
+            ),
+            (
+                690.0,
+                11.0,
+                Font::Helvetica,
+                "Headcount increased by twelve people in total.",
+            ),
+            (
+                665.0,
+                11.0,
+                Font::Helvetica,
+                "The board approved the expansion plan unanimously.",
+            ),
+        ];
+        for (y, size, font, text) in lines {
+            page.text().set_font(font, size).at(50.0, y).write(text)?;
+        }
+        doc.add_page(page);
+        doc.to_bytes()?
+    };
+
+    // A custom strategy: collapse the whole document into a single chunk
+    // (useful when the downstream store wants one vector per document). It
+    // ignores the token budget entirely — the pipeline still computes the
+    // `oversized` flag from its own budget, so the chunk is correctly flagged.
+    struct WholeDocumentChunk;
+    impl ChunkingStrategy for WholeDocumentChunk {
+        fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+            if elements.is_empty() {
+                return Vec::new();
+            }
+            // One group holding every element, in order.
+            vec![ChunkGroup::new(elements.to_vec(), None)]
+        }
+    }
+
+    // 2a. Default pipeline == rag_chunks(): the built-in HybridChunker merges
+    //     adjacent paragraphs up to the token budget.
+    let doc = PdfDocument::new(PdfReader::new(Cursor::new(&pdf_bytes))?);
+    let default_chunks = doc.rag_chunks_with_pipeline(&AnalysisPipeline::new())?;
+
+    // 2b. Same document, custom strategy.
+    let doc = PdfDocument::new(PdfReader::new(Cursor::new(&pdf_bytes))?);
+    let custom_chunks = doc.rag_chunks_with_pipeline(
+        &AnalysisPipeline::new().with_chunking(Box::new(WholeDocumentChunk)),
+    )?;
+
+    println!("Default HybridChunker → {} chunk(s):", default_chunks.len());
+    for c in &default_chunks {
+        println!(
+            "  [{}] {:?}",
+            c.metadata.chunk_id.get(..8).unwrap_or(""),
+            truncate(&c.text, 60)
+        );
+    }
+
+    println!(
+        "\nCustom whole-document strategy → {} chunk(s):",
+        custom_chunks.len()
+    );
+    for c in &custom_chunks {
+        // The pipeline — not the strategy — derived the id, prev/next links, and
+        // the oversized flag (this single chunk holds the whole document).
+        println!(
+            "  [{}] oversized={} :: {:?}",
+            c.metadata.chunk_id.get(..8).unwrap_or(""),
+            c.is_oversized,
+            truncate(&c.text, 60)
+        );
+    }
+
+    // The default merges by token budget; the custom strategy collapses to one.
+    assert!(custom_chunks.len() <= default_chunks.len());
+    assert_eq!(custom_chunks.len(), 1);
+    // Decorator-ready: a strategy can also hold a `HybridChunker`, call it for
+    // base groups, and refine — "delegate to the default and refine".
+    let _wrap_the_default = HybridChunker::default();
+    Ok(())
+}
+
+#[cfg(feature = "unstable-spi")]
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let cut: String = s.chars().take(n).collect();
+        format!("{cut}…")
+    }
+}
+
+#[cfg(not(feature = "unstable-spi"))]
+fn main() {
+    eprintln!("This example requires the `unstable-spi` feature:");
+    eprintln!("  cargo run --example analysis_spi_custom_chunking --features unstable-spi");
+}

--- a/oxidize-pdf-core/examples/analysis_spi_full_pipeline.rs
+++ b/oxidize-pdf-core/examples/analysis_spi_full_pipeline.rs
@@ -1,0 +1,167 @@
+//! Analysis SPI — a full pipeline: classify → chunk on the labels → enrich.
+//!
+//! This mirrors how a closed, domain-specific crate (think `oxidize-legal`)
+//! would extend the RAG pipeline WITHOUT forking the MIT core: it plugs in three
+//! seams and the core never learns the domain semantics — it only transports the
+//! opaque `ClassLabel` string and the open `extra` bag.
+//!
+//!   1. `ElementClassifier` labels each element before chunking
+//!      (here: paragraphs starting with "CLAUSE" → "clause").
+//!   2. `ChunkingStrategy` reads the labels to decide boundaries
+//!      (here: every clause starts a new chunk; other text appends to it).
+//!   3. `MetadataEnricher` writes provider-specific fields into `extra`
+//!      (here: `legal.is_clause` and `legal.clause_number`).
+//!
+//! Run with:
+//!   cargo run --example analysis_spi_full_pipeline --features "unstable-spi semantic"
+
+#[cfg(all(feature = "unstable-spi", feature = "semantic"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    use oxidize_pdf::pipeline::{
+        AnalysisPipeline, ChunkGroup, ChunkMetadata, ChunkingStrategy, ClassLabel, ClassifyContext,
+        Element, ElementClassifier, EnrichContext, MetadataEnricher,
+    };
+    use oxidize_pdf::text::Font;
+    use oxidize_pdf::{Document, Page};
+    use std::io::Cursor;
+
+    // ---- Build a throwaway "contract" PDF -------------------------------
+    // One section per page. The partitioner merges adjacent same-font lines
+    // within a page into a single element but never across pages, so each page
+    // yields one element whose text starts with the section's leading line —
+    // exactly what the clause classifier keys on.
+    let pdf_bytes = {
+        let mut doc = Document::new();
+        let pages: [&[&str]; 3] = [
+            &["This Agreement is entered into by the parties named below."],
+            &[
+                "CLAUSE 1 Each party shall perform its obligations in good faith.",
+                "The foregoing applies to all schedules attached to this Agreement.",
+            ],
+            &[
+                "CLAUSE 2 Either party may terminate on thirty days written notice.",
+                "Notices must be delivered to the registered address of record.",
+            ],
+        ];
+        for lines in pages {
+            let mut page = Page::a4();
+            let mut y = 780.0;
+            for line in lines {
+                page.text()
+                    .set_font(Font::Helvetica, 11.0)
+                    .at(50.0, y)
+                    .write(line)?;
+                y -= 25.0;
+            }
+            doc.add_page(page);
+        }
+        doc.to_bytes()?
+    };
+
+    // ---- Seam 1: classify elements --------------------------------------
+    struct ClauseClassifier;
+    impl ElementClassifier for ClauseClassifier {
+        fn classify(&self, element: &Element, _ctx: &ClassifyContext) -> Option<ClassLabel> {
+            element
+                .text()
+                .starts_with("CLAUSE")
+                .then(|| ClassLabel::new("clause"))
+        }
+    }
+
+    // ---- Seam 2: chunk on the labels ------------------------------------
+    // A clause-labelled element opens a new chunk; unlabelled text appends to
+    // the open chunk. The built-in HybridChunker cannot do this — it has no
+    // notion of "clause".
+    struct SplitOnClause;
+    impl ChunkingStrategy for SplitOnClause {
+        fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+            let mut groups: Vec<ChunkGroup> = Vec::new();
+            for e in elements {
+                let opens_clause = e.metadata().class_label.as_deref() == Some("clause");
+                if opens_clause || groups.is_empty() {
+                    groups.push(ChunkGroup::new(vec![e.clone()], None));
+                } else {
+                    groups.last_mut().unwrap().elements.push(e.clone());
+                }
+            }
+            groups
+        }
+    }
+
+    // ---- Seam 3: enrich `extra` -----------------------------------------
+    struct ClauseEnricher;
+    impl MetadataEnricher for ClauseEnricher {
+        fn enrich(&self, ctx: &EnrichContext, meta: &mut ChunkMetadata) {
+            let is_clause = ctx
+                .elements
+                .iter()
+                .any(|e| e.metadata().class_label.as_deref() == Some("clause"));
+            meta.extra
+                .insert("legal.is_clause".to_string(), serde_json::json!(is_clause));
+            // Pull the clause number out of "CLAUSE <n> ..." if present.
+            if let Some(num) = ctx
+                .elements
+                .iter()
+                .find_map(|e| e.text().strip_prefix("CLAUSE "))
+                .and_then(|rest| rest.split_whitespace().next())
+            {
+                meta.extra
+                    .insert("legal.clause_number".to_string(), serde_json::json!(num));
+            }
+        }
+    }
+
+    // ---- Assemble and run the pipeline ----------------------------------
+    let pipeline = AnalysisPipeline::new()
+        .with_classifier(Box::new(ClauseClassifier))
+        .with_chunking(Box::new(SplitOnClause))
+        .with_enricher(Box::new(ClauseEnricher));
+
+    let doc = PdfDocument::new(PdfReader::new(Cursor::new(&pdf_bytes))?);
+    let chunks = doc.rag_chunks_with_pipeline(&pipeline)?;
+
+    println!(
+        "{} chunk(s) produced by the legal-style pipeline:\n",
+        chunks.len()
+    );
+    for c in &chunks {
+        let is_clause = c
+            .metadata
+            .extra
+            .get("legal.is_clause")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let number = c
+            .metadata
+            .extra
+            .get("legal.clause_number")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        println!(
+            "• clause={is_clause:<5} number={number:<3} text={:?}",
+            c.text
+        );
+        // Show the serialized metadata.extra a RAG store would receive.
+        println!("    extra = {}", serde_json::to_string(&c.metadata.extra)?);
+    }
+
+    // The preamble (no clause) is one chunk; each CLAUSE opens another →
+    // exactly three chunks, two of them clause-labelled.
+    let clause_chunks = chunks
+        .iter()
+        .filter(|c| c.metadata.extra.get("legal.is_clause") == Some(&serde_json::json!(true)))
+        .count();
+    assert_eq!(chunks.len(), 3);
+    assert_eq!(clause_chunks, 2);
+    Ok(())
+}
+
+#[cfg(not(all(feature = "unstable-spi", feature = "semantic")))]
+fn main() {
+    eprintln!("This example requires the `unstable-spi` and `semantic` features:");
+    eprintln!(
+        "  cargo run --example analysis_spi_full_pipeline --features \"unstable-spi semantic\""
+    );
+}

--- a/oxidize-pdf-core/examples/rag_realworld.rs
+++ b/oxidize-pdf-core/examples/rag_realworld.rs
@@ -209,6 +209,22 @@ pub fn jsonl_line(
     entry_url: &str,
     chunk: &RagChunk,
 ) -> String {
+    let m = &chunk.metadata;
+    // Citation anchor: where in the source PDF this chunk lives (the RAG
+    // coordinate-fidelity differentiator).
+    let page_regions: Vec<_> = m
+        .page_regions
+        .iter()
+        .map(|r| {
+            json!({
+                "page": r.page,
+                "x": r.bbox.x,
+                "y": r.bbox.y,
+                "width": r.bbox.width,
+                "height": r.bbox.height,
+            })
+        })
+        .collect();
     let value = json!({
         "id": format!("{}-{:04}", entry_slug, chunk.chunk_index),
         "text": chunk.text,
@@ -219,9 +235,25 @@ pub fn jsonl_line(
             "language": entry_language,
             "page_numbers": chunk.page_numbers,
             "heading_context": chunk.heading_context,
+            "heading_path": m.heading_path,
             "element_types": chunk.element_types,
             "token_estimate": chunk.token_estimate,
             "is_oversized": chunk.is_oversized,
+            "chunk_id": m.chunk_id,
+            "prev_chunk_id": m.prev_chunk_id,
+            "next_chunk_id": m.next_chunk_id,
+            "page_span": m.page_span,
+            "page_regions": page_regions,
+            "char_count": m.char_count,
+            "word_count": m.word_count,
+            "content_types": {
+                "has_table": m.content_types.has_table,
+                "has_list": m.content_types.has_list,
+                "has_code": m.content_types.has_code,
+                "heading_only": m.content_types.heading_only,
+            },
+            "table_rows": m.table_rows,
+            "table_cols": m.table_cols,
         }
     });
     value.to_string()

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1519,7 +1519,27 @@ impl<R: Read + Seek> PdfDocument<R> {
             .into_iter()
             .map(|g| crate::pipeline::HybridChunk::from_group(g, pipeline.max_tokens))
             .collect();
-        Ok(self.build_rag_chunks(&hybrid, source))
+        #[allow(unused_mut)]
+        let mut chunks = self.build_rag_chunks(&hybrid, source);
+        #[cfg(feature = "semantic")]
+        if !pipeline.enrichers.is_empty() {
+            // Enrich each chunk's `extra` bag. The hybrid chunk (kept alongside)
+            // supplies the source elements; text/heading_path are snapshotted to
+            // release the immutable borrow before mutating `metadata`.
+            for (chunk, hc) in chunks.iter_mut().zip(hybrid.iter()) {
+                let text = chunk.text.clone();
+                let heading_path = chunk.metadata.heading_path.clone();
+                let ctx = crate::pipeline::EnrichContext {
+                    text: &text,
+                    elements: hc.elements(),
+                    heading_path: &heading_path,
+                };
+                for enricher in &pipeline.enrichers {
+                    enricher.enrich(&ctx, &mut chunk.metadata);
+                }
+            }
+        }
+        Ok(chunks)
     }
 
     /// Build linked [`RagChunk`]s from hybrid chunks, optionally stamping a

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1406,6 +1406,46 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(self.build_rag_chunks(&hybrid_chunks, None))
     }
 
+    /// Build RAG chunks stamped with source-document metadata.
+    ///
+    /// Auto-fills `title`/`author`/`creation_date`/`total_pages` from the info
+    /// dictionary (only where the caller left them `None`); the caller-supplied
+    /// `source` provides `filename`/`doc_hash` (and may override any auto-filled
+    /// field). `doc_hash`, when set, becomes the stable prefix of every
+    /// `chunk_id`. Same chunking pipeline as [`rag_chunks`](Self::rag_chunks).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use oxidize_pdf::parser::PdfDocument;
+    /// use oxidize_pdf::pipeline::DocumentSource;
+    ///
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// let mut source = DocumentSource::default();
+    /// source.filename = Some("document.pdf".to_string());
+    /// source.doc_hash = Some("sha256-prefix".to_string());
+    /// let chunks = doc.rag_chunks_with_source(source)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn rag_chunks_with_source(
+        &self,
+        mut source: crate::pipeline::DocumentSource,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        if let Ok(meta) = self.metadata() {
+            source.title = source.title.or(meta.title);
+            source.author = source.author.or(meta.author);
+            source.creation_date = source.creation_date.or(meta.creation_date);
+            source.total_pages = source.total_pages.or(meta.page_count);
+        }
+        if source.total_pages.is_none() {
+            source.total_pages = self.page_count().ok();
+        }
+        let elements = self.partition()?;
+        let chunker = crate::pipeline::HybridChunker::default();
+        let hybrid_chunks = chunker.chunk(&elements);
+        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
+    }
+
     /// Build linked [`RagChunk`]s from hybrid chunks, optionally stamping a
     /// [`DocumentSource`](crate::pipeline::DocumentSource), then wiring
     /// prev/next ids. Shared by all `rag_chunks*` entry points (DRY).

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1403,12 +1403,31 @@ impl<R: Read + Seek> PdfDocument<R> {
         let elements = self.partition()?;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        let rag_chunks = hybrid_chunks
-            .iter()
-            .enumerate()
-            .map(|(idx, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(idx, hc))
-            .collect();
-        Ok(rag_chunks)
+        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+    }
+
+    /// Build linked [`RagChunk`]s from hybrid chunks, optionally stamping a
+    /// [`DocumentSource`](crate::pipeline::DocumentSource), then wiring
+    /// prev/next ids. Shared by all `rag_chunks*` entry points (DRY).
+    fn build_rag_chunks(
+        &self,
+        hybrid_chunks: &[crate::pipeline::HybridChunk],
+        source: Option<crate::pipeline::DocumentSource>,
+    ) -> Vec<crate::pipeline::RagChunk> {
+        let mut chunks: Vec<crate::pipeline::RagChunk> = match &source {
+            Some(s) => hybrid_chunks
+                .iter()
+                .enumerate()
+                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk_with_source(i, hc, s))
+                .collect(),
+            None => hybrid_chunks
+                .iter()
+                .enumerate()
+                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(i, hc))
+                .collect(),
+        };
+        crate::pipeline::chunk_metadata::link_chunks(&mut chunks);
+        chunks
     }
 
     /// Extract and chunk the document using a pre-configured extraction profile.
@@ -1436,12 +1455,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         let elements = self.partition_with_profile(profile)?;
         let chunker = crate::pipeline::HybridChunker::default();
         let hybrid_chunks = chunker.chunk(&elements);
-        let rag_chunks = hybrid_chunks
-            .iter()
-            .enumerate()
-            .map(|(idx, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(idx, hc))
-            .collect();
-        Ok(rag_chunks)
+        Ok(self.build_rag_chunks(&hybrid_chunks, None))
     }
 
     /// Combine a pre-configured extraction profile with a custom chunking config.
@@ -1468,11 +1482,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         let elements = self.partition_with_profile(profile)?;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(hybrid_chunks
-            .iter()
-            .enumerate()
-            .map(|(idx, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(idx, hc))
-            .collect())
+        Ok(self.build_rag_chunks(&hybrid_chunks, None))
     }
 
     /// Extract chunks as a JSON string ready for vector store ingestion.

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1480,11 +1480,29 @@ impl<R: Read + Seek> PdfDocument<R> {
     }
 
     /// Run a custom [`AnalysisPipeline`](crate::pipeline::AnalysisPipeline):
-    /// partition, apply the pipeline's chunking strategy, then build linked
-    /// `RagChunk`s (ids, prev/next, metadata, optional source) exactly as the
-    /// other `rag_chunks*` entry points do.
+    /// partition, optionally classify elements, apply the pipeline's chunking
+    /// strategy, build linked `RagChunk`s (ids, prev/next, metadata, optional
+    /// source) exactly as the other `rag_chunks*` entry points do, then run any
+    /// enrichers over each chunk's `extra` bag.
     ///
     /// `AnalysisPipeline::new()` reproduces [`rag_chunks`](Self::rag_chunks).
+    ///
+    /// **Stability:** requires `unstable-spi`; exempt from semver until promoted.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use oxidize_pdf::parser::PdfDocument;
+    /// # use oxidize_pdf::pipeline::AnalysisPipeline;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// // Default pipeline == rag_chunks(); swap in a custom strategy/classifier/
+    /// // enricher via the builder to extend it.
+    /// let chunks = doc.rag_chunks_with_pipeline(&AnalysisPipeline::new())?;
+    /// println!("{} chunks", chunks.len());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(feature = "unstable-spi")]
     pub fn rag_chunks_with_pipeline(
         &self,
@@ -1519,6 +1537,8 @@ impl<R: Read + Seek> PdfDocument<R> {
             .into_iter()
             .map(|g| crate::pipeline::HybridChunk::from_group(g, pipeline.max_tokens))
             .collect();
+        // `mut` is needed only for the enricher pass below (gated `semantic`);
+        // without that feature the binding is never mutated — silence the warning.
         #[allow(unused_mut)]
         let mut chunks = self.build_rag_chunks(&hybrid, source);
         #[cfg(feature = "semantic")]

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1429,7 +1429,34 @@ impl<R: Read + Seek> PdfDocument<R> {
     /// ```
     pub fn rag_chunks_with_source(
         &self,
+        source: crate::pipeline::DocumentSource,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        self.rag_chunks_with_source_and_config(
+            source,
+            crate::pipeline::HybridChunkConfig::default(),
+        )
+    }
+
+    /// Like [`rag_chunks_with_source`](Self::rag_chunks_with_source) but with a
+    /// custom chunking configuration — for callers that need both
+    /// source-document stamping and a non-default token budget.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use oxidize_pdf::parser::PdfDocument;
+    /// use oxidize_pdf::pipeline::{DocumentSource, HybridChunkConfig};
+    ///
+    /// let doc = PdfDocument::open("document.pdf")?;
+    /// let source = DocumentSource::with_file(Some("document.pdf".into()), None);
+    /// let config = HybridChunkConfig { max_tokens: 256, ..Default::default() };
+    /// let chunks = doc.rag_chunks_with_source_and_config(source, config)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn rag_chunks_with_source_and_config(
+        &self,
         mut source: crate::pipeline::DocumentSource,
+        config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         if let Ok(meta) = self.metadata() {
             source.title = source.title.or(meta.title);
@@ -1441,7 +1468,7 @@ impl<R: Read + Seek> PdfDocument<R> {
             source.total_pages = self.page_count().ok();
         }
         let elements = self.partition()?;
-        let chunker = crate::pipeline::HybridChunker::default();
+        let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
         Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
     }

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1494,7 +1494,26 @@ impl<R: Read + Seek> PdfDocument<R> {
         if let Some(src) = source.as_mut() {
             self.autofill_source(src);
         }
-        let elements = self.partition()?;
+        let mut elements = self.partition()?;
+        if let Some(classifier) = pipeline.classifier.as_deref() {
+            // Two passes: read labels against an immutable slice, then apply —
+            // the classifier inspects neighbours via `ClassifyContext`, so it
+            // cannot run while the slice is being mutated.
+            let labels: Vec<Option<crate::pipeline::ClassLabel>> = (0..elements.len())
+                .map(|index| {
+                    let ctx = crate::pipeline::ClassifyContext {
+                        elements: &elements,
+                        index,
+                    };
+                    classifier.classify(&elements[index], &ctx)
+                })
+                .collect();
+            for (element, label) in elements.iter_mut().zip(labels) {
+                if let Some(label) = label {
+                    element.metadata_mut().class_label = Some(label.0.into_owned());
+                }
+            }
+        }
         let groups = pipeline.chunking.chunk(&elements);
         let hybrid: Vec<crate::pipeline::HybridChunk> = groups
             .into_iter()

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1458,19 +1458,49 @@ impl<R: Read + Seek> PdfDocument<R> {
         mut source: crate::pipeline::DocumentSource,
         config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        self.autofill_source(&mut source);
+        let elements = self.partition()?;
+        let chunker = crate::pipeline::HybridChunker::new(config);
+        let hybrid_chunks = chunker.chunk(&elements);
+        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
+    }
+
+    /// Fill `title`/`author`/`creation_date`/`total_pages` from the info
+    /// dictionary where the caller left them `None`.
+    fn autofill_source(&self, source: &mut crate::pipeline::DocumentSource) {
         if let Ok(meta) = self.metadata() {
-            source.title = source.title.or(meta.title);
-            source.author = source.author.or(meta.author);
-            source.creation_date = source.creation_date.or(meta.creation_date);
+            source.title = source.title.take().or(meta.title);
+            source.author = source.author.take().or(meta.author);
+            source.creation_date = source.creation_date.take().or(meta.creation_date);
             source.total_pages = source.total_pages.or(meta.page_count);
         }
         if source.total_pages.is_none() {
             source.total_pages = self.page_count().ok();
         }
+    }
+
+    /// Run a custom [`AnalysisPipeline`](crate::pipeline::AnalysisPipeline):
+    /// partition, apply the pipeline's chunking strategy, then build linked
+    /// `RagChunk`s (ids, prev/next, metadata, optional source) exactly as the
+    /// other `rag_chunks*` entry points do.
+    ///
+    /// `AnalysisPipeline::new()` reproduces [`rag_chunks`](Self::rag_chunks).
+    #[cfg(feature = "unstable-spi")]
+    pub fn rag_chunks_with_pipeline(
+        &self,
+        pipeline: &crate::pipeline::AnalysisPipeline,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let mut source = pipeline.source.clone();
+        if let Some(src) = source.as_mut() {
+            self.autofill_source(src);
+        }
         let elements = self.partition()?;
-        let chunker = crate::pipeline::HybridChunker::new(config);
-        let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
+        let groups = pipeline.chunking.chunk(&elements);
+        let hybrid: Vec<crate::pipeline::HybridChunk> = groups
+            .into_iter()
+            .map(|g| crate::pipeline::HybridChunk::from_group(g, pipeline.max_tokens))
+            .collect();
+        Ok(self.build_rag_chunks(&hybrid, source))
     }
 
     /// Build linked [`RagChunk`]s from hybrid chunks, optionally stamping a

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -159,8 +159,15 @@ pub struct ChunkMetadata {
     /// Sentence count (uses the chunker's sentence splitter).
     pub sentence_count: usize,
     /// Detected language code (ISO 639-3, via `whatlang`); `None` if the
-    /// `lang-detect` feature is off or detection is inconclusive.
+    /// `language-detection` feature is off or detection is inconclusive.
     pub language: Option<String>,
+    /// Detection confidence in `(0, 1]` for [`language`](Self::language);
+    /// `None` when no language was detected.
+    pub language_confidence: Option<f32>,
+    /// Whether `whatlang` considered the [`language`](Self::language)
+    /// detection reliable. Consumers should gate language-based routing on
+    /// this; `None` when no language was detected.
+    pub language_reliable: Option<bool>,
     /// Deterministic, stable identifier for this chunk.
     pub chunk_id: String,
     /// Identifier of the previous chunk in the document, if any.
@@ -197,6 +204,18 @@ impl ChunkMetadata {
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
         let (page_span, page_regions) = page_anchor(elements);
+        // Detect once; fill code + confidence + reliability together.
+        #[cfg(feature = "language-detection")]
+        let (language, language_confidence, language_reliable) = match detect_language_full(text) {
+            Some((code, conf, reliable)) => (Some(code), Some(conf), Some(reliable)),
+            None => (None, None, None),
+        };
+        #[cfg(not(feature = "language-detection"))]
+        let (language, language_confidence, language_reliable): (
+            Option<String>,
+            Option<f32>,
+            Option<bool>,
+        ) = (None, None, None);
         ChunkMetadata {
             heading_path,
             dominant_font: agg.dominant_font,
@@ -208,10 +227,9 @@ impl ChunkMetadata {
             char_count: char_count(text),
             word_count: word_count(text),
             sentence_count: sentence_count(text),
-            #[cfg(feature = "language-detection")]
-            language: detect_language(text),
-            #[cfg(not(feature = "language-detection"))]
-            language: None,
+            language,
+            language_confidence,
+            language_reliable,
             chunk_id: content_chunk_id(doc_hash, chunk_index, full_text),
             prev_chunk_id: None,
             next_chunk_id: None,
@@ -277,10 +295,25 @@ pub(crate) fn link_chunks(chunks: &mut [crate::pipeline::RagChunk]) {
 /// Requires the `language-detection` feature.
 #[cfg(feature = "language-detection")]
 pub fn detect_language(text: &str) -> Option<String> {
+    detect_language_full(text).map(|(code, _, _)| code)
+}
+
+/// Run `whatlang` once and return `(code, confidence, reliable)`; `None` for
+/// empty/whitespace-only input or when no detection is produced. Single call
+/// site so [`ChunkMetadata`] can fill code + confidence + reliability without
+/// detecting twice.
+#[cfg(feature = "language-detection")]
+pub(crate) fn detect_language_full(text: &str) -> Option<(String, f32, bool)> {
     if text.trim().is_empty() {
         return None;
     }
-    whatlang::detect(text).map(|info| info.lang().code().to_string())
+    whatlang::detect(text).map(|info| {
+        (
+            info.lang().code().to_string(),
+            info.confidence() as f32,
+            info.is_reliable(),
+        )
+    })
 }
 
 /// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
@@ -517,5 +550,36 @@ mod tests {
         let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
         assert_eq!(m.page_span, None);
         assert!(m.page_regions.is_empty());
+    }
+
+    #[cfg(feature = "language-detection")]
+    #[test]
+    fn language_reliability_populated_alongside_code() {
+        let els = vec![para("x", "F", 10.0, false, 1.0)];
+        let text =
+            "The annual report summarizes the financial performance of the company over the year.";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+        assert_eq!(m.language.as_deref(), Some("eng"));
+        let conf = m
+            .language_confidence
+            .expect("confidence present when a language is detected");
+        assert!(
+            conf > 0.0 && conf <= 1.0,
+            "confidence must be in (0, 1], got {conf}"
+        );
+        assert_eq!(
+            m.language_reliable,
+            Some(true),
+            "a full English sentence must be a reliable detection"
+        );
+    }
+
+    #[cfg(feature = "language-detection")]
+    #[test]
+    fn language_reliability_none_for_empty_text() {
+        let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
+        assert_eq!(m.language, None);
+        assert_eq!(m.language_confidence, None);
+        assert_eq!(m.language_reliable, None);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -1,0 +1,98 @@
+//! Chunk-level metadata for RAG output.
+//!
+//! Surfaces data already computed by the partitioner (heading hierarchy, font,
+//! style, confidence) plus new retrieval signals (content-type flags, counts,
+//! stable IDs, language) and optional source-document metadata.
+
+#[cfg(feature = "semantic")]
+use serde::{Deserialize, Serialize};
+
+/// Boolean flags describing the kinds of content present in a chunk.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct ContentTypeFlags {
+    /// The chunk contains at least one table element.
+    pub has_table: bool,
+    /// The chunk contains at least one list item.
+    pub has_list: bool,
+    /// The chunk contains at least one code block.
+    pub has_code: bool,
+    /// The chunk is composed solely of heading (title) elements.
+    pub heading_only: bool,
+}
+
+/// Metadata about the source document a chunk came from.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct DocumentSource {
+    /// Document title from the info dictionary, if present.
+    pub title: Option<String>,
+    /// Document author from the info dictionary, if present.
+    pub author: Option<String>,
+    /// Creation date string from the info dictionary, if present.
+    pub creation_date: Option<String>,
+    /// Originating file name (caller-supplied — the pipeline does not know it).
+    pub filename: Option<String>,
+    /// Stable document hash (caller-supplied; used as the chunk_id prefix).
+    pub doc_hash: Option<String>,
+    /// Total page count of the source document.
+    pub total_pages: Option<u32>,
+}
+
+/// Per-chunk metadata attached to every [`RagChunk`](crate::pipeline::RagChunk).
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct ChunkMetadata {
+    /// Full section breadcrumb, root→leaf (e.g. `["1 Intro", "1.2 Scope"]`).
+    pub heading_path: Vec<String>,
+    /// Dominant font (char-weighted majority across the chunk's elements).
+    pub dominant_font: Option<String>,
+    /// Dominant font size (char-weighted majority).
+    pub dominant_font_size: Option<f64>,
+    /// True if the majority of characters are bold.
+    pub is_bold: bool,
+    /// True if the majority of characters are italic.
+    pub is_italic: bool,
+    /// Lowest classification confidence among the chunk's elements.
+    pub min_confidence: f32,
+    /// Content-type flags derived from element types.
+    pub content_types: ContentTypeFlags,
+    /// Character count of the chunk text.
+    pub char_count: usize,
+    /// Whitespace-separated word count.
+    pub word_count: usize,
+    /// Sentence count (uses the chunker's sentence splitter).
+    pub sentence_count: usize,
+    /// Detected language code (ISO 639-3, via `whatlang`); `None` if the
+    /// `lang-detect` feature is off or detection is inconclusive.
+    pub language: Option<String>,
+    /// Deterministic, stable identifier for this chunk.
+    pub chunk_id: String,
+    /// Identifier of the previous chunk in the document, if any.
+    pub prev_chunk_id: Option<String>,
+    /// Identifier of the next chunk in the document, if any.
+    pub next_chunk_id: Option<String>,
+    /// Source-document metadata, if available.
+    pub source: Option<DocumentSource>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_metadata_default_is_empty() {
+        let m = ChunkMetadata::default();
+        assert!(m.heading_path.is_empty());
+        assert_eq!(m.dominant_font, None);
+        assert!(!m.is_bold);
+        assert_eq!(m.min_confidence, 0.0);
+        assert!(!m.content_types.has_table);
+        assert_eq!(m.char_count, 0);
+        assert_eq!(m.language, None);
+        assert_eq!(m.chunk_id, "");
+        assert!(m.source.is_none());
+    }
+}

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -6,6 +6,8 @@
 
 #[cfg(feature = "semantic")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "semantic")]
+use std::collections::BTreeMap;
 
 use crate::pipeline::element::{Element, ElementBBox};
 use crate::pipeline::hybrid_chunking::split_into_sentences;
@@ -188,6 +190,12 @@ pub struct ChunkMetadata {
     /// Column count (widest row) of the same table reported by
     /// [`table_rows`](Self::table_rows); `None` when the chunk has no table.
     pub table_cols: Option<usize>,
+    /// Open extension bag for provider-supplied fields (e.g. a closed analyzer
+    /// stamping `legal.clause_number`). Namespacing keys by provider avoids
+    /// collisions. Serializes nested under `"extra"`; omitted when empty.
+    #[cfg(feature = "semantic")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 use sha2::{Digest, Sha256};
@@ -245,6 +253,8 @@ impl ChunkMetadata {
             page_regions,
             table_rows,
             table_cols,
+            #[cfg(feature = "semantic")]
+            extra: BTreeMap::new(),
         }
     }
 }
@@ -651,5 +661,35 @@ mod tests {
         let m = ChunkMetadata::from_elements(&els, "just prose", "just prose", 0, None);
         assert_eq!(m.table_rows, None);
         assert_eq!(m.table_cols, None);
+    }
+
+    #[cfg(feature = "semantic")]
+    #[test]
+    fn extra_bag_defaults_empty_and_roundtrips() {
+        let mut m = ChunkMetadata::default();
+        assert!(m.extra.is_empty(), "extra defaults to empty");
+
+        // Empty extra is omitted from the serialized output.
+        let json_empty = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json_empty.contains("\"extra\""),
+            "empty extra must be skipped in JSON"
+        );
+
+        // Populated extra survives a deterministic round-trip.
+        m.extra
+            .insert("legal.clause_number".to_string(), serde_json::json!("3.2"));
+        m.extra.insert(
+            "legal.defined_terms".to_string(),
+            serde_json::json!(["Party", "Agreement"]),
+        );
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("\"extra\""));
+        let back: ChunkMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.extra, m.extra, "extra survives round-trip");
+        assert_eq!(
+            back.extra.get("legal.clause_number").unwrap(),
+            &serde_json::json!("3.2")
+        );
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -182,6 +182,12 @@ pub struct ChunkMetadata {
     /// Per-page citation regions (union bbox of the chunk's elements on each
     /// page), sorted ascending by page. Empty when the chunk has no elements.
     pub page_regions: Vec<PageRegion>,
+    /// Row count of the chunk's largest table (by row count), or `None` if the
+    /// chunk has no table. Lets a consumer filter/route table-bearing chunks.
+    pub table_rows: Option<usize>,
+    /// Column count (widest row) of the same table reported by
+    /// [`table_rows`](Self::table_rows); `None` when the chunk has no table.
+    pub table_cols: Option<usize>,
 }
 
 use sha2::{Digest, Sha256};
@@ -204,6 +210,7 @@ impl ChunkMetadata {
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
         let (page_span, page_regions) = page_anchor(elements);
+        let (table_rows, table_cols) = table_dims(elements);
         // Detect once; fill code + confidence + reliability together.
         #[cfg(feature = "language-detection")]
         let (language, language_confidence, language_reliable) = match detect_language_full(text) {
@@ -236,8 +243,27 @@ impl ChunkMetadata {
             source: None,
             page_span,
             page_regions,
+            table_rows,
+            table_cols,
         }
     }
+}
+
+/// Dimensions of the chunk's largest table (by row count): `(rows, widest row)`.
+/// `(None, None)` when the chunk contains no table element.
+fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
+    elements
+        .iter()
+        .filter_map(|e| match e {
+            Element::Table(t) => Some(&t.rows),
+            _ => None,
+        })
+        .max_by_key(|rows| rows.len())
+        .map(|rows| {
+            let cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+            (Some(rows.len()), Some(cols))
+        })
+        .unwrap_or((None, None))
 }
 
 /// Union of two axis-aligned bounding boxes.
@@ -465,8 +491,14 @@ mod tests {
         assert!(!m.content_types.has_table);
         assert_eq!(m.char_count, 0);
         assert_eq!(m.language, None);
+        assert_eq!(m.language_confidence, None);
+        assert_eq!(m.language_reliable, None);
         assert_eq!(m.chunk_id, "");
         assert!(m.source.is_none());
+        assert_eq!(m.page_span, None);
+        assert!(m.page_regions.is_empty());
+        assert_eq!(m.table_rows, None);
+        assert_eq!(m.table_cols, None);
     }
 
     #[test]
@@ -581,5 +613,43 @@ mod tests {
         assert_eq!(m.language, None);
         assert_eq!(m.language_confidence, None);
         assert_eq!(m.language_reliable, None);
+    }
+
+    fn table_with(rows: Vec<Vec<&str>>) -> Element {
+        Element::Table(crate::pipeline::element::TableElementData {
+            rows: rows
+                .into_iter()
+                .map(|r| r.into_iter().map(String::from).collect())
+                .collect(),
+            metadata: ElementMetadata::default(),
+        })
+    }
+
+    #[test]
+    fn table_dims_from_largest_table() {
+        let small = table_with(vec![vec!["a", "b"]]); // 1 row x 2 cols
+        let big = table_with(vec![vec!["a"], vec!["b"], vec!["c"]]); // 3 rows x 1 col
+        let els = vec![para("x", "F", 10.0, false, 1.0), small, big];
+        let text = "x";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+        // Largest by row count wins.
+        assert_eq!(m.table_rows, Some(3));
+        assert_eq!(m.table_cols, Some(1));
+    }
+
+    #[test]
+    fn table_cols_uses_widest_row() {
+        let ragged = table_with(vec![vec!["a", "b"], vec!["c", "d", "e", "f"]]);
+        let m = ChunkMetadata::from_elements(&[ragged], "t", "t", 0, None);
+        assert_eq!(m.table_rows, Some(2));
+        assert_eq!(m.table_cols, Some(4));
+    }
+
+    #[test]
+    fn table_dims_none_without_table() {
+        let els = vec![para("just prose", "F", 10.0, false, 1.0)];
+        let m = ChunkMetadata::from_elements(&els, "just prose", "just prose", 0, None);
+        assert_eq!(m.table_rows, None);
+        assert_eq!(m.table_cols, None);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::pipeline::element::Element;
+use crate::pipeline::hybrid_chunking::split_into_sentences;
 
 /// Char-weighted aggregates over a chunk's elements.
 // consumed by ChunkMetadata::from_elements (Task 6)
@@ -145,10 +146,85 @@ pub struct ChunkMetadata {
     pub source: Option<DocumentSource>,
 }
 
+// consumed by ChunkMetadata::from_elements (Task 6)
+#[allow(dead_code)]
+pub(crate) fn content_type_flags(elements: &[Element]) -> ContentTypeFlags {
+    let mut flags = ContentTypeFlags::default();
+    let mut all_titles = !elements.is_empty();
+    for e in elements {
+        match e {
+            Element::Table(_) => flags.has_table = true,
+            Element::ListItem(_) => flags.has_list = true,
+            Element::CodeBlock(_) => flags.has_code = true,
+            _ => {}
+        }
+        if !matches!(e, Element::Title(_)) {
+            all_titles = false;
+        }
+    }
+    flags.heading_only = all_titles;
+    flags
+}
+
+// consumed by ChunkMetadata::from_elements (Task 6)
+#[allow(dead_code)]
+pub(crate) fn char_count(text: &str) -> usize {
+    text.chars().count()
+}
+
+// consumed by ChunkMetadata::from_elements (Task 6)
+#[allow(dead_code)]
+pub(crate) fn word_count(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+// consumed by ChunkMetadata::from_elements (Task 6)
+#[allow(dead_code)]
+pub(crate) fn sentence_count(text: &str) -> usize {
+    if text.trim().is_empty() {
+        return 0;
+    }
+    split_into_sentences(text).len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+
+    fn table_el() -> Element {
+        Element::Table(crate::pipeline::element::TableElementData {
+            rows: vec![],
+            metadata: crate::pipeline::element::ElementMetadata::default(),
+        })
+    }
+
+    #[test]
+    fn content_types_and_counts() {
+        let els = vec![
+            para("Hello world. Second sentence!", "F", 10.0, false, 1.0),
+            table_el(),
+        ];
+        let flags = content_type_flags(&els);
+        assert!(flags.has_table);
+        assert!(!flags.has_list);
+        assert!(!flags.heading_only);
+
+        let text = "Hello world. Second sentence!";
+        assert_eq!(char_count(text), text.chars().count());
+        assert_eq!(word_count(text), 4);
+        assert_eq!(sentence_count(text), 2);
+    }
+
+    #[test]
+    fn heading_only_when_all_titles() {
+        let d = crate::pipeline::element::ElementData {
+            text: "Title".to_string(),
+            metadata: crate::pipeline::element::ElementMetadata::default(),
+        };
+        let els = vec![Element::Title(d)];
+        assert!(content_type_flags(&els).heading_only);
+    }
 
     fn para(text: &str, font: &str, size: f64, bold: bool, conf: f64) -> Element {
         let metadata = ElementMetadata {

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -182,6 +182,19 @@ impl ChunkMetadata {
     }
 }
 
+/// Fill `prev_chunk_id` / `next_chunk_id` on each chunk from its neighbours' ids.
+pub(crate) fn link_chunks(chunks: &mut [crate::pipeline::RagChunk]) {
+    let ids: Vec<String> = chunks.iter().map(|c| c.metadata.chunk_id.clone()).collect();
+    for (i, c) in chunks.iter_mut().enumerate() {
+        c.metadata.prev_chunk_id = if i > 0 {
+            Some(ids[i - 1].clone())
+        } else {
+            None
+        };
+        c.metadata.next_chunk_id = ids.get(i + 1).cloned();
+    }
+}
+
 /// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
 /// `doc_hash` or, absent that, the first 8 bytes of SHA-256(full_text) in hex.
 pub(crate) fn content_chunk_id(doc_hash: Option<&str>, index: usize, full_text: &str) -> String {

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -145,11 +145,11 @@ pub struct ChunkMetadata {
 
 use sha2::{Digest, Sha256};
 
-#[allow(dead_code)] // wired into RagChunk::from_hybrid_chunk (Task 7)
 impl ChunkMetadata {
     /// Build chunk metadata from the chunk's elements and text. `full_text` is
     /// used for the content-hash id; `doc_hash` (when `Some`) overrides it.
-    /// Language and prev/next links are filled by later passes.
+    /// Language is detected here when the `language-detection` feature is on;
+    /// prev/next links are filled by a later pass ([`link_chunks`]).
     pub(crate) fn from_elements(
         elements: &[Element],
         text: &str,
@@ -336,6 +336,13 @@ mod tests {
         let b = content_chunk_id(None, 0, "the quick brown fox");
         assert_eq!(a, b, "same text + index → same id");
         assert!(a.ends_with(":0"));
+        // Hashless prefix is exactly 8 bytes of SHA-256 → 16 hex chars; pin the
+        // width so a change to the digest slice can't silently shrink the id.
+        assert_eq!(
+            a.split(':').next().unwrap().len(),
+            16,
+            "hashless chunk_id prefix must be 16 hex chars (8 bytes)"
+        );
 
         let with_hash = content_chunk_id(Some("dochash123"), 7, "ignored when hash present");
         assert_eq!(with_hash, "dochash123:7");

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -11,8 +11,6 @@ use crate::pipeline::element::Element;
 use crate::pipeline::hybrid_chunking::split_into_sentences;
 
 /// Char-weighted aggregates over a chunk's elements.
-// consumed by ChunkMetadata::from_elements (Task 6)
-#[allow(dead_code)]
 pub(crate) struct Aggregates {
     pub dominant_font: Option<String>,
     pub dominant_font_size: Option<f64>,
@@ -21,7 +19,6 @@ pub(crate) struct Aggregates {
     pub min_confidence: f32,
 }
 
-#[allow(dead_code)]
 impl Aggregates {
     pub(crate) fn from_elements(elements: &[Element]) -> Self {
         let mut font_weight: Vec<(String, usize)> = Vec::new();
@@ -148,10 +145,45 @@ pub struct ChunkMetadata {
 
 use sha2::{Digest, Sha256};
 
+#[allow(dead_code)] // wired into RagChunk::from_hybrid_chunk (Task 7)
+impl ChunkMetadata {
+    /// Build chunk metadata from the chunk's elements and text. `full_text` is
+    /// used for the content-hash id; `doc_hash` (when `Some`) overrides it.
+    /// Language and prev/next links are filled by later passes.
+    pub(crate) fn from_elements(
+        elements: &[Element],
+        text: &str,
+        full_text: &str,
+        chunk_index: usize,
+        doc_hash: Option<&str>,
+    ) -> Self {
+        let agg = Aggregates::from_elements(elements);
+        let heading_path = elements
+            .first()
+            .map(|e| e.metadata().heading_path.clone())
+            .unwrap_or_default();
+        ChunkMetadata {
+            heading_path,
+            dominant_font: agg.dominant_font,
+            dominant_font_size: agg.dominant_font_size,
+            is_bold: agg.is_bold,
+            is_italic: agg.is_italic,
+            min_confidence: agg.min_confidence,
+            content_types: content_type_flags(elements),
+            char_count: char_count(text),
+            word_count: word_count(text),
+            sentence_count: sentence_count(text),
+            language: None,
+            chunk_id: content_chunk_id(doc_hash, chunk_index, full_text),
+            prev_chunk_id: None,
+            next_chunk_id: None,
+            source: None,
+        }
+    }
+}
+
 /// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
 /// `doc_hash` or, absent that, the first 8 bytes of SHA-256(full_text) in hex.
-// consumed by ChunkMetadata::from_elements (Task 6) and link_chunks (Task 7)
-#[allow(dead_code)]
 pub(crate) fn content_chunk_id(doc_hash: Option<&str>, index: usize, full_text: &str) -> String {
     let doc_id = match doc_hash {
         Some(h) => h.to_string(),
@@ -168,8 +200,6 @@ pub(crate) fn content_chunk_id(doc_hash: Option<&str>, index: usize, full_text: 
     format!("{doc_id}:{index}")
 }
 
-// consumed by ChunkMetadata::from_elements (Task 6)
-#[allow(dead_code)]
 pub(crate) fn content_type_flags(elements: &[Element]) -> ContentTypeFlags {
     let mut flags = ContentTypeFlags::default();
     let mut all_titles = !elements.is_empty();
@@ -188,20 +218,14 @@ pub(crate) fn content_type_flags(elements: &[Element]) -> ContentTypeFlags {
     flags
 }
 
-// consumed by ChunkMetadata::from_elements (Task 6)
-#[allow(dead_code)]
 pub(crate) fn char_count(text: &str) -> usize {
     text.chars().count()
 }
 
-// consumed by ChunkMetadata::from_elements (Task 6)
-#[allow(dead_code)]
 pub(crate) fn word_count(text: &str) -> usize {
     text.split_whitespace().count()
 }
 
-// consumed by ChunkMetadata::from_elements (Task 6)
-#[allow(dead_code)]
 pub(crate) fn sentence_count(text: &str) -> usize {
     if text.trim().is_empty() {
         return 0;
@@ -302,5 +326,21 @@ mod tests {
         assert_eq!(m.language, None);
         assert_eq!(m.chunk_id, "");
         assert!(m.source.is_none());
+    }
+
+    #[test]
+    fn build_metadata_from_chunk_elements() {
+        let els = vec![
+            para("aaaa", "Helvetica", 12.0, true, 0.8),
+            para("bb. cc.", "Helvetica", 12.0, false, 0.6),
+        ];
+        let text = "aaaa\nbb. cc.";
+        let m = ChunkMetadata::from_elements(&els, text, text, 3, None);
+        assert_eq!(m.dominant_font.as_deref(), Some("Helvetica"));
+        assert!((m.min_confidence - 0.6).abs() < 1e-6);
+        assert_eq!(m.char_count, text.chars().count());
+        assert_eq!(m.chunk_id, content_chunk_id(None, 3, text));
+        assert!(m.source.is_none());
+        assert_eq!(m.language, None); // language filled separately in a later task
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -7,6 +7,73 @@
 #[cfg(feature = "semantic")]
 use serde::{Deserialize, Serialize};
 
+use crate::pipeline::element::Element;
+
+/// Char-weighted aggregates over a chunk's elements.
+// consumed by ChunkMetadata::from_elements (Task 6)
+#[allow(dead_code)]
+pub(crate) struct Aggregates {
+    pub dominant_font: Option<String>,
+    pub dominant_font_size: Option<f64>,
+    pub is_bold: bool,
+    pub is_italic: bool,
+    pub min_confidence: f32,
+}
+
+#[allow(dead_code)]
+impl Aggregates {
+    pub(crate) fn from_elements(elements: &[Element]) -> Self {
+        let mut font_weight: Vec<(String, usize)> = Vec::new();
+        let mut size_weight: Vec<(f64, usize)> = Vec::new();
+        let mut bold_chars = 0usize;
+        let mut italic_chars = 0usize;
+        let mut total_chars = 0usize;
+        let mut min_conf = 1.0f32;
+
+        for e in elements {
+            let w = e.text().chars().count();
+            total_chars += w;
+            let meta = e.metadata();
+            if let Some(f) = &meta.font_name {
+                match font_weight.iter_mut().find(|(name, _)| name == f) {
+                    Some((_, c)) => *c += w,
+                    None => font_weight.push((f.clone(), w)),
+                }
+            }
+            if let Some(s) = meta.font_size {
+                match size_weight.iter_mut().find(|(sz, _)| (*sz - s).abs() < 0.1) {
+                    Some((_, c)) => *c += w,
+                    None => size_weight.push((s, w)),
+                }
+            }
+            if meta.is_bold {
+                bold_chars += w;
+            }
+            if meta.is_italic {
+                italic_chars += w;
+            }
+            min_conf = min_conf.min(meta.confidence as f32);
+        }
+
+        let dominant_font = font_weight
+            .into_iter()
+            .max_by_key(|(_, c)| *c)
+            .map(|(name, _)| name);
+        let dominant_font_size = size_weight
+            .into_iter()
+            .max_by_key(|(_, c)| *c)
+            .map(|(sz, _)| sz);
+
+        Self {
+            dominant_font,
+            dominant_font_size,
+            is_bold: total_chars > 0 && bold_chars * 2 > total_chars,
+            is_italic: total_chars > 0 && italic_chars * 2 > total_chars,
+            min_confidence: if elements.is_empty() { 0.0 } else { min_conf },
+        }
+    }
+}
+
 /// Boolean flags describing the kinds of content present in a chunk.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
@@ -81,6 +148,35 @@ pub struct ChunkMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+
+    fn para(text: &str, font: &str, size: f64, bold: bool, conf: f64) -> Element {
+        let metadata = ElementMetadata {
+            font_name: Some(font.to_string()),
+            font_size: Some(size),
+            is_bold: bold,
+            confidence: conf,
+            ..ElementMetadata::default()
+        };
+        Element::Paragraph(ElementData {
+            text: text.to_string(),
+            metadata,
+        })
+    }
+
+    #[test]
+    fn aggregate_picks_char_weighted_dominant_font_and_min_confidence() {
+        // "aaaa" (4 chars) Helvetica bold conf=0.9 ; "bb" (2) Times conf=0.5
+        let els = vec![
+            para("aaaa", "Helvetica", 12.0, true, 0.9),
+            para("bb", "Times", 10.0, false, 0.5),
+        ];
+        let agg = Aggregates::from_elements(&els);
+        assert_eq!(agg.dominant_font.as_deref(), Some("Helvetica"));
+        assert_eq!(agg.dominant_font_size, Some(12.0));
+        assert!(agg.is_bold, "4 bold chars vs 2 non-bold → bold majority");
+        assert!((agg.min_confidence - 0.5).abs() < 1e-6);
+    }
 
     #[test]
     fn chunk_metadata_default_is_empty() {

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -105,6 +105,21 @@ pub struct DocumentSource {
     pub total_pages: Option<u32>,
 }
 
+impl DocumentSource {
+    /// Construct a source from the two caller-supplied fields (`filename`,
+    /// `doc_hash`); the rest (`title`/`author`/`creation_date`/`total_pages`)
+    /// are left `None` for [`rag_chunks_with_source`](crate::parser::PdfDocument::rag_chunks_with_source)
+    /// to auto-fill from the info dictionary. Provided because `DocumentSource`
+    /// is `#[non_exhaustive]`, so external callers cannot use a struct literal.
+    pub fn with_file(filename: Option<String>, doc_hash: Option<String>) -> Self {
+        Self {
+            filename,
+            doc_hash,
+            ..Default::default()
+        }
+    }
+}
+
 /// Per-chunk metadata attached to every [`RagChunk`](crate::pipeline::RagChunk).
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
@@ -363,6 +378,22 @@ mod tests {
         assert_eq!(m.language, None);
         assert_eq!(m.chunk_id, "");
         assert!(m.source.is_none());
+    }
+
+    #[test]
+    fn document_source_with_file_sets_only_supplied_fields() {
+        let s = DocumentSource::with_file(Some("doc.pdf".to_string()), Some("h7".to_string()));
+        assert_eq!(s.filename.as_deref(), Some("doc.pdf"));
+        assert_eq!(s.doc_hash.as_deref(), Some("h7"));
+        // Everything the caller did not supply stays None for the info-dict
+        // auto-fill pass to populate.
+        assert_eq!(s.title, None);
+        assert_eq!(s.author, None);
+        assert_eq!(s.creation_date, None);
+        assert_eq!(s.total_pages, None);
+
+        let empty = DocumentSource::with_file(None, None);
+        assert_eq!(empty, DocumentSource::default());
     }
 
     #[test]

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -146,6 +146,28 @@ pub struct ChunkMetadata {
     pub source: Option<DocumentSource>,
 }
 
+use sha2::{Digest, Sha256};
+
+/// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
+/// `doc_hash` or, absent that, the first 8 bytes of SHA-256(full_text) in hex.
+// consumed by ChunkMetadata::from_elements (Task 6) and link_chunks (Task 7)
+#[allow(dead_code)]
+pub(crate) fn content_chunk_id(doc_hash: Option<&str>, index: usize, full_text: &str) -> String {
+    let doc_id = match doc_hash {
+        Some(h) => h.to_string(),
+        None => {
+            let mut hasher = Sha256::new();
+            hasher.update(full_text.as_bytes());
+            let digest = hasher.finalize();
+            digest[..8]
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        }
+    };
+    format!("{doc_id}:{index}")
+}
+
 // consumed by ChunkMetadata::from_elements (Task 6)
 #[allow(dead_code)]
 pub(crate) fn content_type_flags(elements: &[Element]) -> ContentTypeFlags {
@@ -252,6 +274,20 @@ mod tests {
         assert_eq!(agg.dominant_font_size, Some(12.0));
         assert!(agg.is_bold, "4 bold chars vs 2 non-bold → bold majority");
         assert!((agg.min_confidence - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn chunk_id_is_deterministic_and_prefixed() {
+        let a = content_chunk_id(None, 0, "the quick brown fox");
+        let b = content_chunk_id(None, 0, "the quick brown fox");
+        assert_eq!(a, b, "same text + index → same id");
+        assert!(a.ends_with(":0"));
+
+        let with_hash = content_chunk_id(Some("dochash123"), 7, "ignored when hash present");
+        assert_eq!(with_hash, "dochash123:7");
+
+        let other = content_chunk_id(None, 0, "different text");
+        assert_ne!(a, other);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -7,7 +7,7 @@
 #[cfg(feature = "semantic")]
 use serde::{Deserialize, Serialize};
 
-use crate::pipeline::element::Element;
+use crate::pipeline::element::{Element, ElementBBox};
 use crate::pipeline::hybrid_chunking::split_into_sentences;
 
 /// Char-weighted aggregates over a chunk's elements.
@@ -120,6 +120,19 @@ impl DocumentSource {
     }
 }
 
+/// Citation anchor for a chunk on a single page: the axis-aligned union of all
+/// the chunk's element bounding boxes that fall on that page. Lets a RAG
+/// consumer cite back to an exact region of the source PDF.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct PageRegion {
+    /// Page the region is on (as stored on the elements).
+    pub page: u32,
+    /// Union bounding box of the chunk's elements on this page.
+    pub bbox: ElementBBox,
+}
+
 /// Per-chunk metadata attached to every [`RagChunk`](crate::pipeline::RagChunk).
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
@@ -156,6 +169,12 @@ pub struct ChunkMetadata {
     pub next_chunk_id: Option<String>,
     /// Source-document metadata, if available.
     pub source: Option<DocumentSource>,
+    /// First and last page the chunk's elements touch (inclusive), or `None`
+    /// when the chunk has no positioned elements.
+    pub page_span: Option<(u32, u32)>,
+    /// Per-page citation regions (union bbox of the chunk's elements on each
+    /// page), sorted ascending by page. Empty when the chunk has no elements.
+    pub page_regions: Vec<PageRegion>,
 }
 
 use sha2::{Digest, Sha256};
@@ -177,6 +196,7 @@ impl ChunkMetadata {
             .first()
             .map(|e| e.metadata().heading_path.clone())
             .unwrap_or_default();
+        let (page_span, page_regions) = page_anchor(elements);
         ChunkMetadata {
             heading_path,
             dominant_font: agg.dominant_font,
@@ -196,8 +216,44 @@ impl ChunkMetadata {
             prev_chunk_id: None,
             next_chunk_id: None,
             source: None,
+            page_span,
+            page_regions,
         }
     }
+}
+
+/// Union of two axis-aligned bounding boxes.
+fn union_bbox(a: ElementBBox, b: ElementBBox) -> ElementBBox {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let right = a.right().max(b.right());
+    let top = a.top().max(b.top());
+    ElementBBox::new(x, y, right - x, top - y)
+}
+
+/// Compute the chunk's citation anchor: `(page_span, page_regions)`. Groups the
+/// elements by page, unions their bboxes per page, and sorts the regions by
+/// page ascending. Returns `(None, vec![])` for an element-less chunk.
+fn page_anchor(elements: &[Element]) -> (Option<(u32, u32)>, Vec<PageRegion>) {
+    let mut by_page: Vec<(u32, ElementBBox)> = Vec::new();
+    for e in elements {
+        let page = e.metadata().page;
+        let bbox = *e.bbox();
+        match by_page.iter_mut().find(|(p, _)| *p == page) {
+            Some(slot) => slot.1 = union_bbox(slot.1, bbox),
+            None => by_page.push((page, bbox)),
+        }
+    }
+    if by_page.is_empty() {
+        return (None, Vec::new());
+    }
+    by_page.sort_by_key(|(p, _)| *p);
+    let span = (by_page.first().unwrap().0, by_page.last().unwrap().0);
+    let regions = by_page
+        .into_iter()
+        .map(|(page, bbox)| PageRegion { page, bbox })
+        .collect();
+    (Some(span), regions)
 }
 
 /// Fill `prev_chunk_id` / `next_chunk_id` on each chunk from its neighbours' ids.
@@ -413,5 +469,53 @@ mod tests {
         // the chunk text (the exact code is whatlang's call, not asserted here).
         #[cfg(not(feature = "language-detection"))]
         assert_eq!(m.language, None);
+    }
+
+    fn el_at(text: &str, page: u32, x: f64, y: f64, w: f64, h: f64) -> Element {
+        Element::Paragraph(ElementData {
+            text: text.to_string(),
+            metadata: ElementMetadata {
+                page,
+                bbox: crate::pipeline::element::ElementBBox::new(x, y, w, h),
+                ..ElementMetadata::default()
+            },
+        })
+    }
+
+    #[test]
+    fn citation_anchor_page_span_and_per_page_union_bbox() {
+        let els = vec![
+            el_at("a", 1, 10.0, 700.0, 100.0, 20.0), // page1: x[10,110] y[700,720]
+            el_at("b", 1, 50.0, 600.0, 200.0, 10.0), // page1: x[50,250] y[600,610]
+            el_at("c", 2, 30.0, 500.0, 40.0, 40.0),  // page2: x[30,70]  y[500,540]
+        ];
+        let text = "a\nb\nc";
+        let m = ChunkMetadata::from_elements(&els, text, text, 0, None);
+
+        assert_eq!(m.page_span, Some((1, 2)));
+        assert_eq!(m.page_regions.len(), 2);
+        // Sorted ascending by page.
+        assert_eq!(m.page_regions[0].page, 1);
+        assert_eq!(m.page_regions[1].page, 2);
+
+        // Page 1 region = union of its two element bboxes.
+        let p1 = &m.page_regions[0].bbox;
+        assert_eq!(p1.x, 10.0);
+        assert_eq!(p1.y, 600.0);
+        assert_eq!(p1.right(), 250.0);
+        assert_eq!(p1.top(), 720.0);
+
+        // Page 2 region = the single element's bbox.
+        let p2 = &m.page_regions[1].bbox;
+        assert_eq!(p2.x, 30.0);
+        assert_eq!(p2.right(), 70.0);
+        assert_eq!(p2.top(), 540.0);
+    }
+
+    #[test]
+    fn citation_anchor_empty_for_no_elements() {
+        let m = ChunkMetadata::from_elements(&[], "", "", 0, None);
+        assert_eq!(m.page_span, None);
+        assert!(m.page_regions.is_empty());
     }
 }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -173,6 +173,9 @@ impl ChunkMetadata {
             char_count: char_count(text),
             word_count: word_count(text),
             sentence_count: sentence_count(text),
+            #[cfg(feature = "language-detection")]
+            language: detect_language(text),
+            #[cfg(not(feature = "language-detection"))]
             language: None,
             chunk_id: content_chunk_id(doc_hash, chunk_index, full_text),
             prev_chunk_id: None,
@@ -193,6 +196,20 @@ pub(crate) fn link_chunks(chunks: &mut [crate::pipeline::RagChunk]) {
         };
         c.metadata.next_chunk_id = ids.get(i + 1).cloned();
     }
+}
+
+/// Detect the dominant language of `text` as an ISO 639-3 code (e.g. `"eng"`,
+/// `"spa"`), via `whatlang`. Returns `None` for empty/whitespace-only input or
+/// when `whatlang` produces no detection. The detection is best-effort: on
+/// short or ambiguous text the code may be unreliable.
+///
+/// Requires the `language-detection` feature.
+#[cfg(feature = "language-detection")]
+pub fn detect_language(text: &str) -> Option<String> {
+    if text.trim().is_empty() {
+        return None;
+    }
+    whatlang::detect(text).map(|info| info.lang().code().to_string())
 }
 
 /// Deterministic chunk id: `<doc_id>:<index>` where `doc_id` is the supplied
@@ -354,6 +371,9 @@ mod tests {
         assert_eq!(m.char_count, text.chars().count());
         assert_eq!(m.chunk_id, content_chunk_id(None, 3, text));
         assert!(m.source.is_none());
-        assert_eq!(m.language, None); // language filled separately in a later task
+        // Without the feature the field stays None; with it, detection runs on
+        // the chunk text (the exact code is whatlang's call, not asserted here).
+        #[cfg(not(feature = "language-detection"))]
+        assert_eq!(m.language, None);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -260,6 +260,16 @@ pub struct ElementMetadata {
     pub parent_heading: Option<String>,
     /// Full ancestor heading breadcrumb, root→leaf. Empty if outside any heading.
     pub heading_path: Vec<String>,
+    /// Open class label assigned by a custom
+    /// [`ElementClassifier`](crate::pipeline::spi::ElementClassifier) before
+    /// chunking (e.g. `"clause"`, `"definition"`). `None` unless a classifier
+    /// set it. A chunking strategy may read it to make boundary decisions.
+    #[cfg(feature = "unstable-spi")]
+    #[cfg_attr(
+        feature = "semantic",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub class_label: Option<String>,
 }
 
 impl Default for ElementMetadata {
@@ -274,6 +284,8 @@ impl Default for ElementMetadata {
             is_italic: false,
             parent_heading: None,
             heading_path: Vec::new(),
+            #[cfg(feature = "unstable-spi")]
+            class_label: None,
         }
     }
 }

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -131,6 +131,11 @@ impl Element {
         self.metadata_mut().parent_heading = heading;
     }
 
+    /// Set the full heading breadcrumb for this element.
+    pub fn set_heading_path(&mut self, path: Vec<String>) {
+        self.metadata_mut().heading_path = path;
+    }
+
     /// Returns the number of rows if this is a Table element.
     pub fn row_count(&self) -> Option<usize> {
         match self {
@@ -253,6 +258,8 @@ pub struct ElementMetadata {
     pub is_italic: bool,
     /// The text of the nearest preceding Title element, if any.
     pub parent_heading: Option<String>,
+    /// Full ancestor heading breadcrumb, root→leaf. Empty if outside any heading.
+    pub heading_path: Vec<String>,
 }
 
 impl Default for ElementMetadata {
@@ -266,6 +273,7 @@ impl Default for ElementMetadata {
             is_bold: false,
             is_italic: false,
             parent_heading: None,
+            heading_path: Vec::new(),
         }
     }
 }

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -446,7 +446,7 @@ fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
 
 /// Split text into sentence-like segments preserving punctuation.
 /// Splits on `. `, `! `, `? `, and `\n`.
-fn split_into_sentences(text: &str) -> Vec<String> {
+pub(crate) fn split_into_sentences(text: &str) -> Vec<String> {
     let mut sentences = Vec::new();
     let mut current = String::new();
     let mut iter = text.chars().peekable();

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -479,7 +479,7 @@ pub(crate) fn split_into_sentences(text: &str) -> Vec<String> {
 }
 
 /// Create a new Paragraph element from an existing element's metadata, replacing the text.
-/// Preserves provenance (page, bbox, parent_heading).
+/// Preserves provenance (page, bbox, parent_heading, heading_path).
 fn make_text_fragment_element(source: &Element, fragment_text: &str) -> Element {
     let metadata = source.metadata().clone();
     Element::Paragraph(ElementData {
@@ -488,6 +488,7 @@ fn make_text_fragment_element(source: &Element, fragment_text: &str) -> Element 
             page: metadata.page,
             bbox: metadata.bbox,
             parent_heading: metadata.parent_heading,
+            heading_path: metadata.heading_path,
             ..Default::default()
         },
     })

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -133,6 +133,25 @@ impl HybridChunk {
             heading_context: self.heading_context,
         }
     }
+
+    /// Build a chunk from a [`ChunkGroup`](crate::pipeline::spi::ChunkGroup),
+    /// recomputing `oversized` against `max_tokens`. Used by the pipeline when a
+    /// custom strategy produced the grouping.
+    #[cfg(feature = "unstable-spi")]
+    pub(crate) fn from_group(group: crate::pipeline::spi::ChunkGroup, max_tokens: usize) -> Self {
+        let text = group
+            .elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let oversized = estimate_tokens(&text) > max_tokens;
+        HybridChunk {
+            elements: group.elements,
+            heading_context: group.heading_context,
+            oversized,
+        }
+    }
 }
 
 /// Hybrid chunker that merges adjacent elements and propagates heading context.
@@ -512,5 +531,34 @@ impl crate::pipeline::spi::ChunkingStrategy for HybridChunker {
             .into_iter()
             .map(HybridChunk::into_group)
             .collect()
+    }
+}
+
+#[cfg(all(test, feature = "unstable-spi"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_group_recomputes_oversized_and_preserves_content() {
+        use crate::pipeline::spi::ChunkGroup;
+
+        let big = Element::Paragraph(ElementData {
+            text: "one two three four five six seven eight".to_string(),
+            metadata: ElementMetadata::default(),
+        });
+        // Budget far below the token count → oversized.
+        let group = ChunkGroup::new(vec![big.clone()], Some("H".to_string()));
+        let hc = HybridChunk::from_group(group, 2);
+        assert!(
+            hc.is_oversized(),
+            "8-word chunk over a 2-token budget is oversized"
+        );
+        assert_eq!(hc.heading_context.as_deref(), Some("H"));
+        assert_eq!(hc.elements().len(), 1);
+
+        // Generous budget → not oversized.
+        let group2 = ChunkGroup::new(vec![big], None);
+        let hc2 = HybridChunk::from_group(group2, 100);
+        assert!(!hc2.is_oversized());
     }
 }

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -123,6 +123,16 @@ impl HybridChunk {
     pub fn is_oversized(&self) -> bool {
         self.oversized
     }
+
+    /// Convert into a [`ChunkGroup`](crate::pipeline::spi::ChunkGroup),
+    /// dropping the derived `oversized` flag (the pipeline recomputes it).
+    #[cfg(feature = "unstable-spi")]
+    pub(crate) fn into_group(self) -> crate::pipeline::spi::ChunkGroup {
+        crate::pipeline::spi::ChunkGroup {
+            elements: self.elements,
+            heading_context: self.heading_context,
+        }
+    }
 }
 
 /// Hybrid chunker that merges adjacent elements and propagates heading context.
@@ -492,4 +502,15 @@ fn make_text_fragment_element(source: &Element, fragment_text: &str) -> Element 
             ..Default::default()
         },
     })
+}
+
+#[cfg(feature = "unstable-spi")]
+impl crate::pipeline::spi::ChunkingStrategy for HybridChunker {
+    fn chunk(&self, elements: &[Element]) -> Vec<crate::pipeline::spi::ChunkGroup> {
+        // Call the inherent method explicitly to avoid recursing into this impl.
+        HybridChunker::chunk(self, elements)
+            .into_iter()
+            .map(HybridChunk::into_group)
+            .collect()
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -11,7 +11,7 @@ pub mod semantic_chunking;
 
 #[cfg(feature = "language-detection")]
 pub use chunk_metadata::detect_language;
-pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource};
+pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource, PageRegion};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,
     KeyValueElementData, TableElementData,

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -9,6 +9,8 @@ pub mod rag;
 pub mod reading_order;
 pub mod semantic_chunking;
 
+#[cfg(feature = "language-detection")]
+pub use chunk_metadata::detect_language;
 pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -8,6 +8,8 @@ pub mod profile;
 pub mod rag;
 pub mod reading_order;
 pub mod semantic_chunking;
+#[cfg(feature = "unstable-spi")]
+pub mod spi;
 
 #[cfg(feature = "language-detection")]
 pub use chunk_metadata::detect_language;
@@ -24,3 +26,5 @@ pub use profile::{ExtractionProfile, ProfileConfig};
 pub use rag::RagChunk;
 pub use reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker};
+#[cfg(feature = "unstable-spi")]
+pub use spi::{ChunkGroup, ChunkingStrategy};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -27,4 +27,6 @@ pub use rag::RagChunk;
 pub use reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker};
 #[cfg(feature = "unstable-spi")]
-pub use spi::{AnalysisPipeline, ChunkGroup, ChunkingStrategy};
+pub use spi::{
+    AnalysisPipeline, ChunkGroup, ChunkingStrategy, ClassLabel, ClassifyContext, ElementClassifier,
+};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -30,3 +30,5 @@ pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker}
 pub use spi::{
     AnalysisPipeline, ChunkGroup, ChunkingStrategy, ClassLabel, ClassifyContext, ElementClassifier,
 };
+#[cfg(all(feature = "unstable-spi", feature = "semantic"))]
+pub use spi::{EnrichContext, MetadataEnricher};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -27,4 +27,4 @@ pub use rag::RagChunk;
 pub use reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 pub use semantic_chunking::{SemanticChunk, SemanticChunkConfig, SemanticChunker};
 #[cfg(feature = "unstable-spi")]
-pub use spi::{ChunkGroup, ChunkingStrategy};
+pub use spi::{AnalysisPipeline, ChunkGroup, ChunkingStrategy};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -1,4 +1,4 @@
-mod chunk_metadata;
+pub(crate) mod chunk_metadata;
 pub mod element;
 pub mod export;
 pub mod graph;

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -1,3 +1,4 @@
+mod chunk_metadata;
 pub mod element;
 pub mod export;
 pub mod graph;
@@ -8,6 +9,7 @@ pub mod rag;
 pub mod reading_order;
 pub mod semantic_chunking;
 
+pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,
     KeyValueElementData, TableElementData,

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -574,6 +574,7 @@ impl Partitioner {
             .iter()
             .filter(|e| matches!(e, Element::Title(_)))
             .filter_map(|e| e.metadata().font_size)
+            .filter(|s| s.is_finite() && *s > 0.0)
             .collect();
         sizes.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
         let mut buckets: Vec<f64> = Vec::new();
@@ -584,13 +585,20 @@ impl Partitioner {
         }
 
         let level_of = |size: Option<f64>| -> u8 {
-            let Some(s) = size else { return 1 };
-            for (i, b) in buckets.iter().enumerate() {
-                if (s - b).abs() <= b * 0.05 {
-                    return (i + 1) as u8;
+            match size {
+                Some(s) if s.is_finite() && s > 0.0 => {
+                    for (i, b) in buckets.iter().enumerate() {
+                        if (s - b).abs() <= b * 0.05 {
+                            return (i + 1) as u8;
+                        }
+                    }
+                    buckets.len().max(1) as u8
                 }
+                // Unknown / non-finite / non-positive size: treat as one level
+                // deeper than the deepest known bucket, so the title is appended
+                // as a leaf child and never pops a known-size ancestor.
+                _ => (buckets.len() + 1) as u8,
             }
-            buckets.len().max(1) as u8
         };
 
         // 2. Walk elements maintaining a (level, text) stack.
@@ -1632,5 +1640,45 @@ mod tests {
             Some("1.2 Scope")
         );
         assert_eq!(linked[4].metadata().heading_path, vec!["2 Methods"]);
+    }
+
+    #[test]
+    fn heading_path_unknown_size_title_appends_not_resets() {
+        use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+        let title = |t: &str, size: Option<f64>| {
+            let metadata = ElementMetadata {
+                font_size: size,
+                ..ElementMetadata::default()
+            };
+            Element::Title(ElementData {
+                text: t.to_string(),
+                metadata,
+            })
+        };
+        let para = |t: &str| {
+            Element::Paragraph(ElementData {
+                text: t.to_string(),
+                metadata: ElementMetadata::default(),
+            })
+        };
+
+        // Big(20) > Small(10) > a None-size title must NOT clear the breadcrumb;
+        // it is appended at the deepest level.
+        let elements = vec![
+            title("H1", Some(20.0)),
+            title("H1.1", Some(10.0)),
+            title("NoSize", None),
+            para("body"),
+        ];
+        let linked = Partitioner::assign_heading_paths(elements);
+        // The None-size title is deepest; it sits under H1>H1.1.
+        assert_eq!(
+            linked[3].metadata().heading_path,
+            vec!["H1", "H1.1", "NoSize"]
+        );
+        assert_eq!(
+            linked[3].metadata().parent_heading.as_deref(),
+            Some("NoSize")
+        );
     }
 }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -885,6 +885,8 @@ fn meta_from_fragment(f: &TextFragment, page: u32) -> ElementMetadata {
         is_italic: f.is_italic,
         parent_heading: None,
         heading_path: Vec::new(),
+        #[cfg(feature = "unstable-spi")]
+        class_label: None,
     }
 }
 

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -560,15 +560,51 @@ impl Partitioner {
             }
         }
 
-        // Post-classification relationship pass: assign parent_heading
-        let mut current_heading: Option<String> = None;
-        for element in &mut elements {
-            if matches!(element, Element::Title(_)) {
-                current_heading = Some(element.text().to_string());
+        // Post-classification relationship pass: assign parent_heading + heading_path
+        elements = Self::assign_heading_paths(elements);
+
+        elements
+    }
+
+    /// Assign `heading_path` (full breadcrumb) and `parent_heading` (its leaf) to
+    /// every element, inferring heading level from Title font sizes.
+    pub(crate) fn assign_heading_paths(mut elements: Vec<Element>) -> Vec<Element> {
+        // 1. Rank distinct Title font sizes desc, merging sizes within 5%.
+        let mut sizes: Vec<f64> = elements
+            .iter()
+            .filter(|e| matches!(e, Element::Title(_)))
+            .filter_map(|e| e.metadata().font_size)
+            .collect();
+        sizes.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        let mut buckets: Vec<f64> = Vec::new();
+        for s in sizes {
+            if !buckets.iter().any(|b| (b - s).abs() <= b * 0.05) {
+                buckets.push(s);
             }
-            element.set_parent_heading(current_heading.clone());
         }
 
+        let level_of = |size: Option<f64>| -> u8 {
+            let Some(s) = size else { return 1 };
+            for (i, b) in buckets.iter().enumerate() {
+                if (s - b).abs() <= b * 0.05 {
+                    return (i + 1) as u8;
+                }
+            }
+            buckets.len().max(1) as u8
+        };
+
+        // 2. Walk elements maintaining a (level, text) stack.
+        let mut stack: Vec<(u8, String)> = Vec::new();
+        for element in &mut elements {
+            if matches!(element, Element::Title(_)) {
+                let level = level_of(element.metadata().font_size);
+                stack.retain(|(lvl, _)| *lvl < level);
+                stack.push((level, element.text().to_string()));
+            }
+            let path: Vec<String> = stack.iter().map(|(_, t)| t.clone()).collect();
+            element.set_parent_heading(path.last().cloned());
+            element.set_heading_path(path);
+        }
         elements
     }
 }
@@ -836,6 +872,7 @@ fn meta_from_fragment(f: &TextFragment, page: u32) -> ElementMetadata {
         is_bold: f.is_bold,
         is_italic: f.is_italic,
         parent_heading: None,
+        heading_path: Vec::new(),
     }
 }
 
@@ -1554,5 +1591,46 @@ mod tests {
             .filter(|e| matches!(e, Element::Footer(_)))
             .count();
         assert_eq!(footer_count, 0);
+    }
+
+    #[test]
+    fn heading_path_builds_breadcrumb_by_font_size() {
+        use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+        let title = |t: &str, size: f64| {
+            let metadata = ElementMetadata {
+                font_size: Some(size),
+                ..ElementMetadata::default()
+            };
+            Element::Title(ElementData {
+                text: t.to_string(),
+                metadata,
+            })
+        };
+        let para = |t: &str| {
+            Element::Paragraph(ElementData {
+                text: t.to_string(),
+                metadata: ElementMetadata::default(),
+            })
+        };
+
+        // H1(20) > H2(14) > body ; then a new H1(20) resets depth.
+        let elements = vec![
+            title("1 Introduction", 20.0),
+            title("1.2 Scope", 14.0),
+            para("Body text under scope."),
+            title("2 Methods", 20.0),
+            para("Body under methods."),
+        ];
+
+        let linked = Partitioner::assign_heading_paths(elements);
+        assert_eq!(
+            linked[2].metadata().heading_path,
+            vec!["1 Introduction", "1.2 Scope"]
+        );
+        assert_eq!(
+            linked[2].metadata().parent_heading.as_deref(),
+            Some("1.2 Scope")
+        );
+        assert_eq!(linked[4].metadata().heading_path, vec!["2 Methods"]);
     }
 }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -584,20 +584,24 @@ impl Partitioner {
             }
         }
 
+        // Saturating usize->u8: a document with ≥255 distinct title sizes is
+        // implausible, but a silent wrapping cast there would corrupt the level
+        // ordering, so clamp instead.
+        let to_level = |n: usize| -> u8 { u8::try_from(n).unwrap_or(u8::MAX) };
         let level_of = |size: Option<f64>| -> u8 {
             match size {
                 Some(s) if s.is_finite() && s > 0.0 => {
                     for (i, b) in buckets.iter().enumerate() {
                         if (s - b).abs() <= b * 0.05 {
-                            return (i + 1) as u8;
+                            return to_level(i + 1);
                         }
                     }
-                    buckets.len().max(1) as u8
+                    to_level(buckets.len().max(1))
                 }
                 // Unknown / non-finite / non-positive size: treat as one level
                 // deeper than the deepest known bucket, so the title is appended
                 // as a leaf child and never pops a known-size ancestor.
-                _ => (buckets.len() + 1) as u8,
+                _ => to_level(buckets.len() + 1),
             }
         };
 

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
+use crate::pipeline::chunk_metadata::ChunkMetadata;
 use crate::pipeline::element::Element;
 use crate::pipeline::hybrid_chunking::HybridChunk;
-use crate::pipeline::ElementBBox;
+use crate::pipeline::{DocumentSource, ElementBBox};
 
 #[cfg(feature = "semantic")]
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct RagChunk {
     /// Sequential index of this chunk in the document (0-based).
     pub chunk_index: usize,
@@ -68,6 +70,8 @@ pub struct RagChunk {
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,
+    /// Rich per-chunk metadata (heading path, font/style, counts, ids, source).
+    pub metadata: ChunkMetadata,
 }
 
 impl RagChunk {
@@ -78,18 +82,39 @@ impl RagChunk {
         let bounding_boxes = elements.iter().map(|e| *e.bbox()).collect();
         let element_types: Vec<String> =
             elements.iter().map(|e| e.type_name().to_string()).collect();
+        let text = chunk.text();
+        let full_text = chunk.full_text();
+        let metadata = ChunkMetadata::from_elements(elements, &text, &full_text, chunk_index, None);
 
         Self {
             chunk_index,
-            text: chunk.text(),
-            full_text: chunk.full_text(),
+            text,
+            full_text,
             page_numbers,
             bounding_boxes,
             element_types,
             heading_context: chunk.heading_context.clone(),
             token_estimate: chunk.token_estimate(),
             is_oversized: chunk.is_oversized(),
+            metadata,
         }
+    }
+
+    /// Like [`from_hybrid_chunk`](Self::from_hybrid_chunk) but stamping source
+    /// metadata and using `source.doc_hash` for the chunk_id prefix when set.
+    pub fn from_hybrid_chunk_with_source(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        source: &DocumentSource,
+    ) -> Self {
+        let mut c = Self::from_hybrid_chunk(chunk_index, chunk);
+        c.metadata.chunk_id = crate::pipeline::chunk_metadata::content_chunk_id(
+            source.doc_hash.as_deref(),
+            chunk_index,
+            &c.full_text,
+        );
+        c.metadata.source = Some(source.clone());
+        c
     }
 
     /// Serialize this chunk to a JSON string (requires `semantic` feature).

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -77,6 +77,29 @@ pub struct RagChunk {
 impl RagChunk {
     /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its elements.
     pub fn from_hybrid_chunk(chunk_index: usize, chunk: &HybridChunk) -> Self {
+        Self::from_hybrid_chunk_inner(chunk_index, chunk, None)
+    }
+
+    /// Like [`from_hybrid_chunk`](Self::from_hybrid_chunk) but stamping source
+    /// metadata and using `source.doc_hash` for the chunk_id prefix when set.
+    pub fn from_hybrid_chunk_with_source(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        source: &DocumentSource,
+    ) -> Self {
+        let mut c = Self::from_hybrid_chunk_inner(chunk_index, chunk, Some(source));
+        c.metadata.source = Some(source.clone());
+        c
+    }
+
+    /// Shared constructor. `source` (when `Some`) supplies the `doc_hash` used
+    /// as the chunk_id prefix, so the id is computed exactly once — callers that
+    /// also want the full source stamped do that themselves.
+    fn from_hybrid_chunk_inner(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        source: Option<&DocumentSource>,
+    ) -> Self {
         let elements = chunk.elements();
         let page_numbers = collect_pages(elements);
         let bounding_boxes = elements.iter().map(|e| *e.bbox()).collect();
@@ -84,7 +107,9 @@ impl RagChunk {
             elements.iter().map(|e| e.type_name().to_string()).collect();
         let text = chunk.text();
         let full_text = chunk.full_text();
-        let metadata = ChunkMetadata::from_elements(elements, &text, &full_text, chunk_index, None);
+        let doc_hash = source.and_then(|s| s.doc_hash.as_deref());
+        let metadata =
+            ChunkMetadata::from_elements(elements, &text, &full_text, chunk_index, doc_hash);
 
         Self {
             chunk_index,
@@ -98,23 +123,6 @@ impl RagChunk {
             is_oversized: chunk.is_oversized(),
             metadata,
         }
-    }
-
-    /// Like [`from_hybrid_chunk`](Self::from_hybrid_chunk) but stamping source
-    /// metadata and using `source.doc_hash` for the chunk_id prefix when set.
-    pub fn from_hybrid_chunk_with_source(
-        chunk_index: usize,
-        chunk: &HybridChunk,
-        source: &DocumentSource,
-    ) -> Self {
-        let mut c = Self::from_hybrid_chunk(chunk_index, chunk);
-        c.metadata.chunk_id = crate::pipeline::chunk_metadata::content_chunk_id(
-            source.doc_hash.as_deref(),
-            chunk_index,
-            &c.full_text,
-        );
-        c.metadata.source = Some(source.clone());
-        c
     }
 
     /// Serialize this chunk to a JSON string (requires `semantic` feature).

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -54,6 +54,30 @@ impl ClassLabel {
     }
 }
 
+impl AsRef<str> for ClassLabel {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<ClassLabel> for String {
+    fn from(label: ClassLabel) -> String {
+        label.0.into_owned()
+    }
+}
+
+impl PartialEq<str> for ClassLabel {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl PartialEq<&str> for ClassLabel {
+    fn eq(&self, other: &&str) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
 /// Read-only context handed to an [`ElementClassifier`]: the full element slice
 /// and the index of the element being classified, so a classifier can inspect
 /// neighbours (preceding/following elements) to make its decision.
@@ -71,6 +95,11 @@ pub struct ClassifyContext<'a> {
 /// and may be read by a [`ChunkingStrategy`] to decide chunk boundaries.
 pub trait ElementClassifier: Send + Sync {
     /// Return a label for `element`, or `None` to leave it unlabelled.
+    ///
+    /// `ctx` exposes the full element slice for neighbour inspection, but
+    /// implementations should run in O(1) or O(k) — looking at a constant window
+    /// of neighbours — not O(N) over the whole slice, so the overall
+    /// classification pass stays O(N).
     fn classify(&self, element: &Element, ctx: &ClassifyContext) -> Option<ClassLabel>;
 }
 

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -33,3 +33,51 @@ pub trait ChunkingStrategy: Send + Sync {
     /// Group `elements` into chunks. Called once per document.
     fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
 }
+
+use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
+use crate::pipeline::DocumentSource;
+
+/// Configures the analysis pipeline: which chunking strategy to run, the token
+/// budget used to flag oversized chunks, and optional source-document metadata.
+pub struct AnalysisPipeline {
+    pub(crate) chunking: Box<dyn ChunkingStrategy>,
+    pub(crate) max_tokens: usize,
+    pub(crate) source: Option<DocumentSource>,
+}
+
+impl Default for AnalysisPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisPipeline {
+    /// Default pipeline: the built-in `HybridChunker`, default token budget, no
+    /// source. Reproduces `PdfDocument::rag_chunks()` exactly.
+    pub fn new() -> Self {
+        let config = HybridChunkConfig::default();
+        Self {
+            max_tokens: config.max_tokens,
+            chunking: Box::new(HybridChunker::new(config)),
+            source: None,
+        }
+    }
+
+    /// Replace the chunking strategy.
+    pub fn with_chunking(mut self, strategy: Box<dyn ChunkingStrategy>) -> Self {
+        self.chunking = strategy;
+        self
+    }
+
+    /// Set the token budget used to flag oversized chunks.
+    pub fn with_max_tokens(mut self, max_tokens: usize) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Stamp source-document metadata onto every chunk.
+    pub fn with_source(mut self, source: DocumentSource) -> Self {
+        self.source = Some(source);
+        self
+    }
+}

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -1,0 +1,35 @@
+//! Unstable analysis SPI — extension points for the chunking pipeline.
+//!
+//! Behind the `unstable-spi` feature. The trait surface is exempt from semver
+//! while experimental and may change until promoted.
+
+use crate::pipeline::element::Element;
+
+/// A grouping of elements destined to become one chunk. The chunking strategy
+/// decides the boundaries; the pipeline owns everything downstream (RagChunk,
+/// chunk_id, links, metadata).
+#[non_exhaustive]
+pub struct ChunkGroup {
+    /// The elements that form this chunk, in order.
+    pub elements: Vec<Element>,
+    /// Optional heading context to prepend for embedding.
+    pub heading_context: Option<String>,
+}
+
+impl ChunkGroup {
+    /// Construct a group from elements and an optional heading context.
+    pub fn new(elements: Vec<Element>, heading_context: Option<String>) -> Self {
+        Self {
+            elements,
+            heading_context,
+        }
+    }
+}
+
+/// Decides which elements group into a chunk. Implement this in a (possibly
+/// closed) crate to override how the pipeline forms chunks. The pipeline
+/// computes `oversized`, `chunk_id`, prev/next links, and `ChunkMetadata`.
+pub trait ChunkingStrategy: Send + Sync {
+    /// Group `elements` into chunks. Called once per document.
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
+}

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -35,6 +35,45 @@ pub trait ChunkingStrategy: Send + Sync {
     fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
 }
 
+/// An open class label for an element, assigned by an [`ElementClassifier`].
+///
+/// The label is an opaque string the core only transports — domain semantics
+/// (what `"clause"` or `"definition"` mean) live entirely in the provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassLabel(pub std::borrow::Cow<'static, str>);
+
+impl ClassLabel {
+    /// Construct a label from any string-like value.
+    pub fn new(label: impl Into<std::borrow::Cow<'static, str>>) -> Self {
+        Self(label.into())
+    }
+
+    /// The label as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Read-only context handed to an [`ElementClassifier`]: the full element slice
+/// and the index of the element being classified, so a classifier can inspect
+/// neighbours (preceding/following elements) to make its decision.
+pub struct ClassifyContext<'a> {
+    /// All elements of the document, in order.
+    pub elements: &'a [Element],
+    /// Index of the element currently being classified.
+    pub index: usize,
+}
+
+/// Assigns an open [`ClassLabel`] to an element before chunking. Implement this
+/// in a (possibly closed) crate to refine the core's classification with
+/// domain-specific classes. Runs once per element; the label is stored on
+/// [`ElementMetadata::class_label`](crate::pipeline::ElementMetadata::class_label)
+/// and may be read by a [`ChunkingStrategy`] to decide chunk boundaries.
+pub trait ElementClassifier: Send + Sync {
+    /// Return a label for `element`, or `None` to leave it unlabelled.
+    fn classify(&self, element: &Element, ctx: &ClassifyContext) -> Option<ClassLabel>;
+}
+
 use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
 use crate::pipeline::DocumentSource;
 
@@ -44,6 +83,7 @@ pub struct AnalysisPipeline {
     pub(crate) chunking: Box<dyn ChunkingStrategy>,
     pub(crate) max_tokens: usize,
     pub(crate) source: Option<DocumentSource>,
+    pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
 }
 
 impl Default for AnalysisPipeline {
@@ -61,6 +101,7 @@ impl AnalysisPipeline {
             max_tokens: config.max_tokens,
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
+            classifier: None,
         }
     }
 
@@ -88,6 +129,16 @@ impl AnalysisPipeline {
     #[must_use]
     pub fn with_source(mut self, source: DocumentSource) -> Self {
         self.source = Some(source);
+        self
+    }
+
+    /// Set a classifier that labels elements (writing
+    /// [`ElementMetadata::class_label`](crate::pipeline::ElementMetadata::class_label))
+    /// after partitioning and before chunking. The chunking strategy may then
+    /// read the labels to decide boundaries.
+    #[must_use]
+    pub fn with_classifier(mut self, classifier: Box<dyn ElementClassifier>) -> Self {
+        self.classifier = Some(classifier);
         self
     }
 }

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -30,6 +30,9 @@ impl ChunkGroup {
 /// Decides which elements group into a chunk. Implement this in a (possibly
 /// closed) crate to override how the pipeline forms chunks. The pipeline
 /// computes `oversized`, `chunk_id`, prev/next links, and `ChunkMetadata`.
+///
+/// **Stability:** behind `unstable-spi`; exempt from semver until promoted.
+/// The signature may change between releases while experimental.
 pub trait ChunkingStrategy: Send + Sync {
     /// Group `elements` into chunks. Called once per document.
     fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup>;
@@ -93,6 +96,8 @@ pub struct ClassifyContext<'a> {
 /// domain-specific classes. Runs once per element; the label is stored on
 /// [`ElementMetadata::class_label`](crate::pipeline::ElementMetadata::class_label)
 /// and may be read by a [`ChunkingStrategy`] to decide chunk boundaries.
+///
+/// **Stability:** behind `unstable-spi`; exempt from semver until promoted.
 pub trait ElementClassifier: Send + Sync {
     /// Return a label for `element`, or `None` to leave it unlabelled.
     ///
@@ -121,6 +126,9 @@ pub struct EnrichContext<'a> {
 /// (possibly closed) crate to surface domain signals (e.g. `legal.clause_number`)
 /// without the core ever knowing their semantics. Enrichers run in registration
 /// order; namespace keys to avoid collisions.
+///
+/// **Stability:** behind `unstable-spi` + `semantic`; exempt from semver until
+/// promoted.
 #[cfg(feature = "semantic")]
 pub trait MetadataEnricher: Send + Sync {
     /// Enrich `meta.extra` using the read-only `ctx`.
@@ -131,7 +139,10 @@ use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
 use crate::pipeline::DocumentSource;
 
 /// Configures the analysis pipeline: which chunking strategy to run, the token
-/// budget used to flag oversized chunks, and optional source-document metadata.
+/// budget used to flag oversized chunks, optional source-document metadata, an
+/// optional element classifier, and optional metadata enrichers.
+///
+/// **Stability:** behind `unstable-spi`; exempt from semver until promoted.
 pub struct AnalysisPipeline {
     pub(crate) chunking: Box<dyn ChunkingStrategy>,
     pub(crate) max_tokens: usize,

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -8,6 +8,7 @@ use crate::pipeline::element::Element;
 /// A grouping of elements destined to become one chunk. The chunking strategy
 /// decides the boundaries; the pipeline owns everything downstream (RagChunk,
 /// chunk_id, links, metadata).
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ChunkGroup {
     /// The elements that form this chunk, in order.
@@ -64,18 +65,27 @@ impl AnalysisPipeline {
     }
 
     /// Replace the chunking strategy.
+    ///
+    /// `max_tokens` is independent of the strategy: it stays at whatever
+    /// [`new`](Self::new) or [`with_max_tokens`](Self::with_max_tokens) set it
+    /// to (default 512) and is used only to flag oversized chunks. A custom
+    /// strategy that chunks to a different budget should also call
+    /// [`with_max_tokens`](Self::with_max_tokens) so the oversized flag matches.
+    #[must_use]
     pub fn with_chunking(mut self, strategy: Box<dyn ChunkingStrategy>) -> Self {
         self.chunking = strategy;
         self
     }
 
     /// Set the token budget used to flag oversized chunks.
+    #[must_use]
     pub fn with_max_tokens(mut self, max_tokens: usize) -> Self {
         self.max_tokens = max_tokens;
         self
     }
 
     /// Stamp source-document metadata onto every chunk.
+    #[must_use]
     pub fn with_source(mut self, source: DocumentSource) -> Self {
         self.source = Some(source);
         self

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -74,6 +74,30 @@ pub trait ElementClassifier: Send + Sync {
     fn classify(&self, element: &Element, ctx: &ClassifyContext) -> Option<ClassLabel>;
 }
 
+/// Read-only context handed to a [`MetadataEnricher`]: the chunk's embedding
+/// text, its source elements, and its heading breadcrumb. The enricher uses
+/// these to compute provider-specific fields it writes into `extra`.
+#[cfg(feature = "semantic")]
+pub struct EnrichContext<'a> {
+    /// The chunk's text (elements joined by newlines).
+    pub text: &'a str,
+    /// The elements that compose this chunk, in order.
+    pub elements: &'a [Element],
+    /// The chunk's heading breadcrumb, root→leaf.
+    pub heading_path: &'a [String],
+}
+
+/// Writes provider-specific fields into a chunk's open `extra` bag after the
+/// pipeline has derived its metadata and linked it. Implement this in a
+/// (possibly closed) crate to surface domain signals (e.g. `legal.clause_number`)
+/// without the core ever knowing their semantics. Enrichers run in registration
+/// order; namespace keys to avoid collisions.
+#[cfg(feature = "semantic")]
+pub trait MetadataEnricher: Send + Sync {
+    /// Enrich `meta.extra` using the read-only `ctx`.
+    fn enrich(&self, ctx: &EnrichContext, meta: &mut crate::pipeline::ChunkMetadata);
+}
+
 use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
 use crate::pipeline::DocumentSource;
 
@@ -84,6 +108,8 @@ pub struct AnalysisPipeline {
     pub(crate) max_tokens: usize,
     pub(crate) source: Option<DocumentSource>,
     pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
+    #[cfg(feature = "semantic")]
+    pub(crate) enrichers: Vec<Box<dyn MetadataEnricher>>,
 }
 
 impl Default for AnalysisPipeline {
@@ -102,6 +128,8 @@ impl AnalysisPipeline {
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
             classifier: None,
+            #[cfg(feature = "semantic")]
+            enrichers: Vec::new(),
         }
     }
 
@@ -139,6 +167,16 @@ impl AnalysisPipeline {
     #[must_use]
     pub fn with_classifier(mut self, classifier: Box<dyn ElementClassifier>) -> Self {
         self.classifier = Some(classifier);
+        self
+    }
+
+    /// Register an enricher that writes provider-specific fields into each
+    /// chunk's `extra` bag after metadata is derived and chunks are linked.
+    /// Enrichers run in registration order.
+    #[cfg(feature = "semantic")]
+    #[must_use]
+    pub fn with_enricher(mut self, enricher: Box<dyn MetadataEnricher>) -> Self {
+        self.enrichers.push(enricher);
         self
     }
 }

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -17,13 +17,18 @@
 //! 1. Parse the base PDF, resolve the `/AcroForm` field tree (handling
 //!    `/Kids` and hierarchical names via `/Parent`).
 //! 2. Clone the affected field dictionaries, set `/V`, and set
-//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2 — compliant
-//!    viewers regenerate the appearance stream; `/AP` generation is a
-//!    documented follow-up).
-//! 3. Emit ONLY the modified objects (each reusing its existing object id),
-//!    a PARTIAL incremental cross-reference section covering only the
-//!    changed ids, and a trailer chaining `/Prev` to the previous
-//!    `startxref`, reusing the base `/Root` and `/ID`.
+//!    `/AcroForm/NeedAppearances true` (ISO 32000-1 §12.7.2).
+//! 3. Synthesize the visual appearance so non-compliant viewers and
+//!    flatten/print pipelines (which never regenerate from `/V`) still show
+//!    the value: text fields (`/FT /Tx`) get a freshly-built `/AP /N` Form
+//!    XObject; button fields (`/FT /Btn`) get `/AS` set to the selected
+//!    state, activating their pre-authored `/AP`. `NeedAppearances` stays
+//!    true — the two are complementary, not in conflict.
+//! 4. Emit the modified objects (each reusing its existing object id), the
+//!    newly-allocated appearance streams (ids from the base `/Size`), a
+//!    PARTIAL incremental cross-reference section covering only the changed
+//!    ids, and a trailer chaining `/Prev` to the previous `startxref`,
+//!    reusing the base `/Root` and `/ID`.
 //!
 //! The original bytes are emitted verbatim as the prefix of the output, so
 //! every untouched object, page, font and content stream is preserved
@@ -32,6 +37,7 @@
 use crate::error::{PdfError, Result};
 use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
 use crate::parser::PdfReader;
+use crate::text::TextEncoding;
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -238,8 +244,50 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
         }
     }
 
-    // Flag NeedAppearances so viewers regenerate the appearance stream.
+    // Keep NeedAppearances true: our synthesized /AP serves non-compliant
+    // viewers and flatten/print pipelines, while compliant viewers may still
+    // regenerate from /V. The two are not in conflict.
     acro_dict.insert("NeedAppearances".to_string(), PdfObject::Boolean(true));
+
+    // Synthesize /AP appearance streams. New stream objects take fresh ids
+    // starting at base_size (the next free object number); the field/widget
+    // dicts are mutated to reference them. The AcroForm-level /DA is the
+    // fallback font selector when a field carries none.
+    let acro_da = da_of(&acro_dict);
+    let widgets_by_parent = collect_widgets_by_parent(&mut reader);
+    let mut new_streams: Vec<(u32, Vec<u8>, [f64; 4], Vec<u8>)> = Vec::new();
+    let mut extra_widgets: Vec<(u32, u16, PdfDictionary)> = Vec::new();
+    let mut next_id = base_size;
+    for (num, gen, dict) in modified.iter_mut() {
+        let ft = dict
+            .get("FT")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.clone());
+        match ft.as_deref() {
+            Some("Tx") => {
+                synthesize_text_field_ap(
+                    (*num, *gen),
+                    dict,
+                    &acro_da,
+                    &mut reader,
+                    &widgets_by_parent,
+                    &mut next_id,
+                    &mut new_streams,
+                    &mut extra_widgets,
+                )?;
+            }
+            Some("Btn") => {
+                // Buttons (checkbox/radio) carry pre-authored /AP states; the
+                // visible state is selected by /AS, not a synthesized stream.
+                if let Some(PdfObject::String(v)) = dict.get("V").cloned() {
+                    let state = String::from_utf8_lossy(v.as_bytes()).into_owned();
+                    dict.insert("AS".to_string(), PdfObject::Name(PdfName(state)));
+                }
+            }
+            _ => {}
+        }
+    }
+    let total_size = next_id;
 
     // ----- assemble appended bytes -----
     let mut out = Vec::with_capacity(base_bytes.len() + 1024);
@@ -253,10 +301,24 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
         changed.push((*num, *gen, offset));
     }
 
+    // Widget annotations rewritten to carry /AP (separate-widget /Kids layout).
+    for (num, gen, dict) in &extra_widgets {
+        let offset = out.len() as u64;
+        write_indirect_object(&mut out, *num, *gen, dict)?;
+        changed.push((*num, *gen, offset));
+    }
+
     // AcroForm object.
     let acro_offset = out.len() as u64;
     write_indirect_object(&mut out, acro_ref.0, acro_ref.1, &acro_dict)?;
     changed.push((acro_ref.0, acro_ref.1, acro_offset));
+
+    // Appearance-stream Form XObjects (new objects).
+    for (id, content, bbox, resources) in &new_streams {
+        let offset = out.len() as u64;
+        write_indirect_stream_object(&mut out, *id, 0, content, *bbox, resources)?;
+        changed.push((*id, 0, offset));
+    }
 
     let xref_pos = out.len() as u64;
     // Keep the permanent first /ID element; regenerate the second so the
@@ -270,7 +332,7 @@ fn fill_many_impl(base_bytes: &[u8], fields: &[(&str, &str)]) -> Result<Vec<u8>>
     out.extend_from_slice(&write_incremental_trailer(
         base_startxref,
         base_root,
-        base_size,
+        total_size,
         xref_pos,
         id_pair,
     ));
@@ -318,6 +380,369 @@ fn first_id_bytes(id: Option<&PdfObject>) -> Option<Vec<u8>> {
 // ---------------------------------------------------------------------------
 // Low-level serialization (Vec<u8>, no PdfWriter state)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Appearance-stream (/AP /N) synthesis
+//
+// The filler operates on parser-side `PdfObject`s with NO `Document` / font
+// registry, so it CANNOT drive the writer-side `forms::appearance` generator
+// (which needs a resolved `Font` handle for the Type0/CID path). The two
+// genuinely shareable, correctness-critical pieces are reused directly:
+// WinAnsi strict encoding (`TextEncoding::WinAnsiEncoding`) and PDF literal
+// escaping (`write_literal_string`). The remaining BT/Tf/Td/Tj/ET scaffold is
+// PDF wire syntax, not algorithm — replicating it here is simpler and lower
+// risk than bridging the writer object model. Scope is therefore built-in
+// non-symbolic Type1 fonts (the dominant `/DA` case: Helv/Cour/Times).
+// ---------------------------------------------------------------------------
+
+/// Map a `/DA` font resource name to a Standard-14 `/BaseFont`. AcroForm `/DR`
+/// commonly aliases the base-14 fonts (Acrobat's `Helv`, `HeBo`, `Cour`,
+/// `TiRo`, …). Unknown names pass through verbatim — they may already be a
+/// real base font (e.g. `Helvetica-Bold`).
+fn da_font_to_base_font(name: &str) -> &str {
+    match name {
+        "Helv" => "Helvetica",
+        "HeBO" | "HeBo" => "Helvetica-Bold",
+        "HeOb" => "Helvetica-Oblique",
+        "Cour" => "Courier",
+        "CoBO" | "CoBo" => "Courier-Bold",
+        "TiRo" => "Times-Roman",
+        "TiBo" => "Times-Bold",
+        "TiIt" => "Times-Italic",
+        "Symb" => "Symbol",
+        "ZaDb" => "ZapfDingbats",
+        other => other,
+    }
+}
+
+/// Read a 4-number `/Rect` ([llx lly urx ury]) as `[f64; 4]`, accepting
+/// integer or real components.
+fn rect_of(dict: &PdfDictionary) -> Option<[f64; 4]> {
+    let arr = dict.get("Rect").and_then(|o| o.as_array())?;
+    if arr.0.len() != 4 {
+        return None;
+    }
+    let mut r = [0.0f64; 4];
+    for (i, slot) in r.iter_mut().enumerate() {
+        *slot = arr.0[i].as_real()?;
+    }
+    Some(r)
+}
+
+/// Extract a `/DA` string value from a dictionary entry, if present and a
+/// string object.
+fn da_of(dict: &PdfDictionary) -> Option<String> {
+    dict.get("DA")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+}
+
+/// Build the `/AP /N` content stream for a single-line text widget: a
+/// `q … BT /Font size Tf x y Td (value) Tj ET … Q` sequence in the widget's
+/// local (BBox) coordinate space. Returns the content bytes, the BBox and the
+/// serialized `/Resources` dict. Fails (rather than emitting `?`) when the
+/// value carries a codepoint WinAnsiEncoding cannot represent — matching the
+/// writer-side generator's strict contract.
+fn build_text_ap(
+    value: &str,
+    da_font_name: &str,
+    da_font_size: f64,
+    rect: [f64; 4],
+) -> Result<(Vec<u8>, [f64; 4], Vec<u8>)> {
+    let width = (rect[2] - rect[0]).abs();
+    let height = (rect[3] - rect[1]).abs();
+    // Size 0 is "auto"; with no glyph metrics here, pick a sane concrete size.
+    let font_size = if da_font_size > 0.0 {
+        da_font_size
+    } else {
+        12.0
+    };
+
+    let encoded = TextEncoding::WinAnsiEncoding
+        .encode_strict(value)
+        .map_err(|ch| {
+            PdfError::EncodingError(format!(
+                "form value contains character {:?} (U+{:04X}) not representable in \
+                 WinAnsiEncoding used by built-in font {:?}; an embedded Type0 font \
+                 would be required (not yet supported on the incremental fill path)",
+                ch, ch as u32, da_font_name,
+            ))
+        })?;
+
+    // Vertical centring identical to forms::appearance::TextFieldAppearance.
+    let pad = 2.0;
+    let text_y = (height - font_size) / 2.0 + font_size * 0.3;
+
+    let mut content = Vec::new();
+    content.extend_from_slice(b"q\n");
+    content.extend_from_slice(b"BT\n");
+    content
+        .extend_from_slice(format!("/{da_font_name} {} Tf\n", format_real(font_size)).as_bytes());
+    content.extend_from_slice(b"0 g\n");
+    content
+        .extend_from_slice(format!("{} {} Td\n", format_real(pad), format_real(text_y)).as_bytes());
+    write_literal_string(&mut content, &encoded);
+    content.extend_from_slice(b" Tj\n");
+    content.extend_from_slice(b"ET\n");
+    content.extend_from_slice(b"Q");
+
+    // /Resources << /Font << /{da_font_name} << /Type /Font /Subtype /Type1
+    //                        /BaseFont /{base} >> >> >>
+    let mut font_entry = PdfDictionary::new();
+    font_entry.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Font".to_string())),
+    );
+    font_entry.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("Type1".to_string())),
+    );
+    font_entry.insert(
+        "BaseFont".to_string(),
+        PdfObject::Name(PdfName(da_font_to_base_font(da_font_name).to_string())),
+    );
+    let mut font_dict = PdfDictionary::new();
+    font_dict.insert(da_font_name.to_string(), PdfObject::Dictionary(font_entry));
+    let mut resources = PdfDictionary::new();
+    resources.insert("Font".to_string(), PdfObject::Dictionary(font_dict));
+    let mut resources_bytes = Vec::new();
+    write_dict(&mut resources_bytes, &resources)?;
+
+    Ok((content, [0.0, 0.0, width, height], resources_bytes))
+}
+
+/// Resolve the effective `(font_name, size)` for a widget from its own `/DA`,
+/// then the field's `/DA`, then the AcroForm `/DA`, defaulting to Helvetica 12.
+fn resolve_da(
+    widget_da: Option<&str>,
+    field_da: Option<&str>,
+    acro_da: Option<&str>,
+) -> (String, f64) {
+    widget_da
+        .and_then(parse_da_string)
+        .or_else(|| field_da.and_then(parse_da_string))
+        .or_else(|| acro_da.and_then(parse_da_string))
+        .unwrap_or_else(|| ("Helv".to_string(), 12.0))
+}
+
+/// Map each field object id to the widget annotation ids that reference it via
+/// `/Parent`, by walking the page tree and scanning every page's `/Annots`.
+/// This recovers the widget(s) for the common layout where a single-widget
+/// field omits `/Kids` and is linked only by the widget's `/Parent`
+/// back-reference (ISO 32000-1 §12.7.3.1 NOTE).
+fn collect_widgets_by_parent(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> HashMap<(u32, u16), Vec<(u32, u16)>> {
+    let mut map: HashMap<(u32, u16), Vec<(u32, u16)>> = HashMap::new();
+    let root = match reader.pages() {
+        Ok(p) => p.clone(),
+        Err(_) => return map,
+    };
+    // Iterative page-tree walk with a visited set + bound (defensive against
+    // cyclic or pathological /Kids).
+    let mut stack: Vec<(u32, u16)> = match root.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    let mut visited: std::collections::HashSet<(u32, u16)> = std::collections::HashSet::new();
+    let mut budget = 100_000u32;
+    while let Some(node_ref) = stack.pop() {
+        if budget == 0 || !visited.insert(node_ref) {
+            continue;
+        }
+        budget -= 1;
+        let node = match reader
+            .get_object(node_ref.0, node_ref.1)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+        {
+            Some(d) => d,
+            None => continue,
+        };
+        // Intermediate Pages node: descend.
+        if let Some(PdfObject::Array(kids)) = node.get("Kids") {
+            let is_pages = node
+                .get("Type")
+                .and_then(|o| o.as_name())
+                .map(|n| n.0 == "Pages")
+                .unwrap_or(false);
+            if is_pages || node.get("Count").is_some() {
+                for k in &kids.0 {
+                    if let Some(r) = k.as_reference() {
+                        stack.push(r);
+                    }
+                }
+                continue;
+            }
+        }
+        // Leaf page: scan /Annots for widgets carrying a /Parent reference.
+        if let Some(PdfObject::Array(annots)) = node.get("Annots") {
+            let annot_refs: Vec<(u32, u16)> =
+                annots.0.iter().filter_map(|o| o.as_reference()).collect();
+            for (an, ag) in annot_refs {
+                if let Some(annot) = reader
+                    .get_object(an, ag)
+                    .ok()
+                    .and_then(|o| o.as_dict().cloned())
+                {
+                    if let Some(parent) = annot.get("Parent").and_then(|o| o.as_reference()) {
+                        map.entry(parent).or_default().push((an, ag));
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
+/// Synthesize the `/AP /N` stream(s) for one text field, mutating the field
+/// (merged layout) or its widget annotations (separate-widget layouts) to
+/// reference a freshly-allocated appearance object. New stream descriptors go
+/// to `new_streams`; rewritten widgets go to `extra_widgets`.
+///
+/// Three layouts (ISO 32000-1 §12.7.3.1 / §12.5.6.19):
+/// - field dict carries `/Rect` → merged field+widget; `/AP` on the field.
+/// - field dict has `/Kids` widget annotations → `/AP` on each kid.
+/// - field has neither, widgets linked only by `/Parent` → resolved via
+///   `widgets_by_parent`.
+fn synthesize_text_field_ap(
+    field_id: (u32, u16),
+    field_dict: &mut PdfDictionary,
+    acro_da: &Option<String>,
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    widgets_by_parent: &HashMap<(u32, u16), Vec<(u32, u16)>>,
+    next_id: &mut u32,
+    new_streams: &mut Vec<(u32, Vec<u8>, [f64; 4], Vec<u8>)>,
+    extra_widgets: &mut Vec<(u32, u16, PdfDictionary)>,
+) -> Result<()> {
+    let value = match field_dict.get("V") {
+        Some(PdfObject::String(s)) => String::from_utf8_lossy(s.as_bytes()).into_owned(),
+        _ => return Ok(()),
+    };
+    let field_da = da_of(field_dict);
+
+    // Merged field+widget: the field dict itself has the /Rect.
+    if let Some(rect) = rect_of(field_dict) {
+        let (font_name, font_size) =
+            resolve_da(field_da.as_deref(), field_da.as_deref(), acro_da.as_deref());
+        let (content, bbox, resources) = build_text_ap(&value, &font_name, font_size, rect)?;
+        let ap_id = *next_id;
+        *next_id += 1;
+        new_streams.push((ap_id, content, bbox, resources));
+        let mut ap = PdfDictionary::new();
+        ap.insert("N".to_string(), PdfObject::Reference(ap_id, 0));
+        field_dict.insert("AP".to_string(), PdfObject::Dictionary(ap));
+        return Ok(());
+    }
+
+    // Separate-widget layouts: widget refs from /Kids, else from the
+    // /Parent reverse map.
+    let mut widget_refs: Vec<(u32, u16)> = match field_dict.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    if widget_refs.is_empty() {
+        if let Some(refs) = widgets_by_parent.get(&field_id) {
+            widget_refs = refs.clone();
+        }
+    }
+    for (kn, kg) in widget_refs {
+        let mut kid = match reader
+            .get_object(kn, kg)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+        {
+            Some(d) => d,
+            None => continue,
+        };
+        let is_widget = kid
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0 == "Widget")
+            .unwrap_or(false);
+        let rect = match rect_of(&kid) {
+            Some(r) if is_widget => r,
+            _ => continue,
+        };
+        let widget_da = da_of(&kid);
+        let (font_name, font_size) = resolve_da(
+            widget_da.as_deref(),
+            field_da.as_deref(),
+            acro_da.as_deref(),
+        );
+        let (content, bbox, resources) = build_text_ap(&value, &font_name, font_size, rect)?;
+        let ap_id = *next_id;
+        *next_id += 1;
+        new_streams.push((ap_id, content, bbox, resources));
+        let mut ap = PdfDictionary::new();
+        ap.insert("N".to_string(), PdfObject::Reference(ap_id, 0));
+        kid.insert("AP".to_string(), PdfObject::Dictionary(ap));
+        extra_widgets.push((kn, kg, kid));
+    }
+    Ok(())
+}
+
+/// Parse a `/DA` (default appearance) string, returning the selected font
+/// resource name (without the leading `/`) and size in points.
+///
+/// A `/DA` value is a content-stream fragment whose font selector is
+/// `/{name} {size} Tf` (ISO 32000-1 §12.7.3.3), optionally preceded by colour
+/// operators (`g`, `rg`, `k`). The scanner finds the `Tf` operator and takes
+/// the two tokens immediately before it. A size of `0` is the auto-size
+/// sentinel (the viewer chooses) and is preserved verbatim. Returns `None`
+/// when no well-formed font selector is present.
+fn parse_da_string(da: &str) -> Option<(String, f64)> {
+    let tokens: Vec<&str> = da.split_whitespace().collect();
+    let tf_idx = tokens.iter().position(|t| *t == "Tf")?;
+    if tf_idx < 2 {
+        return None;
+    }
+    let name_tok = tokens[tf_idx - 2];
+    let size_tok = tokens[tf_idx - 1];
+    let name = name_tok.strip_prefix('/')?;
+    if name.is_empty() {
+        return None;
+    }
+    let size: f64 = size_tok.parse().ok()?;
+    Some((name.to_string(), size))
+}
+
+/// Write a Form XObject appearance-stream object
+/// `{num} {gen} obj\n<< /Type /XObject /Subtype /Form /BBox [...] /Length L
+/// /Resources ... >>\nstream\n{content}\nendstream\nendobj\n`.
+///
+/// The content is emitted UNCOMPRESSED, so `/Length` is exactly the raw byte
+/// count — no filter, no two-pass buffering. `resources_snippet` is a
+/// pre-serialized `<< ... >>` dictionary (built by the caller via the
+/// module's `write_dict`) inlined as the `/Resources` value.
+fn write_indirect_stream_object(
+    out: &mut Vec<u8>,
+    num: u32,
+    gen: u16,
+    content: &[u8],
+    bbox: [f64; 4],
+    resources_snippet: &[u8],
+) -> Result<()> {
+    out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
+    out.extend_from_slice(b"<< /Type /XObject /Subtype /Form /BBox [");
+    out.extend_from_slice(
+        format!(
+            "{} {} {} {}",
+            format_real(bbox[0]),
+            format_real(bbox[1]),
+            format_real(bbox[2]),
+            format_real(bbox[3])
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(b"] /Resources ");
+    out.extend_from_slice(resources_snippet);
+    out.extend_from_slice(format!(" /Length {} >>\n", content.len()).as_bytes());
+    out.extend_from_slice(b"stream\n");
+    out.extend_from_slice(content);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    Ok(())
+}
 
 /// Write `{num} {gen} obj\n<dict>\nendobj\n` into `out`.
 fn write_indirect_object(
@@ -588,5 +1013,72 @@ mod tests {
         let mut out = Vec::new();
         write_literal_string(&mut out, b"a(b)c\\d");
         assert_eq!(out, b"(a\\(b\\)c\\\\d)");
+    }
+
+    // ----- Cycle 1: /DA string parsing -----
+
+    #[test]
+    fn parse_da_string_extracts_font_and_size() {
+        assert_eq!(
+            parse_da_string("/Helv 12 Tf 0 g"),
+            Some(("Helv".to_string(), 12.0))
+        );
+        assert_eq!(
+            parse_da_string("/Helvetica-Bold 9.5 Tf 0 g"),
+            Some(("Helvetica-Bold".to_string(), 9.5))
+        );
+        // Color operators before Tf must not confuse the scanner.
+        assert_eq!(
+            parse_da_string("0 0 1 rg /Cour 8 Tf"),
+            Some(("Cour".to_string(), 8.0))
+        );
+        // Size 0 is the auto-size sentinel (viewer chooses); preserved as 0.0.
+        assert_eq!(parse_da_string("/F1 0 Tf"), Some(("F1".to_string(), 0.0)));
+        assert_eq!(parse_da_string(""), None);
+        assert_eq!(parse_da_string("garbage"), None);
+        // A Tf with no preceding name/size is not a valid font selector.
+        assert_eq!(parse_da_string("Tf"), None);
+    }
+
+    // ----- Cycle 2: appearance stream object serialization -----
+
+    #[test]
+    fn write_indirect_stream_object_produces_valid_form_xobject() {
+        let content = b"q BT /Helv 12 Tf 2 5 Td (Hi) Tj ET Q";
+        let mut resources = Vec::new();
+        resources.extend_from_slice(b"<< /Font << /Helv << /Type /Font >> >> >>");
+        let mut out = Vec::new();
+        write_indirect_stream_object(&mut out, 9, 0, content, [0.0, 0.0, 200.0, 20.0], &resources)
+            .unwrap();
+        let s = String::from_utf8(out.clone()).unwrap();
+
+        assert!(s.starts_with("9 0 obj\n<<"), "object header: {s}");
+        assert!(s.contains("/Type /XObject"), "must be XObject: {s}");
+        assert!(s.contains("/Subtype /Form"), "must be Form: {s}");
+        assert!(s.contains("/BBox [0 0 200 20]"), "bbox: {s}");
+        assert!(
+            s.contains(&format!("/Length {}", content.len())),
+            "length must equal raw content byte count: {s}"
+        );
+        assert!(s.contains("/Resources << /Font"), "resources inlined: {s}");
+        // Exact stream framing around the verbatim content.
+        let marker = format!(
+            "stream\n{}\nendstream\nendobj\n",
+            String::from_utf8_lossy(content)
+        );
+        assert!(s.ends_with(&marker), "stream framing: {s}");
+
+        // Deterministic.
+        let mut out2 = Vec::new();
+        write_indirect_stream_object(
+            &mut out2,
+            9,
+            0,
+            content,
+            [0.0, 0.0, 200.0, 20.0],
+            &resources,
+        )
+        .unwrap();
+        assert_eq!(out, out2, "serialization must be deterministic");
     }
 }

--- a/oxidize-pdf-core/tests/analysis_spi_corpus_parity_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_corpus_parity_test.rs
@@ -1,0 +1,139 @@
+//! End-to-end regression guard: the analysis SPI's default path must be
+//! byte-identical to the legacy `rag_chunks()` path on REAL documents, not just
+//! a synthetic two-paragraph page. Closes spec §10.1 (corpus parity) with the
+//! committed fixtures instead of a network corpus.
+//!
+//! If `AnalysisPipeline::new()` ever diverges from `rag_chunks()` — e.g. a
+//! regression in the `HybridChunker → ChunkGroup → HybridChunk` round-trip
+//! (`into_group`/`from_group`) — this fails on the first differing chunk.
+#![cfg(feature = "unstable-spi")]
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{AnalysisPipeline, RagChunk};
+
+/// Real, structurally diverse, git-tracked fixtures: English prose, a
+/// two-column arXiv paper, a Spanish government bulletin, a SWE-bench RAG
+/// document, and a generic poppler test PDF.
+const FIXTURES: &[&str] = &[
+    "tests/fixtures/Cold_Email_Hacks.pdf",
+    "tests/fixtures/issue_272_higgs_arxiv_1207_7214.pdf",
+    "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf",
+    "tests/fixtures/issue_235_t.pdf",
+    "tests/fixtures/poppler-85140-0.pdf",
+];
+
+fn chunks_via_legacy(path: &str) -> Vec<RagChunk> {
+    let doc = PdfDocument::new(PdfReader::open(path).expect("open"));
+    doc.rag_chunks().expect("rag_chunks")
+}
+
+fn chunks_via_spi(path: &str) -> Vec<RagChunk> {
+    let doc = PdfDocument::new(PdfReader::open(path).expect("open"));
+    doc.rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("rag_chunks_with_pipeline")
+}
+
+/// Assert every field of every chunk is identical between the two paths.
+fn assert_chunks_identical(path: &str, legacy: &[RagChunk], spi: &[RagChunk]) {
+    assert_eq!(
+        spi.len(),
+        legacy.len(),
+        "{path}: chunk count differs (legacy {}, spi {})",
+        legacy.len(),
+        spi.len()
+    );
+    for (i, (l, s)) in legacy.iter().zip(spi.iter()).enumerate() {
+        assert_eq!(s.chunk_index, l.chunk_index, "{path}#{i}: chunk_index");
+        assert_eq!(s.text, l.text, "{path}#{i}: text");
+        assert_eq!(s.full_text, l.full_text, "{path}#{i}: full_text");
+        assert_eq!(s.page_numbers, l.page_numbers, "{path}#{i}: page_numbers");
+        assert_eq!(
+            s.bounding_boxes, l.bounding_boxes,
+            "{path}#{i}: bounding_boxes"
+        );
+        assert_eq!(
+            s.element_types, l.element_types,
+            "{path}#{i}: element_types"
+        );
+        assert_eq!(
+            s.heading_context, l.heading_context,
+            "{path}#{i}: heading_context"
+        );
+        assert_eq!(
+            s.token_estimate, l.token_estimate,
+            "{path}#{i}: token_estimate"
+        );
+        assert_eq!(s.is_oversized, l.is_oversized, "{path}#{i}: is_oversized");
+        // ChunkMetadata derives PartialEq → compares heading_path, fonts,
+        // counts, chunk_id, prev/next links, source, citation anchor, table
+        // dims (and `extra` under `semantic`) in one shot.
+        assert_eq!(s.metadata, l.metadata, "{path}#{i}: metadata");
+    }
+}
+
+#[test]
+fn default_pipeline_is_byte_identical_to_rag_chunks_on_real_corpus() {
+    let mut total_chunks = 0usize;
+    let mut total_text_chunks = 0usize;
+    for path in FIXTURES {
+        let legacy = chunks_via_legacy(path);
+        let spi = chunks_via_spi(path);
+
+        // Parity holds per fixture, including a legitimately text-free PDF
+        // (poppler-85140-0 yields zero chunks in BOTH paths — still parity).
+        assert_chunks_identical(path, &legacy, &spi);
+        total_chunks += legacy.len();
+        total_text_chunks += legacy.iter().filter(|c| !c.text.trim().is_empty()).count();
+    }
+    // Guard against a vacuous pass: the corpus as a whole must produce a
+    // substantial number of chunks carrying real text, otherwise "identical"
+    // would prove nothing.
+    assert!(
+        total_chunks >= 100,
+        "expected many chunks across the corpus, got {total_chunks}"
+    );
+    assert!(
+        total_text_chunks >= 100,
+        "expected many non-empty-text chunks, got {total_text_chunks}"
+    );
+}
+
+#[test]
+fn custom_config_via_pipeline_matches_rag_chunks_with() {
+    use oxidize_pdf::pipeline::{HybridChunkConfig, HybridChunker};
+
+    // A non-default budget through the SPI matches `rag_chunks_with(config)` of
+    // the same budget — but `AnalysisPipeline::max_tokens` only drives the
+    // `oversized` flag (spec §4/§6), so reproducing a custom-budget chunking
+    // requires swapping in a `HybridChunker` built with that config AND setting
+    // the matching oversized budget. (Calling only `with_max_tokens` would leave
+    // the default 512-token chunker in place — a different grouping, by design.)
+    let path = "tests/fixtures/Cold_Email_Hacks.pdf";
+    let config = HybridChunkConfig {
+        max_tokens: 128,
+        ..HybridChunkConfig::default()
+    };
+
+    let legacy = {
+        let doc = PdfDocument::new(PdfReader::open(path).expect("open"));
+        doc.rag_chunks_with(config.clone())
+            .expect("rag_chunks_with")
+    };
+    let spi = {
+        let doc = PdfDocument::new(PdfReader::open(path).expect("open"));
+        let pipeline = AnalysisPipeline::new()
+            .with_chunking(Box::new(HybridChunker::new(config.clone())))
+            .with_max_tokens(config.max_tokens);
+        doc.rag_chunks_with_pipeline(&pipeline)
+            .expect("rag_chunks_with_pipeline")
+    };
+
+    // The custom 128-token budget produces strictly more chunks than the default
+    // 512 path would (≈100 vs ≈42) — proves the config actually took effect.
+    assert!(
+        legacy.len() > 50,
+        "128-token budget should fragment more than the default; got {}",
+        legacy.len()
+    );
+    assert_chunks_identical(path, &legacy, &spi);
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -517,3 +517,36 @@ fn class_label_string_ergonomics() {
     let owned: String = ClassLabel::new("definition".to_string()).into();
     assert_eq!(owned, "definition");
 }
+
+#[test]
+fn pipeline_owns_oversized_flag_regardless_of_strategy() {
+    // Spec §10.5: a strategy that emits an over-budget group → the pipeline
+    // marks is_oversized. OnePerElement keeps each (multi-word) paragraph in its
+    // own group; a 1-token budget makes every real text chunk over-budget.
+    let bytes = build_two_section_doc();
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+
+    let tight = AnalysisPipeline::new()
+        .with_chunking(Box::new(OnePerElement))
+        .with_max_tokens(1);
+    let oversized = parsed
+        .rag_chunks_with_pipeline(&tight)
+        .expect("rag_chunks_with_pipeline");
+    assert!(
+        oversized.iter().any(|c| c.is_oversized),
+        "tiny budget → the pipeline flags oversized even though the strategy ignores budget"
+    );
+
+    // Same strategy, generous budget → nothing oversized. Proves the flag tracks
+    // the pipeline's budget, not the strategy.
+    let loose = AnalysisPipeline::new()
+        .with_chunking(Box::new(OnePerElement))
+        .with_max_tokens(10_000);
+    let none_over = parsed
+        .rag_chunks_with_pipeline(&loose)
+        .expect("rag_chunks_with_pipeline");
+    assert!(
+        none_over.iter().all(|c| !c.is_oversized),
+        "generous budget → no chunk is oversized"
+    );
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -275,3 +275,107 @@ fn default_pipeline_has_no_classifier_and_leaves_labels_unset() {
         "without a classifier, no element carries a class label"
     );
 }
+
+// --- MetadataEnricher seam (§7), gated on `semantic` (writes `extra`) ---
+
+#[cfg(feature = "semantic")]
+mod enricher {
+    use super::*;
+    use oxidize_pdf::pipeline::{ChunkMetadata, EnrichContext, MetadataEnricher};
+
+    /// Enricher that stamps the chunk's word count and element count into the
+    /// open `extra` bag, proving it can read text + elements and write `extra`.
+    struct CountEnricher;
+
+    impl MetadataEnricher for CountEnricher {
+        fn enrich(&self, ctx: &EnrichContext, meta: &mut ChunkMetadata) {
+            let words = ctx.text.split_whitespace().count();
+            meta.extra
+                .insert("test.word_count".to_string(), serde_json::json!(words));
+            meta.extra.insert(
+                "test.element_count".to_string(),
+                serde_json::json!(ctx.elements.len()),
+            );
+            // heading_path is reachable too.
+            meta.extra.insert(
+                "test.heading_depth".to_string(),
+                serde_json::json!(ctx.heading_path.len()),
+            );
+        }
+    }
+
+    #[test]
+    fn enricher_writes_namespaced_keys_into_extra() {
+        let bytes = build_two_section_doc();
+        let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+        let pipeline = AnalysisPipeline::new().with_enricher(Box::new(CountEnricher));
+        let chunks = parsed
+            .rag_chunks_with_pipeline(&pipeline)
+            .expect("rag_chunks_with_pipeline");
+
+        assert!(!chunks.is_empty());
+        for c in &chunks {
+            let wc = c.metadata.extra.get("test.word_count").expect("word_count");
+            assert_eq!(
+                wc.as_u64().unwrap() as usize,
+                c.text.split_whitespace().count(),
+                "enricher saw the real chunk text"
+            );
+            let ec = c
+                .metadata
+                .extra
+                .get("test.element_count")
+                .expect("element_count");
+            assert!(ec.as_u64().unwrap() >= 1, "chunk has >= 1 element");
+            assert!(c.metadata.extra.contains_key("test.heading_depth"));
+        }
+    }
+
+    #[test]
+    fn enrichers_run_in_order_last_writer_wins_per_key() {
+        struct StampA;
+        struct StampB;
+        impl MetadataEnricher for StampA {
+            fn enrich(&self, _ctx: &EnrichContext, meta: &mut ChunkMetadata) {
+                meta.extra
+                    .insert("ns.order".to_string(), serde_json::json!("A"));
+            }
+        }
+        impl MetadataEnricher for StampB {
+            fn enrich(&self, _ctx: &EnrichContext, meta: &mut ChunkMetadata) {
+                meta.extra
+                    .insert("ns.order".to_string(), serde_json::json!("B"));
+            }
+        }
+
+        let bytes = build_two_section_doc();
+        let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+        let pipeline = AnalysisPipeline::new()
+            .with_enricher(Box::new(StampA))
+            .with_enricher(Box::new(StampB));
+        let chunks = parsed
+            .rag_chunks_with_pipeline(&pipeline)
+            .expect("rag_chunks_with_pipeline");
+
+        for c in &chunks {
+            assert_eq!(
+                c.metadata.extra.get("ns.order").unwrap(),
+                &serde_json::json!("B"),
+                "enrichers apply in insertion order; B runs after A"
+            );
+        }
+    }
+
+    #[test]
+    fn no_enricher_leaves_extra_empty() {
+        let bytes = build_two_section_doc();
+        let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+        let chunks = parsed
+            .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+            .expect("rag_chunks_with_pipeline");
+        assert!(
+            chunks.iter().all(|c| c.metadata.extra.is_empty()),
+            "default pipeline does not touch extra"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -140,3 +140,45 @@ fn custom_strategy_drives_chunk_count_and_pipeline_owns_ids() {
         assert!(!c.metadata.chunk_id.is_empty());
     }
 }
+
+/// A strategy that delegates to the default and then merges every pair of
+/// adjacent groups — proving "delegate to the default and refine".
+struct PairMerger {
+    inner: HybridChunker,
+}
+
+impl ChunkingStrategy for PairMerger {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+        let base = ChunkingStrategy::chunk(&self.inner, elements);
+        let mut out = Vec::new();
+        let mut iter = base.into_iter();
+        while let Some(mut a) = iter.next() {
+            if let Some(b) = iter.next() {
+                a.elements.extend(b.elements);
+            }
+            out.push(a);
+        }
+        out
+    }
+}
+
+#[test]
+fn decorator_wraps_default_and_refines() {
+    let elements = vec![para("alpha"), para("bravo"), para("charlie"), para("delta")];
+
+    let inner = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 1, // force one element per group from the default
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let base_count = ChunkingStrategy::chunk(&inner, &elements).len();
+    assert_eq!(base_count, 4, "default emits one group per element here");
+
+    let decorated = PairMerger { inner };
+    let groups = decorated.chunk(&elements);
+    assert_eq!(groups.len(), 2, "pairs merged: 4 groups -> 2");
+    assert_eq!(groups[0].elements.len(), 2);
+    assert_eq!(groups[1].elements.len(), 2);
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -60,3 +60,83 @@ fn hybrid_chunker_is_the_default_strategy() {
         assert_eq!(g.heading_context, h.heading_context);
     }
 }
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::AnalysisPipeline;
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+fn build_two_section_doc() -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Section One")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 730.0)
+        .write("First body paragraph with enough words to chunk on its own line.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 700.0)
+        .write("Second body paragraph also with several words to fill a bucket.")
+        .unwrap();
+    doc.add_page(page);
+    doc.to_bytes().expect("pdf generation")
+}
+
+#[test]
+fn default_pipeline_matches_rag_chunks() {
+    let bytes = build_two_section_doc();
+
+    let parsed_a = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let baseline = parsed_a.rag_chunks().expect("rag_chunks");
+
+    let parsed_b = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let via_pipeline = parsed_b
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("rag_chunks_with_pipeline");
+
+    assert_eq!(
+        via_pipeline.len(),
+        baseline.len(),
+        "default pipeline produces the same chunk count"
+    );
+    for (p, b) in via_pipeline.iter().zip(baseline.iter()) {
+        assert_eq!(p.text, b.text, "same chunk text");
+        assert_eq!(p.metadata.chunk_id, b.metadata.chunk_id, "same chunk_id");
+        assert_eq!(p.is_oversized, b.is_oversized, "same oversized flag");
+        assert_eq!(
+            p.metadata.prev_chunk_id, b.metadata.prev_chunk_id,
+            "same prev link"
+        );
+    }
+}
+
+#[test]
+fn custom_strategy_drives_chunk_count_and_pipeline_owns_ids() {
+    let bytes = build_two_section_doc();
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+
+    let pipeline = AnalysisPipeline::new().with_chunking(Box::new(OnePerElement));
+    let chunks = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+
+    // One element per chunk → at least as many chunks as the default merge.
+    assert!(chunks.len() >= 3, "one-per-element yields >= 3 chunks");
+    // The pipeline (not the strategy) derived ids and links.
+    assert!(chunks[0].metadata.prev_chunk_id.is_none());
+    assert_eq!(
+        chunks[0].metadata.next_chunk_id.as_deref(),
+        Some(chunks[1].metadata.chunk_id.as_str()),
+        "pipeline wired prev/next"
+    );
+    for c in &chunks {
+        assert!(!c.metadata.chunk_id.is_empty());
+    }
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -503,3 +503,17 @@ mod seams_compose {
         );
     }
 }
+
+#[test]
+fn class_label_string_ergonomics() {
+    let label = ClassLabel::new("clause");
+    // AsRef<str>
+    assert_eq!(label.as_ref() as &str, "clause");
+    // PartialEq<str> / PartialEq<&str>
+    assert_eq!(label, *"clause");
+    assert!(label == "clause");
+    assert!(label != "definition");
+    // From<ClassLabel> for String
+    let owned: String = ClassLabel::new("definition".to_string()).into();
+    assert_eq!(owned, "definition");
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -182,3 +182,96 @@ fn decorator_wraps_default_and_refines() {
     assert_eq!(groups[0].elements.len(), 2);
     assert_eq!(groups[1].elements.len(), 2);
 }
+
+// --- ElementClassifier seam (§7) ---
+
+use oxidize_pdf::pipeline::{ClassLabel, ClassifyContext, ElementClassifier};
+
+/// Classifier that labels any element whose text contains "CLAUSE".
+struct MarkClause;
+
+impl ElementClassifier for MarkClause {
+    fn classify(&self, element: &Element, ctx: &ClassifyContext) -> Option<ClassLabel> {
+        // ctx must expose the surrounding elements and this element's index.
+        assert_eq!(ctx.elements[ctx.index].text(), element.text());
+        if element.text().contains("CLAUSE") {
+            Some(ClassLabel::new("clause"))
+        } else {
+            None
+        }
+    }
+}
+
+/// Strategy that copies each element's `class_label` into the group's
+/// heading_context — making the classifier's effect observable downstream.
+struct ExposeLabel;
+
+impl ChunkingStrategy for ExposeLabel {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+        elements
+            .iter()
+            .map(|e| ChunkGroup::new(vec![e.clone()], e.metadata().class_label.clone()))
+            .collect()
+    }
+}
+
+#[test]
+fn classifier_runs_before_chunking_and_sets_class_label() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 760.0)
+        .write("Intro paragraph without the marker word here.")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 730.0)
+        .write("CLAUSE 1 the parties hereby agree to the following terms.")
+        .unwrap();
+    doc.add_page(page);
+    let bytes = doc.to_bytes().expect("pdf generation");
+
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let pipeline = AnalysisPipeline::new()
+        .with_classifier(Box::new(MarkClause))
+        .with_chunking(Box::new(ExposeLabel));
+    let chunks = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+
+    // Exactly the chunk(s) whose text carries "CLAUSE" inherit the label;
+    // others have no heading_context from a label.
+    let labeled: Vec<&str> = chunks
+        .iter()
+        .filter(|c| c.heading_context.as_deref() == Some("clause"))
+        .map(|c| c.text.as_str())
+        .collect();
+    assert_eq!(
+        labeled.len(),
+        1,
+        "exactly one element carries the CLAUSE label"
+    );
+    assert!(labeled[0].contains("CLAUSE"));
+
+    let unlabeled = chunks
+        .iter()
+        .filter(|c| c.heading_context.is_none())
+        .count();
+    assert!(unlabeled >= 1, "the intro element is unlabeled");
+}
+
+#[test]
+fn default_pipeline_has_no_classifier_and_leaves_labels_unset() {
+    let bytes = build_two_section_doc();
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    // No classifier configured → ExposeLabel sees only None labels.
+    let pipeline = AnalysisPipeline::new().with_chunking(Box::new(ExposeLabel));
+    let chunks = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+    assert!(
+        chunks.iter().all(|c| c.heading_context.is_none()),
+        "without a classifier, no element carries a class label"
+    );
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -379,3 +379,127 @@ mod enricher {
         );
     }
 }
+
+// --- Capstone: classifier + label-aware strategy + enricher compose (§7 e2e) ---
+
+#[cfg(feature = "semantic")]
+mod seams_compose {
+    use super::*;
+    use oxidize_pdf::pipeline::{ChunkMetadata, EnrichContext, MetadataEnricher};
+
+    /// Labels elements that begin a clause.
+    struct ClauseClassifier;
+    impl ElementClassifier for ClauseClassifier {
+        fn classify(&self, element: &Element, _ctx: &ClassifyContext) -> Option<ClassLabel> {
+            element
+                .text()
+                .starts_with("CLAUSE")
+                .then(|| ClassLabel::new("clause"))
+        }
+    }
+
+    /// Strategy that starts a new group at every element labelled "clause";
+    /// non-clause elements append to the current group. A boundary DECISION
+    /// driven by the classifier's label — the core's HybridChunker can't do this.
+    struct SplitOnClause;
+    impl ChunkingStrategy for SplitOnClause {
+        fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+            let mut groups: Vec<ChunkGroup> = Vec::new();
+            for e in elements {
+                let is_clause = e.metadata().class_label.as_deref() == Some("clause");
+                if is_clause || groups.is_empty() {
+                    groups.push(ChunkGroup::new(
+                        vec![e.clone()],
+                        e.metadata().class_label.clone(),
+                    ));
+                } else {
+                    groups.last_mut().unwrap().elements.push(e.clone());
+                }
+            }
+            groups
+        }
+    }
+
+    /// Reads the classifier's label off the chunk's elements (via `ctx`) and
+    /// stamps it onto `extra` under a namespaced key — proving the enricher sees
+    /// the classifier's output end-to-end.
+    struct ClauseEnricher;
+    impl MetadataEnricher for ClauseEnricher {
+        fn enrich(&self, ctx: &EnrichContext, meta: &mut ChunkMetadata) {
+            let is_clause = ctx
+                .elements
+                .iter()
+                .any(|e| e.metadata().class_label.as_deref() == Some("clause"));
+            meta.extra
+                .insert("legal.is_clause".to_string(), serde_json::json!(is_clause));
+        }
+    }
+
+    fn three_clause_doc() -> Vec<u8> {
+        let mut doc = Document::new();
+        let mut page = Page::a4();
+        let lines = [
+            (
+                760.0,
+                "Preamble text that precedes any clause in the agreement.",
+            ),
+            (
+                730.0,
+                "CLAUSE 1 the first obligation of the parties is stated here.",
+            ),
+            (
+                700.0,
+                "Continuation of clause one with additional detail and terms.",
+            ),
+            (
+                670.0,
+                "CLAUSE 2 the second obligation follows in this separate clause.",
+            ),
+        ];
+        for (y, t) in lines {
+            page.text()
+                .set_font(Font::Helvetica, 11.0)
+                .at(50.0, y)
+                .write(t)
+                .unwrap();
+        }
+        doc.add_page(page);
+        doc.to_bytes().expect("pdf generation")
+    }
+
+    #[test]
+    fn classifier_drives_strategy_boundaries_and_enricher_reads_through() {
+        let bytes = three_clause_doc();
+        let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+        let pipeline = AnalysisPipeline::new()
+            .with_classifier(Box::new(ClauseClassifier))
+            .with_chunking(Box::new(SplitOnClause))
+            .with_enricher(Box::new(ClauseEnricher));
+        let chunks = parsed
+            .rag_chunks_with_pipeline(&pipeline)
+            .expect("rag_chunks_with_pipeline");
+
+        // Preamble starts group 0 (no clause yet); each CLAUSE opens a new group.
+        // → exactly 3 groups: [preamble], [CLAUSE 1 + continuation], [CLAUSE 2].
+        assert_eq!(chunks.len(), 3, "two clause boundaries split into 3 chunks");
+
+        // The two clause chunks carry the label end-to-end into `extra`.
+        let clause_chunks: Vec<&_> = chunks
+            .iter()
+            .filter(|c| c.metadata.extra.get("legal.is_clause") == Some(&serde_json::json!(true)))
+            .collect();
+        assert_eq!(clause_chunks.len(), 2, "two chunks are clause-labelled");
+        for c in &clause_chunks {
+            assert!(c.text.contains("CLAUSE"));
+        }
+        // The continuation merged into clause 1, not its own chunk.
+        let clause1 = clause_chunks
+            .iter()
+            .find(|c| c.text.contains("CLAUSE 1"))
+            .unwrap();
+        assert!(
+            clause1.text.contains("Continuation"),
+            "non-clause element appended to the open clause group"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -33,3 +33,30 @@ fn custom_strategy_is_object_safe_and_groups_per_element() {
     assert_eq!(groups[0].elements[0].text(), "alpha");
     assert_eq!(groups[2].elements[0].text(), "charlie");
 }
+
+use oxidize_pdf::pipeline::{HybridChunkConfig, HybridChunker, MergePolicy};
+
+#[test]
+fn hybrid_chunker_is_the_default_strategy() {
+    let elements = vec![para("alpha one two three"), para("bravo four five six")];
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 4,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+
+    // Inherent API: Vec<HybridChunk>.
+    let hybrid = HybridChunker::chunk(&chunker, &elements);
+    // Trait API: Vec<ChunkGroup>, same grouping.
+    let groups = ChunkingStrategy::chunk(&chunker, &elements);
+
+    assert_eq!(groups.len(), hybrid.len(), "same number of chunks");
+    for (g, h) in groups.iter().zip(hybrid.iter()) {
+        let g_text: Vec<&str> = g.elements.iter().map(|e| e.text()).collect();
+        let h_text: Vec<&str> = h.elements().iter().map(|e| e.text()).collect();
+        assert_eq!(g_text, h_text, "same element grouping");
+        assert_eq!(g.heading_context, h.heading_context);
+    }
+}

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -1,0 +1,35 @@
+//! Integration tests for the unstable analysis SPI.
+#![cfg(feature = "unstable-spi")]
+
+use oxidize_pdf::pipeline::{ChunkGroup, ChunkingStrategy};
+use oxidize_pdf::pipeline::{Element, ElementData, ElementMetadata};
+
+/// A strategy that emits exactly one chunk per element.
+struct OnePerElement;
+
+impl ChunkingStrategy for OnePerElement {
+    fn chunk(&self, elements: &[Element]) -> Vec<ChunkGroup> {
+        elements
+            .iter()
+            .map(|e| ChunkGroup::new(vec![e.clone()], None))
+            .collect()
+    }
+}
+
+fn para(text: &str) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })
+}
+
+#[test]
+fn custom_strategy_is_object_safe_and_groups_per_element() {
+    let strategy: Box<dyn ChunkingStrategy> = Box::new(OnePerElement);
+    let elements = vec![para("alpha"), para("bravo"), para("charlie")];
+    let groups = strategy.chunk(&elements);
+    assert_eq!(groups.len(), 3, "one chunk per element");
+    assert_eq!(groups[0].elements.len(), 1);
+    assert_eq!(groups[0].elements[0].text(), "alpha");
+    assert_eq!(groups[2].elements[0].text(), "charlie");
+}

--- a/oxidize-pdf-core/tests/common/mod.rs
+++ b/oxidize-pdf-core/tests/common/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod colorspace_inspect;
 pub mod pdf_assembler;
+pub mod rag_helpers;
 pub mod synthetic_pdf;
 
 /// Count the number of /Type /Page entries in PDF bytes (excluding /Type /Pages).

--- a/oxidize-pdf-core/tests/common/rag_helpers.rs
+++ b/oxidize-pdf-core/tests/common/rag_helpers.rs
@@ -1,0 +1,47 @@
+//! Shared RAG test helpers.
+
+use oxidize_pdf::pipeline::{
+    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+    MergePolicy, RagChunk,
+};
+
+/// Build a `RagChunk` with caller-pinned public fields.
+///
+/// `RagChunk` is `#[non_exhaustive]`, so external crates cannot build it via a
+/// struct literal. Construct one through the public `from_hybrid_chunk` API and
+/// override the public fields each test needs to pin.
+#[allow(clippy::too_many_arguments)]
+pub fn make_rag_chunk(
+    chunk_index: usize,
+    text: &str,
+    full_text: &str,
+    page_numbers: Vec<u32>,
+    bounding_boxes: Vec<ElementBBox>,
+    element_types: Vec<String>,
+    heading_context: Option<String>,
+    token_estimate: usize,
+    is_oversized: bool,
+) -> RagChunk {
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })]);
+    let mut chunk = RagChunk::from_hybrid_chunk(chunk_index, &chunks[0]);
+    chunk.chunk_index = chunk_index;
+    chunk.text = text.to_string();
+    chunk.full_text = full_text.to_string();
+    chunk.page_numbers = page_numbers;
+    chunk.bounding_boxes = bounding_boxes;
+    chunk.element_types = element_types;
+    chunk.heading_context = heading_context;
+    chunk.token_estimate = token_estimate;
+    chunk.is_oversized = is_oversized;
+    chunk
+}

--- a/oxidize-pdf-core/tests/incremental_form_fill_ap_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_ap_test.rs
@@ -1,0 +1,471 @@
+//! Integration tests for `/AP` appearance-stream regeneration in
+//! `IncrementalFormFiller` (follow-up to issue #318).
+//!
+//! `fill_*` sets `/V` and flags `NeedAppearances true`. Non-compliant viewers
+//! and flatten/print pipelines never regenerate from `/V`, so they need a real
+//! `/AP /N` Form XObject. These tests verify that the filler synthesizes that
+//! stream for text fields and sets `/AS` for button fields — asserting decoded
+//! content, not status codes (no smoke tests).
+
+use oxidize_pdf::forms::{FormManager, TextField, Widget, WidgetAppearance};
+use oxidize_pdf::geometry::{Point, Rectangle};
+use oxidize_pdf::parser::objects::PdfObject;
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+mod common;
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Single-page PDF with merged field+widget text fields (the FormManager
+/// layout: each field dict carries `/Subtype /Widget`, `/Rect` and `/DA`).
+fn build_base_pdf_with_fields(names: &[&str]) -> Vec<u8> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut fm = FormManager::new();
+
+    let mut y = 700.0;
+    for name in names {
+        let rect = Rectangle::new(Point::new(100.0, y), Point::new(300.0, y + 20.0));
+        let widget = Widget::new(rect).with_appearance(WidgetAppearance::default());
+        let field = TextField::new(*name);
+        let field_ref = fm
+            .add_text_field(field, widget.clone(), None)
+            .expect("add_text_field");
+        page.add_form_widget_with_ref(widget, field_ref)
+            .expect("add_form_widget_with_ref");
+        y -= 40.0;
+    }
+
+    doc.add_page(page);
+    doc.set_form_manager(fm);
+    doc.to_bytes().expect("serialize base document")
+}
+
+// ---------------------------------------------------------------------------
+// /AP/N resolution + content inspection
+// ---------------------------------------------------------------------------
+
+/// Resolve the `/AP/N` stream bytes (decoded) of a specific object id.
+fn ap_n_bytes_of_object(pdf: &[u8], num: u32, gen: u16) -> Option<Vec<u8>> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    let ap = dict.get("AP").and_then(|o| o.as_dict())?.clone();
+    let normal = ap.get("N")?.clone();
+    match normal {
+        PdfObject::Reference(n, g) => {
+            let xobj = reader.get_object(n, g).ok()?.clone();
+            let stream = xobj.as_stream()?;
+            stream.decode(reader.options()).ok()
+        }
+        PdfObject::Stream(ref s) => s.decode(reader.options()).ok(),
+        _ => None,
+    }
+}
+
+/// The `/AP/N` stream dict of a specific object id (for /Type, /BBox checks).
+fn ap_n_stream_dict(
+    pdf: &[u8],
+    num: u32,
+    gen: u16,
+) -> Option<oxidize_pdf::parser::objects::PdfDictionary> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let dict = reader.get_object(num, gen).ok()?.as_dict()?.clone();
+    let ap = dict.get("AP").and_then(|o| o.as_dict())?.clone();
+    match ap.get("N")?.clone() {
+        PdfObject::Reference(n, g) => {
+            let xobj = reader.get_object(n, g).ok()?.clone();
+            xobj.as_stream().map(|s| s.dict.clone())
+        }
+        PdfObject::Stream(ref s) => Some(s.dict.clone()),
+        _ => None,
+    }
+}
+
+/// Object id of the first widget annotation on the first page. Appearance
+/// streams are read by viewers from the annotation, so this is the
+/// layout-agnostic place to look (merged field+widget OR separate widget).
+fn first_widget_annot_id(pdf: &[u8]) -> Option<(u32, u16)> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let pages = reader.pages().ok()?.clone();
+    let kids = pages.get("Kids").and_then(|o| o.as_array())?;
+    let (pn, pg) = kids.0[0].as_reference()?;
+    let page = reader.get_object(pn, pg).ok()?.as_dict()?.clone();
+    let annots = page.get("Annots").and_then(|o| o.as_array())?;
+    annots.0[0].as_reference()
+}
+
+/// Object id of a terminal field by fully-qualified name.
+#[allow(dead_code)]
+fn field_object_id(pdf: &[u8], name: &str) -> Option<(u32, u16)> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog.get("AcroForm")?.as_reference()?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let fields: Vec<(u32, u16)> = match acro.get("Fields") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => return None,
+    };
+    for r in fields {
+        if let Some(found) = walk_for_id(&mut reader, r, "", name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn walk_for_id(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    node_ref: (u32, u16),
+    prefix: &str,
+    target: &str,
+) -> Option<(u32, u16)> {
+    let node = reader
+        .get_object(node_ref.0, node_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    let partial = node
+        .get("T")
+        .and_then(|o| o.as_string())
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+    let full = match (&partial, prefix.is_empty()) {
+        (Some(t), true) => t.clone(),
+        (Some(t), false) => format!("{prefix}.{t}"),
+        (None, _) => prefix.to_string(),
+    };
+    let kids: Vec<(u32, u16)> = match node.get("Kids") {
+        Some(PdfObject::Array(arr)) => arr.0.iter().filter_map(|o| o.as_reference()).collect(),
+        _ => Vec::new(),
+    };
+    let kids_are_subfields = kids.iter().any(|(n, g)| {
+        reader
+            .get_object(*n, *g)
+            .ok()
+            .and_then(|o| o.as_dict().cloned())
+            .map(|d| d.contains_key("T"))
+            .unwrap_or(false)
+    });
+    if kids.is_empty() || !kids_are_subfields {
+        if partial.is_some() && full == target {
+            return Some(node_ref);
+        }
+        None
+    } else {
+        for kid in kids {
+            if let Some(found) = walk_for_id(reader, kid, &full, target) {
+                return Some(found);
+            }
+        }
+        None
+    }
+}
+
+fn needappearances(pdf: &[u8]) -> Option<bool> {
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let acro_ref = catalog.get("AcroForm")?.as_reference()?;
+    let acro = reader
+        .get_object(acro_ref.0, acro_ref.1)
+        .ok()?
+        .as_dict()?
+        .clone();
+    match acro.get("NeedAppearances") {
+        Some(PdfObject::Boolean(b)) => Some(*b),
+        _ => None,
+    }
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 3 — text field, merged field+widget layout
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_text_field_ap_n_stream_contains_value() {
+    let base = build_base_pdf_with_fields(&["name"]);
+    let output = IncrementalFormFiller::new(&base)
+        .fill("name", "Alice")
+        .expect("fill");
+
+    // Base bytes preserved verbatim.
+    assert_eq!(&output[..base.len()], &base[..], "verbatim prefix");
+
+    let (num, gen) = first_widget_annot_id(&output).expect("resolve widget annot id");
+
+    let content = ap_n_bytes_of_object(&output, num, gen)
+        .expect("widget must carry an /AP/N stream after fill");
+
+    assert!(
+        contains(&content, b"BT"),
+        "content begins text: {content:?}"
+    );
+    assert!(contains(&content, b"Tf"), "content selects a font");
+    assert!(contains(&content, b"Td"), "content positions text");
+    assert!(contains(&content, b"Alice"), "value text present in Tj");
+    assert!(contains(&content, b"ET"), "content ends text");
+
+    let sdict = ap_n_stream_dict(&output, num, gen).expect("stream dict");
+    assert_eq!(
+        sdict
+            .get("Type")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("XObject"),
+        "AP/N must be an XObject"
+    );
+    assert_eq!(
+        sdict
+            .get("Subtype")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("Form"),
+        "AP/N must be a Form XObject"
+    );
+    assert!(sdict.contains_key("BBox"), "AP/N must carry /BBox");
+
+    assert_eq!(
+        needappearances(&output),
+        Some(true),
+        "NeedAppearances stays true (additive, viewers may still regenerate)"
+    );
+
+    // Full round-trip parse succeeds.
+    assert!(
+        PdfReader::new(Cursor::new(&output)).is_ok(),
+        "output must re-parse"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 4 — button field: set /AS, preserve pre-authored /AP
+// ---------------------------------------------------------------------------
+
+/// A checkbox (merged field+widget) carrying pre-authored `/AP` on/off states.
+fn build_checkbox_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] >>".to_vec(),
+        b"<< /FT /Btn /T (agree) /Type /Annot /Subtype /Widget /Rect [100 700 120 720] \
+           /AP << /N << /Yes 6 0 R /Off 7 0 R >> >> /AS /Off >>"
+            .to_vec(),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 20 20]",
+            b"q 1 0 0 RG Q",
+        ),
+        stream_obj("/Type /XObject /Subtype /Form /BBox [0 0 20 20]", b"q Q"),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_button_field_sets_as_to_on_state() {
+    let base = build_checkbox_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("agree", "Yes")
+        .expect("fill checkbox");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse output");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+
+    assert_eq!(
+        field
+            .get("AS")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str()),
+        Some("Yes"),
+        "/AS must select the on-state so the pre-authored /AP/N/Yes shows"
+    );
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str())
+            .or_else(|| field.get("V").and_then(|o| o.as_string()).map(|_| "Yes")),
+        Some("Yes"),
+        "/V must record the selected state"
+    );
+    // Pre-authored /AP preserved: /N still maps the two appearance states.
+    let ap = field
+        .get("AP")
+        .and_then(|o| o.as_dict())
+        .expect("AP preserved");
+    let n = ap
+        .get("N")
+        .and_then(|o| o.as_dict())
+        .expect("AP/N dict preserved");
+    assert!(
+        n.contains_key("Yes") && n.contains_key("Off"),
+        "states preserved"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 5 — text field, separate widget via /Kids
+// ---------------------------------------------------------------------------
+
+fn build_kids_text_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [6 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] /DA (/Helv 12 Tf 0 g) >>".to_vec(),
+        b"<< /FT /Tx /T (city) /DA (/Helv 12 Tf 0 g) /Kids [6 0 R] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [100 700 300 720] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_text_field_kids_layout_ap_on_widget() {
+    let base = build_kids_text_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("city", "Berlin")
+        .expect("fill kids-layout text field");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_string())
+            .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()),
+        Some("Berlin".to_string()),
+        "field carries /V"
+    );
+    assert!(
+        !field.contains_key("AP"),
+        "field with no /Rect must not bear /AP"
+    );
+
+    // The widget (obj 6) carries the synthesized /AP/N.
+    let content =
+        ap_n_bytes_of_object(&output, 6, 0).expect("widget kid must carry /AP/N after fill");
+    assert!(contains(&content, b"BT"), "text begins");
+    assert!(contains(&content, b"Berlin"), "value present");
+    assert!(contains(&content, b"ET"), "text ends");
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 6 — multi-field, mixed layouts in one incremental update
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_many_ap_merged_and_kids() {
+    let base = build_base_pdf_with_fields(&["alpha", "beta"]);
+    let output = IncrementalFormFiller::new(&base)
+        .fill_many(&[("alpha", "Foo"), ("beta", "Bar")])
+        .expect("fill_many");
+
+    // Both widgets (page annotations) carry an /AP/N with their own value.
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let pages = reader.pages().expect("pages").clone();
+    let (pn, pg) = pages.get("Kids").and_then(|o| o.as_array()).unwrap().0[0]
+        .as_reference()
+        .unwrap();
+    let page = reader
+        .get_object(pn, pg)
+        .expect("page")
+        .as_dict()
+        .unwrap()
+        .clone();
+    let annots: Vec<(u32, u16)> = page
+        .get("Annots")
+        .and_then(|o| o.as_array())
+        .unwrap()
+        .0
+        .iter()
+        .filter_map(|o| o.as_reference())
+        .collect();
+    assert_eq!(annots.len(), 2, "two widgets");
+
+    let mut seen = Vec::new();
+    for (n, g) in annots {
+        let c = ap_n_bytes_of_object(&output, n, g).expect("each widget has /AP/N");
+        if contains(&c, b"Foo") {
+            seen.push("Foo");
+        }
+        if contains(&c, b"Bar") {
+            seen.push("Bar");
+        }
+    }
+    seen.sort_unstable();
+    assert_eq!(
+        seen,
+        vec!["Bar", "Foo"],
+        "both values rendered in distinct APs"
+    );
+
+    assert_eq!(
+        needappearances(&output),
+        Some(true),
+        "NeedAppearances retained"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 7 — unknown /FT: set /V, no /AP, no error
+// ---------------------------------------------------------------------------
+
+fn build_sig_field_pdf() -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R] >>".to_vec(),
+        b"<< /Fields [5 0 R] >>".to_vec(),
+        b"<< /FT /Sig /T (sig) /Type /Annot /Subtype /Widget /Rect [100 700 300 720] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn fill_unknown_ft_sets_v_without_ap() {
+    let base = build_sig_field_pdf();
+    let output = IncrementalFormFiller::new(&base)
+        .fill("sig", "ignored")
+        .expect("unknown FT must not error");
+
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let field = reader
+        .get_object(5, 0)
+        .expect("field 5")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert_eq!(
+        field
+            .get("V")
+            .and_then(|o| o.as_string())
+            .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned()),
+        Some("ignored".to_string()),
+        "/V set even for unhandled field types"
+    );
+    assert!(
+        !field.contains_key("AP"),
+        "no /AP synthesized for unknown FT"
+    );
+}

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -156,6 +156,37 @@ fn base_startxref(bytes: &[u8]) -> u64 {
     reader.trailer().xref_offset
 }
 
+/// Base trailer `/Size` (= the first object id a fresh appearance stream takes).
+fn base_size(bytes: &[u8]) -> u32 {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    reader.trailer().size().expect("base /Size") as u32
+}
+
+/// Object ids of the first page's widget annotations (the bearers of /AP after
+/// a fill in the separate-widget layouts).
+fn page_widget_ids(bytes: &[u8]) -> Vec<u32> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
+    let pages = reader.pages().expect("pages").clone();
+    let (pn, pg) = match pages.get("Kids").and_then(|o| o.as_array()) {
+        Some(arr) => arr.0[0].as_reference().expect("page ref"),
+        None => return Vec::new(),
+    };
+    let page = reader
+        .get_object(pn, pg)
+        .expect("page")
+        .as_dict()
+        .expect("page dict")
+        .clone();
+    match page.get("Annots") {
+        Some(PdfObject::Array(arr)) => arr
+            .0
+            .iter()
+            .filter_map(|o| o.as_reference().map(|(n, _)| n))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Read `/Prev` from an appended incremental trailer (text form).
 fn appended_prev(appended: &[u8]) -> u64 {
     let s = String::from_utf8_lossy(appended);
@@ -220,15 +251,20 @@ fn fill_single_field_incremental_roundtrip() {
         "/AcroForm/NeedAppearances must be true"
     );
 
-    // 4) Appended xref lists exactly the changed objects: field + AcroForm.
+    // 4) Appended xref lists the changed objects: field + its widget + AcroForm
+    //    + one synthesized /AP appearance stream (the new follow-up behaviour).
     let appended = &output[base.len()..];
     let mut ids = appended_xref_object_numbers(appended);
     ids.sort_unstable();
-    let mut expected = vec![field_id_after.0, acro_id.0];
+    let widget_ids = page_widget_ids(&base);
+    let ap_stream_id = base_size(&base); // single text field -> single new stream
+    let mut expected = vec![field_id_after.0, acro_id.0, ap_stream_id];
+    expected.extend(widget_ids);
     expected.sort_unstable();
+    expected.dedup();
     assert_eq!(
         ids, expected,
-        "appended xref must list exactly the field and AcroForm objects"
+        "appended xref must list the field, its widget, the AcroForm and the new /AP stream"
     );
 
     // 5) /Prev chains to the base startxref.
@@ -264,9 +300,13 @@ fn fill_many_fields_incremental_roundtrip() {
         Some(true)
     );
 
-    // Appended xref: two field objects + one AcroForm object = 3 distinct ids.
+    // Appended xref: 2 fields + 2 widgets + AcroForm + 2 /AP streams = 7 ids.
     let ids = appended_xref_object_numbers(&output[base.len()..]);
-    assert_eq!(ids.len(), 3, "two fields + AcroForm, got {ids:?}");
+    assert_eq!(
+        ids.len(),
+        7,
+        "two fields + two widgets + AcroForm + two /AP streams, got {ids:?}"
+    );
 }
 
 #[test]
@@ -422,8 +462,18 @@ fn fill_field_with_widget_kids() {
         Some("user@example.com"),
         "/V must be set on the terminal field object (5), not lost in widget recursion"
     );
-    // Only the field (5) + AcroForm (4) change — the widget (6) is untouched.
+    // Field (5) gets /V, AcroForm (4) gets NeedAppearances, the widget (6) is
+    // rewritten with /AP, and one new appearance stream (7) is appended.
     let mut ids = appended_xref_object_numbers(&output[base.len()..]);
     ids.sort_unstable();
-    assert_eq!(ids, vec![4, 5]);
+    assert_eq!(ids, vec![4, 5, 6, 7]);
+    // The widget (6) now carries a synthesized /AP/N showing the value.
+    let mut reader = PdfReader::new(Cursor::new(&output)).expect("parse");
+    let widget = reader
+        .get_object(6, 0)
+        .expect("widget 6")
+        .as_dict()
+        .expect("dict")
+        .clone();
+    assert!(widget.contains_key("AP"), "widget gains /AP");
 }

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -8,7 +8,7 @@
 //! list. It does NOT assert mere absence of crash.
 
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
-use oxidize_pdf::pipeline::{HybridChunkConfig, MergePolicy, RagChunk};
+use oxidize_pdf::pipeline::{DocumentSource, HybridChunkConfig, MergePolicy, RagChunk};
 use oxidize_pdf::text::Font;
 use oxidize_pdf::{Document, Page};
 use std::io::Cursor;
@@ -138,4 +138,69 @@ fn rag_chunks_have_linked_ids_and_metadata() {
         chunks[0].metadata.source.is_none(),
         "rag_chunks_with must not stamp a DocumentSource"
     );
+}
+
+/// Task 8: `rag_chunks_with_source` auto-fills title/author/total_pages from the
+/// parsed info dictionary, preserves the caller-supplied filename/doc_hash, and
+/// uses the doc_hash as the chunk_id prefix. Content-verifying: asserts the
+/// exact source fields, not mere presence.
+#[test]
+fn source_metadata_pulled_from_info_dict() {
+    let mut doc = Document::new();
+    doc.set_title("Spec Sheet");
+    doc.set_author("ACME");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Section One")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 720.0)
+        .write("Body paragraph with enough words to form at least one chunk reliably.")
+        .unwrap();
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+
+    // `DocumentSource` is `#[non_exhaustive]` (forward-compat for new fields), so
+    // external callers build it from `default()` + field assignment, never a
+    // struct literal.
+    let mut source = DocumentSource::default();
+    source.filename = Some("spec.pdf".to_string());
+    source.doc_hash = Some("abc123".to_string());
+    let chunks = parsed
+        .rag_chunks_with_source(source)
+        .expect("rag_chunks_with_source must succeed");
+
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    let s = chunks[0]
+        .metadata
+        .source
+        .as_ref()
+        .expect("chunk must carry source metadata");
+
+    // Auto-filled from the info dictionary.
+    assert_eq!(s.title.as_deref(), Some("Spec Sheet"));
+    assert_eq!(s.author.as_deref(), Some("ACME"));
+    assert!(
+        s.total_pages.unwrap() >= 1,
+        "total_pages must be auto-filled from the document"
+    );
+
+    // Caller-supplied, preserved.
+    assert_eq!(s.filename.as_deref(), Some("spec.pdf"));
+    assert_eq!(s.doc_hash.as_deref(), Some("abc123"));
+
+    // doc_hash drives the chunk_id prefix on every chunk.
+    for (i, c) in chunks.iter().enumerate() {
+        assert_eq!(
+            c.metadata.chunk_id,
+            format!("abc123:{i}"),
+            "chunk[{i}].chunk_id must be doc_hash-prefixed"
+        );
+    }
 }

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -292,3 +292,54 @@ fn rag_chunk_language_detected_on_udhr_chinese_fixture() {
         "dominant detected language across chunks must be Chinese (cmn); tally={tally:?}"
     );
 }
+
+/// Task 10: a `RagChunk` (with nested `ChunkMetadata`) survives a JSON
+/// round-trip under the `semantic` feature — the nested metadata serializes and
+/// deserializes back identically. Content-verifying on the structural fields.
+#[cfg(feature = "semantic")]
+#[test]
+fn rag_chunk_metadata_json_roundtrip() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Roundtrip Heading")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 720.0)
+        .write("Body paragraph with enough words to produce one serializable chunk.")
+        .unwrap();
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+
+    let json = chunks[0].to_json().expect("serialize chunk to JSON");
+    assert!(
+        json.contains("\"metadata\""),
+        "json must carry nested metadata"
+    );
+    assert!(
+        json.contains("\"heading_path\""),
+        "json must carry heading_path"
+    );
+    assert!(json.contains("\"chunk_id\""), "json must carry chunk_id");
+
+    let back: RagChunk = serde_json::from_str(&json).expect("deserialize chunk from JSON");
+    assert_eq!(
+        back.metadata.chunk_id, chunks[0].metadata.chunk_id,
+        "chunk_id must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.heading_path, chunks[0].metadata.heading_path,
+        "heading_path must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.char_count, chunks[0].metadata.char_count,
+        "char_count must survive the round-trip"
+    );
+}

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -204,3 +204,91 @@ fn source_metadata_pulled_from_info_dict() {
         );
     }
 }
+
+/// Task 9: `detect_language` returns the dominant ISO 639-3 code via `whatlang`,
+/// gated behind the existing `language-detection` feature. Empty input yields
+/// `None`.
+#[cfg(feature = "language-detection")]
+#[test]
+fn language_detected_for_english_and_spanish() {
+    use oxidize_pdf::pipeline::detect_language;
+    assert_eq!(
+        detect_language("The quick brown fox jumps over the lazy dog repeatedly."),
+        Some("eng".to_string())
+    );
+    assert_eq!(
+        detect_language("El veloz murciélago hindú comía feliz cardillo y kiwi en su jardín."),
+        Some("spa".to_string())
+    );
+    assert_eq!(detect_language(""), None);
+    assert_eq!(detect_language("   \n\t  "), None);
+}
+
+/// Task 9: with the feature on, `rag_chunks` populates `metadata.language` for
+/// chunks whose body is long enough for a reliable detection.
+#[cfg(feature = "language-detection")]
+#[test]
+fn rag_chunk_language_populated_end_to_end() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let english = [
+        "The annual report summarizes the financial performance of the company.",
+        "Revenue increased steadily across every regional market during the year.",
+        "The board recommends a dividend in line with the long term policy framework.",
+    ];
+    let mut y = 760.0;
+    for line in english {
+        page.text()
+            .set_font(Font::Helvetica, 11.0)
+            .at(50.0, y)
+            .write(line)
+            .unwrap();
+        y -= 20.0;
+    }
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    assert_eq!(
+        chunks[0].metadata.language.as_deref(),
+        Some("eng"),
+        "English body must be detected as eng"
+    );
+}
+
+/// Task 9 Step 6: real-fixture assertion through the RAG pipeline. Opens the
+/// UDHR Chinese fixture, runs `rag_chunks`, and asserts the dominant detected
+/// `metadata.language` is Chinese (`cmn`). This exercises the
+/// partition → HybridChunker → `RagChunk.metadata.language` path end-to-end,
+/// distinct from the `ai::DocumentChunker` corpus coverage.
+#[cfg(all(feature = "language-detection", feature = "multilingual-fixtures"))]
+#[test]
+fn rag_chunk_language_detected_on_udhr_chinese_fixture() {
+    use oxidize_pdf::parser::PdfReader;
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    let path = Path::new("tests/fixtures/multilingual").join("udhr_chinese.pdf");
+    let doc = PdfReader::open_document(&path).expect("open udhr_chinese.pdf");
+    let chunks = doc.rag_chunks().expect("rag_chunks on fixture");
+    assert!(!chunks.is_empty(), "fixture must yield chunks");
+
+    let mut tally: HashMap<String, usize> = HashMap::new();
+    for c in &chunks {
+        if let Some(code) = c.metadata.language.as_deref() {
+            *tally.entry(code.to_string()).or_default() += 1;
+        }
+    }
+    let dominant = tally
+        .iter()
+        .max_by_key(|(_, n)| **n)
+        .map(|(code, _)| code.as_str());
+    assert_eq!(
+        dominant,
+        Some("cmn"),
+        "dominant detected language across chunks must be Chinese (cmn); tally={tally:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -1,0 +1,141 @@
+//! Integration test for Task 7: ChunkMetadata wired into RagChunk, with
+//! prev/next linkage (Task 5b `link_chunks`) populated end-to-end through the
+//! `PdfDocument::rag_chunks*` entry points.
+//!
+//! This is a content-verifying test: it builds a real two-section PDF, parses
+//! it back, runs the actual chunking pipeline, and asserts that the resulting
+//! `RagChunk`s carry populated metadata and a correctly chained prev/next id
+//! list. It does NOT assert mere absence of crash.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{HybridChunkConfig, MergePolicy, RagChunk};
+use oxidize_pdf::text::Font;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// Build a small PDF whose body, chunked with a tight token budget, yields at
+/// least two chunks. Each paragraph carries a unique marker so we can verify
+/// the chunks are distinct content (not duplicated).
+fn build_chunks() -> Vec<RagChunk> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("SECTION ALPHA HEADING")
+        .unwrap();
+
+    // Several body paragraphs, each with enough words that a small max_tokens
+    // budget forces a flush between them.
+    let body_lines = [
+        (720.0, "Alpha marker paragraph with several words to fill the first token budget bucket completely."),
+        (700.0, "Bravo marker paragraph with several words to fill the second token budget bucket completely."),
+        (680.0, "Charlie marker paragraph with several words to fill the third token budget bucket completely."),
+        (660.0, "Delta marker paragraph with several words to fill the fourth token budget bucket completely."),
+    ];
+    for (y, line) in body_lines {
+        page.text()
+            .set_font(Font::Helvetica, 11.0)
+            .at(50.0, y)
+            .write(line)
+            .unwrap();
+    }
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+
+    // Tight token budget to force multiple chunks; merge adjacent so paragraphs
+    // accrete into a bucket until the budget overflows.
+    let config = HybridChunkConfig {
+        max_tokens: 12,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+    parsed
+        .rag_chunks_with(config)
+        .expect("rag_chunks_with must succeed")
+}
+
+#[test]
+fn rag_chunks_have_linked_ids_and_metadata() {
+    let chunks = build_chunks();
+    assert!(
+        chunks.len() >= 2,
+        "expected at least two chunks to verify linkage, got {}",
+        chunks.len()
+    );
+
+    // First chunk has no predecessor; last has no successor.
+    assert!(
+        chunks[0].metadata.prev_chunk_id.is_none(),
+        "first chunk must have prev_chunk_id == None"
+    );
+    let last = chunks.len() - 1;
+    assert!(
+        chunks[last].metadata.next_chunk_id.is_none(),
+        "last chunk must have next_chunk_id == None"
+    );
+
+    // Adjacent chunks' ids chain forward and backward.
+    for i in 0..chunks.len() {
+        if i > 0 {
+            assert_eq!(
+                chunks[i].metadata.prev_chunk_id.as_deref(),
+                Some(chunks[i - 1].metadata.chunk_id.as_str()),
+                "chunk[{i}].prev_chunk_id must equal chunk[{}].chunk_id",
+                i - 1
+            );
+        }
+        if i + 1 < chunks.len() {
+            assert_eq!(
+                chunks[i].metadata.next_chunk_id.as_deref(),
+                Some(chunks[i + 1].metadata.chunk_id.as_str()),
+                "chunk[{i}].next_chunk_id must equal chunk[{}].chunk_id",
+                i + 1
+            );
+        }
+    }
+
+    // chunk_id is non-empty and unique per chunk.
+    for (i, c) in chunks.iter().enumerate() {
+        assert!(
+            !c.metadata.chunk_id.is_empty(),
+            "chunk[{i}].chunk_id must be non-empty"
+        );
+        assert!(
+            c.metadata.chunk_id.ends_with(&format!(":{i}")),
+            "chunk[{i}].chunk_id must end with :{i}, got {:?}",
+            c.metadata.chunk_id
+        );
+    }
+
+    // Metadata is genuinely populated (not the Default::default() placeholder):
+    // every chunk has real character/word/sentence counts derived from its text.
+    for (i, c) in chunks.iter().enumerate() {
+        assert!(
+            c.metadata.char_count > 0,
+            "chunk[{i}].metadata.char_count must be > 0"
+        );
+        assert_eq!(
+            c.metadata.char_count,
+            c.text.chars().count(),
+            "chunk[{i}].metadata.char_count must match its text length"
+        );
+        assert!(
+            c.metadata.word_count > 0,
+            "chunk[{i}].metadata.word_count must be > 0"
+        );
+    }
+
+    // Source is not stamped through the plain (non-source) entry point.
+    assert!(
+        chunks[0].metadata.source.is_none(),
+        "rag_chunks_with must not stamp a DocumentSource"
+    );
+}

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -340,6 +340,77 @@ fn rag_chunk_metadata_json_roundtrip() {
         back.metadata.char_count, chunks[0].metadata.char_count,
         "char_count must survive the round-trip"
     );
+    // Enrichment fields survive serialization too.
+    assert!(json.contains("\"page_span\""), "json must carry page_span");
+    assert!(
+        json.contains("\"page_regions\""),
+        "json must carry page_regions"
+    );
+    assert_eq!(
+        back.metadata.page_span, chunks[0].metadata.page_span,
+        "page_span must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.page_regions, chunks[0].metadata.page_regions,
+        "page_regions must survive the round-trip"
+    );
+    assert_eq!(
+        back.metadata.table_rows, chunks[0].metadata.table_rows,
+        "table_rows must survive the round-trip"
+    );
+}
+
+/// Enrichment end-to-end: the citation anchor (page_span + page_regions) is
+/// populated through the real `rag_chunks` pipeline, with regions that fall
+/// inside the A4 page box. Content-verifying, not mere presence.
+#[test]
+fn citation_anchor_populated_through_rag_chunks() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("Anchored Section")
+        .unwrap();
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(50.0, 720.0)
+        .write("Body paragraph positioned on the page so the chunk has a real bounding box.")
+        .unwrap();
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+    let chunks = parsed.rag_chunks().expect("rag_chunks must succeed");
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+
+    let m = &chunks[0].metadata;
+    // Page numbers follow the pipeline's own indexing (0-based here); assert
+    // the span is well-ordered rather than assuming a base.
+    let (first, last) = m.page_span.expect("page_span must be populated");
+    assert!(
+        last >= first,
+        "page_span must be well-ordered: ({first},{last})"
+    );
+    // Single-page document → exactly one region.
+    assert_eq!(
+        m.page_regions.len(),
+        1,
+        "single-page chunk must have exactly one citation region"
+    );
+    assert_eq!(m.page_regions[0].page, first, "region page must match span");
+    for region in &m.page_regions {
+        let b = &region.bbox;
+        // A4 is ~595x842 pt; the region must sit within a generous page box.
+        assert!(
+            b.x >= 0.0 && b.y >= 0.0 && b.right() <= 700.0 && b.top() <= 900.0,
+            "region bbox must fall inside the A4 page, got {b:?}"
+        );
+        assert!(
+            b.width > 0.0 && b.height > 0.0,
+            "region bbox must be non-degenerate, got {b:?}"
+        );
+    }
 }
 
 /// #2: `rag_chunks_with_source_and_config` both stamps the source metadata and

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -166,12 +166,10 @@ fn source_metadata_pulled_from_info_dict() {
     let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
     let parsed = PdfDocument::new(reader);
 
-    // `DocumentSource` is `#[non_exhaustive]` (forward-compat for new fields), so
-    // external callers build it from `default()` + field assignment, never a
-    // struct literal.
-    let mut source = DocumentSource::default();
-    source.filename = Some("spec.pdf".to_string());
-    source.doc_hash = Some("abc123".to_string());
+    // `DocumentSource` is `#[non_exhaustive]`; `with_file` is the ergonomic
+    // constructor for the two caller-supplied fields (filename, doc_hash).
+    let source =
+        DocumentSource::with_file(Some("spec.pdf".to_string()), Some("abc123".to_string()));
     let chunks = parsed
         .rag_chunks_with_source(source)
         .expect("rag_chunks_with_source must succeed");
@@ -342,4 +340,80 @@ fn rag_chunk_metadata_json_roundtrip() {
         back.metadata.char_count, chunks[0].metadata.char_count,
         "char_count must survive the round-trip"
     );
+}
+
+/// #2: `rag_chunks_with_source_and_config` both stamps the source metadata and
+/// honours a custom chunking config — closing the gap where a caller needed
+/// source stamping AND a non-default token budget. Verified by comparing chunk
+/// counts at a tight budget against the default-config source path on the same
+/// document.
+#[test]
+fn rag_chunks_with_source_and_config_applies_both() {
+    let mut doc = Document::new();
+    doc.set_title("Budgeted");
+    let mut page = Page::a4();
+    let body = [
+        (
+            760.0,
+            "Alpha paragraph with several distinct words filling a token bucket fully.",
+        ),
+        (
+            740.0,
+            "Bravo paragraph with several distinct words filling a token bucket fully.",
+        ),
+        (
+            720.0,
+            "Charlie paragraph with several distinct words filling a token bucket fully.",
+        ),
+        (
+            700.0,
+            "Delta paragraph with several distinct words filling a token bucket fully.",
+        ),
+    ];
+    for (y, line) in body {
+        page.text()
+            .set_font(Font::Helvetica, 11.0)
+            .at(50.0, y)
+            .write(line)
+            .unwrap();
+    }
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+    let reader = PdfReader::new(Cursor::new(&pdf_bytes)).expect("parse generated PDF");
+    let parsed = PdfDocument::new(reader);
+
+    let default_source = DocumentSource::with_file(None, Some("h".to_string()));
+    let default_chunks = parsed
+        .rag_chunks_with_source(default_source)
+        .expect("default-config source path");
+
+    let tight_config = HybridChunkConfig {
+        max_tokens: 8,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+    let tight_source = DocumentSource::with_file(None, Some("h".to_string()));
+    let tight_chunks = parsed
+        .rag_chunks_with_source_and_config(tight_source, tight_config)
+        .expect("config-aware source path");
+
+    // Config took effect: a tight budget yields strictly more chunks.
+    assert!(
+        tight_chunks.len() > default_chunks.len(),
+        "tight max_tokens must produce more chunks ({} tight vs {} default)",
+        tight_chunks.len(),
+        default_chunks.len()
+    );
+    // Source still stamped, with auto-filled info-dict title.
+    let s = tight_chunks[0]
+        .metadata
+        .source
+        .as_ref()
+        .expect("source must be stamped through the config path");
+    assert_eq!(s.title.as_deref(), Some("Budgeted"));
+    assert_eq!(s.doc_hash.as_deref(), Some("h"));
+    // doc_hash drives the chunk_id prefix here too.
+    assert!(tight_chunks[0].metadata.chunk_id.starts_with("h:"));
 }

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -3,6 +3,10 @@ use oxidize_pdf::pipeline::{
     MergePolicy, RagChunk,
 };
 
+#[path = "common/mod.rs"]
+mod common;
+use common::rag_helpers::make_rag_chunk;
+
 fn make_para(text: &str, page: u32, x: f64, y: f64) -> Element {
     Element::Paragraph(ElementData {
         text: text.to_string(),
@@ -12,45 +16,6 @@ fn make_para(text: &str, page: u32, x: f64, y: f64) -> Element {
             ..Default::default()
         },
     })
-}
-
-/// `RagChunk` is `#[non_exhaustive]`, so external crates cannot build it via a
-/// struct literal. Construct one through the public `from_hybrid_chunk` API and
-/// override the public fields these tests need to pin.
-#[allow(clippy::too_many_arguments)]
-fn make_rag_chunk(
-    chunk_index: usize,
-    text: &str,
-    full_text: &str,
-    page_numbers: Vec<u32>,
-    bounding_boxes: Vec<ElementBBox>,
-    element_types: Vec<String>,
-    heading_context: Option<String>,
-    token_estimate: usize,
-    is_oversized: bool,
-) -> RagChunk {
-    let chunker = HybridChunker::new(HybridChunkConfig {
-        max_tokens: 512,
-        overlap_tokens: 0,
-        merge_adjacent: false,
-        propagate_headings: false,
-        merge_policy: MergePolicy::AnyInlineContent,
-    });
-    let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
-        text: text.to_string(),
-        metadata: ElementMetadata::default(),
-    })]);
-    let mut chunk = RagChunk::from_hybrid_chunk(chunk_index, &chunks[0]);
-    chunk.chunk_index = chunk_index;
-    chunk.text = text.to_string();
-    chunk.full_text = full_text.to_string();
-    chunk.page_numbers = page_numbers;
-    chunk.bounding_boxes = bounding_boxes;
-    chunk.element_types = element_types;
-    chunk.heading_context = heading_context;
-    chunk.token_estimate = token_estimate;
-    chunk.is_oversized = is_oversized;
-    chunk
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -14,19 +14,58 @@ fn make_para(text: &str, page: u32, x: f64, y: f64) -> Element {
     })
 }
 
+/// `RagChunk` is `#[non_exhaustive]`, so external crates cannot build it via a
+/// struct literal. Construct one through the public `from_hybrid_chunk` API and
+/// override the public fields these tests need to pin.
+#[allow(clippy::too_many_arguments)]
+fn make_rag_chunk(
+    chunk_index: usize,
+    text: &str,
+    full_text: &str,
+    page_numbers: Vec<u32>,
+    bounding_boxes: Vec<ElementBBox>,
+    element_types: Vec<String>,
+    heading_context: Option<String>,
+    token_estimate: usize,
+    is_oversized: bool,
+) -> RagChunk {
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })]);
+    let mut chunk = RagChunk::from_hybrid_chunk(chunk_index, &chunks[0]);
+    chunk.chunk_index = chunk_index;
+    chunk.text = text.to_string();
+    chunk.full_text = full_text.to_string();
+    chunk.page_numbers = page_numbers;
+    chunk.bounding_boxes = bounding_boxes;
+    chunk.element_types = element_types;
+    chunk.heading_context = heading_context;
+    chunk.token_estimate = token_estimate;
+    chunk.is_oversized = is_oversized;
+    chunk
+}
+
 #[test]
 fn test_rag_chunk_has_required_fields() {
-    let chunk = RagChunk {
-        chunk_index: 0,
-        text: "Hello world.".to_string(),
-        full_text: "Introduction\n\nHello world.".to_string(),
-        page_numbers: vec![0],
-        bounding_boxes: vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
-        element_types: vec!["paragraph".to_string()],
-        heading_context: Some("Introduction".to_string()),
-        token_estimate: 2,
-        is_oversized: false,
-    };
+    let chunk = make_rag_chunk(
+        0,
+        "Hello world.",
+        "Introduction\n\nHello world.",
+        vec![0],
+        vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
+        vec!["paragraph".to_string()],
+        Some("Introduction".to_string()),
+        2,
+        false,
+    );
 
     assert_eq!(chunk.chunk_index, 0);
     assert_eq!(chunk.text, "Hello world.");
@@ -112,17 +151,17 @@ fn test_rag_chunk_collects_pages_from_multi_page_elements() {
 #[cfg(feature = "semantic")]
 #[test]
 fn test_rag_chunk_serializes_to_json() {
-    let chunk = RagChunk {
-        chunk_index: 3,
-        text: "Some text content.".to_string(),
-        full_text: "Heading\n\nSome text content.".to_string(),
-        page_numbers: vec![0, 1],
-        bounding_boxes: vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
-        element_types: vec!["paragraph".to_string()],
-        heading_context: Some("Heading".to_string()),
-        token_estimate: 3,
-        is_oversized: false,
-    };
+    let chunk = make_rag_chunk(
+        3,
+        "Some text content.",
+        "Heading\n\nSome text content.",
+        vec![0, 1],
+        vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
+        vec!["paragraph".to_string()],
+        Some("Heading".to_string()),
+        3,
+        false,
+    );
 
     let json = serde_json::to_string(&chunk).expect("serialization must succeed");
 
@@ -138,17 +177,17 @@ fn test_rag_chunk_serializes_to_json() {
 #[cfg(feature = "semantic")]
 #[test]
 fn test_rag_chunk_to_json_method() {
-    let chunk = RagChunk {
-        chunk_index: 0,
-        text: "Test.".to_string(),
-        full_text: "Test.".to_string(),
-        page_numbers: vec![0],
-        bounding_boxes: vec![],
-        element_types: vec!["paragraph".to_string()],
-        heading_context: None,
-        token_estimate: 1,
-        is_oversized: false,
-    };
+    let chunk = make_rag_chunk(
+        0,
+        "Test.",
+        "Test.",
+        vec![0],
+        vec![],
+        vec!["paragraph".to_string()],
+        None,
+        1,
+        false,
+    );
 
     let json = chunk.to_json().expect("to_json must succeed");
     assert!(json.starts_with('{'));

--- a/oxidize-pdf-core/tests/rag_realworld_jsonl_test.rs
+++ b/oxidize-pdf-core/tests/rag_realworld_jsonl_test.rs
@@ -7,50 +7,91 @@
 #[allow(dead_code)]
 mod example;
 
-use oxidize_pdf::pipeline::{ElementBBox, RagChunk};
+use oxidize_pdf::pipeline::{
+    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+    MergePolicy, RagChunk,
+};
 use serde_json::Value;
 
+/// `RagChunk` is `#[non_exhaustive]`, so external crates cannot build it via a
+/// struct literal. Construct one through the public `from_hybrid_chunk` API and
+/// override the public fields each sample needs to pin.
+#[allow(clippy::too_many_arguments)]
+fn make_rag_chunk(
+    chunk_index: usize,
+    text: &str,
+    full_text: &str,
+    page_numbers: Vec<u32>,
+    bounding_boxes: Vec<ElementBBox>,
+    element_types: Vec<String>,
+    heading_context: Option<String>,
+    token_estimate: usize,
+    is_oversized: bool,
+) -> RagChunk {
+    let chunker = HybridChunker::new(HybridChunkConfig {
+        max_tokens: 512,
+        overlap_tokens: 0,
+        merge_adjacent: false,
+        propagate_headings: false,
+        merge_policy: MergePolicy::AnyInlineContent,
+    });
+    let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })]);
+    let mut chunk = RagChunk::from_hybrid_chunk(chunk_index, &chunks[0]);
+    chunk.chunk_index = chunk_index;
+    chunk.text = text.to_string();
+    chunk.full_text = full_text.to_string();
+    chunk.page_numbers = page_numbers;
+    chunk.bounding_boxes = bounding_boxes;
+    chunk.element_types = element_types;
+    chunk.heading_context = heading_context;
+    chunk.token_estimate = token_estimate;
+    chunk.is_oversized = is_oversized;
+    chunk
+}
+
 fn sample_chunk_with_heading() -> RagChunk {
-    RagChunk {
-        chunk_index: 3,
-        text: "Artículo 1. Objeto y ámbito de aplicación.".to_string(),
-        full_text: "CAPÍTULO I > Artículo 1\n\nArtículo 1. Objeto y ámbito de aplicación."
-            .to_string(),
-        page_numbers: vec![3, 4],
-        bounding_boxes: vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
-        element_types: vec!["heading".to_string(), "paragraph".to_string()],
-        heading_context: Some("CAPÍTULO I > Artículo 1".to_string()),
-        token_estimate: 487,
-        is_oversized: false,
-    }
+    make_rag_chunk(
+        3,
+        "Artículo 1. Objeto y ámbito de aplicación.",
+        "CAPÍTULO I > Artículo 1\n\nArtículo 1. Objeto y ámbito de aplicación.",
+        vec![3, 4],
+        vec![ElementBBox::new(50.0, 700.0, 400.0, 12.0)],
+        vec!["heading".to_string(), "paragraph".to_string()],
+        Some("CAPÍTULO I > Artículo 1".to_string()),
+        487,
+        false,
+    )
 }
 
 fn sample_chunk_without_heading() -> RagChunk {
-    RagChunk {
-        chunk_index: 0,
-        text: "Plain body text with no heading.".to_string(),
-        full_text: "Plain body text with no heading.".to_string(),
-        page_numbers: vec![1],
-        bounding_boxes: vec![ElementBBox::new(0.0, 0.0, 10.0, 10.0)],
-        element_types: vec!["paragraph".to_string()],
-        heading_context: None,
-        token_estimate: 6,
-        is_oversized: false,
-    }
+    make_rag_chunk(
+        0,
+        "Plain body text with no heading.",
+        "Plain body text with no heading.",
+        vec![1],
+        vec![ElementBBox::new(0.0, 0.0, 10.0, 10.0)],
+        vec!["paragraph".to_string()],
+        None,
+        6,
+        false,
+    )
 }
 
 fn sample_oversized_chunk() -> RagChunk {
-    RagChunk {
-        chunk_index: 99,
-        text: "An oversized chunk that exceeds max_tokens.".to_string(),
-        full_text: "Big Section\n\nAn oversized chunk that exceeds max_tokens.".to_string(),
-        page_numbers: vec![10, 11, 12],
-        bounding_boxes: vec![ElementBBox::new(0.0, 0.0, 10.0, 10.0)],
-        element_types: vec!["paragraph".to_string()],
-        heading_context: Some("Big Section".to_string()),
-        token_estimate: 1024,
-        is_oversized: true,
-    }
+    make_rag_chunk(
+        99,
+        "An oversized chunk that exceeds max_tokens.",
+        "Big Section\n\nAn oversized chunk that exceeds max_tokens.",
+        vec![10, 11, 12],
+        vec![ElementBBox::new(0.0, 0.0, 10.0, 10.0)],
+        vec!["paragraph".to_string()],
+        Some("Big Section".to_string()),
+        1024,
+        true,
+    )
 }
 
 #[test]
@@ -144,10 +185,8 @@ fn jsonl_line_is_single_line_with_no_internal_newlines() {
         "JSONL line must not contain a literal newline (serde_json default escapes them)"
     );
     // Field with multiline content should be escaped, not raw-broken
-    let chunk_multiline = RagChunk {
-        text: "Line one.\nLine two.".to_string(),
-        ..chunk
-    };
+    let mut chunk_multiline = chunk;
+    chunk_multiline.text = "Line one.\nLine two.".to_string();
     let line2 = example::jsonl_line("x", "y", "X", "x", "u", &chunk_multiline);
     assert!(
         !line2.contains('\n'),

--- a/oxidize-pdf-core/tests/rag_realworld_jsonl_test.rs
+++ b/oxidize-pdf-core/tests/rag_realworld_jsonl_test.rs
@@ -7,50 +7,12 @@
 #[allow(dead_code)]
 mod example;
 
-use oxidize_pdf::pipeline::{
-    Element, ElementBBox, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
-    MergePolicy, RagChunk,
-};
+use oxidize_pdf::pipeline::{ElementBBox, RagChunk};
 use serde_json::Value;
 
-/// `RagChunk` is `#[non_exhaustive]`, so external crates cannot build it via a
-/// struct literal. Construct one through the public `from_hybrid_chunk` API and
-/// override the public fields each sample needs to pin.
-#[allow(clippy::too_many_arguments)]
-fn make_rag_chunk(
-    chunk_index: usize,
-    text: &str,
-    full_text: &str,
-    page_numbers: Vec<u32>,
-    bounding_boxes: Vec<ElementBBox>,
-    element_types: Vec<String>,
-    heading_context: Option<String>,
-    token_estimate: usize,
-    is_oversized: bool,
-) -> RagChunk {
-    let chunker = HybridChunker::new(HybridChunkConfig {
-        max_tokens: 512,
-        overlap_tokens: 0,
-        merge_adjacent: false,
-        propagate_headings: false,
-        merge_policy: MergePolicy::AnyInlineContent,
-    });
-    let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
-        text: text.to_string(),
-        metadata: ElementMetadata::default(),
-    })]);
-    let mut chunk = RagChunk::from_hybrid_chunk(chunk_index, &chunks[0]);
-    chunk.chunk_index = chunk_index;
-    chunk.text = text.to_string();
-    chunk.full_text = full_text.to_string();
-    chunk.page_numbers = page_numbers;
-    chunk.bounding_boxes = bounding_boxes;
-    chunk.element_types = element_types;
-    chunk.heading_context = heading_context;
-    chunk.token_estimate = token_estimate;
-    chunk.is_oversized = is_oversized;
-    chunk
-}
+#[path = "common/mod.rs"]
+mod common;
+use common::rag_helpers::make_rag_chunk;
 
 fn sample_chunk_with_heading() -> RagChunk {
     make_rag_chunk(


### PR DESCRIPTION
## Release v2.16.0

MINOR release. Additive only — no breaking changes, no new dependencies, MSRV 1.88 preserved. Bundles everything merged to `develop` since v2.15.0.

### Highlights

- **Analysis SPI** (#327, behind `unstable-spi`; `extra`/enricher behind `semantic`): extension points so a closed crate can plug custom chunking, classification, and metadata enrichment into the RAG pipeline without forking the MIT core.
  - `ChunkingStrategy` + `ChunkGroup`; `HybridChunker` is the default impl.
  - `ElementClassifier` + `ClassLabel` + `ElementMetadata::class_label`.
  - `MetadataEnricher` + `EnrichContext`; `ChunkMetadata::extra: BTreeMap<String, serde_json::Value>` open bag.
  - `AnalysisPipeline` builder + `PdfDocument::rag_chunks_with_pipeline` (`new()` reproduces `rag_chunks()` exactly).
  - The trait surface is exempt from semver while experimental.
- **Rich chunk metadata for RAG** (#325): every `RagChunk` now carries a nested `ChunkMetadata` (heading breadcrumb, char-weighted font/style, content-type flags, char/word/sentence counts, deterministic `chunk_id`, prev/next links, optional source). `rag_chunks_with_source[_and_config]` + `DocumentSource::with_file`. Optional language detection behind `language-detection`.
- **Chunk metadata enrichment v2** (#326): citation anchor (`page_span` + per-page union `page_regions`), language confidence/reliability, table dimensions (`table_rows`/`table_cols`).
- **Form appearance synthesis** (#324): `IncrementalFormFiller` now synthesizes `/AP` appearance streams for filled fields.

### Verification

- Lib 6585/0; full feature matrix (default / `unstable-spi` / `semantic` / both) builds + clippy clean.
- SPI: 13 integration tests + real-corpus e2e parity (`AnalysisPipeline::new()` byte-identical to `rag_chunks()` across 5 fixtures — 548 chunks, 0 field diffs).
- CI green on the source branches; two new CI steps exercise the SPI feature matrix.
- Two runnable examples: `analysis_spi_custom_chunking`, `analysis_spi_full_pipeline`.

### Not in this release (follow-up)

- Surfacing `RagChunk.metadata`/`extra` in the Python and .NET bridges (separate repos).
- An `oxidize-legal`-style proprietary crate implementing the SPI seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)