### PR TITLE
feat(pipeline): run AnalysisPipeline over caller-provided elements (#360)

### DIFF
--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1514,11 +1514,40 @@ impl<R: Read + Seek> PdfDocument<R> {
         &self,
         pipeline: &crate::pipeline::AnalysisPipeline,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let elements = self.partition_with(pipeline.partition_config.clone())?;
+        self.rag_chunks_from_elements(elements, pipeline)
+    }
+
+    /// Run a custom [`AnalysisPipeline`](crate::pipeline::AnalysisPipeline)
+    /// (classify → chunk → enrich) over **caller-provided** elements, instead of
+    /// the document's own partition.
+    ///
+    /// This is the element-source seam behind
+    /// [`rag_chunks_with_pipeline`](Self::rag_chunks_with_pipeline), which is
+    /// exactly `self.rag_chunks_from_elements(self.partition_with(cfg)?, pipeline)`.
+    /// Use it to feed externally-recovered elements (e.g. list items a two-column
+    /// layout scrambles past the partitioner) into the same enriched chunk flow
+    /// as the rest of the document — with uniform classification and enrichment,
+    /// avoiding the `RagChunk` metadata-stamping workaround that bypasses both
+    /// (issue #360). Partitioned and recovered elements can be mixed freely.
+    ///
+    /// The pipeline's [`PartitionConfig`](crate::pipeline::PartitionConfig) is not
+    /// consulted here — the caller has already chosen the elements. The pipeline's
+    /// [`source`](crate::pipeline::AnalysisPipeline::with_source), when set, is
+    /// still autofilled from this document (title/author/page count) and stamped
+    /// onto the chunks, exactly as in `rag_chunks_with_pipeline`.
+    ///
+    /// **Stability:** requires `unstable-spi`; exempt from semver until promoted.
+    #[cfg(feature = "unstable-spi")]
+    pub fn rag_chunks_from_elements(
+        &self,
+        mut elements: Vec<crate::pipeline::Element>,
+        pipeline: &crate::pipeline::AnalysisPipeline,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let mut source = pipeline.source.clone();
         if let Some(src) = source.as_mut() {
             self.autofill_source(src);
         }
-        let mut elements = self.partition_with(pipeline.partition_config.clone())?;
         if let Some(classifier) = pipeline.classifier.as_deref() {
             // Two passes: read labels against an immutable slice, then apply —
             // the classifier inspects neighbours via `ClassifyContext`, so it

--- a/oxidize-pdf-core/tests/issue_360_rag_chunks_from_elements_test.rs
+++ b/oxidize-pdf-core/tests/issue_360_rag_chunks_from_elements_test.rs
@@ -1,0 +1,168 @@
+//! Issue #360: expose a public way to run a custom `AnalysisPipeline`
+//! (classifier → chunking → enrichers) over caller-provided `Element`s, instead
+//! of forcing the element source to be the document's own `partition_with`.
+//!
+//! This lets a consumer feed externally-recovered elements (e.g. list items a
+//! two-column layout scrambles past the partitioner) into the same enriched
+//! chunk flow as the rest of the document — without the `RagChunk`
+//! metadata-stamping workaround, which bypasses the classifier and enrichers.
+//!
+//! Contract under test:
+//! - `rag_chunks_from_elements(elements, pipeline)` runs the classify→chunk→
+//!   enrich stages over exactly the caller's `elements`.
+//! - `rag_chunks_with_pipeline(pipeline)` is behaviourally
+//!   `rag_chunks_from_elements(partition_with(pipeline.partition_config), pipeline)`,
+//!   i.e. the existing path is preserved.
+#![cfg(feature = "unstable-spi")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{
+    AnalysisPipeline, ClassLabel, ClassifyContext, Element, ElementClassifier, ElementData,
+    ElementMetadata, PartitionConfig, RagChunk,
+};
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+fn open() -> PdfDocument<std::fs::File> {
+    PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"))
+}
+
+fn texts(chunks: &[RagChunk]) -> Vec<String> {
+    chunks.iter().map(|c| c.text.clone()).collect()
+}
+
+/// A classifier that records how many elements it was asked to classify.
+struct CountingClassifier(Arc<AtomicUsize>);
+
+impl ElementClassifier for CountingClassifier {
+    fn classify(&self, _element: &Element, _ctx: &ClassifyContext) -> Option<ClassLabel> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        None
+    }
+}
+
+#[test]
+fn rag_chunks_from_elements_matches_pipeline_over_the_same_partition() {
+    let doc = open();
+    let pipeline = AnalysisPipeline::new();
+
+    // The existing entry point: it partitions internally with the default config.
+    let via_partition = doc
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+
+    // The new entry point fed the *same* elements the existing path would derive.
+    let elements = doc
+        .partition_with(PartitionConfig::default())
+        .expect("partition_with(default)");
+    let via_elements = doc
+        .rag_chunks_from_elements(elements, &pipeline)
+        .expect("rag_chunks_from_elements");
+
+    assert!(
+        !via_partition.is_empty(),
+        "partition path produced no chunks"
+    );
+    assert_eq!(
+        texts(&via_partition),
+        texts(&via_elements),
+        "rag_chunks_from_elements over the default partition must reproduce \
+         rag_chunks_with_pipeline exactly"
+    );
+}
+
+#[test]
+fn rag_chunks_from_elements_runs_over_caller_elements_not_the_partition() {
+    let doc = open();
+
+    // Caller provides a deliberately small, hand-trimmed element set — far fewer
+    // than the document's full partition.
+    let all = doc
+        .partition_with(PartitionConfig::default())
+        .expect("partition_with(default)");
+    let full_len = all.len();
+    let provided: Vec<Element> = all.into_iter().take(3).collect();
+    assert!(
+        full_len > provided.len(),
+        "fixture must have more than {} partitioned elements (got {})",
+        provided.len(),
+        full_len
+    );
+
+    // The classifier stage must see exactly the caller's elements, proving the
+    // element source is the provided vector and not the document partition.
+    let counter = Arc::new(AtomicUsize::new(0));
+    let pipeline =
+        AnalysisPipeline::new().with_classifier(Box::new(CountingClassifier(counter.clone())));
+
+    let chunks = doc
+        .rag_chunks_from_elements(provided, &pipeline)
+        .expect("rag_chunks_from_elements");
+
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        3,
+        "classifier ran over {} elements but the caller provided 3 — the \
+         partition was used instead of the provided elements",
+        counter.load(Ordering::Relaxed)
+    );
+    assert!(
+        !chunks.is_empty(),
+        "three real elements should still yield at least one chunk"
+    );
+}
+
+#[test]
+fn rag_chunks_from_elements_carries_synthetic_recovered_content() {
+    // The motivating use case (#360): mix the document's partitioned elements
+    // with an externally-recovered element the partitioner never produced (e.g.
+    // a list item a two-column layout scrambled), and get it into the same
+    // enriched chunk flow. The recovered text must reach the output chunks.
+    let doc = open();
+
+    let mut elements: Vec<Element> = doc
+        .partition_with(PartitionConfig::default())
+        .expect("partition_with(default)")
+        .into_iter()
+        .take(2)
+        .collect();
+
+    const RECOVERED: &str = "RECOVERED_LIST_ITEM_scrambled_by_two_column_layout";
+    elements.push(Element::Paragraph(ElementData {
+        text: RECOVERED.to_string(),
+        metadata: ElementMetadata::default(),
+    }));
+
+    let chunks = doc
+        .rag_chunks_from_elements(elements, &AnalysisPipeline::new())
+        .expect("rag_chunks_from_elements");
+
+    let joined: String = chunks
+        .iter()
+        .map(|c| c.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        joined.contains(RECOVERED),
+        "the externally-recovered element must flow through the pipeline into \
+         the chunks; got: {joined:?}"
+    );
+}
+
+#[test]
+fn rag_chunks_from_elements_with_no_elements_yields_no_chunks() {
+    // A caller may legitimately hand over an empty recovered set; that must be
+    // a clean empty result, not an error or panic.
+    let doc = open();
+    let chunks = doc
+        .rag_chunks_from_elements(Vec::new(), &AnalysisPipeline::new())
+        .expect("rag_chunks_from_elements over an empty element set");
+    assert!(
+        chunks.is_empty(),
+        "no elements must yield no chunks, got {}",
+        chunks.len()
+    );
+}


### PR DESCRIPTION
## Summary

`PdfDocument::rag_chunks_with_pipeline` was the only entry that runs a custom `AnalysisPipeline` (classifier → chunking → enrichers), and it hard-coded its element source as `partition_with(pipeline.partition_config)`. A consumer (e.g. oxidize-legal) had no public way to run those stages over **caller-provided** elements — externally-recovered content such as numbered-list items a two-column layout scrambles past the partitioner. The only workaround built `RagChunk`s out-of-band and hand-stamped `metadata.extra`, bypassing the classifier and enrichers (#360).

## Change

New public `rag_chunks_from_elements(&self, elements: Vec<Element>, pipeline: &AnalysisPipeline) -> ParseResult<Vec<RagChunk>>`. `rag_chunks_with_pipeline` becomes a delegator:

```rust
let elements = self.partition_with(pipeline.partition_config.clone())?;
self.rag_chunks_from_elements(elements, pipeline)
```

- The classify→chunk→`build_rag_chunks`→enrich body is factored out verbatim; no logic changed.
- `PartitionConfig` is not consulted in the new entry (the caller chose the elements); the pipeline `source` is still autofilled from the document and stamped, exactly as before.
- Both methods gated `#[cfg(feature = "unstable-spi")]`.
- Rejected the issue's alternatives: `AnalysisPipeline::run` (would move `autofill_source`/`build_rag_chunks` off `PdfDocument`) and a public `HybridChunk`/`RagChunk` constructor (bypasses classifier/enrichers — the inferior workaround).

## SemVer: PATCH

Additive and entirely behind `unstable-spi` (semver-exempt) → no stable public API change.

## Tests (TDD, RED-first)

- **Parity**: `rag_chunks_from_elements(partition_with(default), pipeline)` reproduces `rag_chunks_with_pipeline(pipeline)` exactly.
- **Caller-source**: a `CountingClassifier` over a 3-element caller-provided vector sees exactly 3 (proves the source is the caller's vector, not the document partition).
- **End-to-end recovery**: a synthetic `Element::Paragraph` mixed with partitioned elements flows through into the output chunks.
- **Edge**: empty input yields no chunks.

## Verification

- `cargo test --features unstable-spi --test issue_360_rag_chunks_from_elements_test` → 4/0.
- No regression: `issue_345_pipeline_partition_config_test`, `analysis_spi_corpus_parity_test` green (corpus parity = byte-identical).
- `clippy --lib --all-features` clean; MSRV 1.88 lib compiles (all-features, locked).

Reviewed by two quality passes (second: ready to merge).

Addresses #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)