### PR TITLE
fix(extraction): insert newline between TJ blocks on different lines (#381)

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -937,6 +937,25 @@ impl TextExtractor {
                                     // for Artifact scopes (issue #330).
                                     let skip_text =
                                         skip_artifact_text(&state, self.options.include_artifacts);
+
+                                    // Pen origin in user space = (CTM × text_matrix)(0, 0).
+                                    let (x, y) = text_origin(&state);
+
+                                    // Insert a newline when this TJ piece starts on a
+                                    // different visual line than the previously shown
+                                    // text (issue #381). Only the vertical case is
+                                    // handled here: horizontal word spacing within a
+                                    // line is governed by the `TextElement::Spacing`
+                                    // kern logic below, and adding a dx-based space
+                                    // would wrongly split a single word that a TJ array
+                                    // draws as several positioned pieces.
+                                    if !skip_text
+                                        && !extracted_text.is_empty()
+                                        && (y - last_y).abs() > self.options.newline_threshold
+                                    {
+                                        extracted_text.push('\n');
+                                    }
+
                                     if !skip_text {
                                         extracted_text.push_str(&decoded);
                                     }
@@ -955,7 +974,6 @@ impl TextExtractor {
                                     };
 
                                     if self.options.preserve_layout {
-                                        let (x, y) = text_origin(&state);
                                         emit_text_fragment(
                                             &mut fragments,
                                             &decoded,
@@ -966,6 +984,12 @@ impl TextExtractor {
                                             self.options.include_artifacts,
                                         );
                                     }
+
+                                    // Keep the pen position in sync so a following
+                                    // `Tj`/`TJ` measures its gap from the right origin
+                                    // (issue #381: a stale `last_y` dropped newlines).
+                                    last_x = x + text_width;
+                                    last_y = y;
 
                                     let tx = text_width * state.horizontal_scale / 100.0;
                                     state.text_matrix = multiply_matrix(

--- a/oxidize-pdf-core/tests/issue_381_tj_newline_test.rs
+++ b/oxidize-pdf-core/tests/issue_381_tj_newline_test.rs
@@ -1,0 +1,183 @@
+//! Regression tests for issue #381.
+//!
+//! Flat-text extraction (`preserve_layout = false`) must insert a newline
+//! between `TJ` (`ShowTextArray`) blocks drawn on different visual lines.
+//! Before the fix, the `TextElement::Text` arm of `ShowTextArray` neither
+//! checked the pen origin against `newline_threshold` nor updated
+//! `last_x`/`last_y`, so text on separate lines was glued together and a
+//! following `Tj` measured its gap from a stale position.
+//!
+//! Nuance (also asserted): the fix adds ONLY the vertical (newline) case.
+//! A single word drawn as several positioned pieces inside one `TJ` array on
+//! the same line must NOT gain a spurious newline — horizontal spacing stays
+//! governed by the existing `TextElement::Spacing` kern logic.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false (the affected flat path).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_blocks_on_different_lines_get_a_newline() {
+    // Δy = 700 - 680 = 20 > newline_threshold (10) => a '\n' must separate them.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(user@example.com)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(* footnote text here)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        !text.contains("user@example.com*"),
+        "TJ blocks on different lines were glued together: {text:?}"
+    );
+    assert!(
+        text.contains("user@example.com\n* footnote text here"),
+        "expected a newline between the two TJ lines, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_pieces_of_one_word_on_same_line_are_not_split() {
+    // A single word "example" drawn as three positioned pieces inside ONE TJ
+    // array, all at the same y. Kerning between pieces is expressed as small
+    // negative adjustments (below tj_space_threshold), so nothing should break
+    // the word — and crucially, no newline may appear.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n",
+        "[(ex) -5 (am) -5 (ple)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        text.contains("example"),
+        "same-line TJ pieces of one word were split: {text:?}"
+    );
+    assert!(
+        !text.contains('\n'),
+        "no newline expected within a single visual line, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_then_tj_on_same_line_stay_joined() {
+    // Two TJ blocks at the SAME y (same line) must not get a newline: the fix
+    // is vertical-only.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(Hello)] TJ\n",
+        "1 0 0 1 90 700 Tm\n[(World)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        !text.contains('\n'),
+        "no newline expected for TJ blocks on the same line, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_then_bare_tj_on_different_line_gets_newline() {
+    // Real-world streams mix `Tj` and `TJ`. The TJ arm must keep `last_y` in
+    // sync so a following bare `Tj` (whose newline check reads `last_y`) still
+    // sees the line change — and vice versa. Guards the `last_y` write in the
+    // TJ arm against the read in the `ShowText` (Tj) arm.
+    let tj_then_tj = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(TJ line)] TJ\n",
+        "1 0 0 1 50 680 Tm\n(Tj line) Tj\nET"
+    );
+    assert!(
+        extract_flat(tj_then_tj).contains("TJ line\nTj line"),
+        "TJ→Tj across lines lost the newline: {:?}",
+        extract_flat(tj_then_tj)
+    );
+
+    let tj_then_ta = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n(Tj line) Tj\n",
+        "1 0 0 1 50 680 Tm\n[(TJ line)] TJ\nET"
+    );
+    assert!(
+        extract_flat(tj_then_ta).contains("Tj line\nTJ line"),
+        "Tj→TJ across lines lost the newline: {:?}",
+        extract_flat(tj_then_ta)
+    );
+}
+
+#[test]
+fn tj_updates_position_so_following_tj_measures_correctly() {
+    // TJ on line 1, then TJ on line 2, then TJ back near line 1's y but a full
+    // line below the previous. Each vertical jump > threshold must newline.
+    // This exercises last_y being kept in sync by the TJ arm (stale last_y
+    // would drop the second newline).
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(line one)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(line two)] TJ\n",
+        "1 0 0 1 50 660 Tm\n[(line three)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert_eq!(
+        text.matches('\n').count(),
+        2,
+        "expected exactly two newlines across three TJ lines, got: {text:?}"
+    );
+    assert!(
+        text.contains("line one\nline two\nline three"),
+        "lines were not separated correctly: {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes flat-text extraction (`preserve_layout = false`) gluing text from `TJ`
(`ShowTextArray`) operators drawn on different visual lines.

The `ShowTextArray → TextElement::Text` arm neither checked the pen origin
against `newline_threshold` nor updated `last_x`/`last_y`. Since `TJ` is the
most common text operator in real-world PDFs, text on separate lines was
concatenated with no separator, and a following `Tj` measured its gap from a
stale position.

## Fix

Give the `TJ` text arm the same **vertical** position-awareness as `ShowText`
(`Tj`): insert `\n` when the pen's `y` moves more than `newline_threshold`
since the last shown text, and keep `last_x`/`last_y` in sync.

Only the vertical case is added. A `dx`-based space (as `Tj` does) would
wrongly split a single word that a `TJ` array draws as several positioned
pieces; horizontal spacing stays governed by the existing
`TextElement::Spacing` kern logic. The `preserve_layout = true` reconstruction
path is unaffected (it rebuilds text from sorted fragments).

## Tests (TDD, RED→GREEN)

`tests/issue_381_tj_newline_test.rs` (5 tests):
- `TJ` blocks on different lines get a newline (the reporter's repro).
- One-word `TJ` pieces on the same line are not split.
- `TJ` + `TJ` on the same line stay joined (vertical-only).
- Cross-operator `Tj`↔`TJ` across lines keeps `last_y` in sync.
- Three `TJ` lines → exactly two newlines.

## Verification

- New: 5/0. Library `text::` 791/0. Full lib 6597/0 (pre-commit hook).
- ~90 adjacent extraction tests pass (kern #272, artifacts #330, widths #302,
  actualtext, CTM, MCID, two-column, text_flow, invoice, BOE).
- `clippy --lib` + `clippy --test issue_381 -D warnings` clean; `fmt` clean.

SemVer: **PATCH** (bugfix, no public API change).

## Notes

- Quality review (quality-rust) surfaced a preexisting, unrelated bug: pen
  tracking ignores `Tz` (`horizontal_scale`). Filed separately as #386; not
  bundled here to keep this PR focused.

Addresses #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
