### PR TITLE
fix(page/pdf_writer): Removed unnecessary renaming of fonts when gene…

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -1625,36 +1625,8 @@ impl Page {
         final_content.extend_from_slice(&text_tail);
 
         // Add any content that was added via add_text_flow
-        // Phase 2.3: Rewrite font references in preserved content if fonts were renamed
-        let content_to_add = if let Some(ref preserved_res) = self.preserved_resources {
-            // Check if we have preserved fonts that need renaming
-            if let Some(fonts_dict) = preserved_res.get("Font") {
-                if let crate::pdf_objects::Object::Dictionary(ref fonts) = fonts_dict {
-                    // Build font mapping (F1 → OrigF1, Arial → OrigArial, etc.)
-                    let mut font_mapping = std::collections::HashMap::new();
-                    for (original_name, _) in fonts.iter() {
-                        let new_name = format!("Orig{}", original_name.as_str());
-                        font_mapping.insert(original_name.as_str().to_string(), new_name);
-                    }
-
-                    // Rewrite font references in preserved content
-                    if !font_mapping.is_empty() && !self.content.is_empty() {
-                        use crate::writer::rewrite_font_references;
-                        rewrite_font_references(&self.content, &font_mapping)
-                    } else {
-                        self.content.clone()
-                    }
-                } else {
-                    self.content.clone()
-                }
-            } else {
-                self.content.clone()
-            }
-        } else {
-            self.content.clone()
-        };
-
-        final_content.extend_from_slice(&content_to_add);
+        // Phase 2.3
+        final_content.extend_from_slice(&self.content);
 
         // Render footer if present
         if let Some(footer) = &self.footer {

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -7,8 +7,6 @@ mod pdf_writer;
 mod signature;
 mod xref_stream_writer;
 
-// Phase 2 utilities for font preservation
-pub(crate) use content_stream_utils::{rename_preserved_fonts, rewrite_font_references};
 pub use incremental_form_fill::IncrementalFormFiller;
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2913,15 +2913,6 @@ impl<W: Write> PdfWriter<W> {
             // Convert pdf_objects::Dictionary to writer Dictionary FIRST
             let mut preserved_writer_dict = self.convert_pdf_objects_dict_to_writer(preserved_res);
 
-            // Step 1: Rename preserved fonts (F1 → OrigF1)
-            if let Some(Object::Dictionary(fonts)) = preserved_writer_dict.get("Font") {
-                // Rename font dictionary keys using our utility function
-                let renamed_fonts = crate::writer::rename_preserved_fonts(fonts);
-
-                // Replace Font dictionary with renamed version
-                preserved_writer_dict.set("Font", Object::Dictionary(renamed_fonts));
-            }
-
             // Phase 3.3: Write embedded font streams as indirect objects
             // Fonts that were resolved in Phase 3.2 have embedded Stream objects
             // We need to write these streams as separate PDF objects and replace with References


### PR DESCRIPTION
## Summary

When generating and writing a page there is no need to rename fonts. When this is removed this resolve issue with a `rewrite_font_references` which fails with this file [testi.pdf](https://github.com/user-attachments/files/29678028/testi.pdf).

Is there any real reason to add `Orig` prefix to a font's name.

## Changes

Remove renaming of names of fonts

## Testing

Created two test file with same font names F1 and F2 using diferent fonts
[a.pdf](https://github.com/user-attachments/files/29678073/a.pdf)
[b.pdf](https://github.com/user-attachments/files/29678074/b.pdf)

Here is a result without this patch 
[merged_documents_without_patch.pdf](https://github.com/user-attachments/files/29678262/merget_documents_without_patch.pdf)

and a result with this patch 
[merged_documents_with_patch.pdf](https://github.com/user-attachments/files/29678272/merget_documents_with_patch.pdf)
 
<!-- How did you verify this? Paste relevant test output. -->

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --all -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean
- [ ] New behavior is covered by tests that assert real content (no smoke tests)

## Checklist

- [x] Branch follows gitflow (targets `develop`)
- [ ] CHANGELOG.md updated for user-facing changes
- [ ] No breaking change to existing public APIs (or it is documented above)
