### PR TITLE
fix(#330): align extracted_text with fragments under Artifact filter

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -864,8 +864,14 @@ impl TextExtractor {
                         // Pen origin in user space = (CTM × text_matrix)(0, 0).
                         let (x, y) = text_origin(&state);
 
+                        // Mirror the gate inside `emit_text_fragment` so that
+                        // `.text` and `.fragments` stay consistent for pages
+                        // wrapped in an `/Artifact` marked-content scope —
+                        // issue #330.
+                        let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
+
                         // Add spacing based on position change
-                        if !extracted_text.is_empty() {
+                        if !skip_text && !extracted_text.is_empty() {
                             let dx = x - last_x;
                             let dy = (y - last_y).abs();
 
@@ -876,7 +882,9 @@ impl TextExtractor {
                             }
                         }
 
-                        extracted_text.push_str(&decoded);
+                        if !skip_text {
+                            extracted_text.push_str(&decoded);
+                        }
 
                         // Get font info for accurate width calculation.
                         // Width comes from the char codes (`text_bytes`), not
@@ -924,7 +932,14 @@ impl TextExtractor {
                             match item {
                                 TextElement::Text(text_bytes) => {
                                     let decoded = self.decode_text(&text_bytes, &state)?;
-                                    extracted_text.push_str(&decoded);
+                                    // Mirror the gate inside `emit_text_fragment`
+                                    // so `.text` and `.fragments` stay consistent
+                                    // for Artifact scopes (issue #330).
+                                    let skip_text =
+                                        skip_artifact_text(&state, self.options.include_artifacts);
+                                    if !skip_text {
+                                        extracted_text.push_str(&decoded);
+                                    }
 
                                     let text_width = {
                                         let font_info = state
@@ -967,7 +982,10 @@ impl TextExtractor {
                                     // kerns and never emit a literal space byte.
                                     let tx = -(adjustment as f64) / 1000.0 * state.font_size;
 
-                                    if tx > self.options.tj_space_threshold * state.font_size
+                                    let skip_tj_space =
+                                        skip_artifact_text(&state, self.options.include_artifacts);
+                                    if !skip_tj_space
+                                        && tx > self.options.tj_space_threshold * state.font_size
                                         && !extracted_text.is_empty()
                                         && !extracted_text.ends_with(' ')
                                     {
@@ -1027,10 +1045,14 @@ impl TextExtractor {
                         let decoded = self.decode_text(&text, &state)?;
                         let (x, y) = text_origin(&state);
 
-                        if !extracted_text.is_empty() {
-                            extracted_text.push('\n');
+                        // Mirror the artifact gate (issue #330).
+                        let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
+                        if !skip_text {
+                            if !extracted_text.is_empty() {
+                                extracted_text.push('\n');
+                            }
+                            extracted_text.push_str(&decoded);
                         }
-                        extracted_text.push_str(&decoded);
 
                         let text_width = {
                             let font_info = state
@@ -1084,10 +1106,14 @@ impl TextExtractor {
                         let decoded = self.decode_text(&text, &state)?;
                         let (x, y) = text_origin(&state);
 
-                        if !extracted_text.is_empty() {
-                            extracted_text.push('\n');
+                        // Mirror the artifact gate (issue #330).
+                        let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
+                        if !skip_text {
+                            if !extracted_text.is_empty() {
+                                extracted_text.push('\n');
+                            }
+                            extracted_text.push_str(&decoded);
                         }
-                        extracted_text.push_str(&decoded);
 
                         let text_width = {
                             let font_info = state
@@ -1829,6 +1855,21 @@ impl Default for TextExtractor {
 ///
 /// `mcid` and `struct_tag` come from the innermost ancestor on the stack that
 /// declared `/MCID`; non-tagged content leaves both as `None`.
+/// Whether the current marked-content stack should suppress text emission.
+///
+/// Mirrors the gate inside [`emit_text_fragment`]: when an ancestor in the
+/// stack is `/Artifact` and the caller has not opted into artifact content
+/// via `include_artifacts`, neither `.text` nor `.fragments` should receive
+/// the run. Used by the four show-text operator arms to keep `extracted_text`
+/// and `fragments` symmetric — a page whose entire content is an
+/// `/Artifact BMC … EMC` scope (the common pattern for screen-reader-skipped
+/// disclaimers / footers / decorative tagged-PDF content) used to surface
+/// text in `.text` while leaving `.fragments` empty, silently dropping the
+/// page from `partition_with(...)` / `rag_chunks(...)` (issue #330).
+fn skip_artifact_text(state: &TextState, include_artifacts: bool) -> bool {
+    !include_artifacts && state.mc_stack.iter().any(|e| e.is_artifact)
+}
+
 fn emit_text_fragment(
     fragments: &mut Vec<TextFragment>,
     decoded: &str,

--- a/oxidize-pdf-core/tests/issue_330_text_fragments_invariant_test.rs
+++ b/oxidize-pdf-core/tests/issue_330_text_fragments_invariant_test.rs
@@ -1,0 +1,151 @@
+//! Acceptance tests for issue #330: `extract_from_page().text` and
+//! `extract_from_page().fragments` must be CONSISTENT — pages with text
+//! content must not produce zero fragments (silent-drop in RAG pipeline)
+//! and pages with no content must not produce ghost text without fragments.
+//!
+//! Reproducer in #330: a closing legal-disclaimer page in a slide deck
+//! returned `text-len: 2434, fragments: 0` while body pages had `text-len:
+//! 1373, fragments: 834`. Such pages then vanish from `partition_with(...)`
+//! and `rag_chunks(...)` because the partitioner operates on `fragments`,
+//! while the user sees the text in `.text` — silent inconsistency.
+//!
+//! Root cause being verified: `ShowText` / `ShowTextArray` /
+//! `NextLineShowText` / `SetSpacingNextLineShowText` push to
+//! `extracted_text` unconditionally (extraction.rs:879, 927, 1033, 1090)
+//! but `emit_text_fragment` (extraction.rs:1846-1848) returns early when
+//! the marked-content stack contains an Artifact entry and
+//! `include_artifacts` is false (the default). Result: a page entirely
+//! wrapped in an `/Artifact BMC … EMC` (a common pattern for screen-reader
+//! "skip" sections like legal disclaimers and slide footers) produces
+//! text-with-no-fragments.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractedText, ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+fn extract(content: &[u8], include_artifacts: bool) -> ExtractedText {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("reader");
+    let document = PdfDocument::new(reader);
+    let opts = ExtractionOptions {
+        preserve_layout: true,
+        include_artifacts,
+        ..ExtractionOptions::default()
+    };
+    let mut extractor = TextExtractor::with_options(opts);
+    extractor.extract_from_page(&document, 0).expect("extract")
+}
+
+/// Primary RED contract from #330: a page whose content is entirely inside
+/// an `/Artifact BMC … EMC` scope must produce a consistent state —
+/// either text AND fragments are empty (correct for `include_artifacts =
+/// false`), or both are non-empty. The current bug is the asymmetric state
+/// where text > 0 and fragments = 0.
+#[test]
+fn artifact_only_page_has_consistent_text_and_fragments() {
+    // Whole-page Artifact wrap (common pattern for PowerPoint/Keynote
+    // closing-disclaimer slides exported via accessibility-aware tooling).
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n\
+                    /Artifact BMC\n\
+                    (Disclaimer line one of legal boilerplate.) Tj\n\
+                    0 -14 Td\n\
+                    (Disclaimer line two more boilerplate.) Tj\n\
+                    EMC\n\
+                    ET\n";
+
+    let extracted = extract(content, false);
+
+    let text_has_content = !extracted.text.trim().is_empty();
+    let frags_has_content = !extracted.fragments.is_empty();
+    assert_eq!(
+        text_has_content,
+        frags_has_content,
+        ".text and .fragments must agree on whether the page has content. \
+         text-len={} ({:?}); fragments={}",
+        extracted.text.len(),
+        extracted.text,
+        extracted.fragments.len(),
+    );
+}
+
+/// Generalised invariant from #330's Acceptance section: for any page where
+/// `.text` has characters, `.fragments` must be non-empty. Same fixture as
+/// above but the assertion is phrased per the acceptance criterion.
+#[test]
+fn extracted_text_non_empty_implies_fragments_non_empty() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n\
+                    /Artifact BMC\n\
+                    (Footer text that would land in .text but never in .fragments.) Tj\n\
+                    EMC\n\
+                    ET\n";
+
+    let extracted = extract(content, false);
+
+    if !extracted.text.trim().is_empty() {
+        assert!(
+            !extracted.fragments.is_empty(),
+            "Acceptance #330: text contains {} chars but fragments is empty — \
+             silent-drop in the RAG pipeline. text={:?}",
+            extracted.text.len(),
+            extracted.text,
+        );
+    }
+}
+
+/// Opt-in symmetry: with `include_artifacts = true` both surfaces must
+/// carry the artifact content. Guards against an over-correction where the
+/// fix gates `.text` too aggressively and loses the opt-in capability.
+#[test]
+fn include_artifacts_true_emits_both_text_and_fragments() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n\
+                    /Artifact BMC\n\
+                    (Artifact body opted in.) Tj\n\
+                    EMC\n\
+                    ET\n";
+
+    let extracted = extract(content, true);
+
+    assert!(
+        extracted.text.contains("Artifact body opted in"),
+        "with include_artifacts=true, .text must include the artifact content; \
+         got text={:?}",
+        extracted.text
+    );
+    assert!(
+        extracted
+            .fragments
+            .iter()
+            .any(|f| f.text.contains("Artifact body opted in")),
+        "with include_artifacts=true, .fragments must include the artifact content; \
+         got fragments={:?}",
+        extracted
+            .fragments
+            .iter()
+            .map(|f| &f.text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Control: non-artifact text on the same fixture must surface as today —
+/// the fix must not strip ordinary text.
+#[test]
+fn ordinary_text_surfaces_in_both_text_and_fragments() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n\
+                    (Ordinary body text.) Tj\n\
+                    ET\n";
+
+    let extracted = extract(content, false);
+
+    assert!(
+        extracted.text.contains("Ordinary body text"),
+        ".text must carry ordinary (non-artifact) content"
+    );
+    assert!(
+        !extracted.fragments.is_empty(),
+        ".fragments must carry ordinary (non-artifact) content"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #330. `TextExtractor::extract_from_page` produced `text > 0` while `fragments = 0` for pages whose content was entirely wrapped in an `/Artifact BMC … EMC` scope. Such pages then vanished from `partition_with(...)` and `rag_chunks(...)` because both operate on `fragments` — silent-drop in the RAG pipeline despite visible text in `.text`.

The bug class is the project's most-fought failure mode (lineage: #235, #265, #319). This PR closes the artifact-path variant.

### Root cause

The four show-text operator arms in `src/text/extraction.rs` push the decoded run into `extracted_text` unconditionally:

| Arm | Line |
|---|---|
| `ShowText` (`Tj`) | 879 |
| `ShowTextArray::Text` (`TJ` text entries) | 927 |
| `ShowTextArray::Spacing` (synthetic space from wide kerns, #272) | 974 |
| `NextLineShowText` (`'`) | 1033 |
| `SetSpacingNextLineShowText` (`"`) | 1090 |

But `emit_text_fragment` (`extraction.rs:1846-1848`) gates fragment emission on `!include_artifacts && state.mc_stack contains an /Artifact entry`. The two halves of `ExtractedText` therefore diverge:

- A whole-page Artifact wrap (common pattern for slide-deck closing disclaimers, footers, decorative tagged-PDF content) populates `extracted_text` fully.
- The same content is correctly filtered from `fragments` per the existing artifact contract.
- Downstream consumers (`partition`, `rag_chunks`, anything operating on fragments) see an empty page.

### Fix

Factored the artifact gate into a free function `skip_artifact_text(&state, include_artifacts)` and applied it at the five sites above — gates the `extracted_text.push_str(&decoded)` (and the preceding spacing/newline insertion) on the same condition `emit_text_fragment` uses.

Intentionally NOT gated:

- Text-matrix updates, `last_x` / `last_y` bookkeeping, width calculations. These are positional side-effects of the operator regardless of whether the content lands in the output. Subsequent non-artifact text must still be positioned correctly relative to an artifact run that preceded it.
- `emit_text_fragment`'s own inline copy of the check. DRYing the two could be a follow-up, but is out of scope here.

### Commits

1. `491f270` — **RED test** (`tests/issue_330_text_fragments_invariant_test.rs`):
   - `artifact_only_page_has_consistent_text_and_fragments` — whole-page `/Artifact BMC … EMC` wrap; asserts `text.is_empty() == fragments.is_empty()`.
   - `extracted_text_non_empty_implies_fragments_non_empty` — the acceptance criterion from #330 phrased directly.
   - `include_artifacts_true_emits_both_text_and_fragments` — opt-in symmetry control.
   - `ordinary_text_surfaces_in_both_text_and_fragments` — non-artifact control.
   - Verified RED: the two primary tests fail with `text-len=79, fragments=0` and `text-len=61, fragments=0` respectively, exactly the symptom #330 describes. The two controls pass on develop, confirming the bug is localized to the artifact path.
2. `4c4efec` — **GREEN fix**: factor `skip_artifact_text` helper, apply at five emission sites.

### Verification

| Suite | Result |
|---|---|
| `issue_330_text_fragments_invariant_test` | **4/4** (was 2/4 pre-fix) |
| `extraction_artifact_test` | 3/3 (pre-existing artifact contract preserved) |
| `extraction_actualtext_test` | 3/3 |
| `extraction_boe_identity_h_test` | 3/3 |
| `extraction_ctm_test` | 5/5 |
| `extraction_mcid_test` | 2/2 |
| `extraction_profile_test` | 13/13 |
| `extraction_tj_implicit_space_test` | 9/9 |
| `extraction_two_column_writer_roundtrip_test` | 2/2 |
| `extraction_unbalanced_bdc_test` | 2/2 |
| `partition_test` | 17/17 |
| `partition_classifier_regression_test` | 4/4 |
| `partition_ncsc_classifier_test` | 9/9 |
| `rag_chunk_metadata_test` | 4/4 |
| `rag_realworld_jsonl_test` | 4/4 |
| `cargo test --lib` (pre-commit hook) | 6585/0 |

Total: 75 extraction/partition/RAG tests + 6585 lib tests, **0 regressions**.

### Backward compatibility

Behavioural change observable only on pages with `/Artifact BMC` containing text and `include_artifacts = false` (the default). Before this PR: `.text` carried that text. After: `.text` doesn't carry it (matching what `.fragments` and downstream consumers already saw).

This narrows `.text` for the artifact case. Two reasons this is the right direction:

1. **Consistency over capacity**: a silent-drop in RAG is worse than a slightly narrower `.text`. The artifact contract was clear at the fragment level; `.text` was incidentally over-inclusive.
2. **Opt-in unchanged**: `include_artifacts = true` still surfaces both — verified by the symmetry test.

No public API change. No flag added. No CHANGELOG required.

## Test plan

- [x] RED test fails on develop (verified at `491f270`)
- [x] GREEN test passes after fix (verified at `4c4efec`)
- [x] 75 extraction/partition/RAG tests pass with no regression
- [x] Lib tests 6585/0 (pre-commit)
- [ ] CI green on PR

Refs #330. This closes the slide-deck sweep (#329 / #330 / #331 / #334) discovered investigating the user's PowerPoint deck on 2026-06-15.