### PR TITLE
Release v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [3.0.4] - 2026-06-29
+
+### Changed
+
+- `PdfDocument<R>` is now `Send` for `R: Send`. The internal
+  `Rc<ResourceManager>` (which was never cloned or shared) is replaced by an
+  owned `ResourceManager` field; the inner `RefCell` cache is unchanged, so
+  there is no locking overhead and no behavioral change. This lets callers move
+  a document across threads — concretely, the Python bindings can release the
+  GIL (`Python::allow_threads`) around reader operations. `PdfDocument` remains
+  `!Sync` (#369).
+
 ## [3.0.3] - 2026-06-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.3"
+version = "3.0.4"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -15,7 +15,7 @@
 //! # Key Features
 //!
 //! - **Automatic caching**: Objects are cached after first access
-//! - **Resource management**: Shared resources are handled efficiently
+//! - **Resource management**: Objects are cached per-document for efficient reuse
 //! - **Page navigation**: Fast access to any page in the document
 //! - **Reference resolution**: Automatic resolution of indirect references
 //! - **Text extraction**: Built-in support for extracting text from pages
@@ -64,9 +64,9 @@ use std::path::Path;
 /// Resource manager for efficient PDF object caching.
 ///
 /// The ResourceManager provides centralized caching of PDF objects to avoid
-/// repeated parsing and to share resources between different parts of the document.
-/// It uses RefCell for interior mutability, allowing multiple immutable references
-/// to the document while still being able to update the cache.
+/// repeated parsing overhead. It is owned exclusively by a `PdfDocument` and uses
+/// `RefCell` for interior mutability, so cache writes can occur through a shared
+/// borrow of the document.
 ///
 /// # Caching Strategy
 ///
@@ -180,6 +180,13 @@ impl ResourceManager {
 /// - **Lazy Loading**: Pages and resources are loaded on demand
 /// - **Automatic Caching**: Frequently accessed objects are cached
 /// - **Safe API**: Borrow checker issues are handled internally
+///
+/// # Thread Safety
+///
+/// `PdfDocument<R>` is `Send` for `R: Send` (issue #369): it can be moved to
+/// another thread or across a Python GIL boundary (e.g. `Python::allow_threads`).
+/// It is intentionally `!Sync` because `RefCell` does not permit shared concurrent
+/// access; callers that need concurrent reads should use one instance per thread.
 ///
 /// # Example
 ///
@@ -1900,6 +1907,7 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<PdfDocument<std::fs::File>>();
         assert_send::<PdfDocument<Cursor<Vec<u8>>>>();
+        assert_send::<PdfDocument<Cursor<&'static [u8]>>>();
     }
 
     // Issue #369: dropping the unshared Rc must not change cache behavior.

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -60,7 +60,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::path::Path;
-use std::rc::Rc;
 
 /// Resource manager for efficient PDF object caching.
 ///
@@ -212,8 +211,10 @@ pub struct PdfDocument<R: Read + Seek> {
     reader: RefCell<PdfReader<R>>,
     /// Page tree navigator (lazily initialized)
     page_tree: RefCell<Option<PageTree>>,
-    /// Shared resource manager for object caching
-    resources: Rc<ResourceManager>,
+    /// Resource manager for object caching (owned; interior mutability via RefCell).
+    /// Not shared/cloned, so a plain owned field keeps `PdfDocument<R>: Send` for
+    /// `R: Send` without any locking overhead (issue #369).
+    resources: ResourceManager,
     /// Cached document metadata to avoid repeated parsing
     metadata_cache: RefCell<Option<super::reader::DocumentMetadata>>,
 }
@@ -224,7 +225,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         Self {
             reader: RefCell::new(reader),
             page_tree: RefCell::new(None),
-            resources: Rc::new(ResourceManager::new()),
+            resources: ResourceManager::new(),
             metadata_cache: RefCell::new(None),
         }
     }
@@ -1891,6 +1892,26 @@ mod tests {
     use super::*;
     use crate::parser::objects::{PdfObject, PdfString};
     use std::io::Cursor;
+
+    // Issue #369: PdfDocument<R> must be Send so callers (e.g. the PyO3
+    // bindings) can release a thread-blocking lock around reader operations.
+    #[test]
+    fn test_pdf_document_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PdfDocument<std::fs::File>>();
+        assert_send::<PdfDocument<Cursor<Vec<u8>>>>();
+    }
+
+    // Issue #369: dropping the unshared Rc must not change cache behavior.
+    #[test]
+    fn test_resource_cache_roundtrip_after_owned_field() {
+        let rm = ResourceManager::new();
+        assert!(rm.get_cached((7, 0)).is_none());
+        rm.cache_object((7, 0), PdfObject::Integer(42));
+        assert_eq!(rm.get_cached((7, 0)), Some(PdfObject::Integer(42)));
+        rm.clear_cache();
+        assert!(rm.get_cached((7, 0)).is_none());
+    }
 
     // Helper function to create a minimal PDF in memory
     fn create_minimal_pdf() -> Vec<u8> {


### PR DESCRIPTION
## Release 3.0.4

Promotes `develop` to `main` for the 3.0.4 release.

### Included

- **#369** — `PdfDocument<R>` is now `Send` for `R: Send`. Internal
  `Rc<ResourceManager>` (never shared) replaced by an owned `ResourceManager`
  field; `RefCell` cache unchanged → no locking overhead, no behavioral change.
  Unblocks GIL release in the Python bindings (oxidize-python #115).
  `PdfDocument` stays `!Sync`.

### Release steps after merge

- Tag `v3.0.4` on `main` → triggers `release.yml` (auto-publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
