### PR TITLE
fix(#341): xref-stream double-decode breaks strict reader path

### DIFF
--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -526,28 +526,19 @@ impl XRefTable {
                 {
                     tracing::debug!("Parsing XRef stream");
 
-                    // Try to decode the stream, with fallback for corrupted streams
+                    // Decode the stream exactly once. `XRefStream::parse` treats
+                    // its input as already decoded (issue #341), so on decode
+                    // failure we must NOT hand it the raw compressed bytes — they
+                    // are not valid xref entries and only ever "worked" because
+                    // `parse` used to re-decode them. Propagate the error so the
+                    // caller falls back to recovery mode instead.
                     let decoded_data = match stream.decode(options) {
                         Ok(data) => data,
                         Err(e) => {
                             tracing::debug!(
-                                "XRef stream decode failed: {e:?}, attempting raw data fallback"
+                                "XRef stream decode failed: {e:?}, triggering recovery mode"
                             );
-
-                            // If decode fails, try using raw stream data
-                            // This helps with corrupted Flate streams
-                            if !stream.data.is_empty() {
-                                tracing::debug!(
-                                    "Using raw stream data ({} bytes) as fallback",
-                                    stream.data.len()
-                                );
-                                stream.data.clone()
-                            } else {
-                                tracing::debug!(
-                                    "No raw stream data available, triggering recovery mode"
-                                );
-                                return Err(e);
-                            }
+                            return Err(e);
                         }
                     };
 

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -535,7 +535,7 @@ impl XRefTable {
                     let decoded_data = match stream.decode(options) {
                         Ok(data) => data,
                         Err(e) => {
-                            tracing::debug!(
+                            tracing::warn!(
                                 "XRef stream decode failed: {e:?}, triggering recovery mode"
                             );
                             return Err(e);

--- a/oxidize-pdf-core/src/parser/xref_stream.rs
+++ b/oxidize-pdf-core/src/parser/xref_stream.rs
@@ -50,7 +50,14 @@ pub struct XRefStream {
 }
 
 impl XRefStream {
-    /// Parse a cross-reference stream
+    /// Parse a cross-reference stream from already-decoded entry bytes.
+    ///
+    /// `stream_data` must be the decoded (decompressed) content: the caller is
+    /// responsible for running `stream.decode()` before invoking this function.
+    /// The `stream_dict` may still carry `/Filter` and `/DecodeParms`, but this
+    /// function does NOT apply them. Passing raw compressed bytes here would
+    /// re-inflate already-inflated data and produce a bogus "Xref stream data
+    /// truncated" error (issue #341).
     pub fn parse<R: Read + Seek>(
         _reader: &mut R,
         stream_dict: PdfDictionary,
@@ -546,7 +553,11 @@ mod tests {
         );
 
         let (dict, compressed) = builder.build().unwrap();
-        // Mirror production: caller decodes via `stream.decode()` before `parse`.
+        // Mirror production: the caller decodes via `stream.decode()` before
+        // `parse`. The builder emits FlateDecode, so decoding with FlateDecode
+        // here reproduces exactly what `stream.decode()` would yield. If the
+        // builder ever switches filter (predictor/LZW), this line must follow it
+        // or the decoded-input precondition no longer matches production.
         let decoded = apply_filter(&compressed, Filter::FlateDecode).unwrap();
         (dict, decoded)
     }

--- a/oxidize-pdf-core/src/parser/xref_stream.rs
+++ b/oxidize-pdf-core/src/parser/xref_stream.rs
@@ -6,7 +6,6 @@
 //! Cross-reference streams are an alternative to traditional xref tables,
 //! providing more compact representation and supporting compressed object streams.
 
-use crate::parser::filters::{apply_filter, apply_filter_with_params, Filter};
 use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject};
 use crate::parser::ParseOptions;
 use crate::parser::{ParseError, ParseResult};
@@ -118,66 +117,14 @@ impl XRefStream {
                 vec![(0, size)]
             };
 
-        // Calculate entry size from W array for XRef stream predictor handling
-        let entry_size = widths.iter().sum::<usize>();
-
-        // Decode the stream data
-        let decoded_data = if let Some(filter_obj) = stream_dict.get("Filter") {
-            // Apply filters
-            match filter_obj {
-                PdfObject::Name(filter_name) => {
-                    // Use apply_filter_with_params to handle DecodeParms (like Predictor)
-                    let filter = Filter::from_name(filter_name.as_str()).ok_or_else(|| {
-                        ParseError::StreamDecodeError(format!("Unknown filter: {filter_name:?}"))
-                    })?;
-
-                    // Get DecodeParms if available
-                    let decode_params = stream_dict.get("DecodeParms");
-
-                    if let Some(params_obj) = decode_params {
-                        if let Some(mut params_dict) = params_obj.as_dict().cloned() {
-                            // FIX for Issue #83: XRef streams with PNG predictor
-                            // Override /Columns with actual entry size from W array
-                            // This fixes predictor mismatch (e.g., Columns=4 but W=[1,3,2] requires 6)
-                            if params_dict
-                                .get("Predictor")
-                                .and_then(|p| p.as_integer())
-                                .is_some()
-                            {
-                                params_dict.insert(
-                                    "Columns".to_string(),
-                                    PdfObject::Integer(entry_size as i64),
-                                );
-                            }
-                            apply_filter_with_params(&stream_data, filter, Some(&params_dict))?
-                        } else {
-                            apply_filter(&stream_data, filter)?
-                        }
-                    } else {
-                        apply_filter(&stream_data, filter)?
-                    }
-                }
-                PdfObject::Array(filters) => {
-                    let mut data = stream_data;
-                    for filter in filters.0.iter() {
-                        if let Some(filter_name) = filter.as_name() {
-                            data = apply_filter(
-                                &data,
-                                Filter::from_name(filter_name.as_str()).ok_or_else(|| {
-                                    ParseError::StreamDecodeError(format!(
-                                        "Unknown filter: {filter_name:?}"
-                                    ))
-                                })?,
-                            )?;
-                        }
-                    }
-                    data
-                }
-                _ => stream_data,
-            }
-        } else {
-            stream_data
-        };
+        // The `stream_data` argument is ALREADY decoded: the only production
+        // caller (`xref.rs`) runs `stream.decode()` (FlateDecode + any predictor)
+        // before handing the buffer to `parse`. The stream dict still carries
+        // `/Filter` (and possibly `/DecodeParms`), but re-applying the filter
+        // here would inflate already-inflated bytes — yielding 0 bytes and a
+        // bogus "Xref stream data truncated" error (issue #341). The contract is
+        // therefore: `parse` does not decode; it consumes decoded entry bytes.
+        let decoded_data = stream_data;
 
         Ok(XRefStream {
             dict: stream_dict,
@@ -487,6 +434,7 @@ fn compress_data(data: &[u8]) -> ParseResult<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::filters::{apply_filter, Filter};
 
     #[test]
     fn test_read_field() {
@@ -566,6 +514,80 @@ mod tests {
         assert!(dict.get("W").is_some());
         assert!(dict.get("Size").is_some());
         assert!(dict.get("Filter").is_some());
+    }
+
+    /// Build a representative xref stream and decode its data exactly the way
+    /// the production caller (`xref.rs`) does (`stream.decode()` first), then
+    /// return the dict (which still carries `/Filter`) together with the
+    /// already-decoded entry bytes. This is the precise calling convention that
+    /// `XRefStream::parse` receives in production.
+    fn decoded_xref_stream_inputs() -> (PdfDictionary, Vec<u8>) {
+        let mut builder = XRefStreamBuilder::new();
+        builder.add_entry(
+            0,
+            XRefEntry::Free {
+                next_free_object: 0,
+                generation: 65535,
+            },
+        );
+        builder.add_entry(
+            1,
+            XRefEntry::InUse {
+                offset: 15,
+                generation: 0,
+            },
+        );
+        builder.add_entry(
+            2,
+            XRefEntry::Compressed {
+                stream_object_number: 5,
+                index_within_stream: 0,
+            },
+        );
+
+        let (dict, compressed) = builder.build().unwrap();
+        // Mirror production: caller decodes via `stream.decode()` before `parse`.
+        let decoded = apply_filter(&compressed, Filter::FlateDecode).unwrap();
+        (dict, decoded)
+    }
+
+    fn assert_three_entries(stream: &XRefStream) {
+        let entries = stream.to_xref_entries().unwrap();
+        assert_eq!(entries.len(), 3, "must recover all three xref entries");
+        assert!(matches!(entries[0].1, XRefEntry::Free { .. }));
+        assert!(matches!(
+            entries[1].1,
+            XRefEntry::InUse {
+                offset: 15,
+                generation: 0
+            }
+        ));
+        assert!(matches!(
+            entries[2].1,
+            XRefEntry::Compressed {
+                stream_object_number: 5,
+                index_within_stream: 0
+            }
+        ));
+    }
+
+    /// Issue #341: `parse` receives already-decoded data from the only caller.
+    /// It must NOT re-apply the `/Filter` still present in the dict. Before the
+    /// fix, re-inflating already-inflated bytes produced 0 bytes and
+    /// `to_xref_entries` reported "Xref stream data truncated".
+    #[test]
+    fn parse_treats_input_as_already_decoded_flate() {
+        let (dict, decoded) = decoded_xref_stream_inputs();
+        assert!(
+            dict.get("Filter").is_some(),
+            "precondition: dict still carries /Filter, as in production"
+        );
+
+        let mut reader = std::io::Cursor::new(Vec::<u8>::new());
+        let stream =
+            XRefStream::parse(&mut reader, dict, decoded, &ParseOptions::default()).unwrap();
+
+        assert_three_entries(&stream);
     }
 
     #[test]

--- a/oxidize-pdf-core/tests/issue_341_xref_stream_double_decode_test.rs
+++ b/oxidize-pdf-core/tests/issue_341_xref_stream_double_decode_test.rs
@@ -11,7 +11,7 @@
 //! the strict reader path — including documents oxidize-pdf writes itself. The
 //! lenient `PdfReader::open` path masks it via object-scan recovery.
 
-use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::writer::{PdfWriter, WriterConfig};
 use oxidize_pdf::{Document, Font, Page};
 use std::io::Cursor;
@@ -79,5 +79,25 @@ fn multi_page_xref_stream_pdf_parses_via_strict_reader() {
     assert_eq!(
         page_count, 5,
         "five-page xref-stream PDF must report 5 pages"
+    );
+}
+
+/// The fix changed the lenient path too: when `stream.decode()` fails, the
+/// caller now goes straight to scan recovery instead of feeding raw compressed
+/// bytes to `parse`. This guards that a well-formed xref-stream PDF still
+/// resolves correctly under lenient options after that change.
+#[test]
+fn xref_stream_pdf_parses_via_lenient_reader() {
+    let buffer = write_xref_stream_pdf(3);
+
+    let mut reader = PdfReader::new_with_options(Cursor::new(buffer), ParseOptions::lenient())
+        .expect("lenient reader must parse xref-stream PDF");
+    let page_count = reader
+        .page_count()
+        .expect("page_count must succeed on the lenient path");
+
+    assert_eq!(
+        page_count, 3,
+        "three-page xref-stream PDF must report 3 pages on the lenient path"
     );
 }

--- a/oxidize-pdf-core/tests/issue_341_xref_stream_double_decode_test.rs
+++ b/oxidize-pdf-core/tests/issue_341_xref_stream_double_decode_test.rs
@@ -1,0 +1,83 @@
+//! Regression test for issue #341: xref stream double-decode.
+//!
+//! `XRefStream::parse` was designed to receive RAW (filtered) stream data and
+//! decode it once. Its only production caller (`xref.rs`) decodes the stream
+//! first via `stream.decode()` and passes the ALREADY-DECODED buffer. Because
+//! the stream dict still carries `/Filter`, `parse` re-applied the filter to the
+//! already-inflated bytes, which yields 0 bytes, so `to_xref_entries` reported
+//! "Xref stream data truncated".
+//!
+//! This breaks ANY PDF whose cross-reference table is a `/Type /XRef` stream on
+//! the strict reader path — including documents oxidize-pdf writes itself. The
+//! lenient `PdfReader::open` path masks it via object-scan recovery.
+
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::writer::{PdfWriter, WriterConfig};
+use oxidize_pdf::{Document, Font, Page};
+use std::io::Cursor;
+
+/// Build a minimal, well-formed PDF 1.5 whose cross-reference table is a
+/// FlateDecode `/Type /XRef` stream, using oxidize-pdf's own writer.
+fn write_xref_stream_pdf(num_pages: usize) -> Vec<u8> {
+    let mut doc = Document::new();
+    doc.set_title("Issue 341 XRef Stream");
+
+    for i in 0..num_pages {
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Helvetica, 12.0)
+            .at(100.0, 700.0)
+            .write(&format!("Page {}", i + 1))
+            .unwrap();
+        doc.add_page(page);
+    }
+
+    let mut buffer = Vec::new();
+    {
+        let config = WriterConfig {
+            use_xref_streams: true,
+            use_object_streams: false,
+            pdf_version: "1.5".to_string(),
+            compress_streams: true,
+            incremental_update: false,
+        };
+        let mut writer = PdfWriter::with_config(&mut buffer, config);
+        writer.write_document(&mut doc).unwrap();
+    }
+    buffer
+}
+
+#[test]
+fn xref_stream_pdf_parses_via_strict_reader() {
+    let buffer = write_xref_stream_pdf(1);
+
+    // The strict path must register the xref-stream entries and resolve the
+    // page tree. Before the fix this errored with
+    // `SyntaxError { message: "Xref stream data truncated at obj 0" }`.
+    let mut reader =
+        PdfReader::new(Cursor::new(buffer)).expect("strict reader must parse xref-stream PDF");
+    let page_count = reader
+        .page_count()
+        .expect("page_count must succeed on xref-stream PDF");
+
+    assert_eq!(
+        page_count, 1,
+        "single-page xref-stream PDF must report 1 page"
+    );
+}
+
+#[test]
+fn multi_page_xref_stream_pdf_parses_via_strict_reader() {
+    let buffer = write_xref_stream_pdf(5);
+
+    let mut reader =
+        PdfReader::new(Cursor::new(buffer)).expect("strict reader must parse xref-stream PDF");
+    let page_count = reader
+        .page_count()
+        .expect("page_count must succeed on multi-page xref-stream PDF");
+
+    assert_eq!(
+        page_count, 5,
+        "five-page xref-stream PDF must report 5 pages"
+    );
+}


### PR DESCRIPTION
Addresses #341.

## Problema

`XRefStream::parse` recibía un buffer **ya decodificado** de su único caller (`xref.rs` corre `stream.decode()` antes), pero como el stream dict conserva `/Filter`, **re-aplicaba el filtro** sobre bytes ya inflados → 0 bytes → `SyntaxError "Xref stream data truncated"`.

Rompía el path strict (`PdfReader::new`) para **cualquier** documento cuya tabla de referencias cruzadas sea un `/Type /XRef` stream (PDF 1.5+, ubicuos en linearizados/gobierno/EU), incluidos los PDF que genera oxidize-pdf. El path lenient lo enmascaraba con recovery por escaneo de objetos; solo se hizo visible en un fichero cuyo recovery también falla.

## Causa raíz

Desajuste de contrato: el diseño original de `parse` era "recibe crudo, decodifica una vez". El caller se cambió para pre-decodificar (`xref.rs:530`) sin quitar el decode de `parse` → doble decode.

## Fix

- **`xref_stream.rs`**: `parse` trata `stream_data` como ya decodificado y no re-aplica la cadena de filtros (`/Filter` + predictor). Contrato documentado en la firma.
- **`xref.rs`**: en fallo de `stream.decode()` propaga el error para disparar recovery, en vez de pasar bytes crudos comprimidos a `parse` (que no son entries válidos y solo "funcionaban" porque `parse` los re-decodificaba). Log subido a `warn!`.
- Tests del contrato de `parse()` con la convención de producción (datos decodificados + dict con `/Filter`) — path que ningún test cubría (los previos construían `XRefStream` directamente).

## Verificación

- Fixture real del issue (BOE PDF 1.5 linearizado, 78 ObjStm): strict + lenient → `page_count = 180` (antes ambos fallaban).
- RED→GREEN: integración writer→strict reader (1/3/5 páginas) + path lenient + unit `parse_treats_input_as_already_decoded_flate`.
- lib **6596/0** · clippy limpio · fmt limpio.
- t1_spec **22/0** (0 panics/timeouts, 99.7% parsed) · t3_stress **22/0** (0 panics/timeouts, 97.9% parsed) — sin regresiones; no-parseados son fallos esperados pre-existentes.
- parser integration: hybrid 9/0, version 16/0, roundtrip 7/0, malformed 26/0, xref_stream_simple 1/0.

Sin bump de versión (gitflow: lo recoge la próxima release funcional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)