### PR TITLE
chore(parser): quality-review follow-up for #339

### DIFF
--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -2216,7 +2216,11 @@ impl<R: Read + Seek> PdfReader<R> {
         let data = match length {
             Some(len) => {
                 // Trust /Length (ISO 32000 §7.3.8.1): read exactly `len` bytes. This
-                // is correct for binary streams whose bytes may contain "endstream".
+                // is correct for binary streams whose bytes may contain "endstream",
+                // which an endstream-search would mistakenly truncate at. Accepted
+                // tradeoff on this repair path: a stale-too-large /Length would read
+                // past endstream, but that is rarer than binary data containing the
+                // marker, and trusting /Length is the ISO-correct behavior.
                 let body = read_window_at(&mut self.reader, data_abs, len)?;
                 dict.insert(
                     PdfName("Length".to_string()),
@@ -2247,7 +2251,7 @@ impl<R: Read + Seek> PdfReader<R> {
         let rest = dict_content[idx + "/Length".len()..].trim_start();
         let tokens: Vec<&str> = rest.split_whitespace().collect();
 
-        // Indirect reference: "G N R".
+        // Indirect reference: "N G R" (e.g. "42 0 R" — object number, generation, keyword).
         if tokens.len() >= 3 && tokens[2] == "R" {
             if let Ok(len_obj) = tokens[0].parse::<u32>() {
                 return self.resolve_length_object(len_obj);
@@ -2312,8 +2316,18 @@ impl<R: Read + Seek> PdfReader<R> {
             searched = acc.len();
             offset += chunk.len() as u64;
 
-            if chunk.len() < WIN || acc.len() > MAX_STREAM {
-                break; // EOF or guard
+            if chunk.len() < WIN {
+                break; // EOF before endstream
+            }
+            if acc.len() > MAX_STREAM {
+                // Runaway guard: surface the truncation so a downstream decode
+                // failure on the incomplete body is traceable to here rather than
+                // appearing as a cryptic error.
+                tracing::warn!(
+                    "stream body exceeds {} MiB runaway guard without endstream; truncating",
+                    MAX_STREAM / (1024 * 1024)
+                );
+                break;
             }
         }
 

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -328,7 +328,12 @@ pub(crate) fn scan_page_object_refs<R: Read + Seek>(
             None => &window[..],
         };
         let text = String::from_utf8_lossy(region);
-        if text.contains("/Type /Page") && !text.contains("/Type /Pages") {
+        // PDF names need no whitespace before the value: both "/Type /Page" and the
+        // compact "/Type/Page" are valid (ISO 32000-1 §7.3.5). Match both, and
+        // exclude the page-tree node /Type /Pages in either spelling.
+        let is_page = text.contains("/Type /Page") || text.contains("/Type/Page");
+        let is_pages = text.contains("/Type /Pages") || text.contains("/Type/Pages");
+        if is_page && !is_pages {
             pages.push((header.obj_num, 0));
         }
     }
@@ -1964,6 +1969,26 @@ mod tests {
             r.max_read <= 64 * 1024,
             "locate requested {} bytes in a single read (file={total}); not bounded",
             r.max_read
+        );
+    }
+
+    #[test]
+    fn test_scan_page_object_refs_matches_compact_type_page() {
+        // `/Type/Page` without a space before the value is valid PDF (ISO 32000-1
+        // §7.3.5) and is emitted by Ghostscript / pdfTeX. The page scan must detect
+        // it, while still excluding the compact page-tree node `/Type/Pages`.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"%PDF-1.7\n");
+        buf.extend_from_slice(b"1 0 obj\n<< /Type/Catalog /Pages 2 0 R >>\nendobj\n");
+        buf.extend_from_slice(b"2 0 obj\n<< /Type/Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+        buf.extend_from_slice(b"3 0 obj\n<< /Type/Page /Parent 2 0 R >>\nendobj\n");
+
+        let mut r = Cursor::new(buf);
+        let pages = scan_page_object_refs(&mut r).unwrap();
+        assert_eq!(
+            pages,
+            vec![(3, 0)],
+            "compact /Type/Page must be detected and compact /Type/Pages excluded"
         );
     }
 


### PR DESCRIPTION
## Summary

Actionable findings from the #339 quality review (post-merge of PR #350).

- **`scan_page_object_refs`** — detect the compact `/Type/Page` spelling (no space before the value), valid per ISO 32000-1 §7.3.5 and emitted by Ghostscript/pdfTeX; still excludes `/Type/Pages` in either spelling. Pre-existing gap (the original per-line scan had it too), fixed now that this is the authoritative implementation. RED test: `test_scan_page_object_refs_matches_compact_type_page`.
- **`read_stream_until_endstream`** — split the EOF vs `MAX_STREAM` break and `tracing::warn!` on the runaway-guard truncation, so an incomplete body is traceable here.
- **`parse_stream_length`** — fix the indirect-ref comment (`"G N R"` → `"N G R"`).
- **`reconstruct_stream_object_bounded`** — document the deliberate exact-`/Length` read tradeoff on the repair path.

## Deferred (separate follow-ups)

- #351 — filter preservation in the manual recovery path (pre-existing, broader scope).
- #352 — deduplicate `find_bytes` / `find_byte_pattern` (touches many call sites).

## Verification

Parser lib suite green (1227 tests), clippy clean. Pre-commit hook ran the full lib suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)