### PR TITLE
fix(#331): XMP namespaces stored and emitted in deterministic order

### DIFF
--- a/oxidize-pdf-core/src/metadata/xmp.rs
+++ b/oxidize-pdf-core/src/metadata/xmp.rs
@@ -78,7 +78,7 @@ use crate::error::Result;
 use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Standard XMP namespaces
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -175,8 +175,10 @@ enum ContainerType {
 pub struct XmpMetadata {
     /// Properties stored in this metadata
     properties: Vec<XmpProperty>,
-    /// Custom namespaces
-    custom_namespaces: HashMap<String, String>,
+    /// Custom namespaces. Stored as a `BTreeMap` so iteration order is
+    /// deterministic (sorted by prefix), giving byte-stable XMP packets
+    /// across runs and processes (issue #331).
+    custom_namespaces: BTreeMap<String, String>,
 }
 
 impl Default for XmpMetadata {
@@ -190,7 +192,7 @@ impl XmpMetadata {
     pub fn new() -> Self {
         Self {
             properties: Vec::new(),
-            custom_namespaces: HashMap::new(),
+            custom_namespaces: BTreeMap::new(),
         }
     }
 
@@ -349,8 +351,11 @@ impl XmpMetadata {
         xml.push_str("  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n");
         xml.push_str("    <rdf:Description rdf:about=\"\"");
 
-        // Add namespace declarations
-        let mut namespaces: HashMap<String, String> = HashMap::new();
+        // Add namespace declarations. `BTreeMap` (sorted by prefix) keeps the
+        // emitted `xmlns:*` order deterministic across calls — `HashMap`
+        // iteration order is randomized per instance and produced byte-unstable
+        // packets across runs (issue #331).
+        let mut namespaces: BTreeMap<String, String> = BTreeMap::new();
         for prop in &self.properties {
             namespaces.insert(
                 prop.namespace.prefix().to_string(),

--- a/oxidize-pdf-core/tests/issue_331_xmp_deterministic_test.rs
+++ b/oxidize-pdf-core/tests/issue_331_xmp_deterministic_test.rs
@@ -1,0 +1,123 @@
+//! Acceptance tests for issue #331: `XmpMetadata::to_xmp_packet()` must be
+//! deterministic — same inputs must produce byte-identical XMP output across
+//! calls (and across processes), so PDF consumers that content-address bytes,
+//! diff fixtures, or pre-hash for signing get stable results.
+//!
+//! Root cause being fixed: `metadata/xmp.rs:353` builds a `HashMap<String,
+//! String>` of `(prefix, uri)` and iterates it to emit `xmlns:*` declarations.
+//! `HashMap` iteration order is randomized per instance, so each call produces
+//! a different attribute ordering. `custom_namespaces` (line 179) is the same
+//! type at storage time, compounding the issue.
+
+use oxidize_pdf::metadata::xmp::{XmpMetadata, XmpNamespace};
+
+/// Build a metadata packet with enough distinct namespaces that any single
+/// permutation has a high prior probability of being non-canonical.
+fn build_packet() -> XmpMetadata {
+    let mut xmp = XmpMetadata::new();
+    // Six standard prefixes (xmp, pdf, dc, xmpMM, xmpRights, photoshop).
+    xmp.set_text(XmpNamespace::DublinCore, "title", "Issue 331 fixture");
+    xmp.set_text(XmpNamespace::DublinCore, "creator", "test");
+    xmp.set_text(XmpNamespace::XmpBasic, "CreateDate", "2026-06-16T00:00:00Z");
+    xmp.set_text(XmpNamespace::Pdf, "Producer", "oxidize-pdf");
+    xmp.set_text(XmpNamespace::XmpRights, "Marked", "false");
+    xmp.set_text(
+        XmpNamespace::XmpMediaManagement,
+        "DocumentID",
+        "uuid:fixture-331",
+    );
+    xmp.set_text(XmpNamespace::Photoshop, "AuthorsPosition", "test");
+    // Three custom namespaces — different prefix lexical positions so any
+    // sort-order regression is visible.
+    xmp.register_namespace(
+        "zzcustom".to_string(),
+        "https://example.invalid/zzcustom/1.0/".to_string(),
+    );
+    xmp.register_namespace(
+        "aalpha".to_string(),
+        "https://example.invalid/aalpha/1.0/".to_string(),
+    );
+    xmp.register_namespace(
+        "mmid".to_string(),
+        "https://example.invalid/mmid/1.0/".to_string(),
+    );
+    xmp
+}
+
+/// Extract the lines that declare `xmlns:` attributes (the order-sensitive part).
+fn xmlns_lines(packet: &str) -> Vec<&str> {
+    packet
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| l.starts_with("xmlns:"))
+        .collect()
+}
+
+/// Primary RED contract: invoking `to_xmp_packet()` repeatedly on the same
+/// `XmpMetadata` must produce byte-identical output. `HashMap::new()` picks a
+/// fresh random seed each call, so two invocations land different iteration
+/// orders with very high probability across 10 attempts at this fan-in.
+#[test]
+fn xmp_packet_is_byte_stable_across_repeated_calls() {
+    let xmp = build_packet();
+    let baseline = xmp.to_xmp_packet();
+    let mut diverged_at: Option<usize> = None;
+    for i in 1..10 {
+        let again = xmp.to_xmp_packet();
+        if again != baseline {
+            diverged_at = Some(i);
+            // Surface both packets in the failure message so the diff is
+            // readable in CI without re-running.
+            assert_eq!(
+                again,
+                baseline,
+                "to_xmp_packet() diverged on call #{i} — non-deterministic output. \
+                 Baseline xmlns lines:\n  {:#?}\nDivergent xmlns lines:\n  {:#?}",
+                xmlns_lines(&baseline),
+                xmlns_lines(&again)
+            );
+        }
+    }
+    assert!(
+        diverged_at.is_none(),
+        "to_xmp_packet() must be deterministic across all 10 attempts"
+    );
+}
+
+/// Anchor the deterministic contract to its actual semantics: namespace
+/// declarations must be emitted in lexicographic prefix order. Guards against
+/// future refactors that "restore determinism" via a different non-canonical
+/// scheme (e.g. insertion order from a `Vec` that happens to be stable today
+/// but reorders on cheap permutations). Sorted-by-prefix is what `BTreeMap`
+/// provides by type contract.
+#[test]
+fn xmp_namespace_declarations_are_sorted_by_prefix() {
+    let xmp = build_packet();
+    let packet = xmp.to_xmp_packet();
+
+    let prefixes: Vec<String> = xmlns_lines(&packet)
+        .iter()
+        .filter_map(|line| {
+            // line shape: xmlns:<prefix>="<uri>"
+            let after = line.strip_prefix("xmlns:")?;
+            let eq = after.find('=')?;
+            Some(after[..eq].to_string())
+        })
+        .collect();
+
+    assert!(
+        prefixes.len() >= 6,
+        "fixture must declare >= 6 namespaces — got {} ({:?})",
+        prefixes.len(),
+        prefixes
+    );
+
+    let mut sorted = prefixes.clone();
+    sorted.sort();
+    assert_eq!(
+        prefixes, sorted,
+        "xmlns:* declarations must be emitted in lexicographic prefix order — \
+         got {:?}, expected {:?}",
+        prefixes, sorted
+    );
+}


### PR DESCRIPTION
## Summary

Closes #331. `XmpMetadata::to_xmp_packet()` produced a different XMP packet
on every invocation because it built a `HashMap<String, String>` of
`(prefix, uri)` and iterated it to emit `xmlns:*` declarations. `HashMap`
iteration order is randomized per instance, so:

- The same `XmpMetadata` instance produced different bytes across calls.
- Two processes producing the "same" PDF got byte-different outputs.
- Caches keyed on PDF hash thrashed, PDF fixture diffs were unstable,
  pre-hash signing workflows saw false changes.

### Fix

Two-site `HashMap` → `BTreeMap` swap in `src/metadata/xmp.rs`:

- `XmpMetadata.custom_namespaces` (line 179) — registered namespaces are
  now stored sorted by prefix.
- Local `namespaces` map in `to_xmp_packet()` (line 353) — aggregated
  standard + custom namespaces iterate in lexicographic prefix order.

`BTreeMap` was chosen over `HashMap`-then-`sort()` because sorted iteration
is part of the type contract: a future contributor cannot accidentally
re-introduce the bug at the iteration site.

### Out of scope (audit follow-up)

`XmpValue::Struct(HashMap<String, Box<XmpValue>>)` and
`XmpValue::ArrayStruct(Vec<HashMap<...>>)` (xmp.rs:145, 147) hold
`HashMap` and are iterated in `to_xmp_packet` (lines 429, 440) — same bug
class, but distinct surface (changes the `set_struct` / `set_array_of_structs`
public API signatures and the enum variant). Will surface as a follow-up
audit issue covering all `HashMap`→ordered-output sites the repo still has
(per #331 closing paragraph: "This is also a recurrence of the same class
of bug...").

### Commits

1. `7ed701f` — **RED test** (`tests/issue_331_xmp_deterministic_test.rs`):
   - `xmp_packet_is_byte_stable_across_repeated_calls` calls
     `to_xmp_packet()` 10× on the same `XmpMetadata`, asserts every
     output is byte-identical to the first.
   - `xmp_namespace_declarations_are_sorted_by_prefix` anchors the
     contract to its semantics (lexicographic prefix order) so future
     refactors can't satisfy "deterministic" via a non-canonical scheme.
   - Fixture covers 6 standard prefixes (`dc`, `xmp`, `pdf`, `xmpRights`,
     `xmpMM`, `photoshop`) + 3 custom prefixes spread across the lexical
     space (`aalpha`, `mmid`, `zzcustom`) so any sort regression is
     immediately visible.
2. `d070a8b` — **GREEN fix**: `HashMap` → `BTreeMap` in xmp.rs.

### Verification

| Suite | Result |
|---|---|
| `issue_331_xmp_deterministic_test` | **2/2** (was 0/2 pre-fix) |
| `pdfa_integration_test` | 15/15 (XMP round-trip unchanged) |
| `pdfa_validator_coverage_test` | 55/55 |
| `cargo test --lib` (pre-commit hook) | 6585/0 |
| `cargo build --lib` | clean — no other consumers of `register_namespace` rely on insertion order |

### Backward compatibility

- Internal storage swap. Public API unchanged: `register_namespace(prefix,
  uri)` still accepts `(String, String)`, `to_xmp_packet()` still returns
  `String`. No external consumer can observe the change except via byte
  equality of the output (which is the point of the fix).
- No PDF/A test, XMP round-trip test, or writer test relied on the
  randomized order — verified by running the full PDF/A + writer suites.

## Test plan

- [x] RED test fails on develop (verified at `7ed701f`)
- [x] GREEN test passes after fix (verified at `d070a8b`)
- [x] PDF/A + writer suites green (no XMP round-trip regression)
- [x] Lib tests 6585/0 (pre-commit)
- [ ] CI green on PR (ubuntu / win / macOS / MSRV / Examples / T0-T1)
- [ ] Open follow-up audit issue for `XmpValue::Struct` / `ArrayStruct`
      and any other `HashMap`→ordered-output sites in writer/metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)