### PR TITLE
feat(parser): make PdfDocument<R> Send by dropping unshared Rc (#369)

### DIFF
--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -15,7 +15,7 @@
 //! # Key Features
 //!
 //! - **Automatic caching**: Objects are cached after first access
-//! - **Resource management**: Shared resources are handled efficiently
+//! - **Resource management**: Objects are cached per-document for efficient reuse
 //! - **Page navigation**: Fast access to any page in the document
 //! - **Reference resolution**: Automatic resolution of indirect references
 //! - **Text extraction**: Built-in support for extracting text from pages
@@ -64,9 +64,9 @@ use std::path::Path;
 /// Resource manager for efficient PDF object caching.
 ///
 /// The ResourceManager provides centralized caching of PDF objects to avoid
-/// repeated parsing and to share resources between different parts of the document.
-/// It uses RefCell for interior mutability, allowing multiple immutable references
-/// to the document while still being able to update the cache.
+/// repeated parsing overhead. It is owned exclusively by a `PdfDocument` and uses
+/// `RefCell` for interior mutability, so cache writes can occur through a shared
+/// borrow of the document.
 ///
 /// # Caching Strategy
 ///
@@ -180,6 +180,13 @@ impl ResourceManager {
 /// - **Lazy Loading**: Pages and resources are loaded on demand
 /// - **Automatic Caching**: Frequently accessed objects are cached
 /// - **Safe API**: Borrow checker issues are handled internally
+///
+/// # Thread Safety
+///
+/// `PdfDocument<R>` is `Send` for `R: Send` (issue #369): it can be moved to
+/// another thread or across a Python GIL boundary (e.g. `Python::allow_threads`).
+/// It is intentionally `!Sync` because `RefCell` does not permit shared concurrent
+/// access; callers that need concurrent reads should use one instance per thread.
 ///
 /// # Example
 ///
@@ -1900,6 +1907,7 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<PdfDocument<std::fs::File>>();
         assert_send::<PdfDocument<Cursor<Vec<u8>>>>();
+        assert_send::<PdfDocument<Cursor<&'static [u8]>>>();
     }
 
     // Issue #369: dropping the unshared Rc must not change cache behavior.

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -60,7 +60,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::path::Path;
-use std::rc::Rc;
 
 /// Resource manager for efficient PDF object caching.
 ///
@@ -212,8 +211,10 @@ pub struct PdfDocument<R: Read + Seek> {
     reader: RefCell<PdfReader<R>>,
     /// Page tree navigator (lazily initialized)
     page_tree: RefCell<Option<PageTree>>,
-    /// Shared resource manager for object caching
-    resources: Rc<ResourceManager>,
+    /// Resource manager for object caching (owned; interior mutability via RefCell).
+    /// Not shared/cloned, so a plain owned field keeps `PdfDocument<R>: Send` for
+    /// `R: Send` without any locking overhead (issue #369).
+    resources: ResourceManager,
     /// Cached document metadata to avoid repeated parsing
     metadata_cache: RefCell<Option<super::reader::DocumentMetadata>>,
 }
@@ -224,7 +225,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         Self {
             reader: RefCell::new(reader),
             page_tree: RefCell::new(None),
-            resources: Rc::new(ResourceManager::new()),
+            resources: ResourceManager::new(),
             metadata_cache: RefCell::new(None),
         }
     }
@@ -1891,6 +1892,26 @@ mod tests {
     use super::*;
     use crate::parser::objects::{PdfObject, PdfString};
     use std::io::Cursor;
+
+    // Issue #369: PdfDocument<R> must be Send so callers (e.g. the PyO3
+    // bindings) can release a thread-blocking lock around reader operations.
+    #[test]
+    fn test_pdf_document_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PdfDocument<std::fs::File>>();
+        assert_send::<PdfDocument<Cursor<Vec<u8>>>>();
+    }
+
+    // Issue #369: dropping the unshared Rc must not change cache behavior.
+    #[test]
+    fn test_resource_cache_roundtrip_after_owned_field() {
+        let rm = ResourceManager::new();
+        assert!(rm.get_cached((7, 0)).is_none());
+        rm.cache_object((7, 0), PdfObject::Integer(42));
+        assert_eq!(rm.get_cached((7, 0)), Some(PdfObject::Integer(42)));
+        rm.clear_cache();
+        assert!(rm.get_cached((7, 0)).is_none());
+    }
 
     // Helper function to create a minimal PDF in memory
     fn create_minimal_pdf() -> Vec<u8> {


### PR DESCRIPTION
## Summary

Makes `PdfDocument<R>: Send` (for `R: Send`), unblocking GIL release in the Python bindings (oxidize-python #115).

`PdfDocument` held `resources: Rc<ResourceManager>`, the **sole** reason the type was `!Send`. Audit of the codebase shows the `Rc` was **never cloned or shared**: single constructor (`new`; `open`/`into_document` delegate to it), no `Clone` impl, zero `Rc::clone`/shared `.resources`. So the `Rc` provided no sharing — only the `!Send` blocker.

The fix replaces it with an **owned** `ResourceManager` field. `RefCell<HashMap>` inside `ResourceManager` stays as-is (`RefCell<X>` is `Send` when `X: Send`), giving `PdfDocument<R>: Send` with **zero locking overhead**.

## Why not Arc + Mutex (as the issue proposed)

Arc+Mutex is correct but heavier than necessary. Since the `Rc` is unshared, dropping it to an owned field avoids all three trade-offs the issue itself enumerates:
- **Lock overhead** on the hot parse path → 0 (no lock introduced)
- **Poisoning** → N/A
- **Deadlock / re-entrancy** → N/A
- The acceptance-criteria benchmark becomes unnecessary (no overhead to measure)

Arc+Mutex would only be needed if `PdfDocument` had to be `Sync` or if `resources` were genuinely shared across threads/owners — neither applies to the GIL-release use case (the closure runs on the same worker thread).

Full analysis posted on the issue: #369 (comment).

## Changes

- `resources: Rc<ResourceManager>` → `resources: ResourceManager`; `Rc::new(...)` → `ResourceManager::new()`; removed `use std::rc::Rc`.
- Refreshed obsolete "shared resources" docs; documented the `Send`/`!Sync` guarantee.

## Tests (TDD)

- `test_pdf_document_is_send`: compile-time `Send` assert for `PdfDocument<File>`, `PdfDocument<Cursor<Vec<u8>>>`, and `PdfDocument<Cursor<&[u8]>>`. Confirmed RED (`E0277`) before the fix.
- `test_resource_cache_roundtrip_after_owned_field`: cache roundtrip regression (exact value).

## Verification

- `cargo test -p oxidize-pdf --lib`: 6599 passed, 0 failed.
- `RUSTFLAGS="-D warnings" cargo check --all-features --locked` on **stable and MSRV 1.88**: no warnings.
- Module doctests: 28 passed.

## Acceptance criteria

- [x] `PdfDocument<File>: Send` and `PdfDocument<Cursor<Vec<u8>>>: Send` (compile assert).
- [x] No behavioral change; existing suite green.
- [x] No locking overhead introduced (object-cache benchmark not needed — see above).

Addresses #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
