### PR TITLE
feat(extraction): opt-in reorder_columns for flat-text multi-column tables (#389)

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -68,6 +68,14 @@ pub struct ExtractionOptions {
     /// (issue #269 Phase 1). Opt-in by setting `true` when extracting
     /// page furniture matters (e.g. forensic auditing, redaction tools).
     pub include_artifacts: bool,
+    /// Reorder flat-text output by column so per-column tokens stay adjacent in
+    /// multi-column layouts (issue #389). Only affects the flat path
+    /// (`preserve_layout = false`); in layout mode `detect_columns` already
+    /// reorders. Default `false` → the flat path is byte-identical to before.
+    /// When on, `.text` is produced by the fragment pipeline (its shape matches
+    /// the layout path's reconstruction, not stream order); `.fragments` stays
+    /// empty.
+    pub reorder_columns: bool,
 }
 
 impl Default for ExtractionOptions {
@@ -84,6 +92,7 @@ impl Default for ExtractionOptions {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         }
     }
 }
@@ -780,6 +789,22 @@ impl TextExtractor {
             if self.options.preserve_layout && !fragments.is_empty() {
                 extracted_text = self.reconstruct_text_from_fragments(&fragments);
             }
+
+            // Flat path with column reordering (issue #389): fragments were
+            // collected only to reorder. `sort_and_merge_fragments` already ran
+            // at the top of this block (sort_by_position defaults true) and now
+            // applies column clustering via the gate above; call it here too so
+            // the behaviour is independent of `sort_by_position`, then rebuild
+            // the flat text from the reordered fragments and drop them (the
+            // `.fragments` contract only exposes fragments under preserve_layout).
+            if self.options.reorder_columns
+                && !self.options.preserve_layout
+                && !fragments.is_empty()
+            {
+                self.sort_and_merge_fragments(&mut fragments);
+                extracted_text = self.reconstruct_text_from_fragments(&fragments);
+                fragments.clear();
+            }
         }
 
         Ok(ExtractedText {
@@ -910,7 +935,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -985,7 +1010,8 @@ impl TextExtractor {
                                         )
                                     };
 
-                                    if self.options.preserve_layout {
+                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    {
                                         emit_text_fragment(
                                             &mut fragments,
                                             &decoded,
@@ -1098,7 +1124,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1155,7 +1181,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1308,7 +1334,9 @@ impl TextExtractor {
                         // If we just closed the scope that opened the pending run, flush it.
                         if pending.stack_depth + 1 == popped_depth {
                             let run = state.pending_actualtext.take().unwrap();
-                            if run.populated && self.options.preserve_layout {
+                            if run.populated
+                                && (self.options.preserve_layout || self.options.reorder_columns)
+                            {
                                 let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
                                 let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
@@ -1504,7 +1532,7 @@ impl TextExtractor {
         });
 
         // Detect columns if requested
-        if self.options.detect_columns {
+        if self.options.detect_columns || self.options.reorder_columns {
             self.detect_and_sort_columns(fragments);
         }
     }
@@ -2476,6 +2504,7 @@ mod tests {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         };
         assert!(options.preserve_layout);
         assert_eq!(options.space_threshold, 0.5);
@@ -2676,6 +2705,7 @@ mod tests {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         };
         let extractor = TextExtractor::with_options(options.clone());
         assert_eq!(extractor.options.preserve_layout, options.preserve_layout);

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1057,7 +1057,8 @@ impl TextExtractor {
                                         // even though no real `Tj` has fired yet. The
                                         // EMC flush will supply the canonical fragment
                                         // text from the override (Phase 1 #269 contract).
-                                        if self.options.preserve_layout
+                                        if (self.options.preserve_layout
+                                            || self.options.reorder_columns)
                                             && state.pending_actualtext.is_none()
                                         {
                                             // Emit a synthetic single-space fragment at the
@@ -1531,8 +1532,13 @@ impl TextExtractor {
             band_a.total_cmp(&band_b).then_with(|| a.x.total_cmp(&b.x))
         });
 
-        // Detect columns if requested
-        if self.options.detect_columns || self.options.reorder_columns {
+        // Detect columns if requested. `reorder_columns` forces column detection
+        // only on the flat path (`!preserve_layout`); in layout mode `detect_columns`
+        // is the intended control, keeping the `reorder_columns` field flat-only as
+        // documented (issue #389).
+        if self.options.detect_columns
+            || (self.options.reorder_columns && !self.options.preserve_layout)
+        {
             self.detect_and_sort_columns(fragments);
         }
     }

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -102,3 +102,53 @@ fn reorder_columns_preserves_wide_tj_kern_space() {
         "wide TJ kern must stay a space under reorder_columns, not concatenate: {text:?}"
     );
 }
+
+#[test]
+fn default_flat_still_interleaves_columns() {
+    // Documents the pre-fix behaviour and proves the flag is the switch: with
+    // reorder_columns OFF (default), the col1 email is still broken by col2.
+    let text = extract(TWO_COL_EMAILS, ExtractionOptions::default()).text;
+    assert!(
+        !text.contains("user@example.com"),
+        "default flat must remain stream-order (broken email): {text:?}"
+    );
+}
+
+#[test]
+fn reorder_columns_leaves_fragments_empty() {
+    // Contract: reorder_columns fixes only `.text`; `.fragments` stays empty in
+    // flat mode (populated only under preserve_layout).
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let result = extract(TWO_COL_EMAILS, opts);
+    assert!(
+        result.fragments.is_empty(),
+        "flat + reorder_columns must not expose fragments"
+    );
+}
+
+#[test]
+fn single_column_reorder_matches_plain_flat() {
+    // A single-column doc: no column boundary is detected, so reorder_columns
+    // must not split or reorder — the wrapped lines stay in reading order.
+    const ONE_COL: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(alpha beta)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(gamma delta)] TJ\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(ONE_COL, opts).text;
+    // Both lines present, in reading order, words within each line intact.
+    let a = text.find("alpha").expect("alpha present");
+    let g = text.find("gamma").expect("gamma present");
+    assert!(a < g, "reading order preserved for single column: {text:?}");
+    assert!(
+        text.contains("alpha beta") && text.contains("gamma delta"),
+        "words within each line stay intact: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -1,0 +1,80 @@
+//! Regression tests for issue #389 — flat-text column reordering (opt-in).
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+// Two-column table row: col1 email `user@example`+`.com` (x=50,x=100),
+// col2 email `tel@example`+`.com` (x=200,x=250), interleaved in stream order.
+const TWO_COL_EMAILS: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 50 680 Tm\n[(user@example)] TJ\n",
+    "1 0 0 1 200 680 Tm\n[(tel@example)] TJ\n",
+    "1 0 0 1 100 680 Tm\n[(.com)] TJ\n",
+    "1 0 0 1 250 680 Tm\n[(.com)] TJ\nET"
+);
+
+#[test]
+fn reorder_columns_keeps_column_tokens_adjacent() {
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(TWO_COL_EMAILS, opts).text;
+    assert!(
+        text.contains("user@example.com"),
+        "col1 email must be intact under reorder_columns: {text:?}"
+    );
+    assert!(
+        text.contains("tel@example.com"),
+        "col2 email must be intact under reorder_columns: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -78,3 +78,27 @@ fn reorder_columns_keeps_column_tokens_adjacent() {
         "col2 email must be intact under reorder_columns: {text:?}"
     );
 }
+
+#[test]
+fn reorder_columns_preserves_wide_tj_kern_space() {
+    // A word break encoded purely as a wide TJ kern (issue #272), with the kern
+    // in the [tj_space_threshold, space_threshold) * font_size band: -250/1000 *
+    // 10pt = 2.5pt, which is > 2.0pt (tj_space_threshold*fs, so the synthetic
+    // space fires) but < 3.0pt (space_threshold*fs, so `reconstruct_text_from_
+    // fragments` would NOT insert a gap-based space). The synthetic-space
+    // fragment must therefore be collected under reorder_columns too, or the two
+    // words concatenate. Single column → no reordering; this isolates the kern.
+    const KERN_BREAK: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(alpha) -250 (beta)] TJ\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(KERN_BREAK, opts).text;
+    assert!(
+        text.contains("alpha beta"),
+        "wide TJ kern must stay a space under reorder_columns, not concatenate: {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The flat-text extractor (`TextExtractor::new()`, `preserve_layout=false`) emits text in content-stream order. Multi-column tables are drawn left-to-right across columns at each y-level, so a per-column token split across two draw operators (e.g. an email `user@example` + `.com`) gets the adjacent column's operator inserted between its halves — `...user@exampletel@example.com.com` — making it undetectable. On a real 4-column contact table this produced 0 detectable emails. Addresses #389 (reporter: @oshtivi).

## Change

New opt-in `ExtractionOptions.reorder_columns: bool` (default `false`). When set on the flat path, fragments are collected and `.text` is rebuilt via the **existing** fragment pipeline (`sort_and_merge_fragments` with column clustering + `reconstruct_text_from_fragments`) — reusing the layout path's machinery, no duplicated clustering. Per-column tokens come out adjacent.

- Default (`reorder_columns=false`) → the flat path is **byte-identical**; no fragments collected.
- `reorder_columns` is **flat-only**: the column gate fires for it only when `!preserve_layout`; in layout mode `detect_columns` remains the control.
- `.fragments` stays empty in flat mode (fragments were an internal means to reorder; cleared before return).

## Tests (TDD)

`tests/issue_389_flat_reorder_columns_test.rs` (5): reporter two-column email repro (RED→GREEN); a wide-TJ-kern regression (2.5pt kern in the `[tj_space_threshold, space_threshold)` band, guarding the synthetic-space fragment path #272); default-still-interleaves (proves the flag is the switch); `.fragments`-empty contract; single-column no-regression. Neighbour flat-text regression (issue_390 / issue_381 / text_extraction) and lib `text::` 791/0 green; clippy `-D warnings` + fmt clean.

## Compatibility

Additive `ExtractionOptions` field → **SemVer MINOR** (repo precedent: `detect_columns`, `tj_space_threshold` added the same way). Note: `ExtractionOptions` is not `#[non_exhaustive]`, so exhaustive struct-literals need the new field; the two in-crate test literals were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
