### PR TITLE
Release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [3.0.2] - 2026-06-28
+
+### Fixed
+
+- AES-128 and AES-256 documents written by the crate can now be read back.
+  Previously their encrypted content decrypted to empty (text extraction
+  returned nothing) even with the correct password; RC4-128 was unaffected.
+  Three root causes (#364, reported by @peter-ssk):
+  - **AES-128 (R4)**: the reader chose the cipher by encryption revision and
+    decrypted AESV2 streams with RC4. The cipher is now selected from the
+    `/CFM` crypt filter (`/StmF` → `/CF` → `/CFM`), so real-world R4+RC4 files
+    keep working too.
+  - **AES-256 (R5)**: the writer encrypted objects with a password-derived key
+    instead of the random file key sealed in `/UE`, which the reader recovers;
+    the keys differed. The writer now uses the key sealed in `/UE`.
+  - Decryption failures were swallowed into empty content (silent data loss);
+    the reader now surfaces them as errors.
+- Owner-password unlock of AES-256 documents now works, and unlocking an
+  AES-256 document with a wrong password no longer panics (the R5/R6 owner
+  path was previously unimplemented and fell through to R2–R4 logic).
+
+### Security
+
+- Removed debug `eprintln!` statements that leaked the derived encryption key
+  and user password to stderr in debug builds.
+
 ## [3.0.1] - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/document/encryption.rs
+++ b/oxidize-pdf-core/src/document/encryption.rs
@@ -4,7 +4,7 @@ use crate::encryption::{
     EncryptionDictionary, EncryptionKey, OwnerPassword, Permissions, StandardSecurityHandler,
     UserPassword,
 };
-use crate::error::Result;
+use crate::error::{PdfError, Result};
 use crate::objects::ObjectId;
 
 /// Encryption settings for a document
@@ -144,13 +144,26 @@ impl DocumentEncryption {
         .with_r5_entries(ue_entry, oe_entry))
     }
 
-    /// Get encryption key
+    /// Get the object encryption key used to encrypt streams and strings.
+    ///
+    /// For RC4/AES-128 the key is derived from the password (ISO 32000-1 Algorithm 2).
+    /// For AES-256 (R5) the object key is the random file key **sealed in `/UE`**, not a
+    /// password-derived key — `create_aes256_encryption_dict` generates it randomly and
+    /// the reader recovers it via `recover_r5_encryption_key`. Deriving a password-based
+    /// key here would not match what the reader recovers, so encrypted content would
+    /// decrypt to garbage (issue #364).
     pub fn get_encryption_key(
         &self,
         enc_dict: &EncryptionDictionary,
         file_id: Option<&[u8]>,
     ) -> Result<EncryptionKey> {
         let handler = self.handler();
+        if matches!(self.strength, EncryptionStrength::Aes256) {
+            let ue = enc_dict.ue.as_deref().ok_or_else(|| {
+                PdfError::EncryptionError("AES-256 encryption dict missing UE entry".to_string())
+            })?;
+            return handler.recover_r5_encryption_key(&self.user_password, &enc_dict.u, ue);
+        }
         handler.compute_encryption_key(&self.user_password, &enc_dict.o, self.permissions, file_id)
     }
 }

--- a/oxidize-pdf-core/src/encryption/standard_security.rs
+++ b/oxidize-pdf-core/src/encryption/standard_security.rs
@@ -288,25 +288,6 @@ impl StandardSecurityHandler {
                     data.extend_from_slice(id);
                 }
 
-                #[cfg(debug_assertions)]
-                {
-                    eprintln!("[DEBUG compute_key] padded[0..8]: {:02x?}", &padded[..8]);
-                    eprintln!("[DEBUG compute_key] owner_hash len: {}", owner_hash.len());
-                    eprintln!(
-                        "[DEBUG compute_key] P bytes: {:02x?}",
-                        permissions.bits().to_le_bytes()
-                    );
-                    eprintln!("[DEBUG compute_key] data len before MD5: {}", data.len());
-                    // Print full data for comparison
-                    let data_hex: String = data.iter().map(|b| format!("{:02x}", b)).collect();
-                    eprintln!("[DEBUG compute_key] full data hex: {}", data_hex);
-
-                    // Verify specific expected hash for debugging
-                    if data_hex == "7573657228bf4e5e4e758a4164004e56fffa01082e2e00b6d0683e802f0ca9fe94e8094419662a774442fb072e3d9f19e9d130ec09a4d0061e78fe920f7ab62ffcffffff9c5b2a0606f918182e6c5cc0cac374d6" {
-                        eprintln!("[DEBUG compute_key] DATA MATCHES EXPECTED - should produce eee5568378306e35...");
-                    }
-                }
-
                 // For R4 with metadata not encrypted, add extra bytes
                 if self.revision == SecurityHandlerRevision::R4 {
                     // In a full implementation, check EncryptMetadata flag
@@ -315,17 +296,6 @@ impl StandardSecurityHandler {
 
                 // Step 3: Create MD5 hash
                 let mut hash = md5::compute(&data).to_vec();
-
-                #[cfg(debug_assertions)]
-                {
-                    eprintln!(
-                        "[DEBUG compute_key] initial hash[0..8]: {:02x?}",
-                        &hash[..8]
-                    );
-                    let hash_hex: String = hash.iter().map(|b| format!("{:02x}", b)).collect();
-                    eprintln!("[DEBUG compute_key] full hash: {}", hash_hex);
-                    eprintln!("[DEBUG compute_key] key_length: {}", self.key_length);
-                }
 
                 // Step 4: For revision 3+, do 50 additional iterations
                 if self.revision >= SecurityHandlerRevision::R3 {
@@ -336,11 +306,6 @@ impl StandardSecurityHandler {
 
                 // Step 5: Truncate to key length
                 hash.truncate(self.key_length);
-
-                #[cfg(debug_assertions)]
-                {
-                    eprintln!("[DEBUG compute_key] final key: {:02x?}", &hash);
-                }
 
                 Ok(EncryptionKey::new(hash))
             }
@@ -365,20 +330,49 @@ impl StandardSecurityHandler {
         }
     }
 
-    /// Decrypt a string
-    pub fn decrypt_string(&self, data: &[u8], key: &EncryptionKey, obj_id: &ObjectId) -> Vec<u8> {
+    /// Decrypt a string, propagating any decryption error (issue #364).
+    ///
+    /// Prefer this over [`decrypt_string`](Self::decrypt_string) on read paths:
+    /// the latter swallows AES failures into an empty `Vec`, turning corruption
+    /// or a wrong key into *silent data loss* instead of a surfaced error.
+    ///
+    /// `pub(crate)`: an internal read-path helper, not part of the public API.
+    pub(crate) fn try_decrypt_string(
+        &self,
+        data: &[u8],
+        key: &EncryptionKey,
+        obj_id: &ObjectId,
+    ) -> Result<Vec<u8>> {
         match self.revision {
             SecurityHandlerRevision::R4
             | SecurityHandlerRevision::R5
-            | SecurityHandlerRevision::R6 => {
-                // AES path for R4 (AES-128) and R5/R6 (AES-256)
-                self.decrypt_aes(data, key, obj_id).unwrap_or_default()
-            }
-            _ => {
-                // RC4 is symmetric
-                self.encrypt_string(data, key, obj_id)
-            }
+            | SecurityHandlerRevision::R6 => self.decrypt_aes(data, key, obj_id),
+            // RC4 is symmetric and cannot fail (no padding/auth).
+            _ => Ok(self.encrypt_string(data, key, obj_id)),
         }
+    }
+
+    /// Decrypt a stream, propagating any decryption error (issue #364).
+    ///
+    /// See [`try_decrypt_string`](Self::try_decrypt_string) for why read paths
+    /// should use this instead of [`decrypt_stream`](Self::decrypt_stream).
+    ///
+    /// `pub(crate)`: an internal read-path helper, not part of the public API.
+    pub(crate) fn try_decrypt_stream(
+        &self,
+        data: &[u8],
+        key: &EncryptionKey,
+        obj_id: &ObjectId,
+    ) -> Result<Vec<u8>> {
+        // Streams and strings share the same per-object cipher.
+        self.try_decrypt_string(data, key, obj_id)
+    }
+
+    /// Decrypt a string. Lenient: a decryption failure yields an empty `Vec`.
+    /// New code should use [`try_decrypt_string`](Self::try_decrypt_string).
+    pub fn decrypt_string(&self, data: &[u8], key: &EncryptionKey, obj_id: &ObjectId) -> Vec<u8> {
+        self.try_decrypt_string(data, key, obj_id)
+            .unwrap_or_default()
     }
 
     /// Encrypt a stream
@@ -386,20 +380,11 @@ impl StandardSecurityHandler {
         self.encrypt_string(data, key, obj_id)
     }
 
-    /// Decrypt a stream
+    /// Decrypt a stream. Lenient: a decryption failure yields an empty `Vec`.
+    /// New code should use [`try_decrypt_stream`](Self::try_decrypt_stream).
     pub fn decrypt_stream(&self, data: &[u8], key: &EncryptionKey, obj_id: &ObjectId) -> Vec<u8> {
-        match self.revision {
-            SecurityHandlerRevision::R4
-            | SecurityHandlerRevision::R5
-            | SecurityHandlerRevision::R6 => {
-                // AES path for R4 (AES-128) and R5/R6 (AES-256)
-                self.decrypt_aes(data, key, obj_id).unwrap_or_default()
-            }
-            _ => {
-                // RC4 is symmetric
-                self.decrypt_string(data, key, obj_id)
-            }
-        }
+        self.try_decrypt_stream(data, key, obj_id)
+            .unwrap_or_default()
     }
 
     /// Encrypt data using AES.
@@ -2383,6 +2368,46 @@ mod tests {
         let encrypted = handler.encrypt_string(data, &key, &obj_id);
         let decrypted = handler.decrypt_string(&encrypted, &key, &obj_id);
         assert_eq!(decrypted.as_slice(), data);
+    }
+
+    // Issue #364: a failed AES decryption must surface as an error, not be
+    // swallowed into empty content (silent data loss). The `try_*` variants
+    // propagate the error; the legacy `Vec`-returning ones keep the lenient
+    // behaviour for backward compatibility.
+    #[test]
+    fn test_try_decrypt_stream_surfaces_aes_error() {
+        let handler = StandardSecurityHandler::aes_128_r4();
+        let key = EncryptionKey::new(vec![0x11; 16]);
+        let obj_id = ObjectId::new(1, 0);
+
+        // Too short to even contain the 16-byte AES IV → must error.
+        let undecryptable = [0u8; 8];
+
+        let err = handler.try_decrypt_stream(&undecryptable, &key, &obj_id);
+        assert!(
+            err.is_err(),
+            "try_decrypt_stream must return Err on undecryptable AES data, got {err:?}"
+        );
+
+        // The legacy lenient API still swallows into empty Vec (documents the
+        // behaviour the parser path no longer relies on).
+        let lenient = handler.decrypt_stream(&undecryptable, &key, &obj_id);
+        assert!(lenient.is_empty());
+    }
+
+    #[test]
+    fn test_try_decrypt_string_surfaces_aes_error() {
+        let handler = StandardSecurityHandler::aes_128_r4();
+        let key = EncryptionKey::new(vec![0x22; 16]);
+        let obj_id = ObjectId::new(2, 0);
+
+        let undecryptable = [0u8; 4];
+        assert!(
+            handler
+                .try_decrypt_string(&undecryptable, &key, &obj_id)
+                .is_err(),
+            "try_decrypt_string must return Err on undecryptable AES data"
+        );
     }
 
     // ===== SHA-256/512 NIST Vector Tests (Phase 1.3 - RustCrypto Integration) =====

--- a/oxidize-pdf-core/src/parser/encryption_handler.rs
+++ b/oxidize-pdf-core/src/parser/encryption_handler.rs
@@ -6,12 +6,17 @@
 use super::objects::PdfDictionary;
 use super::{ParseError, ParseResult};
 use crate::encryption::{
-    EncryptionKey, Permissions, Rc4, Rc4Key, StandardSecurityHandler, UserPassword,
+    EncryptionKey, OwnerPassword, Permissions, Rc4, Rc4Key, StandardSecurityHandler, UserPassword,
 };
 use crate::objects::ObjectId;
 
-/// Encryption information extracted from PDF trailer
+/// Encryption information extracted from PDF trailer.
+///
+/// `#[non_exhaustive]`: this is parser output, not meant to be constructed by
+/// downstream code. The attribute lets future fields (like `cfm`, added for
+/// issue #364) be added without a breaking change.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EncryptionInfo {
     /// Filter name (should be "Standard")
     pub filter: String,
@@ -31,6 +36,12 @@ pub struct EncryptionInfo {
     pub ue: Option<Vec<u8>>,
     /// OE entry (encrypted owner key, R5/R6 only)
     pub oe: Option<Vec<u8>>,
+    /// Stream crypt filter method (/CFM of the filter named by /StmF), V>=4 only.
+    /// One of "V2" (RC4), "AESV2" (AES-128), "AESV3" (AES-256), "Identity".
+    /// Determines the cipher for revision 4, where R alone is ambiguous.
+    ///
+    /// `pub(crate)`: internal cipher-selection input, not part of the public API.
+    pub(crate) cfm: Option<String>,
 }
 
 /// PDF Encryption Handler
@@ -50,10 +61,22 @@ impl EncryptionHandler {
     pub fn new(encrypt_dict: &PdfDictionary, file_id: Option<Vec<u8>>) -> ParseResult<Self> {
         let encryption_info = Self::parse_encryption_dict(encrypt_dict)?;
 
-        // Create appropriate security handler based on revision
+        // Create the security handler. For V>=4 the cipher is determined by the
+        // stream crypt filter method (/CFM), not by the revision: R4 may be either
+        // RC4 (/V2) or AES-128 (/AESV2). Selecting by revision alone decrypts
+        // AES-128 streams with RC4 → garbage (issue #364).
         let security_handler = match encryption_info.r {
             2 => StandardSecurityHandler::rc4_40bit(),
-            3 | 4 => StandardSecurityHandler::rc4_128bit(),
+            3 => StandardSecurityHandler::rc4_128bit(),
+            4 => match encryption_info.cfm.as_deref() {
+                // RC4-128 crypt filter under R4 (legacy, but valid).
+                Some("V2") => StandardSecurityHandler::rc4_128bit(),
+                // AES-128 is the conventional R4 cipher and what this crate writes.
+                // Default to it for /AESV2, a missing /CFM, or any other value: R4
+                // construction must stay infallible (it always built a handler
+                // before #364), so non-RC4 cases fall back to AES rather than error.
+                _ => StandardSecurityHandler::aes_128_r4(),
+            },
             5 => StandardSecurityHandler::aes_256_r5(),
             6 => StandardSecurityHandler::aes_256_r6(),
             _ => {
@@ -143,6 +166,14 @@ impl EncryptionHandler {
             .and_then(|obj| obj.as_string())
             .map(|s| s.as_bytes().to_vec());
 
+        // Get the stream crypt filter method (V>=4). For V<4 the cipher is fixed
+        // by V/R (RC4), so /CF is absent and cfm stays None.
+        let cfm = if v >= 4 {
+            Self::parse_stream_cfm(dict)
+        } else {
+            None
+        };
+
         Ok(EncryptionInfo {
             filter: filter.to_string(),
             v,
@@ -153,7 +184,32 @@ impl EncryptionHandler {
             length,
             ue,
             oe,
+            cfm,
         })
+    }
+
+    /// Resolve the crypt filter method (/CFM) of the filter named by /StmF.
+    ///
+    /// `/Encrypt` carries `/CF << /StdCF << /CFM /AESV2 >> >>` and `/StmF /StdCF`.
+    /// Returns the CFM name (e.g. "AESV2", "V2"), or "Identity" when streams are
+    /// not encrypted, or None when no crypt filter is declared.
+    fn parse_stream_cfm(dict: &PdfDictionary) -> Option<String> {
+        let stmf = dict
+            .get("StmF")
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.as_str())
+            .unwrap_or("Identity"); // ISO 32000-1 §7.6.5: default /StmF is Identity
+
+        if stmf == "Identity" {
+            return Some("Identity".to_string());
+        }
+
+        let cf = dict.get("CF").and_then(|o| o.as_dict())?;
+        cf.get(stmf)
+            .and_then(|o| o.as_dict())
+            .and_then(|f| f.get("CFM"))
+            .and_then(|o| o.as_name())
+            .map(|n| n.0.clone())
     }
 
     /// Check if PDF is encrypted by looking for Encrypt entry in trailer
@@ -273,6 +329,70 @@ impl EncryptionHandler {
         Ok(is_valid)
     }
 
+    /// R5/R6 owner password unlock (SHA-256/AES-256 based per ISO 32000-2).
+    ///
+    /// Mirrors [`unlock_user_r5_r6`](Self::unlock_user_r5_r6) but validates the
+    /// owner password against the `/O` entry and recovers the file key from `/OE`.
+    fn unlock_owner_r5_r6(&mut self, owner_password: &OwnerPassword) -> ParseResult<bool> {
+        let o_entry = self.encryption_info.o.clone();
+        let u_entry = self.encryption_info.u.clone();
+
+        let is_valid = if self.encryption_info.r == 5 {
+            self.security_handler
+                .validate_r5_owner_password(owner_password, &o_entry)
+        } else {
+            self.security_handler
+                .validate_r6_owner_password(owner_password, &o_entry, &u_entry)
+        }
+        .map_err(|e| ParseError::SyntaxError {
+            position: 0,
+            message: format!(
+                "Failed to validate R{} owner password: {e}",
+                self.encryption_info.r
+            ),
+        })?;
+
+        if is_valid {
+            let oe_entry =
+                self.encryption_info
+                    .oe
+                    .as_deref()
+                    .ok_or_else(|| ParseError::SyntaxError {
+                        position: 0,
+                        message: format!(
+                            "R{} encryption requires OE entry but it is missing",
+                            self.encryption_info.r
+                        ),
+                    })?;
+
+            let key = if self.encryption_info.r == 5 {
+                self.security_handler.recover_r5_owner_encryption_key(
+                    owner_password,
+                    &o_entry,
+                    oe_entry,
+                )
+            } else {
+                self.security_handler.recover_r6_owner_encryption_key(
+                    owner_password,
+                    &o_entry,
+                    &u_entry,
+                    oe_entry,
+                )
+            }
+            .map_err(|e| ParseError::SyntaxError {
+                position: 0,
+                message: format!(
+                    "Failed to recover R{} owner encryption key: {e}",
+                    self.encryption_info.r
+                ),
+            })?;
+
+            self.encryption_key = Some(EncryptionKey::new(key));
+        }
+
+        Ok(is_valid)
+    }
+
     /// Try to unlock PDF with owner password
     ///
     /// Owner password authentication works by:
@@ -280,6 +400,13 @@ impl EncryptionHandler {
     /// 2. Decrypting the O entry to recover the user password
     /// 3. Using the recovered user password to compute the encryption key
     pub fn unlock_with_owner_password(&mut self, password: &str) -> ParseResult<bool> {
+        // R5/R6 (AES-256) use a completely different owner-password algorithm.
+        // The MD5/RC4 path below assumes key_length <= 16 (MD5 output); for R5/R6
+        // key_length is 32, so `hash[..key_length]` would panic. Dispatch first.
+        if self.encryption_info.r >= 5 {
+            return self.unlock_owner_r5_r6(&OwnerPassword(password.to_string()));
+        }
+
         // Standard 32-byte padding from PDF spec
         const PADDING: [u8; 32] = [
             0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41, 0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA,
@@ -340,18 +467,6 @@ impl EncryptionHandler {
 
         let user_password = String::from_utf8_lossy(&decrypted[..user_pwd_end]).to_string();
 
-        #[cfg(debug_assertions)]
-        {
-            eprintln!(
-                "[DEBUG owner unlock] derived user password: {:?}",
-                &user_password
-            );
-            eprintln!(
-                "[DEBUG owner unlock] decrypted bytes: {:02x?}",
-                &decrypted[..8]
-            );
-        }
-
         // Step 6: Try to unlock with the derived user password
         if self.unlock_with_user_password(&user_password)? {
             return Ok(true);
@@ -378,18 +493,36 @@ impl EncryptionHandler {
         self.encryption_key.as_ref()
     }
 
-    /// Decrypt a string object
+    /// Decrypt a string object.
+    ///
+    /// Uses the error-propagating `try_*` variant so an AES decryption failure
+    /// surfaces as an error rather than silently yielding empty content (#364).
     pub fn decrypt_string(&self, data: &[u8], obj_id: &ObjectId) -> ParseResult<Vec<u8>> {
         match &self.encryption_key {
-            Some(key) => Ok(self.security_handler.decrypt_string(data, key, obj_id)),
+            Some(key) => self
+                .security_handler
+                .try_decrypt_string(data, key, obj_id)
+                .map_err(|e| ParseError::SyntaxError {
+                    position: 0,
+                    message: format!("Failed to decrypt string for object {obj_id:?}: {e}"),
+                }),
             None => Err(ParseError::EncryptionNotSupported),
         }
     }
 
-    /// Decrypt a stream object
+    /// Decrypt a stream object.
+    ///
+    /// Uses the error-propagating `try_*` variant so an AES decryption failure
+    /// surfaces as an error rather than silently yielding empty content (#364).
     pub fn decrypt_stream(&self, data: &[u8], obj_id: &ObjectId) -> ParseResult<Vec<u8>> {
         match &self.encryption_key {
-            Some(key) => Ok(self.security_handler.decrypt_stream(data, key, obj_id)),
+            Some(key) => self
+                .security_handler
+                .try_decrypt_stream(data, key, obj_id)
+                .map_err(|e| ParseError::SyntaxError {
+                    position: 0,
+                    message: format!("Failed to decrypt stream for object {obj_id:?}: {e}"),
+                }),
             None => Err(ParseError::EncryptionNotSupported),
         }
     }
@@ -402,7 +535,11 @@ impl EncryptionHandler {
         ) {
             (2, _) => "RC4 40-bit".to_string(),
             (3, len) => format!("RC4 {len}-bit"),
-            (4, len) => format!("RC4 {len}-bit with metadata control"),
+            // R4 may be RC4 or AES-128 depending on the /CFM crypt filter (#364).
+            (4, len) => match self.encryption_info.cfm.as_deref() {
+                Some("V2") => format!("RC4 {len}-bit with metadata control"),
+                _ => "AES-128 (Revision 4)".to_string(),
+            },
             (5, _) => "AES-256 (Revision 5)".to_string(),
             (6, _) => "AES-256 (Revision 6, Unicode passwords)".to_string(),
             (r, len) => format!("Unknown revision {r} with {len}-bit key"),
@@ -588,6 +725,67 @@ mod tests {
         assert_eq!(info.o.len(), 32);
         assert_eq!(info.u.len(), 32);
         assert_eq!(info.p, -4);
+        // V<4 has no crypt filters → cfm is None.
+        assert_eq!(info.cfm, None);
+    }
+
+    /// Build a V=4/R=4 encryption dict whose StdCF crypt filter uses `cfm`.
+    fn create_v4_encryption_dict(cfm: &str) -> PdfDictionary {
+        let mut dict = PdfDictionary::new();
+        dict.insert(
+            "Filter".to_string(),
+            PdfObject::Name(PdfName("Standard".to_string())),
+        );
+        dict.insert("V".to_string(), PdfObject::Integer(4));
+        dict.insert("R".to_string(), PdfObject::Integer(4));
+        dict.insert("Length".to_string(), PdfObject::Integer(128));
+        dict.insert(
+            "O".to_string(),
+            PdfObject::String(PdfString::new(vec![0u8; 32])),
+        );
+        dict.insert(
+            "U".to_string(),
+            PdfObject::String(PdfString::new(vec![0u8; 32])),
+        );
+        dict.insert("P".to_string(), PdfObject::Integer(-4));
+
+        let mut std_cf = PdfDictionary::new();
+        std_cf.insert("CFM".to_string(), PdfObject::Name(PdfName(cfm.to_string())));
+        let mut cf = PdfDictionary::new();
+        cf.insert("StdCF".to_string(), PdfObject::Dictionary(std_cf));
+        dict.insert("CF".to_string(), PdfObject::Dictionary(cf));
+        dict.insert(
+            "StmF".to_string(),
+            PdfObject::Name(PdfName("StdCF".to_string())),
+        );
+        dict
+    }
+
+    #[test]
+    fn test_cfm_parsed_from_crypt_filter() {
+        // Issue #364: R4 cipher is decided by /CFM, not the revision.
+        let aes =
+            EncryptionHandler::parse_encryption_dict(&create_v4_encryption_dict("AESV2")).unwrap();
+        assert_eq!(aes.cfm.as_deref(), Some("AESV2"));
+
+        let rc4 =
+            EncryptionHandler::parse_encryption_dict(&create_v4_encryption_dict("V2")).unwrap();
+        assert_eq!(rc4.cfm.as_deref(), Some("V2"));
+    }
+
+    #[test]
+    fn test_r4_algorithm_info_reflects_cipher() {
+        // AESV2 under R4 must report AES-128, not RC4 (#364).
+        let aes = EncryptionHandler::new(&create_v4_encryption_dict("AESV2"), None).unwrap();
+        assert_eq!(aes.algorithm_info(), "AES-128 (Revision 4)");
+
+        // A legacy R4 PDF using the V2 (RC4) crypt filter still reports RC4.
+        let rc4 = EncryptionHandler::new(&create_v4_encryption_dict("V2"), None).unwrap();
+        assert!(
+            rc4.algorithm_info().starts_with("RC4"),
+            "got: {}",
+            rc4.algorithm_info()
+        );
     }
 
     #[test]
@@ -833,15 +1031,14 @@ mod tests {
         let handler = EncryptionHandler::new(&dict, None).unwrap();
         assert_eq!(handler.algorithm_info(), "RC4 128-bit");
 
-        // Test Rev 4 (128-bit with metadata control)
+        // Test Rev 4 without a V2 crypt filter → AES-128 (the conventional R4
+        // cipher and this crate's default). A legacy RC4 R4 PDF would carry an
+        // explicit /CFM /V2 crypt filter; see test_r4_algorithm_info_reflects_cipher.
         let mut dict = create_test_encryption_dict();
         dict.insert("R".to_string(), PdfObject::Integer(4));
         dict.insert("Length".to_string(), PdfObject::Integer(128));
         let handler = EncryptionHandler::new(&dict, None).unwrap();
-        assert_eq!(
-            handler.algorithm_info(),
-            "RC4 128-bit with metadata control"
-        );
+        assert_eq!(handler.algorithm_info(), "AES-128 (Revision 4)");
 
         // Test Rev 5 (AES-256)
         let mut dict = create_test_encryption_dict();

--- a/oxidize-pdf-core/tests/encryption_write_test.rs
+++ b/oxidize-pdf-core/tests/encryption_write_test.rs
@@ -1,8 +1,9 @@
 use oxidize_pdf::document::{DocumentEncryption, EncryptionStrength};
 use oxidize_pdf::encryption::Permissions;
 use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::ExtractionOptions;
 use oxidize_pdf::writer::PdfWriter;
-use oxidize_pdf::{Document, Page};
+use oxidize_pdf::{Document, Font, Page};
 use std::io::Cursor;
 
 // ── Fase 2: Writer must emit /Encrypt and /ID in trailer ────────────────
@@ -386,5 +387,144 @@ fn test_aes128_content_is_encrypted() {
     assert!(
         !content.contains("SECRET_AES128_MARKER"),
         "AES-128 encrypted PDF must not contain plaintext content — objects are not being encrypted"
+    );
+}
+
+// ── Issue #364: full round-trip — content must be recoverable after unlock ──
+// The Fase 6 tests above stop at unlock() and never extract content, so the
+// broken decryption path was untested. These assert the marker survives a
+// write → read → unlock → extract round-trip for every cipher.
+
+const ROUNDTRIP_MARKER: &str = "ROUNDTRIP_MARKER_42";
+
+/// Write a single-page PDF containing the marker, optionally encrypted, then
+/// read it back, unlock, and extract the text of page 0.
+fn roundtrip_extract(strength: Option<EncryptionStrength>) -> String {
+    let mut doc = Document::new();
+    let mut page = Page::new(595.0, 842.0);
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(72.0, 760.0)
+        .write(ROUNDTRIP_MARKER)
+        .unwrap();
+    doc.add_page(page);
+    if let Some(s) = strength {
+        doc.set_encryption(DocumentEncryption::new("u", "o", Permissions::all(), s));
+    }
+
+    let bytes = doc.to_bytes().expect("write document");
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse written PDF");
+    if reader.is_encrypted() {
+        reader
+            .unlock_with_password("u")
+            .expect("unlock with correct user password");
+    }
+    let pdfdoc = reader.into_document();
+    pdfdoc
+        .extract_text_from_page_with_options(0, ExtractionOptions::default())
+        .expect("extract text")
+        .text
+}
+
+#[test]
+fn test_roundtrip_plaintext_baseline() {
+    let text = roundtrip_extract(None);
+    assert!(
+        text.contains(ROUNDTRIP_MARKER),
+        "plaintext round-trip must recover the marker, got: {text:?}"
+    );
+}
+
+#[test]
+fn test_roundtrip_rc4_128_baseline() {
+    let text = roundtrip_extract(Some(EncryptionStrength::Rc4_128bit));
+    assert!(
+        text.contains(ROUNDTRIP_MARKER),
+        "RC4-128 round-trip must recover the marker, got: {text:?}"
+    );
+}
+
+#[test]
+fn test_roundtrip_aes128_recovers_content() {
+    let text = roundtrip_extract(Some(EncryptionStrength::Aes128));
+    assert!(
+        text.contains(ROUNDTRIP_MARKER),
+        "AES-128 round-trip must recover the marker after unlock, got: {text:?}"
+    );
+}
+
+#[test]
+fn test_roundtrip_aes256_recovers_content() {
+    let text = roundtrip_extract(Some(EncryptionStrength::Aes256));
+    assert!(
+        text.contains(ROUNDTRIP_MARKER),
+        "AES-256 round-trip must recover the marker after unlock, got: {text:?}"
+    );
+}
+
+/// A wrong password must not unlock an AES-256 document (it must report failure,
+/// not silently yield a usable-but-empty reader). Guards against the unlock path
+/// masking a decryption-key mismatch.
+#[test]
+fn test_roundtrip_aes256_wrong_password_does_not_unlock() {
+    let mut doc = Document::new();
+    let mut page = Page::new(595.0, 842.0);
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(72.0, 760.0)
+        .write(ROUNDTRIP_MARKER)
+        .unwrap();
+    doc.add_page(page);
+    doc.set_encryption(DocumentEncryption::new(
+        "u",
+        "o",
+        Permissions::all(),
+        EncryptionStrength::Aes256,
+    ));
+
+    let bytes = doc.to_bytes().expect("write document");
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse written PDF");
+    assert!(reader.is_encrypted());
+
+    let unlocked = reader
+        .unlock_with_password("definitely-wrong")
+        .expect("unlock attempt itself must not error");
+    assert!(!unlocked, "a wrong password must not unlock the document");
+}
+
+/// The owner password must also unlock an AES-256 document and recover content
+/// (exercises the R5 owner-password path: validate /O, recover key from /OE).
+#[test]
+fn test_roundtrip_aes256_owner_password_recovers_content() {
+    let mut doc = Document::new();
+    let mut page = Page::new(595.0, 842.0);
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(72.0, 760.0)
+        .write(ROUNDTRIP_MARKER)
+        .unwrap();
+    doc.add_page(page);
+    doc.set_encryption(DocumentEncryption::new(
+        "u",
+        "owner-secret",
+        Permissions::all(),
+        EncryptionStrength::Aes256,
+    ));
+
+    let bytes = doc.to_bytes().expect("write document");
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse written PDF");
+    let unlocked = reader
+        .unlock_with_password("owner-secret")
+        .expect("owner unlock must not error");
+    assert!(unlocked, "owner password must unlock the document");
+
+    let pdfdoc = reader.into_document();
+    let text = pdfdoc
+        .extract_text_from_page_with_options(0, ExtractionOptions::default())
+        .expect("extract text")
+        .text;
+    assert!(
+        text.contains(ROUNDTRIP_MARKER),
+        "owner-unlocked AES-256 must recover the marker, got: {text:?}"
     );
 }


### PR DESCRIPTION
Release **v3.0.2** (PATCH).

## Included
- **#364** — AES-128/AES-256 written documents could not be read back (content decrypted to empty). Three root causes fixed: R4 cipher now selected by `/CFM` crypt filter (not revision); AES-256 writer uses the key sealed in `/UE`; decryption failures surface as errors instead of silent empty content. Also fixes a reachable panic on wrong-password AES-256 (adds R5/R6 owner-password unlock) and removes debug `eprintln!` that leaked key/password material. Reporter: @peter-ssk.

## SemVer
PATCH — no public API change (new helpers and the `cfm` field are `pub(crate)`).

## Verification
lib 6595/0, full encryption suite green, clippy `--lib --all-features` clean, MSRV 1.88 lib+tests compile. CI green on PR #365 (merged to develop).

After merge: tag `v3.0.2` on main triggers `release.yml` → crates.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)