### PR TITLE
Release 2.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [2.16.6] - 2026-06-23
+
+### Fixed
+
+- The manual stream-reconstruction recovery path (used when a PDF's cross-reference
+  table is damaged or absent) rebuilt each stream dictionary recognizing only the
+  single hardcoded `/Filter /FlateDecode` form. Every other entry was dropped —
+  non-Flate filters (`/DCTDecode`, `/LZWDecode`), filter arrays, `/DecodeParms`,
+  `/Subtype`, `/ColorSpace`, etc. When this path fired on a non-Flate stream, the
+  missing `/Filter` made downstream decoding treat compressed bytes as raw, a silent
+  wrong result. The dictionary is now re-parsed in full with the real object parser,
+  preserving every entry generically. The bounded-memory guarantees from #339 are
+  unchanged: stream bodies are still read bounded by `/Length` (or a bounded scan to
+  `endstream`), never the whole file. (#351)
+
+### Changed
+
+- Deduplicated two byte-identical binary-substring search helpers
+  (`reader::find_bytes` and `xref::find_byte_pattern`) into a single `pub(crate)`
+  implementation, removing the risk of silent divergence. No behavior change. (#352)
+
 ## [2.16.5] - 2026-06-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "2.16.5"
+version = "2.16.6"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.16.5"
+version = "2.16.6"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -3422,6 +3422,42 @@ mod tests {
     }
 
     #[test]
+    fn test_reconstruct_malformed_dict_falls_back_without_panic() {
+        use crate::parser::objects::PdfObject;
+
+        // Issue #351: when the generic dict parse fails (a dictionary the bracket
+        // counter accepted as balanced `<<...>>` but the lexer rejects — here a
+        // dangling key with no value), the reconstruction must not panic and must
+        // still recover the stream via the legacy minimal path. /Length is honored
+        // for the bounded body read; the body must come back intact.
+        let payload = b"0123456789";
+        let len = payload.len();
+        // `/BadKey` has no value before `>>` → parse_with_options errors → fallback.
+        let dict_body = format!(" /Length {len} /BadKey ");
+        let data = build_manual_stream_pdf(&dict_body, payload);
+
+        let mut pdf = PdfReader::new_with_options(Cursor::new(data), ParseOptions::tolerant())
+            .expect("minimal PDF must parse");
+        let obj = pdf
+            .extract_object_or_stream_manually(4)
+            .expect("malformed-dict stream must still be reconstructed via fallback");
+        let stream = match &obj {
+            PdfObject::Stream(s) => s,
+            other => panic!("expected a stream, got {other:?}"),
+        };
+
+        assert_eq!(
+            stream.data, payload,
+            "fallback path must still read the bounded body intact"
+        );
+        // Legacy fallback dict carries no /Filter (none was the Flate literal form).
+        assert!(
+            stream.dict.get("Filter").is_none(),
+            "fallback dict must not invent a /Filter"
+        );
+    }
+
+    #[test]
     fn test_find_page_objects_bounded() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -2138,6 +2138,8 @@ impl<R: Read + Seek> PdfReader<R> {
 
             if let Some(dict_end_pos) = dict_end {
                 let dict_content = String::from_utf8_lossy(&window[dict_start + 2..dict_end_pos]);
+                // Full `<<...>>` slice, for generic re-parsing of the dictionary.
+                let dict_bytes = &window[dict_start..dict_end_pos + 2];
 
                 // Is the dictionary immediately followed by stream data?
                 let after_dict = &window[dict_end_pos + 2..];
@@ -2146,6 +2148,7 @@ impl<R: Read + Seek> PdfReader<R> {
                     let after_dict_abs = obj_offset + (dict_end_pos + 2) as u64;
                     return self.reconstruct_stream_object_bounded(
                         obj_num,
+                        dict_bytes,
                         &dict_content,
                         after_dict_abs,
                         after_dict,
@@ -2179,6 +2182,7 @@ impl<R: Read + Seek> PdfReader<R> {
     fn reconstruct_stream_object_bounded(
         &mut self,
         obj_num: u32,
+        dict_bytes: &[u8],
         dict_content: &str,
         after_dict_abs: u64,
         after_dict: &[u8],
@@ -2186,13 +2190,39 @@ impl<R: Read + Seek> PdfReader<R> {
         use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
         use std::collections::HashMap;
 
-        let mut dict = HashMap::new();
-        if dict_content.contains("/Filter /FlateDecode") {
-            dict.insert(
-                PdfName("Filter".to_string()),
-                PdfObject::Name(PdfName("FlateDecode".to_string())),
+        // Issue #351: reconstruct the FULL stream dictionary by re-parsing the
+        // already-in-memory `<<...>>` bytes with the real object parser, rather than
+        // recognizing only the single hardcoded `/Filter /FlateDecode` form. This
+        // preserves every entry generically — non-Flate filters (`/DCTDecode`,
+        // `/LZWDecode`), filter arrays, `/DecodeParms`, `/Subtype`, `/ColorSpace`,
+        // etc. — which the manual fallback previously dropped, silently corrupting
+        // downstream decoding. The stream body is still read separately and bounded
+        // (Issue #339); only the dictionary construction changed.
+        let opts = self.options.clone();
+        let mut dict: HashMap<PdfName, PdfObject> = {
+            let mut lexer = super::lexer::Lexer::new_with_options(
+                std::io::Cursor::new(dict_bytes),
+                opts.clone(),
             );
-        }
+            match PdfObject::parse_with_options(&mut lexer, &opts) {
+                Ok(PdfObject::Dictionary(d)) => d.0,
+                // The slice ends at `>>`, so no stream body is available here; if the
+                // parser still reports a stream, keep its dictionary.
+                Ok(PdfObject::Stream(s)) => s.dict.0,
+                // Parse failure: fall back to the legacy minimal behavior so this
+                // repair path never regresses below what it preserved before.
+                _ => {
+                    let mut d = HashMap::new();
+                    if dict_content.contains("/Filter /FlateDecode") {
+                        d.insert(
+                            PdfName("Filter".to_string()),
+                            PdfObject::Name(PdfName("FlateDecode".to_string())),
+                        );
+                    }
+                    d
+                }
+            }
+        };
 
         // Resolve the stream length: direct integer, indirect reference, or unknown.
         let length = self.parse_stream_length(dict_content)?;
@@ -2231,7 +2261,16 @@ impl<R: Read + Seek> PdfReader<R> {
             None => {
                 // Unknown length: scan forward in bounded windows to `endstream`,
                 // retaining only the stream bytes (O(stream size), not O(file)).
-                self.read_stream_until_endstream(data_abs)?
+                let body = self.read_stream_until_endstream(data_abs)?;
+                // Pin /Length to the bytes actually read. The generic dict parse may
+                // have carried an unresolvable indirect `/Length N G R`; replacing it
+                // keeps the dictionary consistent with the body and avoids a dangling
+                // reference downstream.
+                dict.insert(
+                    PdfName("Length".to_string()),
+                    PdfObject::Integer(body.len() as i64),
+                );
+                body
             }
         };
 
@@ -3256,6 +3295,130 @@ mod tests {
             total_read <= L + 2 * MANUAL_DICT_WINDOW,
             "manual stream extraction read {total_read} bytes total (file={file_len}); not bounded by object size"
         );
+    }
+
+    /// Build a minimal PDF whose object 4 is a stream reachable only via the manual
+    /// scan fallback (absent from xref), with the given dictionary body and payload.
+    /// Returns the full file bytes. Used by the #351 reconstruction-dict tests.
+    #[cfg(test)]
+    fn build_manual_stream_pdf(obj4_dict_body: &str, payload: &[u8]) -> Vec<u8> {
+        let header = b"%PDF-1.4\n";
+        let obj1 = b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        let obj2 = b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n";
+
+        let mut data = Vec::new();
+        data.extend_from_slice(header);
+        let obj1_start = data.len();
+        data.extend_from_slice(obj1);
+        let obj2_start = data.len();
+        data.extend_from_slice(obj2);
+
+        // Object 4: stream reachable only via the manual scan (not listed in xref).
+        data.extend_from_slice(format!("4 0 obj\n<<{obj4_dict_body}>>\nstream\n").as_bytes());
+        data.extend_from_slice(payload);
+        data.extend_from_slice(b"\nendstream\nendobj\n");
+
+        // xref lists only 0/1/2; startxref at the end so new() parses the file.
+        let xref_start = data.len();
+        let xref = format!(
+            "xref\n0 3\n0000000000 65535 f \n{obj1_start:010} 00000 n \n{obj2_start:010} 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF"
+        );
+        data.extend_from_slice(xref.as_bytes());
+        data
+    }
+
+    #[test]
+    fn test_reconstruct_preserves_non_flate_filter() {
+        use crate::parser::objects::PdfObject;
+
+        // Issue #351: the manual stream reconstruction fallback must preserve the
+        // stream's /Filter generically, not only /FlateDecode. A DCTDecode stream
+        // reached via the manual scan previously lost its /Filter (and /Subtype),
+        // causing downstream to treat compressed bytes as raw — a silent wrong
+        // result. Body content is irrelevant here; the dictionary is the contract.
+        let payload = b"\xff\xd8\xff\xe0not-a-real-jpeg\xff\xd9";
+        let len = payload.len();
+        let dict_body =
+            format!(" /Type /XObject /Subtype /Image /Filter /DCTDecode /Length {len} ");
+        let data = build_manual_stream_pdf(&dict_body, payload);
+
+        let mut pdf = PdfReader::new_with_options(Cursor::new(data), ParseOptions::tolerant())
+            .expect("minimal PDF must parse");
+        let obj = pdf
+            .extract_object_or_stream_manually(4)
+            .expect("stream object 4 must be extracted");
+        let stream = match &obj {
+            PdfObject::Stream(s) => s,
+            other => panic!("expected a stream, got {other:?}"),
+        };
+
+        assert_eq!(
+            stream
+                .dict
+                .get("Filter")
+                .and_then(|o| o.as_name())
+                .map(|n| n.0.as_str()),
+            Some("DCTDecode"),
+            "non-Flate /Filter must be preserved in reconstructed stream dict"
+        );
+        assert_eq!(
+            stream
+                .dict
+                .get("Subtype")
+                .and_then(|o| o.as_name())
+                .map(|n| n.0.as_str()),
+            Some("Image"),
+            "/Subtype must be preserved, not dropped"
+        );
+        assert_eq!(stream.data, payload, "stream body must be intact");
+    }
+
+    #[test]
+    fn test_reconstruct_preserves_filter_array_and_decodeparms() {
+        use crate::parser::objects::PdfObject;
+
+        // Issue #351: filter arrays and /DecodeParms must survive the manual
+        // reconstruction, and the parser must tolerate the no-space `/Filter[`
+        // spacing variant. A LZWDecode→FlateDecode chain with predictor parms is
+        // a realistic case the old hardcoded `/Filter /FlateDecode` match dropped.
+        let payload = b"compressed-bytes-placeholder";
+        let len = payload.len();
+        let dict_body = format!(
+            " /Filter[/LZWDecode /FlateDecode] /DecodeParms[null<< /Predictor 12 /Columns 4 >>] /Length {len} "
+        );
+        let data = build_manual_stream_pdf(&dict_body, payload);
+
+        let mut pdf = PdfReader::new_with_options(Cursor::new(data), ParseOptions::tolerant())
+            .expect("minimal PDF must parse");
+        let obj = pdf
+            .extract_object_or_stream_manually(4)
+            .expect("stream object 4 must be extracted");
+        let stream = match &obj {
+            PdfObject::Stream(s) => s,
+            other => panic!("expected a stream, got {other:?}"),
+        };
+
+        let filter = stream
+            .dict
+            .get("Filter")
+            .and_then(|o| o.as_array())
+            .expect("/Filter array must be preserved");
+        let names: Vec<&str> = filter
+            .0
+            .iter()
+            .filter_map(|o| o.as_name())
+            .map(|n| n.0.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["LZWDecode", "FlateDecode"],
+            "filter array entries must be preserved in order"
+        );
+        assert!(
+            stream.dict.get("DecodeParms").is_some(),
+            "/DecodeParms must be preserved alongside the filter chain"
+        );
+        assert_eq!(stream.data, payload, "stream body must be intact");
     }
 
     #[test]

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -8,7 +8,9 @@ use super::object_stream::ObjectStream;
 use super::objects::{PdfArray, PdfDictionary, PdfObject, PdfString};
 use super::stack_safe::StackSafeContext;
 use super::trailer::PdfTrailer;
-use super::xref::{read_object_window, read_window_at, scan_page_object_refs, XRefTable};
+use super::xref::{
+    find_byte_pattern, read_object_window, read_window_at, scan_page_object_refs, XRefTable,
+};
 use super::{ParseError, ParseResult};
 use crate::objects::ObjectId;
 use std::collections::HashMap;
@@ -21,13 +23,6 @@ use std::path::Path;
 /// object offset, instead of buffering the whole file. Large enough for any
 /// realistic catalog / pages dictionary (incl. multi-thousand-entry `/Kids`).
 const MANUAL_DICT_WINDOW: usize = 256 * 1024;
-
-/// Find a byte pattern in a byte slice
-fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
 
 /// Check if bytes start with "stream" after optional whitespace
 fn is_immediate_stream_start(data: &[u8]) -> bool {
@@ -2114,7 +2109,7 @@ impl<R: Read + Seek> PdfReader<R> {
 
         // The window starts at the "N G obj" header; the object dictionary is the
         // first "<<" that follows.
-        if let Some(dict_start) = find_bytes(&window, b"<<") {
+        if let Some(dict_start) = find_byte_pattern(&window, b"<<") {
             // Handle nested dictionaries properly by counting brackets
             let mut bracket_count = 1;
             let mut pos = dict_start + 2;
@@ -2198,7 +2193,7 @@ impl<R: Read + Seek> PdfReader<R> {
         let length = self.parse_stream_length(dict_content)?;
 
         // Locate "stream" within the bounded window and the first byte of the data.
-        let Some(stream_kw) = find_bytes(after_dict, b"stream") else {
+        let Some(stream_kw) = find_byte_pattern(after_dict, b"stream") else {
             return Err(ParseError::SyntaxError {
                 position: 0,
                 message: format!("Could not reconstruct stream for object {obj_num}"),
@@ -2309,7 +2304,7 @@ impl<R: Read + Seek> PdfReader<R> {
             // Search the freshly added region with an 8-byte overlap so an
             // "endstream" straddling a window boundary is not missed.
             let from = searched.saturating_sub(b"endstream".len() - 1);
-            if let Some(rel) = find_bytes(&acc[from..], b"endstream") {
+            if let Some(rel) = find_byte_pattern(&acc[from..], b"endstream") {
                 acc.truncate(from + rel);
                 break;
             }
@@ -4539,26 +4534,26 @@ startxref
         // =============================================================================
 
         #[test]
-        fn test_find_bytes_basic() {
+        fn test_find_byte_pattern_basic() {
             let haystack = b"Hello World";
             let needle = b"World";
-            let pos = find_bytes(haystack, needle);
+            let pos = find_byte_pattern(haystack, needle);
             assert_eq!(pos, Some(6), "Must find 'World' at position 6");
         }
 
         #[test]
-        fn test_find_bytes_not_found() {
+        fn test_find_byte_pattern_not_found() {
             let haystack = b"Hello World";
             let needle = b"Rust";
-            let pos = find_bytes(haystack, needle);
+            let pos = find_byte_pattern(haystack, needle);
             assert_eq!(pos, None, "Must return None when not found");
         }
 
         #[test]
-        fn test_find_bytes_at_start() {
+        fn test_find_byte_pattern_at_start() {
             let haystack = b"Hello World";
             let needle = b"Hello";
-            let pos = find_bytes(haystack, needle);
+            let pos = find_byte_pattern(haystack, needle);
             assert_eq!(pos, Some(0), "Must find at position 0");
         }
 

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -14,14 +14,13 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 // (Issue #93: Avoid UTF-8 char boundary panics in XRef recovery)
 // ============================================================================
 
-/// Find byte pattern in buffer (replaces String::find for binary-safe searching).
+/// Find a byte pattern in a buffer (replaces `str::find` for binary-safe searching).
+///
+/// Operates on raw bytes, so unlike `str::find` it never panics on UTF-8
+/// boundaries — PDFs are binary and may contain arbitrary byte sequences.
 ///
 /// `pub(crate)` so sibling parser modules (e.g. `reader.rs`) reuse this single
 /// implementation instead of duplicating it (Issue #352).
-///
-/// # Safety
-/// This function operates on raw bytes and never panics on UTF-8 boundaries.
-/// PDFs are binary files and may contain arbitrary byte sequences.
 pub(crate) fn find_byte_pattern(buffer: &[u8], pattern: &[u8]) -> Option<usize> {
     buffer
         .windows(pattern.len())

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -14,12 +14,15 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 // (Issue #93: Avoid UTF-8 char boundary panics in XRef recovery)
 // ============================================================================
 
-/// Find byte pattern in buffer (replaces String::find for binary-safe searching)
+/// Find byte pattern in buffer (replaces String::find for binary-safe searching).
+///
+/// `pub(crate)` so sibling parser modules (e.g. `reader.rs`) reuse this single
+/// implementation instead of duplicating it (Issue #352).
 ///
 /// # Safety
 /// This function operates on raw bytes and never panics on UTF-8 boundaries.
 /// PDFs are binary files and may contain arbitrary byte sequences.
-fn find_byte_pattern(buffer: &[u8], pattern: &[u8]) -> Option<usize> {
+pub(crate) fn find_byte_pattern(buffer: &[u8], pattern: &[u8]) -> Option<usize> {
     buffer
         .windows(pattern.len())
         .position(|window| window == pattern)


### PR DESCRIPTION
## Release 2.16.6

Gitflow release: `release/2.16.6` → `main`.

### Bundle
- **#351** — Recovery path now preserves the full stream dictionary. The manual reconstruction fallback (damaged/absent xref) previously kept only `/Filter /FlateDecode`, dropping non-Flate filters, filter arrays, `/DecodeParms`, `/Subtype`, etc. → silent wrong decode. Now re-parses the dict with the real parser, preserving every entry. Bounded-memory guarantees from #339 unchanged.
- **#352** — Deduplicated `find_bytes`/`find_byte_pattern` into one `pub(crate)` helper. No behavior change.

### Verification
- develop post-merge: lib build clean, reader module 84 tests, t1 corpus 22/0 (pre-merge), 0 regressions.
- Pre-commit green on every commit (fmt + clippy `-D warnings` + lib tests).
- Version bumped 2.16.5 → 2.16.6 (`[workspace.package]`), Cargo.lock + CHANGELOG updated.

After merge: tag `v2.16.6` on main triggers release.yml (auto-publish to crates.io), then back-merge main → develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)