### PR TITLE
fix(encryption): decrypt qpdf AES-256 R5/R6 PDFs (#373)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Treat binary test fixtures as binary so git never applies EOL (CRLF)
+# conversion to them. Without this, small PDFs with no NUL byte in their first
+# 8 KiB are auto-detected as *text* and get LF→CRLF-mangled on Windows checkouts
+# (core.autocrlf=true, the default on GitHub Actions Windows runners), which
+# corrupts the byte offsets and breaks parsing (issue #373 CI: pypdf AES-256
+# fixture parsed as "Unknown keyword: rms" only on windows-latest).
+*.pdf   binary
+*.PDF   binary
+
+# Fonts and images used as fixtures are binary too.
+*.ttf   binary
+*.otf   binary
+*.ttc   binary
+*.woff  binary
+*.woff2 binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.jbig2 binary

--- a/oxidize-pdf-core/src/encryption/standard_security.rs
+++ b/oxidize-pdf-core/src/encryption/standard_security.rs
@@ -390,7 +390,7 @@ impl StandardSecurityHandler {
     /// Encrypt data using AES.
     ///
     /// - **R4**: AES-128-CBC with MD5-based per-object key (ISO 32000-1 §7.6.2 Algorithm 1 + "sAlT")
-    /// - **R5/R6**: AES-256-CBC with SHA-256 key derivation
+    /// - **R5/R6**: AES-256-CBC with the file key used directly (ISO 32000-2 §7.6.4.3, AESV3)
     pub fn encrypt_aes(
         &self,
         data: &[u8],
@@ -403,7 +403,7 @@ impl StandardSecurityHandler {
                 Aes::new(AesKey::new_128(obj_key)?)
             }
             SecurityHandlerRevision::R5 | SecurityHandlerRevision::R6 => {
-                let obj_key = self.compute_aes_object_key(key, obj_id)?;
+                let obj_key = self.compute_aes256_object_key(key, obj_id)?;
                 Aes::new(AesKey::new_256(obj_key)?)
             }
             _ => {
@@ -428,7 +428,7 @@ impl StandardSecurityHandler {
     /// Decrypt data using AES.
     ///
     /// - **R4**: AES-128-CBC with MD5-based per-object key
-    /// - **R5/R6**: AES-256-CBC with SHA-256 key derivation
+    /// - **R5/R6**: AES-256-CBC with the file key used directly (ISO 32000-2 §7.6.4.3, AESV3)
     pub fn decrypt_aes(
         &self,
         data: &[u8],
@@ -450,7 +450,7 @@ impl StandardSecurityHandler {
                 Aes::new(AesKey::new_128(obj_key)?)
             }
             SecurityHandlerRevision::R5 | SecurityHandlerRevision::R6 => {
-                let obj_key = self.compute_aes_object_key(key, obj_id)?;
+                let obj_key = self.compute_aes256_object_key(key, obj_id)?;
                 Aes::new(AesKey::new_256(obj_key)?)
             }
             _ => {
@@ -481,21 +481,27 @@ impl StandardSecurityHandler {
         hash[..key_len].to_vec()
     }
 
-    /// Compute AES-256 object-specific encryption key for Rev 5/6 (SHA-256 based).
-    fn compute_aes_object_key(&self, key: &EncryptionKey, obj_id: &ObjectId) -> Result<Vec<u8>> {
+    /// Object encryption key for the AESV3 crypt filter (Rev 5/6, V5).
+    ///
+    /// ISO 32000-2 §7.6.4.3: for AESV3 the object encryption key **is the file
+    /// encryption key, used directly** — unlike V1/V2/AESV2 (Rev ≤ 4), there is
+    /// no per-object hashing with the object number, generation and `sAlT`. The
+    /// object number is *not* mixed in. Deriving a salted per-object key here
+    /// (as earlier revisions do) yields a wrong AES key and PKCS#7 unpad
+    /// failures on spec-compliant files (issue #373); it also made our own
+    /// AES-256 output unreadable by any other conforming reader.
+    fn compute_aes256_object_key(
+        &self,
+        key: &EncryptionKey,
+        _obj_id: &ObjectId,
+    ) -> Result<Vec<u8>> {
         if self.revision < SecurityHandlerRevision::R5 {
             return Err(crate::error::PdfError::EncryptionError(
-                "SHA-256 AES key derivation only for Rev 5+".to_string(),
+                "AESV3 file-key derivation only for Rev 5+".to_string(),
             ));
         }
 
-        let mut data = Vec::new();
-        data.extend_from_slice(&key.key);
-        data.extend_from_slice(&obj_id.number().to_le_bytes());
-        data.extend_from_slice(&obj_id.generation().to_le_bytes());
-        data.extend_from_slice(b"sAlT");
-
-        Ok(sha256(&data))
+        Ok(key.key.clone())
     }
 
     /// Compute encryption key for AES Rev 5/6
@@ -870,9 +876,12 @@ impl StandardSecurityHandler {
         // Extract key_salt from U[40..48]
         let key_salt = &u_entry[U_KEY_SALT_START..U_KEY_SALT_END];
 
-        // Compute intermediate key using Algorithm 2.B (ISO 32000-2:2020)
-        // For key derivation, we pass the full U entry as the third parameter
-        let hash = compute_hash_r6_algorithm_2b(user_password.0.as_bytes(), key_salt, u_entry)?;
+        // Compute intermediate key using Algorithm 2.B (ISO 32000-2:2020 §7.6.4.3.3).
+        // For the USER password the additional input is EMPTY (the 48-byte U
+        // entry is only used when hashing an OWNER password). This mirrors the
+        // read side (`recover_r6_encryption_key`) so our own R6 UE round-trips
+        // and is decryptable by conforming readers (issue #373).
+        let hash = compute_hash_r6_algorithm_2b(user_password.0.as_bytes(), key_salt, &[])?;
         let intermediate_key = hash[..U_HASH_LENGTH].to_vec();
 
         // Encrypt encryption_key with intermediate_key using AES-256-CBC, IV = 0
@@ -918,9 +927,13 @@ impl StandardSecurityHandler {
         // Extract key_salt from U[40..48]
         let key_salt = &u_entry[U_KEY_SALT_START..U_KEY_SALT_END];
 
-        // Compute intermediate key using Algorithm 2.B (ISO 32000-2:2020)
-        // For key derivation, we pass the full U entry as the third parameter
-        let hash = compute_hash_r6_algorithm_2b(user_password.0.as_bytes(), key_salt, u_entry)?;
+        // Compute intermediate key using Algorithm 2.B (ISO 32000-2:2020 §7.6.4.3.4).
+        // For the USER password the additional input is EMPTY (it is the 48-byte
+        // U entry only when hashing an OWNER password). Passing u_entry here
+        // produces a wrong intermediate key → wrong file key → PKCS#7 unpad
+        // failures on real R6 files, even though validation (which correctly
+        // uses empty input) succeeds (issue #373).
+        let hash = compute_hash_r6_algorithm_2b(user_password.0.as_bytes(), key_salt, &[])?;
         let intermediate_key = hash[..U_HASH_LENGTH].to_vec();
 
         // Decrypt UE to get encryption key using AES-256-CBC with IV = 0

--- a/oxidize-pdf-core/tests/issue_373_qpdf_aes256_stream_decrypt_test.rs
+++ b/oxidize-pdf-core/tests/issue_373_qpdf_aes256_stream_decrypt_test.rs
@@ -1,0 +1,131 @@
+//! Issue #373: qpdf-generated AES-256 (R5/R6) PDFs fail to decrypt streams with
+//! the correct password ("Unpad Error"), while pypdf-generated AES-256 works.
+//!
+//! Two independent root causes (both fixed in `standard_security.rs`):
+//!
+//! 1. **Object key (R5 + R6).** For AES-256 (V5) the object encryption key is the
+//!    file encryption key used *directly* (ISO 32000-2 §7.6.4.3, AESV3 crypt
+//!    filter). The handler instead re-derived a salted per-object key
+//!    (`sha256(key ‖ objnum ‖ gen ‖ "sAlT")`), yielding a wrong AES key → PKCS#7
+//!    unpad failure. The writer used the same wrong derivation, so its own
+//!    fixtures round-tripped and hid the bug; conforming readers of our output
+//!    could not decrypt it.
+//! 2. **R6 key recovery (R6 only).** Algorithm 2.B for the *user* password takes
+//!    an empty additional input; the recovery (and UE generation) instead passed
+//!    the 48-byte U entry, producing a wrong file key → unpad failure even though
+//!    validation (which correctly used empty input) reported success.
+//!
+//! These tests exercise the full stream-decrypt path end to end: parse → unlock →
+//! extract whole-document text, asserting the decrypted content matches the known
+//! plaintext of the base document (`Cold_Email_Hacks.pdf`, the unencrypted source
+//! used by `generate_r5_r6_pdfs.sh`). The prior R5/R6 tests stop at key recovery
+//! (asserting only a 32-byte length) and never decrypt a stream, so both bugs
+//! were untested.
+
+use oxidize_pdf::parser::PdfReader;
+use std::io::Cursor;
+
+const FIXTURES_DIR: &str = "tests/fixtures";
+/// Unencrypted source that every qpdf `encrypted_aes256_*` fixture was derived
+/// from (see `generate_r5_r6_pdfs.sh`).
+const BASE_PDF: &str = "Cold_Email_Hacks.pdf";
+
+/// Parse a fixture, optionally unlock it, and return the concatenated extracted
+/// text of every page. Whole-document extraction avoids depending on any single
+/// page (the base's page 0 is a text-less cover).
+fn extract_all_text(filename: &str, password: Option<&str>) -> String {
+    let path = format!("{FIXTURES_DIR}/{filename}");
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut reader =
+        PdfReader::new(Cursor::new(bytes)).unwrap_or_else(|e| panic!("parse {filename}: {e}"));
+
+    if let Some(pw) = password {
+        let unlocked = reader
+            .unlock_with_password(pw)
+            .unwrap_or_else(|e| panic!("unlock {filename}: {e}"));
+        assert!(unlocked, "correct password must unlock {filename}");
+    }
+
+    let doc = reader.into_document();
+    doc.extract_text()
+        .unwrap_or_else(|e| panic!("extract text from {filename}: {e}"))
+        .into_iter()
+        .map(|p| p.text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A distinctive, stable token (>= 10 alphanumeric chars) from the base
+/// document, used to confirm a decrypted fixture recovers the *real* content
+/// rather than merely not crashing.
+fn base_marker() -> String {
+    let base = extract_all_text(BASE_PDF, None);
+    base.split_whitespace()
+        .find(|w| w.chars().filter(|c| c.is_alphanumeric()).count() >= 10)
+        .unwrap_or_else(|| {
+            panic!(
+                "base {BASE_PDF} has no long token; got {} chars",
+                base.len()
+            )
+        })
+        .to_string()
+}
+
+/// Assert that decrypting `filename` with `password` recovers the base content.
+fn assert_recovers_base(filename: &str, password: &str) {
+    let marker = base_marker();
+    let text = extract_all_text(filename, Some(password));
+    assert!(
+        text.contains(&marker),
+        "decrypted {filename} must contain base token {marker:?}; got {} chars",
+        text.len()
+    );
+}
+
+#[test]
+fn qpdf_aes256_r5_user_stream_decrypts_to_base_content() {
+    assert_recovers_base("encrypted_aes256_r5_user.pdf", "user5");
+}
+
+#[test]
+fn qpdf_aes256_r5_empty_user_stream_decrypts_to_base_content() {
+    assert_recovers_base("encrypted_aes256_r5_empty_user.pdf", "");
+}
+
+#[test]
+fn qpdf_aes256_r6_user_stream_decrypts_to_base_content() {
+    assert_recovers_base("encrypted_aes256_r6_user.pdf", "user6");
+}
+
+#[test]
+fn qpdf_aes256_r6_empty_user_stream_decrypts_to_base_content() {
+    assert_recovers_base("encrypted_aes256_r6_empty_user.pdf", "");
+}
+
+/// Regression guard: pypdf-generated AES-256 R6 already decrypts correctly and
+/// must keep working after the object-key fix (it exercises the same corrected
+/// path — file key used directly). This fixture is a minimal synthetic PDF with
+/// no extractable text, so the guard is that its streams still decrypt to valid
+/// padding (no "Unpad Error") and the page tree remains readable — the exact
+/// path the fix must not regress.
+#[test]
+fn pypdf_aes256_user_stream_still_decrypts_without_unpad_error() {
+    let path = format!("{FIXTURES_DIR}/encrypted_pypdf_aes256_user.pdf");
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse pypdf fixture");
+    assert!(
+        reader
+            .unlock_with_password("pypdf_test")
+            .expect("unlock must not error"),
+        "correct password must unlock pypdf fixture"
+    );
+    let doc = reader.into_document();
+    // page_count + full-document text extraction both decrypt the content
+    // streams; either would surface an Unpad Error if the object key regressed.
+    let pages = doc
+        .page_count()
+        .expect("page_count must succeed after unlock");
+    assert!(pages >= 1, "pypdf fixture must expose at least one page");
+    doc.extract_text()
+        .expect("stream decryption must not fail with Unpad Error");
+}


### PR DESCRIPTION
## Summary

Fixes decryption of spec-compliant **AES-256 (V5, R5/R6)** PDFs. Two independent bugs made qpdf-generated AES-256 files undecryptable with the correct password (`Unpad Error`), and — worse — made our **own** AES-256 output unreadable by any conforming reader. Reported by an external user in #373.

## Root causes

1. **Object key (R5 + R6).** For AESV3 the object encryption key is the file encryption key used **directly** (ISO 32000-2 §7.6.4.3). The handler re-derived a salted per-object key (`sha256(key ‖ objnum ‖ gen ‖ "sAlT")`) → wrong AES key → PKCS#7 unpad failure. Writer and reader shared the wrong derivation, so the crate's own fixtures round-tripped and hid the defect.
2. **R6 key recovery (R6 only).** Algorithm 2.B for the **user** password takes an *empty* additional input; `recover_r6_encryption_key` and the UE-generation both passed the 48-byte U entry instead → wrong file key → unpad failure, even though validation (which correctly used empty input) reported success. The R6 **owner** path is unchanged and correctly keeps passing U.

## Fix

- `compute_aes_object_key` → renamed `compute_aes256_object_key`, returns the file key directly (with an ISO reference to deter re-introducing the salting).
- Algorithm 2.B user-password additional input set to empty on **both** read (recover) and write (UE) sides.

## Tests (TDD, RED-first)

New `tests/issue_373_qpdf_aes256_stream_decrypt_test.rs`: parse → unlock → whole-document extract against the qpdf R5/R6 user/empty fixtures, asserting recovery of the known base-document content (`Cold_Email_Hacks.pdf`). The prior R5/R6 tests stop at key recovery (32-byte length only) and never decrypt a stream, which is why both bugs were untested. Verified experimentally: reverting the fix reproduces the exact `Unpad Error` on all 4 qpdf fixtures.

## Verification

- New test 5/0; `encryption_write` 24/0, `encryption_r5_real` 9/0, `encryption_r6_real` 10/0, `encryption_cross_validation` 10/0; lib 6597/0.
- `cargo clippy --lib --all-features` clean.
- MSRV **1.88** build + test `--all-features --locked` clean.

## Compatibility note

PDFs previously written by oxidize-pdf with AES-256 used the non-compliant object key and are therefore **not** readable by conforming readers (and, after this fix, not by oxidize-pdf either). This corrects the output to be spec-compliant going forward; re-encrypt any affected documents. Should be called out in the release notes.

## Follow-up (out of scope, not in this PR)

The R6/R5 **owner-password** hash construction has the same interoperability defect class (self-consistent round-trip, likely not spec-compliant); tracked separately for an owner-password interop audit.

Addresses #373 (external reporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
