### PR TITLE
feat(pipeline): pluggable TokenCounter with tiktoken (cl100k_base) for RAG chunk sizing (#377)

### DIFF
--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -492,7 +492,6 @@ token-bench = ["dep:tiktoken-rs", "semantic"]
 # Real token counting in the chunking path (pulls tiktoken-rs BPE tables).
 tiktoken = ["dep:tiktoken-rs"]
 
-
 [[example]]
 name = "ai_ready_invoice"
 path = "examples/ai_ready_invoice.rs"

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -489,6 +489,9 @@ rayon = ["dep:rayon"]
 # Run with: cargo test --features token-bench -- --nocapture
 token-bench = ["dep:tiktoken-rs", "semantic"]
 
+# Real token counting in the chunking path (pulls tiktoken-rs BPE tables).
+tiktoken = ["dep:tiktoken-rs"]
+
 
 [[example]]
 name = "ai_ready_invoice"

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1414,6 +1414,28 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(self.build_rag_chunks(&hybrid_chunks, None))
     }
 
+    /// Extract and chunk with a custom [`TokenCounter`](crate::pipeline::TokenCounter).
+    ///
+    /// Identical to [`rag_chunks_with`](Self::rag_chunks_with) except the injected
+    /// counter governs both the chunk split/size decisions and the reported
+    /// `token_estimate` on each [`RagChunk`](crate::pipeline::RagChunk). Use with
+    /// [`TiktokenCounter`](crate::pipeline::TiktokenCounter) (feature `tiktoken`)
+    /// to size chunks against a real subword tokenizer.
+    ///
+    /// Note: this flows through [`HybridChunker`](crate::pipeline::HybridChunker).
+    /// The `unstable-spi` pipeline entry points (`rag_chunks_with_pipeline` /
+    /// `rag_chunks_from_elements`) remain word-proxy only.
+    pub fn rag_chunks_with_counter(
+        &self,
+        config: crate::pipeline::HybridChunkConfig,
+        counter: std::sync::Arc<dyn crate::pipeline::TokenCounter>,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let elements = self.partition()?;
+        let chunker = crate::pipeline::HybridChunker::new(config).with_token_counter(counter);
+        let hybrid_chunks = chunker.chunk(&elements);
+        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+    }
+
     /// Build RAG chunks stamped with source-document metadata.
     ///
     /// Auto-fills `title`/`author`/`creation_date`/`total_pages` from the info

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -1,5 +1,7 @@
 use crate::pipeline::graph::ElementGraph;
+use crate::pipeline::token_counter::{TokenCounter, WordProxyCounter};
 use crate::pipeline::{Element, ElementData, ElementMetadata};
+use std::sync::Arc;
 
 /// Policy for which adjacent element types can be merged into a single chunk.
 ///
@@ -88,6 +90,9 @@ pub struct HybridChunk {
     /// The heading context for this chunk (from `parent_heading` of its elements).
     pub heading_context: Option<String>,
     oversized: bool,
+    /// Token count stamped at construction by the chunker's active counter,
+    /// computed once over the whole chunk text. Returned by `token_estimate()`.
+    token_estimate: usize,
 }
 
 impl HybridChunk {
@@ -114,9 +119,10 @@ impl HybridChunk {
         }
     }
 
-    /// Approximate token count (word count proxy).
+    /// Token count under the counter that produced this chunk (word-proxy by
+    /// default; the chunker's injected `TokenCounter` otherwise).
     pub fn token_estimate(&self) -> usize {
-        estimate_tokens(&self.text())
+        self.token_estimate
     }
 
     /// Whether this chunk exceeds max_tokens (e.g., a large table).
@@ -145,11 +151,15 @@ impl HybridChunk {
             .map(|e| e.display_text())
             .collect::<Vec<_>>()
             .join("\n");
-        let oversized = estimate_tokens(&text) > max_tokens;
+        // The SPI pipeline path is word-proxy only (#377 resolution C): it has no
+        // HybridChunker instance to carry an injected counter.
+        let token_estimate = WordProxyCounter.count(&text);
+        let oversized = token_estimate > max_tokens;
         HybridChunk {
             elements: group.elements,
             heading_context: group.heading_context,
             oversized,
+            token_estimate,
         }
     }
 }
@@ -186,19 +196,53 @@ impl HybridChunk {
 /// ```
 pub struct HybridChunker {
     config: HybridChunkConfig,
+    counter: Arc<dyn TokenCounter>,
 }
 
 impl Default for HybridChunker {
     fn default() -> Self {
         Self {
             config: HybridChunkConfig::default(),
+            counter: Arc::new(WordProxyCounter),
         }
     }
 }
 
 impl HybridChunker {
     pub fn new(config: HybridChunkConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            counter: Arc::new(WordProxyCounter),
+        }
+    }
+
+    /// Inject a token counter governing split/oversize decisions and the stamped
+    /// per-chunk `token_estimate`. Default is `WordProxyCounter`.
+    pub fn with_token_counter(mut self, counter: Arc<dyn TokenCounter>) -> Self {
+        self.counter = counter;
+        self
+    }
+
+    /// Build a chunk, stamping its token count once over the whole chunk text
+    /// with the active counter.
+    fn make_chunk(
+        &self,
+        elements: Vec<Element>,
+        heading_context: Option<String>,
+        oversized: bool,
+    ) -> HybridChunk {
+        let text = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let token_estimate = self.counter.count(&text);
+        HybridChunk {
+            elements,
+            heading_context,
+            oversized,
+            token_estimate,
+        }
     }
 
     /// Chunk a list of elements into hybrid chunks.
@@ -213,7 +257,7 @@ impl HybridChunker {
         let mut buffer_heading: Option<String> = None;
 
         for element in elements {
-            let elem_tokens = estimate_tokens(&element.display_text());
+            let elem_tokens = self.counter.count(&element.display_text());
             let elem_heading = if self.config.propagate_headings {
                 element.metadata().parent_heading.clone()
             } else {
@@ -256,22 +300,19 @@ impl HybridChunker {
             if elem_tokens > self.config.max_tokens && buffer.is_empty() {
                 if is_splittable_element(element) {
                     let text = element.display_text();
-                    let fragments = split_by_sentences(&text, self.config.max_tokens);
+                    let fragments =
+                        split_by_sentences(&text, self.counter.as_ref(), self.config.max_tokens);
                     for fragment in fragments {
                         let fragment_element = make_text_fragment_element(element, fragment.trim());
-                        chunks.push(HybridChunk {
-                            elements: vec![fragment_element],
-                            heading_context: elem_heading.clone(),
-                            oversized: false,
-                        });
+                        chunks.push(self.make_chunk(
+                            vec![fragment_element],
+                            elem_heading.clone(),
+                            false,
+                        ));
                     }
                 } else {
                     // Table, image, code: atomic oversized chunk
-                    chunks.push(HybridChunk {
-                        elements: vec![element.clone()],
-                        heading_context: elem_heading,
-                        oversized: true,
-                    });
+                    chunks.push(self.make_chunk(vec![element.clone()], elem_heading, true));
                 }
                 continue;
             }
@@ -286,11 +327,7 @@ impl HybridChunker {
 
         // Flush remaining
         if !buffer.is_empty() {
-            chunks.push(HybridChunk {
-                elements: std::mem::take(&mut buffer),
-                heading_context: buffer_heading,
-                oversized: false,
-            });
+            chunks.push(self.make_chunk(std::mem::take(&mut buffer), buffer_heading, false));
         }
 
         chunks
@@ -344,16 +381,12 @@ impl HybridChunker {
 
             let section_tokens: usize = section_elements
                 .iter()
-                .map(|e| estimate_tokens(&e.display_text()))
+                .map(|e| self.counter.count(&e.display_text()))
                 .sum();
 
             if section_tokens <= self.config.max_tokens {
                 // Entire section fits in one chunk.
-                chunks.push(HybridChunk {
-                    elements: section_elements,
-                    heading_context: title_heading,
-                    oversized: false,
-                });
+                chunks.push(self.make_chunk(section_elements, title_heading, false));
             } else {
                 // Section is too large — split with standard chunker, then fix heading.
                 let mut sub_chunks = self.chunk(&section_elements);
@@ -386,17 +419,8 @@ impl HybridChunker {
         let heading = buffer_heading.take();
         *buffer_tokens = 0;
 
-        chunks.push(HybridChunk {
-            elements: flushed,
-            heading_context: heading,
-            oversized: false,
-        });
+        chunks.push(self.make_chunk(flushed, heading, false));
     }
-}
-
-/// Simple token estimator: word count (split by whitespace).
-fn estimate_tokens(text: &str) -> usize {
-    text.split_whitespace().count()
 }
 
 /// Whether two adjacent elements can be merged according to the given policy.
@@ -426,10 +450,10 @@ fn is_splittable_element(e: &Element) -> bool {
 }
 
 /// Split text at sentence boundaries (`. `, `! `, `? `, `\n`) into fragments of at most
-/// `max_tokens` words. Greedily accumulates sentences; if a single sentence still exceeds
-/// `max_tokens`, it is emitted as a single fragment (cannot split further without a
-/// semantic break). Never returns an empty Vec.
-fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
+/// `max_tokens` tokens under `counter`. Greedily accumulates sentences; if a single
+/// sentence still exceeds `max_tokens`, it is emitted as a single fragment (cannot split
+/// further without a semantic break). Never returns an empty Vec.
+fn split_by_sentences(text: &str, counter: &dyn TokenCounter, max_tokens: usize) -> Vec<String> {
     // Split into sentences preserving the delimiter as part of the sentence.
     let sentences = split_into_sentences(text);
 
@@ -442,7 +466,7 @@ fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
         if sentence.is_empty() {
             continue;
         }
-        let sentence_tokens = estimate_tokens(sentence);
+        let sentence_tokens = counter.count(sentence);
 
         if current.is_empty() {
             // Starting a new fragment

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -33,4 +33,6 @@ pub use spi::{
 };
 #[cfg(all(feature = "unstable-spi", feature = "semantic"))]
 pub use spi::{EnrichContext, MetadataEnricher};
+#[cfg(feature = "tiktoken")]
+pub use token_counter::TiktokenCounter;
 pub use token_counter::{TokenCounter, WordProxyCounter};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -10,6 +10,7 @@ pub mod reading_order;
 pub mod semantic_chunking;
 #[cfg(feature = "unstable-spi")]
 pub mod spi;
+pub mod token_counter;
 
 #[cfg(feature = "language-detection")]
 pub use chunk_metadata::detect_language;
@@ -32,3 +33,4 @@ pub use spi::{
 };
 #[cfg(all(feature = "unstable-spi", feature = "semantic"))]
 pub use spi::{EnrichContext, MetadataEnricher};
+pub use token_counter::{TokenCounter, WordProxyCounter};

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -23,8 +23,9 @@ use serde::{Deserialize, Serialize};
 /// - `full_text`: heading context + text — **use this for embedding generation**
 /// - `token_estimate`: token count under the chunker's active `TokenCounter`
 ///   (word-count proxy by default; a real tokenizer such as cl100k_base when a
-///   counter is injected via `rag_chunks_with_counter`). Query the counter's
-///   `name()` for provenance.
+///   counter is injected via `rag_chunks_with_counter`). `RagChunk` does not
+///   store the counter; query the counter you injected via its `name()` for
+///   provenance.
 /// - `is_oversized`: true when a single element exceeds `max_tokens`
 ///
 /// # Example
@@ -65,8 +66,8 @@ pub struct RagChunk {
     pub heading_context: Option<String>,
     /// Token count under the chunker's active `TokenCounter` (word-count
     /// proxy by default; a real tokenizer such as cl100k_base when a counter
-    /// is injected via `rag_chunks_with_counter`). Query the counter's
-    /// `name()` for provenance.
+    /// is injected via `rag_chunks_with_counter`). `RagChunk` does not store
+    /// the counter; query the counter you injected via its `name()`.
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -21,7 +21,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// - `text`: raw chunk text for display or keyword search
 /// - `full_text`: heading context + text — **use this for embedding generation**
-/// - `token_estimate`: word-count proxy (multiply by ~1.5 for subword tokens)
+/// - `token_estimate`: token count under the chunker's active `TokenCounter`
+///   (word-count proxy by default; a real tokenizer such as cl100k_base when a
+///   counter is injected via `rag_chunks_with_counter`). Query the counter's
+///   `name()` for provenance.
 /// - `is_oversized`: true when a single element exceeds `max_tokens`
 ///
 /// # Example
@@ -60,13 +63,10 @@ pub struct RagChunk {
     pub element_types: Vec<String>,
     /// Heading context inherited from the nearest parent heading.
     pub heading_context: Option<String>,
-    /// Approximate token count (word-count proxy).
-    ///
-    /// Computed as the number of whitespace-separated words. LLM subword
-    /// tokenizers (BPE/WordPiece) typically produce 1.3–1.7x more tokens
-    /// than the raw word count. Size your chunk budget accordingly: a
-    /// `max_tokens: 512` setting corresponds to roughly 300–390 actual
-    /// subword tokens for typical English prose.
+    /// Token count under the chunker's active `TokenCounter` (word-count
+    /// proxy by default; a real tokenizer such as cl100k_base when a counter
+    /// is injected via `rag_chunks_with_counter`). Query the counter's
+    /// `name()` for provenance.
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,

--- a/oxidize-pdf-core/src/pipeline/semantic_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/semantic_chunking.rs
@@ -1,4 +1,6 @@
+use crate::pipeline::token_counter::{TokenCounter, WordProxyCounter};
 use crate::pipeline::Element;
+use std::sync::Arc;
 
 /// Configuration for semantic chunking.
 #[derive(Debug, Clone)]
@@ -42,6 +44,7 @@ impl SemanticChunkConfig {
 pub struct SemanticChunk {
     elements: Vec<Element>,
     oversized: bool,
+    token_estimate: usize,
 }
 
 impl SemanticChunk {
@@ -59,9 +62,9 @@ impl SemanticChunk {
             .join("\n")
     }
 
-    /// Approximate token count (word count proxy).
+    /// Token count under the counter that produced this chunk.
     pub fn token_estimate(&self) -> usize {
-        estimate_tokens(&self.text())
+        self.token_estimate
     }
 
     /// Page numbers spanned by this chunk.
@@ -81,19 +84,63 @@ impl SemanticChunk {
 /// Semantic chunker that respects element boundaries.
 pub struct SemanticChunker {
     config: SemanticChunkConfig,
+    counter: Arc<dyn TokenCounter>,
 }
 
 impl Default for SemanticChunker {
     fn default() -> Self {
         Self {
             config: SemanticChunkConfig::default(),
+            counter: Arc::new(WordProxyCounter),
         }
     }
 }
 
 impl SemanticChunker {
     pub fn new(config: SemanticChunkConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            counter: Arc::new(WordProxyCounter),
+        }
+    }
+
+    /// Inject a token counter governing split/oversize decisions and the stamped
+    /// per-chunk `token_estimate`. Default is `WordProxyCounter`.
+    pub fn with_token_counter(mut self, counter: Arc<dyn TokenCounter>) -> Self {
+        self.counter = counter;
+        self
+    }
+
+    fn element_tokens(&self, element: &Element) -> usize {
+        self.counter.count(&element.display_text())
+    }
+
+    fn make_chunk(&self, elements: Vec<Element>, oversized: bool) -> SemanticChunk {
+        let text = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let token_estimate = self.counter.count(&text);
+        SemanticChunk {
+            elements,
+            oversized,
+            token_estimate,
+        }
+    }
+
+    fn make_paragraph_chunk(
+        &self,
+        text: &str,
+        meta: &crate::pipeline::ElementMetadata,
+    ) -> SemanticChunk {
+        self.make_chunk(
+            vec![Element::Paragraph(crate::pipeline::ElementData {
+                text: text.to_string(),
+                metadata: meta.clone(),
+            })],
+            false,
+        )
     }
 
     /// Chunk a list of elements into semantic chunks.
@@ -107,7 +154,7 @@ impl SemanticChunker {
         let mut current_tokens = 0usize;
 
         for element in elements {
-            let elem_tokens = element_token_count(element);
+            let elem_tokens = self.element_tokens(element);
 
             // Non-splittable elements (Table, Title, Header, Footer, Image)
             if !is_splittable(element) {
@@ -126,10 +173,7 @@ impl SemanticChunker {
 
                 // If element alone exceeds max_tokens, it gets its own oversized chunk
                 if elem_tokens > self.config.max_tokens && current_elements.is_empty() {
-                    chunks.push(SemanticChunk {
-                        elements: vec![element.clone()],
-                        oversized: true,
-                    });
+                    chunks.push(self.make_chunk(vec![element.clone()], true));
                     continue;
                 }
 
@@ -172,9 +216,9 @@ impl SemanticChunker {
                 let mut buf_tokens = 0;
 
                 for sentence in &sentences {
-                    let s_tokens = estimate_tokens(sentence);
+                    let s_tokens = self.counter.count(sentence);
                     if buf_tokens + s_tokens > self.config.max_tokens && !sentence_buf.is_empty() {
-                        chunks.push(make_paragraph_chunk(&sentence_buf, &meta));
+                        chunks.push(self.make_paragraph_chunk(&sentence_buf, &meta));
                         sentence_buf.clear();
                         buf_tokens = 0;
                     }
@@ -197,10 +241,7 @@ impl SemanticChunker {
 
         // Flush remaining
         if !current_elements.is_empty() {
-            chunks.push(SemanticChunk {
-                elements: current_elements,
-                oversized: false,
-            });
+            chunks.push(self.make_chunk(current_elements, false));
         }
 
         chunks
@@ -215,10 +256,7 @@ impl SemanticChunker {
         oversized: bool,
     ) {
         let flushed = std::mem::take(current_elements);
-        chunks.push(SemanticChunk {
-            elements: flushed.clone(),
-            oversized,
-        });
+        chunks.push(self.make_chunk(flushed.clone(), oversized));
 
         // Apply overlap: carry trailing elements from flushed chunk into the next
         if self.config.overlap_tokens > 0 {
@@ -227,7 +265,7 @@ impl SemanticChunker {
 
             // Walk backwards through flushed elements to collect overlap
             for elem in flushed.iter().rev() {
-                let t = element_token_count(elem);
+                let t = self.element_tokens(elem);
                 if overlap_tokens + t > self.config.overlap_tokens && !overlap_elements.is_empty() {
                     break;
                 }
@@ -250,16 +288,6 @@ fn is_splittable(element: &Element) -> bool {
         element,
         Element::Paragraph(_) | Element::ListItem(_) | Element::CodeBlock(_) | Element::KeyValue(_)
     )
-}
-
-/// Approximate token count for an element.
-fn element_token_count(element: &Element) -> usize {
-    estimate_tokens(&element.display_text())
-}
-
-/// Simple token estimator: word count (split by whitespace).
-fn estimate_tokens(text: &str) -> usize {
-    text.split_whitespace().count()
 }
 
 /// Split text into sentences.
@@ -286,14 +314,4 @@ fn split_sentences(text: &str) -> Vec<String> {
     }
 
     sentences
-}
-
-fn make_paragraph_chunk(text: &str, meta: &crate::pipeline::ElementMetadata) -> SemanticChunk {
-    SemanticChunk {
-        elements: vec![Element::Paragraph(crate::pipeline::ElementData {
-            text: text.to_string(),
-            metadata: meta.clone(),
-        })],
-        oversized: false,
-    }
 }

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -23,6 +23,33 @@ impl TokenCounter for WordProxyCounter {
     }
 }
 
+/// Real token counter backed by tiktoken's cl100k_base BPE (GPT-3.5/4 family).
+#[cfg(feature = "tiktoken")]
+pub struct TiktokenCounter {
+    bpe: tiktoken_rs::CoreBPE,
+}
+
+#[cfg(feature = "tiktoken")]
+impl TiktokenCounter {
+    /// Load the cl100k_base BPE rank tables (embedded in the crate; infallible
+    /// in practice — the tables ship with `tiktoken-rs`).
+    pub fn cl100k_base() -> Self {
+        Self {
+            bpe: tiktoken_rs::cl100k_base().expect("cl100k_base tokenizer tables"),
+        }
+    }
+}
+
+#[cfg(feature = "tiktoken")]
+impl TokenCounter for TiktokenCounter {
+    fn count(&self, text: &str) -> usize {
+        self.bpe.encode_ordinary(text).len()
+    }
+    fn name(&self) -> &'static str {
+        "cl100k_base"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,5 +62,34 @@ mod tests {
         assert_eq!(c.count("  multiple   spaces  "), 2);
         assert_eq!(c.count("punct, and! more?"), 3);
         assert_eq!(c.name(), "word-proxy");
+    }
+}
+
+#[cfg(all(test, feature = "tiktoken"))]
+mod tiktoken_tests {
+    use super::*;
+
+    #[test]
+    fn cl100k_exact_reference_counts() {
+        let c = TiktokenCounter::cl100k_base();
+        // Pinned cl100k_base values (OpenAI reference tokenizer).
+        assert_eq!(c.count(""), 0);
+        assert_eq!(c.count("hello world"), 2);
+        assert_eq!(c.count("The quick brown fox"), 4);
+        assert_eq!(c.name(), "cl100k_base");
+    }
+
+    #[test]
+    fn cl100k_diverges_from_word_proxy_on_subword() {
+        let tk = TiktokenCounter::cl100k_base();
+        let wp = WordProxyCounter;
+        // A URL is one whitespace "word" but many BPE tokens.
+        let url = "https://example.com/verify";
+        assert_eq!(wp.count(url), 1);
+        assert!(
+            tk.count(url) > 1,
+            "tiktoken should split the URL: {}",
+            tk.count(url)
+        );
     }
 }

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -62,6 +62,13 @@ mod tests {
         assert_eq!(c.count("  multiple   spaces  "), 2);
         assert_eq!(c.count("punct, and! more?"), 3);
         assert_eq!(c.name(), "word-proxy");
+
+        // Property: the default counter must stay identical to the historical
+        // `split_whitespace().count()` word-proxy — this is the byte-identity
+        // invariant the whole feature rests on (#377).
+        for s in ["", "a b c", "  x  y ", "line1\nline2\tthree", "único café"] {
+            assert_eq!(c.count(s), s.split_whitespace().count());
+        }
     }
 }
 

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -1,0 +1,39 @@
+//! Pluggable token counting for chunk-size decisions and reported estimates.
+
+/// Counts tokens in a string. Implementations back chunk-size decisions and the
+/// reported `token_estimate` with a real tokenizer.
+pub trait TokenCounter: Send + Sync {
+    /// Number of tokens in `text` under this counter.
+    fn count(&self, text: &str) -> usize;
+    /// Stable provenance identifier, e.g. `"word-proxy"` or `"cl100k_base"`.
+    fn name(&self) -> &'static str;
+}
+
+/// Zero-dependency default: whitespace-separated word count. Reproduces the
+/// historical `estimate_tokens` behaviour exactly.
+#[derive(Debug, Default, Clone)]
+pub struct WordProxyCounter;
+
+impl TokenCounter for WordProxyCounter {
+    fn count(&self, text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+    fn name(&self) -> &'static str {
+        "word-proxy"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_proxy_matches_split_whitespace() {
+        let c = WordProxyCounter;
+        assert_eq!(c.count(""), 0);
+        assert_eq!(c.count("hello world"), 2);
+        assert_eq!(c.count("  multiple   spaces  "), 2);
+        assert_eq!(c.count("punct, and! more?"), 3);
+        assert_eq!(c.name(), "word-proxy");
+    }
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -125,3 +125,72 @@ fn rag_chunks_with_counter_word_proxy_parity() {
         assert_eq!(b.token_estimate, i.token_estimate);
     }
 }
+
+#[cfg(feature = "tiktoken")]
+mod tiktoken_integration {
+    use super::para;
+    use oxidize_pdf::pipeline::{
+        HybridChunkConfig, HybridChunker, TiktokenCounter, TokenCounter, WordProxyCounter,
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn injected_tiktoken_stamps_exact_wholetext_count() {
+        // Single paragraph, subword-heavy. Stamp must equal cl100k count of the
+        // whole chunk text, not the word count.
+        let text = "https://example.com/verify?token=abc123";
+        let elements = vec![para(text)];
+        let chunker = HybridChunker::new(HybridChunkConfig {
+            max_tokens: 10_000, // large: keep it a single chunk
+            ..Default::default()
+        })
+        .with_token_counter(Arc::new(TiktokenCounter::cl100k_base()));
+        let chunks = chunker.chunk(&elements);
+        assert_eq!(chunks.len(), 1);
+
+        let expected = TiktokenCounter::cl100k_base().count(text);
+        assert_eq!(chunks[0].token_estimate(), expected);
+        // And it must differ from the word-proxy (1 word, no whitespace).
+        assert_eq!(WordProxyCounter.count(text), 1);
+        assert!(expected > 1);
+    }
+
+    #[test]
+    fn tiktoken_drives_split_word_proxy_would_not() {
+        // Two subword-heavy paragraphs. Under word-proxy each is 1 "word" → they
+        // stay merged under a tiny budget. Under cl100k each is many tokens → the
+        // summed decision exceeds the budget and they do NOT merge.
+        let a = "https://example.com/alpha/one/two/three";
+        let b = "https://example.com/beta/four/five/six";
+
+        // Precondition guard: the split test only proves what it claims if each
+        // URL individually exceeds max_tokens (5) under cl100k. Confirmed
+        // empirically: cl100k_base().count(a) == 12, count(b) == 12.
+        let count_a = TiktokenCounter::cl100k_base().count(a);
+        let count_b = TiktokenCounter::cl100k_base().count(b);
+        assert!(count_a > 5, "a should exceed max_tokens=5, got {}", count_a);
+        assert!(count_b > 5, "b should exceed max_tokens=5, got {}", count_b);
+
+        let elements = vec![para(a), para(b)];
+        let cfg = HybridChunkConfig {
+            max_tokens: 5,
+            ..Default::default()
+        };
+
+        // Word-proxy: elem_tokens(a)=1, elem_tokens(b)=1, 1+1<=5 → may merge into 1 chunk.
+        let wp_chunks = HybridChunker::new(cfg.clone()).chunk(&elements);
+
+        // Tiktoken: each URL is >5 cl100k tokens → cannot merge; also each single
+        // element exceeds max_tokens → splittable path fires.
+        let tk_chunks = HybridChunker::new(cfg)
+            .with_token_counter(Arc::new(TiktokenCounter::cl100k_base()))
+            .chunk(&elements);
+
+        assert!(
+            tk_chunks.len() > wp_chunks.len(),
+            "tiktoken should produce more chunks: wp={} tk={}",
+            wp_chunks.len(),
+            tk_chunks.len()
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -50,3 +50,78 @@ fn semantic_with_token_counter_builder_exists() {
     let chunks = chunker.chunk(&elements);
     assert_eq!(chunks[0].token_estimate(), 3);
 }
+
+/// Build a small in-memory PDF whose body, chunked with a tight token budget,
+/// yields several chunks. Pattern mirrors `rag_chunk_metadata_test.rs::build_chunks`.
+fn build_test_document() -> oxidize_pdf::parser::PdfDocument<std::io::Cursor<Vec<u8>>> {
+    use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    use oxidize_pdf::text::Font;
+    use oxidize_pdf::{Document, Page};
+    use std::io::Cursor;
+
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("SECTION ALPHA HEADING")
+        .unwrap();
+
+    let body_lines = [
+        (720.0, "Alpha marker paragraph with several words to fill the first token budget bucket completely."),
+        (700.0, "Bravo marker paragraph with several words to fill the second token budget bucket completely."),
+        (680.0, "Charlie marker paragraph with several words to fill the third token budget bucket completely."),
+        (660.0, "Delta marker paragraph with several words to fill the fourth token budget bucket completely."),
+        (640.0, "Echo marker paragraph with several words to fill the fifth token budget bucket completely."),
+        (620.0, "Foxtrot marker paragraph with several words to fill the sixth token budget bucket completely."),
+    ];
+    for (y, line) in body_lines {
+        page.text()
+            .set_font(Font::Helvetica, 11.0)
+            .at(50.0, y)
+            .write(line)
+            .unwrap();
+    }
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(pdf_bytes)).expect("parse generated PDF");
+    PdfDocument::new(reader)
+}
+
+#[test]
+fn rag_chunks_with_counter_word_proxy_parity() {
+    use oxidize_pdf::pipeline::{HybridChunkConfig, MergePolicy, WordProxyCounter};
+
+    let doc = build_test_document();
+
+    // Tight token budget to force multiple chunks; merge adjacent so paragraphs
+    // accrete into a bucket until the budget overflows.
+    let config = HybridChunkConfig {
+        max_tokens: 12,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+
+    let base = doc.rag_chunks_with(config.clone()).unwrap();
+    let injected = doc
+        .rag_chunks_with_counter(config, Arc::new(WordProxyCounter))
+        .unwrap();
+
+    assert!(
+        base.len() >= 2,
+        "expected at least two chunks to make the parity check meaningful, got {}",
+        base.len()
+    );
+
+    // Same grouping/metadata; word-proxy injection changes nothing.
+    assert_eq!(base.len(), injected.len());
+    for (b, i) in base.iter().zip(&injected) {
+        assert_eq!(b.text, i.text);
+        assert_eq!(b.token_estimate, i.token_estimate);
+    }
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -30,3 +30,23 @@ fn with_token_counter_accepts_word_proxy_explicitly() {
     let chunks = chunker.chunk(&elements);
     assert_eq!(chunks[0].token_estimate(), 3);
 }
+
+#[test]
+fn default_semantic_chunker_stamps_word_count() {
+    use oxidize_pdf::pipeline::{SemanticChunkConfig, SemanticChunker};
+    let elements = vec![para("one two three four five")];
+    let chunker = SemanticChunker::new(SemanticChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].token_estimate(), 5);
+}
+
+#[test]
+fn semantic_with_token_counter_builder_exists() {
+    use oxidize_pdf::pipeline::{SemanticChunkConfig, SemanticChunker, WordProxyCounter};
+    let elements = vec![para("one two three")];
+    let chunker = SemanticChunker::new(SemanticChunkConfig::default())
+        .with_token_counter(Arc::new(WordProxyCounter));
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks[0].token_estimate(), 3);
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -1,0 +1,32 @@
+//! #377 — TokenCounter injection into the chunking path.
+use oxidize_pdf::pipeline::{
+    Element, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+};
+use std::sync::Arc;
+
+fn para(text: &str) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })
+}
+
+#[test]
+fn default_hybrid_chunker_stamps_word_count() {
+    // No injection → WordProxyCounter → token_estimate == whitespace word count.
+    let elements = vec![para("alpha beta gamma delta")];
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].token_estimate(), 4);
+}
+
+#[test]
+fn with_token_counter_accepts_word_proxy_explicitly() {
+    use oxidize_pdf::pipeline::WordProxyCounter;
+    let elements = vec![para("alpha beta gamma")];
+    let chunker = HybridChunker::new(HybridChunkConfig::default())
+        .with_token_counter(Arc::new(WordProxyCounter));
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks[0].token_estimate(), 3);
+}


### PR DESCRIPTION
## Summary

Adds a pluggable `TokenCounter` seam so RAG chunk budgets can be counted with a real tiktoken (cl100k_base) tokenizer behind a feature flag, while the default build keeps its exact word-proxy behaviour. Addresses #377.

## What changed

- New `pipeline::token_counter`: trait `TokenCounter { count, name }` (Send+Sync, object-safe), `WordProxyCounter` (zero-dep default, `split_whitespace().count()`), and `TiktokenCounter` (cl100k_base) behind a new `tiktoken = ["dep:tiktoken-rs"]` feature.
- `HybridChunker` / `SemanticChunker` gain `counter: Arc<dyn TokenCounter>` + `with_token_counter(..)`. Each produced chunk **stamps** `token_estimate` once over the whole chunk text; `token_estimate()` returns the stamp (no lazy recompute). Free `estimate_tokens` fns removed.
- New `PdfDocument::rag_chunks_with_counter(config, counter)`; `RagChunk.token_estimate` reflects the active counter.

## Design invariants (verified by whole-branch review)

- **Default build byte-identical**: word-proxy == `split_whitespace().count()`; join-by-`\n` makes sum-of-per-element == whole-text count, so grouping + stamp are unchanged. Property test guards this.
- **Sum-vs-whole (intentional)**: split/merge decisions sum per-element counts; the stamp counts the whole joined text. They diverge under BPE by design (decision is conservative, stamp is exact).
- **SPI path stays word-proxy**: `HybridChunk::from_group` (unstable-spi) stamps via `WordProxyCounter` — scoped out of counter injection.
- **Feature-gated**: `TiktokenCounter` and all uses `#[cfg(feature = "tiktoken")]`; default pulls no new dep.

## Tests

`tests/issue_377_token_counter_test.rs`: 5 default-feature + 2 `tiktoken` (exact whole-text stamp; tiktoken-driven split the word-proxy would not make, with a precondition guard). Full lib suite green (6601).

## Compatibility

Additive public API only → **SemVer MINOR** (next release 3.1.0). MSRV 1.88 builds with `--features tiktoken` (`cargo +1.88 build --lib --features tiktoken --locked`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
