### PR TITLE
fix(#334 items 4-5): FontCache::font_names sorted; item #4 verified SAFE

### DIFF
--- a/oxidize-pdf-core/src/fonts/font_cache.rs
+++ b/oxidize-pdf-core/src/fonts/font_cache.rs
@@ -44,12 +44,20 @@ impl FontCache {
         fonts.contains_key(name)
     }
 
-    /// Get all font names in the cache
+    /// Get all font names in the cache, sorted lexicographically.
+    ///
+    /// Sorting is intentional: the writer (`PdfWriter::write_fonts`) iterates
+    /// this list to allocate ObjectIds for each font. Returning `HashMap`
+    /// iteration order (randomized per instance) caused two builds of the
+    /// same document to allocate different ObjectIds, cascading into
+    /// divergent xref tables and resource references — see #334 item #5.
     pub fn font_names(&self) -> Vec<String> {
         let Ok(fonts) = self.fonts.read() else {
             return Vec::new();
         };
-        fonts.keys().cloned().collect()
+        let mut names: Vec<String> = fonts.keys().cloned().collect();
+        names.sort();
+        names
     }
 
     /// Clear the cache

--- a/oxidize-pdf-core/tests/issue_334_item5_font_order_deterministic_test.rs
+++ b/oxidize-pdf-core/tests/issue_334_item5_font_order_deterministic_test.rs
@@ -1,0 +1,161 @@
+//! Acceptance test for #334 item #5: PDF byte output must be deterministic
+//! when multiple custom fonts are registered, regardless of the order the
+//! caller registered them.
+//!
+//! Root cause: `FontCache::font_names()` (src/fonts/font_cache.rs:48-53)
+//! returns `fonts.keys().cloned().collect()` from a
+//! `HashMap<String, Arc<Font>>`. The order is randomized per HashMap
+//! instance. `PdfWriter::write_fonts` iterates that order to allocate
+//! ObjectIds (via `write_font_with_unicode_support` → `allocate_object_id`),
+//! so two builds of the same document allocate different ObjectIds for the
+//! same font. Every cross-reference downstream (xref table entries,
+//! `/Resources /Font /Fn N 0 R` references, page content stream fingerprints)
+//! changes accordingly.
+//!
+//! Test bypasses `Document::to_bytes()`/`save()` because both call
+//! `update_modification_date()` which writes `Utc::now()` into the metadata
+//! — that alone would make every output differ in the `/ModDate` and
+//! `xmp:ModifyDate` bytes. Going through `PdfWriter::write_document`
+//! directly keeps `creation_date` and `modification_date` pinned for full
+//! byte-equality.
+
+use chrono::{TimeZone, Utc};
+use oxidize_pdf::writer::{PdfWriter, WriterConfig};
+use oxidize_pdf::{Document, Font, Page};
+
+const LATIN_FONT_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+
+fn load_font() -> Option<Vec<u8>> {
+    if std::path::Path::new(LATIN_FONT_PATH).exists() {
+        Some(std::fs::read(LATIN_FONT_PATH).expect("read font fixture"))
+    } else {
+        eprintln!("SKIPPED: font fixture not found at {LATIN_FONT_PATH}");
+        None
+    }
+}
+
+/// Build a document with three custom fonts whose names are lexically
+/// non-monotonic relative to insertion order, then serialize via the writer
+/// with pinned dates. Returns the PDF bytes.
+fn build_pdf_bytes() -> Option<Vec<u8>> {
+    let font_data = load_font()?;
+    let mut doc = Document::new();
+    // Pin both dates so the writer emits the same /CreationDate and
+    // /ModDate every call — the only timing-dependent bytes in the writer
+    // come from these two fields.
+    let pinned = Utc.with_ymd_and_hms(2026, 6, 16, 0, 0, 0).unwrap();
+    doc.set_creation_date(pinned);
+    doc.set_modification_date(pinned);
+
+    // Non-monotonic registration order: z, a, m. If FontCache::font_names()
+    // returns its `HashMap<String, ...>::keys()` directly (the bug), the
+    // iteration order varies between runs and cascades through ObjectId
+    // allocation. With a sorted return, iteration is always
+    // [alpha, malpha, zalpha] regardless of insertion order.
+    doc.add_font_from_bytes("zalpha", font_data.clone())
+        .expect("register zalpha");
+    doc.add_font_from_bytes("alpha", font_data.clone())
+        .expect("register alpha");
+    doc.add_font_from_bytes("malpha", font_data)
+        .expect("register malpha");
+
+    // Use each font on a page so they all get tracked in
+    // `document_used_chars_by_font` and pass the `has_usage` filter in
+    // `write_fonts`. Without this, unused fonts are skipped and the bug
+    // does not surface.
+    let mut page = Page::new(612.0, 792.0);
+    page.text()
+        .set_font(Font::custom("zalpha"), 12.0)
+        .at(50.0, 700.0)
+        .write("Zalpha quick brown fox")
+        .expect("zalpha write");
+    page.text()
+        .set_font(Font::custom("alpha"), 12.0)
+        .at(50.0, 680.0)
+        .write("Alpha lazy dog jumps")
+        .expect("alpha write");
+    page.text()
+        .set_font(Font::custom("malpha"), 12.0)
+        .at(50.0, 660.0)
+        .write("Malpha cat naps softly")
+        .expect("malpha write");
+    doc.add_page(page);
+
+    // Bypass Document::to_bytes(): it calls update_modification_date()
+    // unconditionally. Go through PdfWriter directly with pinned dates.
+    let mut buffer = Vec::new();
+    let config = WriterConfig {
+        use_xref_streams: false,
+        use_object_streams: false,
+        pdf_version: "1.7".to_string(),
+        compress_streams: true,
+        incremental_update: false,
+    };
+    let mut writer = PdfWriter::with_config(&mut buffer, config);
+    writer
+        .write_document(&mut doc)
+        .expect("PdfWriter::write_document");
+    Some(buffer)
+}
+
+/// Primary contract: building the same document N times in the same process
+/// produces N byte-identical PDFs. Without the FontCache sort fix, each
+/// build picks a different HashMap iteration order → different font
+/// ObjectId assignments → diverging xref tables and resource refs.
+#[test]
+fn pdf_bytes_with_multiple_fonts_are_stable_across_builds() {
+    let baseline = match build_pdf_bytes() {
+        Some(b) => b,
+        None => return,
+    };
+    let mut first_diverge: Option<(usize, usize)> = None;
+    for i in 1..10 {
+        let again = build_pdf_bytes().expect("font fixture available on first build but not later");
+        if again != baseline {
+            // Find the byte index where they first differ for a useful
+            // failure message; capture both lengths so a wholesale size
+            // mismatch surfaces clearly.
+            let diff_idx = baseline
+                .iter()
+                .zip(again.iter())
+                .position(|(a, b)| a != b)
+                .unwrap_or_else(|| baseline.len().min(again.len()));
+            first_diverge = Some((i, diff_idx));
+            break;
+        }
+    }
+    assert!(
+        first_diverge.is_none(),
+        "PDF bytes diverged on build #{} at byte offset {} — non-deterministic font ObjectId allocation (FontCache::font_names() returns HashMap order)",
+        first_diverge.unwrap().0,
+        first_diverge.unwrap().1,
+    );
+}
+
+/// Anchor the contract to its semantics: `Document::custom_font_names()`
+/// (which writes_fonts iterates) must return names in lexicographic order
+/// regardless of registration order. Guards against future refactors that
+/// "restore byte stability" via a non-canonical scheme.
+#[test]
+fn custom_font_names_returns_sorted() {
+    let font_data = match load_font() {
+        Some(d) => d,
+        None => return,
+    };
+    let mut doc = Document::new();
+    // Register in deliberately non-sorted order.
+    doc.add_font_from_bytes("zalpha", font_data.clone())
+        .unwrap();
+    doc.add_font_from_bytes("alpha", font_data.clone()).unwrap();
+    doc.add_font_from_bytes("malpha", font_data).unwrap();
+
+    let names = doc.custom_font_names();
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(
+        names, sorted,
+        "Document::custom_font_names() must return names in lexicographic order — \
+         got {:?}, expected {:?}",
+        names, sorted
+    );
+}


### PR DESCRIPTION
## Summary

Closes audit items **#4 and #5** in #334.

- **Item #5** — confirmed bug, fixed. Root cause was deeper than the issue body described.
- **Item #4** — investigated, **verified SAFE**. No code change required.

Items #1, #2, #3 are addressed in **#335** (XMP Struct/ArrayStruct).

### Item #5 — fix

`FontCache::font_names()` (`src/fonts/font_cache.rs:48-53`) returned `fonts.keys().cloned().collect()` from a `HashMap<String, Arc<Font>>` — randomized iteration order per instance. `PdfWriter::write_fonts` iterates that list to drive `write_font_with_unicode_support` → `allocate_object_id` per font, so identical documents allocated **different ObjectIds** to the same fonts across runs. Every cross-reference downstream (xref entries, `/Resources /Font /Fn N 0 R` references, page content stream IDs) cascaded from those allocations.

The audit issue body framed #5 around the **return value** of `write_fonts` (a `HashMap<String, ObjectId>`). The real root cause was upstream, in `FontCache::font_names()`. The return-value HashMap is consumed by `write_pages` to emit resource dicts, but those dicts are unordered by PDF spec — the byte instability is dominated by the upstream allocation order, not the downstream emission order.

#### Change

```rust
// src/fonts/font_cache.rs:48-53
pub fn font_names(&self) -> Vec<String> {
    let Ok(fonts) = self.fonts.read() else { return Vec::new(); };
    let mut names: Vec<String> = fonts.keys().cloned().collect();
    names.sort();
    names
}
```

Internal storage unchanged (`HashMap<String, Arc<Font>>`). Public API unchanged. Lookup-by-key paths (`get_font`, `has_font`) are unaffected.

### Item #4 — verified SAFE, no fix needed

`document_used_chars_by_font: HashMap<String, HashSet<char>>` (`pdf_writer/mod.rs:134`) is purely a lookup table. All four consumers are deterministic regardless of iteration order:

| Consumer | Why deterministic |
|---|---|
| **CIDToGIDMap generation** (`pdf_writer:2051`) | Writes to a fixed-size array at position `unicode * 2`. Iteration order has no effect on output. |
| **ToUnicode CMap generation** (`pdf_writer:2110-2131`) | `mappings.sort_by_key(\|&(cid, _)\| cid)` before serializing. Explicit sort. |
| **W array (font widths)** (`pdf_writer:1889-1890`) | `sorted_chars.sort_by_key(\|(unicode, _)\| *unicode)`. Explicit sort. |
| **TrueType subsetter** (`truetype_subsetter.rs:544-545, 905-906, 1014-1015`) | `sorted_glyphs.sort()` before emitting the subset. Explicit sort in every glyph-iteration path. |

The outer `HashMap<String, HashSet<char>>` is never iterated for output — only `.get(font_name)` for lookup. The inner `HashSet<char>` is iterated but consumed through a sort step in every path. Iteration order has no observable byte effect.

### Commits

1. `5beb203` — **RED test** (`tests/issue_334_item5_font_order_deterministic_test.rs`):
   - `pdf_bytes_with_multiple_fonts_are_stable_across_builds` builds the same document 10× (3 custom fonts registered in non-monotonic order: `zalpha`, `alpha`, `malpha`; each used on a single page), serializes via `PdfWriter::write_document` with pinned creation/modification dates, asserts byte-identical output.
   - `custom_font_names_returns_sorted` anchors the contract.
   - Test bypasses `Document::to_bytes()` / `save()` because both call `update_modification_date()` (Utc::now()) which would mask the bug under `/ModDate` and `xmp:ModifyDate` timestamp churn. Going through `PdfWriter::write_document` directly with pinned dates isolates the font-ordering effect.
2. `c0c13b5` — **GREEN fix**: sort the `Vec<String>` returned by `FontCache::font_names`.

### Verification

| Suite | Result |
|---|---|
| `issue_334_item5_font_order_deterministic_test` | **2/2** (was 0/2 pre-fix; diverged at byte offset 57 on build #2) |
| `font_workflows_integration` | 31/31 |
| `font_metrics_per_document_test` | 9/9 |
| `font_subset_pdf_round_trip_test` | 7/7 |
| `font_subset_size_test` | 5/5 |
| `font_subset_post_and_cidtogidmap_test` | 8/8 |
| `issue_287_glyph_coverage_test` | 7/7 |
| `cff_subsetter_test` | 6/6 |
| `cargo test --lib` (pre-commit hook) | 6585/0 |

### Backward compatibility

Internal sort only. Public API unchanged. The only observable change is byte-stability of the PDF output across runs — which is the point.

## Test plan

- [x] RED test fails on develop (verified at `5beb203`)
- [x] GREEN test passes after fix (verified at `c0c13b5`)
- [x] All font/writer regression suites green (73/73)
- [x] Lib tests 6585/0 (pre-commit)
- [ ] CI green on PR

Refs #334 — with this PR + #335 merged, all five audit items in #334 are resolved. Issue #334 can be closed when both PRs land.