### PR TITLE
feat(#345): AnalysisPipeline.with_partition_config for configurable partition

### DIFF
--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1487,6 +1487,12 @@ impl<R: Read + Seek> PdfDocument<R> {
     ///
     /// `AnalysisPipeline::new()` reproduces [`rag_chunks`](Self::rag_chunks).
     ///
+    /// Partitioning uses the pipeline's
+    /// [`PartitionConfig`](crate::pipeline::PartitionConfig) (default unless set
+    /// via [`with_partition_config`](crate::pipeline::AnalysisPipeline::with_partition_config)),
+    /// so a structure-aware consumer can override the table detector when it
+    /// misclassifies the document (issue #345).
+    ///
     /// **Stability:** requires `unstable-spi`; exempt from semver until promoted.
     ///
     /// # Example
@@ -1512,7 +1518,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         if let Some(src) = source.as_mut() {
             self.autofill_source(src);
         }
-        let mut elements = self.partition()?;
+        let mut elements = self.partition_with(pipeline.partition_config.clone())?;
         if let Some(classifier) = pipeline.classifier.as_deref() {
             // Two passes: read labels against an immutable slice, then apply —
             // the classifier inspects neighbours via `ClassifyContext`, so it

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -136,7 +136,7 @@ pub trait MetadataEnricher: Send + Sync {
 }
 
 use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
-use crate::pipeline::DocumentSource;
+use crate::pipeline::{DocumentSource, PartitionConfig};
 
 /// Configures the analysis pipeline: which chunking strategy to run, the token
 /// budget used to flag oversized chunks, optional source-document metadata, an
@@ -148,7 +148,7 @@ pub struct AnalysisPipeline {
     pub(crate) max_tokens: usize,
     pub(crate) source: Option<DocumentSource>,
     pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
-    pub(crate) partition_config: crate::pipeline::PartitionConfig,
+    pub(crate) partition_config: PartitionConfig,
     #[cfg(feature = "semantic")]
     pub(crate) enrichers: Vec<Box<dyn MetadataEnricher>>,
 }
@@ -169,7 +169,7 @@ impl AnalysisPipeline {
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
             classifier: None,
-            partition_config: crate::pipeline::PartitionConfig::default(),
+            partition_config: PartitionConfig::default(),
             #[cfg(feature = "semantic")]
             enrichers: Vec::new(),
         }
@@ -195,8 +195,8 @@ impl AnalysisPipeline {
         self
     }
 
-    /// Set the [`PartitionConfig`](crate::pipeline::PartitionConfig) used to
-    /// partition the document before classification and chunking.
+    /// Set the [`PartitionConfig`] used to partition the document before
+    /// classification and chunking.
     ///
     /// By default the pipeline partitions with `PartitionConfig::default()`
     /// (table detection on). Override this when the default table detector
@@ -204,7 +204,7 @@ impl AnalysisPipeline {
     /// into empty `table` elements — so a structure-aware consumer can run over
     /// a correctly-partitioned document (issue #345).
     #[must_use]
-    pub fn with_partition_config(mut self, config: crate::pipeline::PartitionConfig) -> Self {
+    pub fn with_partition_config(mut self, config: PartitionConfig) -> Self {
         self.partition_config = config;
         self
     }

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -148,6 +148,7 @@ pub struct AnalysisPipeline {
     pub(crate) max_tokens: usize,
     pub(crate) source: Option<DocumentSource>,
     pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
+    pub(crate) partition_config: crate::pipeline::PartitionConfig,
     #[cfg(feature = "semantic")]
     pub(crate) enrichers: Vec<Box<dyn MetadataEnricher>>,
 }
@@ -168,6 +169,7 @@ impl AnalysisPipeline {
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
             classifier: None,
+            partition_config: crate::pipeline::PartitionConfig::default(),
             #[cfg(feature = "semantic")]
             enrichers: Vec::new(),
         }
@@ -190,6 +192,20 @@ impl AnalysisPipeline {
     #[must_use]
     pub fn with_max_tokens(mut self, max_tokens: usize) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Set the [`PartitionConfig`](crate::pipeline::PartitionConfig) used to
+    /// partition the document before classification and chunking.
+    ///
+    /// By default the pipeline partitions with `PartitionConfig::default()`
+    /// (table detection on). Override this when the default table detector
+    /// misclassifies the document — e.g. single-column prose pages collapsed
+    /// into empty `table` elements — so a structure-aware consumer can run over
+    /// a correctly-partitioned document (issue #345).
+    #[must_use]
+    pub fn with_partition_config(mut self, config: crate::pipeline::PartitionConfig) -> Self {
+        self.partition_config = config;
         self
     }
 

--- a/oxidize-pdf-core/tests/issue_345_pipeline_partition_config_test.rs
+++ b/oxidize-pdf-core/tests/issue_345_pipeline_partition_config_test.rs
@@ -1,0 +1,83 @@
+//! Issue #345: a custom `AnalysisPipeline` must be able to run over a
+//! configurable partition. Before the fix, `rag_chunks_with_pipeline`
+//! hard-coded `self.partition()` (default `PartitionConfig`), so a downstream
+//! consumer could not avoid the table-detector behaviour that turns
+//! single-column prose pages into page-spanning (empty) `table` elements.
+//!
+//! Contract under test: `AnalysisPipeline::with_partition_config` threads a
+//! `PartitionConfig` into `rag_chunks_with_pipeline`, and the pipeline honours
+//! it. The default round-trips to the unconfigured behaviour exactly.
+//!
+//! Fixture: `issue_272_boe_sumario_2025_01_15.pdf` — a Spanish government
+//! bulletin where the default table detector emits 29 empty `table` elements
+//! (34 elements total), while `detect_tables = false` partitions the same
+//! pages into 338 prose/list elements. That structural delta is the observable
+//! signal that the partition config reached the partitioner.
+#![cfg(feature = "unstable-spi")]
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{AnalysisPipeline, PartitionConfig, RagChunk};
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+fn open() -> PdfDocument<std::fs::File> {
+    PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"))
+}
+
+fn texts(chunks: &[RagChunk]) -> Vec<String> {
+    chunks.iter().map(|c| c.text.clone()).collect()
+}
+
+#[test]
+fn rag_chunks_with_pipeline_honors_custom_partition_config() {
+    let doc = open();
+
+    let default_chunks = doc
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("default pipeline");
+
+    let cfg = PartitionConfig {
+        detect_tables: false,
+        ..Default::default()
+    };
+    let custom_chunks = doc
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new().with_partition_config(cfg))
+        .expect("custom pipeline");
+
+    // Neither path is degenerate.
+    assert!(!default_chunks.is_empty(), "default produced no chunks");
+    assert!(!custom_chunks.is_empty(), "custom produced no chunks");
+
+    // The partition config must reach the partitioner: with detect_tables=false
+    // the 29 page-spanning empty tables explode into their constituent prose
+    // elements, so the chunk set is materially different from the default.
+    // If the config is ignored (the #345 bug), both calls run the default
+    // partition and these vectors are identical.
+    assert_ne!(
+        texts(&default_chunks),
+        texts(&custom_chunks),
+        "partition_config was ignored: detect_tables=false produced chunks \
+         identical to the default partition"
+    );
+}
+
+#[test]
+fn explicit_default_partition_config_matches_unconfigured_pipeline() {
+    let doc = open();
+
+    let unconfigured = doc
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("unconfigured pipeline");
+    let explicit_default = doc
+        .rag_chunks_with_pipeline(
+            &AnalysisPipeline::new().with_partition_config(PartitionConfig::default()),
+        )
+        .expect("explicit-default pipeline");
+
+    // Setting the default config explicitly must not change anything.
+    assert_eq!(
+        texts(&unconfigured),
+        texts(&explicit_default),
+        "explicit PartitionConfig::default() diverged from the unconfigured pipeline"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_345_pipeline_partition_config_test.rs
+++ b/oxidize-pdf-core/tests/issue_345_pipeline_partition_config_test.rs
@@ -15,8 +15,14 @@
 //! signal that the partition config reached the partitioner.
 #![cfg(feature = "unstable-spi")]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
-use oxidize_pdf::pipeline::{AnalysisPipeline, PartitionConfig, RagChunk};
+use oxidize_pdf::pipeline::{
+    AnalysisPipeline, ClassLabel, ClassifyContext, Element, ElementClassifier, PartitionConfig,
+    RagChunk,
+};
 
 const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
 
@@ -50,14 +56,78 @@ fn rag_chunks_with_pipeline_honors_custom_partition_config() {
 
     // The partition config must reach the partitioner: with detect_tables=false
     // the 29 page-spanning empty tables explode into their constituent prose
-    // elements, so the chunk set is materially different from the default.
-    // If the config is ignored (the #345 bug), both calls run the default
-    // partition and these vectors are identical.
+    // elements, which the HybridChunker then re-groups — so the chunk set is
+    // materially different from the default. If the config is ignored (the #345
+    // bug), both calls run the default partition and these vectors are identical.
+    //
+    // Note: the direction is not asserted — detect_tables=false yields *fewer*,
+    // larger prose chunks than the table-fragmented default on this fixture, so
+    // a `custom.len() > default.len()` guard would be a false failure.
     assert_ne!(
         texts(&default_chunks),
         texts(&custom_chunks),
-        "partition_config was ignored: detect_tables=false produced chunks \
-         identical to the default partition"
+        "partition_config was ignored: detect_tables=false ({} chunks) produced \
+         chunks identical to the default partition ({} chunks)",
+        custom_chunks.len(),
+        default_chunks.len()
+    );
+}
+
+/// A classifier that records how many elements it was asked to classify,
+/// without changing any output.
+struct CountingClassifier(Arc<AtomicUsize>);
+
+impl ElementClassifier for CountingClassifier {
+    fn classify(&self, _element: &Element, _ctx: &ClassifyContext) -> Option<ClassLabel> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        None
+    }
+}
+
+#[test]
+fn partition_config_governs_the_elements_seen_by_the_classifier() {
+    let doc = open();
+
+    let cfg = PartitionConfig {
+        detect_tables: false,
+        ..Default::default()
+    };
+
+    // Ground truth: the elements the configured partition produces, computed
+    // independently of the pipeline.
+    let expected = doc
+        .partition_with(cfg.clone())
+        .expect("partition_with(cfg)")
+        .len();
+
+    // The classifier stage must run over exactly those elements — proving the
+    // pipeline's PartitionConfig governs the *mechanism* (which elements reach
+    // the rest of the pipeline), not merely some downstream chunk-text delta.
+    let counter = Arc::new(AtomicUsize::new(0));
+    let pipeline = AnalysisPipeline::new()
+        .with_partition_config(cfg)
+        .with_classifier(Box::new(CountingClassifier(counter.clone())));
+    let _ = doc
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        expected,
+        "classifier ran over {} elements but the configured partition yields {}",
+        counter.load(Ordering::Relaxed),
+        expected
+    );
+
+    // Guard against a vacuous match: the configured partition must genuinely
+    // differ from the default, otherwise this would pass even if the config
+    // were ignored.
+    let default_len = doc.partition().expect("partition").len();
+    assert_ne!(
+        expected, default_len,
+        "fixture no longer distinguishes detect_tables on/off ({} vs {}); \
+         the test can no longer detect an ignored partition_config",
+        expected, default_len
     );
 }
 


### PR DESCRIPTION
## Summary

Addresses the primary (API) request of #345: let a custom `AnalysisPipeline` (SPI classifier / chunking / enrichers) run over a **configurable** partition.

`rag_chunks_with_pipeline` hard-coded `self.partition()` (default `PartitionConfig`), so a downstream consumer (oxidize-legal, validating the `unstable-spi` seams) could not avoid the table detector turning single-column prose pages into empty `table` elements. `partition_with(detect_tables=false)` already produces correct elements, but there was no way to feed that config through the pipeline.

## Change

- `AnalysisPipeline` gains a `partition_config: PartitionConfig` field (default = `PartitionConfig::default()`) and a `with_partition_config` builder, consistent with the existing `with_*` builders.
- `rag_chunks_with_pipeline` partitions via `self.partition_with(pipeline.partition_config.clone())`.
- The default round-trips to the previous behaviour, so the existing corpus-parity guard (byte-identical to `rag_chunks()`) still holds.

No breaking changes. The secondary detector-quality part of #345 (empty `table` over single-column prose, possible dup of #329) is intentionally **out of scope** here — follow-up.

## Tests (TDD, RED first)

`tests/issue_345_pipeline_partition_config_test.rs`:
- `rag_chunks_with_pipeline_honors_custom_partition_config` — `detect_tables=false` through the pipeline yields a materially different chunk set than the default, on the committed `issue_272_boe_sumario` fixture (34 vs 338 elements). Direction is deliberately not asserted: `detect_tables=false` yields *fewer*, larger prose chunks (25 vs 34), so a `custom > default` guard would be a false failure (measured).
- `partition_config_governs_the_elements_seen_by_the_classifier` — a counting classifier must run over exactly the elements produced by `partition_with(cfg)`, with a non-vacuous guard that the configured partition differs from the default. Verifies the **mechanism**, not just a downstream delta.
- `explicit_default_partition_config_matches_unconfigured_pipeline` — explicit `PartitionConfig::default()` reproduces the unconfigured pipeline.

## Verification

- 3/3 new tests green; full SPI suite (9/9) + corpus-parity green; 6596 lib tests pass (pre-commit).
- `cargo fmt --check`, `clippy --workspace --lib -D warnings` clean; builds with default and `unstable-spi,semantic` features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)