### PR TITLE
Release 3.1.0 (#377 TokenCounter, #389 reorder_columns, #390 line-wrap fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-06
+
+### Added
+
+- `TokenCounter` trait (`pipeline::token_counter`) with a zero-dependency
+  `WordProxyCounter` default and a feature-gated `TiktokenCounter` (cl100k_base,
+  behind the new `tiktoken` feature). `HybridChunker`/`SemanticChunker` gain
+  `with_token_counter(..)`; each chunk stamps its `token_estimate` with the
+  active counter, and `PdfDocument::rag_chunks_with_counter(config, counter)`
+  injects a counter into the RAG path. The default build is byte-identical
+  (word-proxy) and pulls no new dependency (#377).
+- `ExtractionOptions.reorder_columns` (opt-in, default `false`): on the flat
+  text path (`preserve_layout = false`), reorders output by column so
+  per-column tokens stay adjacent in multi-column tables (emails/phones split
+  across draw operators become detectable again). Reuses the existing
+  column-detection machinery; `.fragments` stays empty; default off is
+  byte-identical (#389).
+
+### Fixed
+
+- Flat-text extraction no longer glues the last word of one visual line to the
+  first word of the next when the line height is below `newline_threshold` and
+  the line wraps back to the left: a large backward horizontal jump is now
+  treated as a line break in both the `Tj` and `TJ` handlers (#390).
+
 ## [3.0.4] - 2026-06-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.0.5"
+version = "3.1.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.5"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -492,7 +492,6 @@ token-bench = ["dep:tiktoken-rs", "semantic"]
 # Real token counting in the chunking path (pulls tiktoken-rs BPE tables).
 tiktoken = ["dep:tiktoken-rs"]
 
-
 [[example]]
 name = "ai_ready_invoice"
 path = "examples/ai_ready_invoice.rs"

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -489,6 +489,9 @@ rayon = ["dep:rayon"]
 # Run with: cargo test --features token-bench -- --nocapture
 token-bench = ["dep:tiktoken-rs", "semantic"]
 
+# Real token counting in the chunking path (pulls tiktoken-rs BPE tables).
+tiktoken = ["dep:tiktoken-rs"]
+
 
 [[example]]
 name = "ai_ready_invoice"

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1414,6 +1414,28 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(self.build_rag_chunks(&hybrid_chunks, None))
     }
 
+    /// Extract and chunk with a custom [`TokenCounter`](crate::pipeline::TokenCounter).
+    ///
+    /// Identical to [`rag_chunks_with`](Self::rag_chunks_with) except the injected
+    /// counter governs both the chunk split/size decisions and the reported
+    /// `token_estimate` on each [`RagChunk`](crate::pipeline::RagChunk). Use with
+    /// [`TiktokenCounter`](crate::pipeline::TiktokenCounter) (feature `tiktoken`)
+    /// to size chunks against a real subword tokenizer.
+    ///
+    /// Note: this flows through [`HybridChunker`](crate::pipeline::HybridChunker).
+    /// The `unstable-spi` pipeline entry points (`rag_chunks_with_pipeline` /
+    /// `rag_chunks_from_elements`) remain word-proxy only.
+    pub fn rag_chunks_with_counter(
+        &self,
+        config: crate::pipeline::HybridChunkConfig,
+        counter: std::sync::Arc<dyn crate::pipeline::TokenCounter>,
+    ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
+        let elements = self.partition()?;
+        let chunker = crate::pipeline::HybridChunker::new(config).with_token_counter(counter);
+        let hybrid_chunks = chunker.chunk(&elements);
+        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+    }
+
     /// Build RAG chunks stamped with source-document metadata.
     ///
     /// Auto-fills `title`/`author`/`creation_date`/`total_pages` from the info

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -1,5 +1,7 @@
 use crate::pipeline::graph::ElementGraph;
+use crate::pipeline::token_counter::{TokenCounter, WordProxyCounter};
 use crate::pipeline::{Element, ElementData, ElementMetadata};
+use std::sync::Arc;
 
 /// Policy for which adjacent element types can be merged into a single chunk.
 ///
@@ -88,6 +90,9 @@ pub struct HybridChunk {
     /// The heading context for this chunk (from `parent_heading` of its elements).
     pub heading_context: Option<String>,
     oversized: bool,
+    /// Token count stamped at construction by the chunker's active counter,
+    /// computed once over the whole chunk text. Returned by `token_estimate()`.
+    token_estimate: usize,
 }
 
 impl HybridChunk {
@@ -114,9 +119,10 @@ impl HybridChunk {
         }
     }
 
-    /// Approximate token count (word count proxy).
+    /// Token count under the counter that produced this chunk (word-proxy by
+    /// default; the chunker's injected `TokenCounter` otherwise).
     pub fn token_estimate(&self) -> usize {
-        estimate_tokens(&self.text())
+        self.token_estimate
     }
 
     /// Whether this chunk exceeds max_tokens (e.g., a large table).
@@ -145,11 +151,15 @@ impl HybridChunk {
             .map(|e| e.display_text())
             .collect::<Vec<_>>()
             .join("\n");
-        let oversized = estimate_tokens(&text) > max_tokens;
+        // The SPI pipeline path is word-proxy only (#377 resolution C): it has no
+        // HybridChunker instance to carry an injected counter.
+        let token_estimate = WordProxyCounter.count(&text);
+        let oversized = token_estimate > max_tokens;
         HybridChunk {
             elements: group.elements,
             heading_context: group.heading_context,
             oversized,
+            token_estimate,
         }
     }
 }
@@ -186,19 +196,53 @@ impl HybridChunk {
 /// ```
 pub struct HybridChunker {
     config: HybridChunkConfig,
+    counter: Arc<dyn TokenCounter>,
 }
 
 impl Default for HybridChunker {
     fn default() -> Self {
         Self {
             config: HybridChunkConfig::default(),
+            counter: Arc::new(WordProxyCounter),
         }
     }
 }
 
 impl HybridChunker {
     pub fn new(config: HybridChunkConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            counter: Arc::new(WordProxyCounter),
+        }
+    }
+
+    /// Inject a token counter governing split/oversize decisions and the stamped
+    /// per-chunk `token_estimate`. Default is `WordProxyCounter`.
+    pub fn with_token_counter(mut self, counter: Arc<dyn TokenCounter>) -> Self {
+        self.counter = counter;
+        self
+    }
+
+    /// Build a chunk, stamping its token count once over the whole chunk text
+    /// with the active counter.
+    fn make_chunk(
+        &self,
+        elements: Vec<Element>,
+        heading_context: Option<String>,
+        oversized: bool,
+    ) -> HybridChunk {
+        let text = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let token_estimate = self.counter.count(&text);
+        HybridChunk {
+            elements,
+            heading_context,
+            oversized,
+            token_estimate,
+        }
     }
 
     /// Chunk a list of elements into hybrid chunks.
@@ -213,7 +257,7 @@ impl HybridChunker {
         let mut buffer_heading: Option<String> = None;
 
         for element in elements {
-            let elem_tokens = estimate_tokens(&element.display_text());
+            let elem_tokens = self.counter.count(&element.display_text());
             let elem_heading = if self.config.propagate_headings {
                 element.metadata().parent_heading.clone()
             } else {
@@ -256,22 +300,19 @@ impl HybridChunker {
             if elem_tokens > self.config.max_tokens && buffer.is_empty() {
                 if is_splittable_element(element) {
                     let text = element.display_text();
-                    let fragments = split_by_sentences(&text, self.config.max_tokens);
+                    let fragments =
+                        split_by_sentences(&text, self.counter.as_ref(), self.config.max_tokens);
                     for fragment in fragments {
                         let fragment_element = make_text_fragment_element(element, fragment.trim());
-                        chunks.push(HybridChunk {
-                            elements: vec![fragment_element],
-                            heading_context: elem_heading.clone(),
-                            oversized: false,
-                        });
+                        chunks.push(self.make_chunk(
+                            vec![fragment_element],
+                            elem_heading.clone(),
+                            false,
+                        ));
                     }
                 } else {
                     // Table, image, code: atomic oversized chunk
-                    chunks.push(HybridChunk {
-                        elements: vec![element.clone()],
-                        heading_context: elem_heading,
-                        oversized: true,
-                    });
+                    chunks.push(self.make_chunk(vec![element.clone()], elem_heading, true));
                 }
                 continue;
             }
@@ -286,11 +327,7 @@ impl HybridChunker {
 
         // Flush remaining
         if !buffer.is_empty() {
-            chunks.push(HybridChunk {
-                elements: std::mem::take(&mut buffer),
-                heading_context: buffer_heading,
-                oversized: false,
-            });
+            chunks.push(self.make_chunk(std::mem::take(&mut buffer), buffer_heading, false));
         }
 
         chunks
@@ -344,16 +381,12 @@ impl HybridChunker {
 
             let section_tokens: usize = section_elements
                 .iter()
-                .map(|e| estimate_tokens(&e.display_text()))
+                .map(|e| self.counter.count(&e.display_text()))
                 .sum();
 
             if section_tokens <= self.config.max_tokens {
                 // Entire section fits in one chunk.
-                chunks.push(HybridChunk {
-                    elements: section_elements,
-                    heading_context: title_heading,
-                    oversized: false,
-                });
+                chunks.push(self.make_chunk(section_elements, title_heading, false));
             } else {
                 // Section is too large — split with standard chunker, then fix heading.
                 let mut sub_chunks = self.chunk(&section_elements);
@@ -386,17 +419,8 @@ impl HybridChunker {
         let heading = buffer_heading.take();
         *buffer_tokens = 0;
 
-        chunks.push(HybridChunk {
-            elements: flushed,
-            heading_context: heading,
-            oversized: false,
-        });
+        chunks.push(self.make_chunk(flushed, heading, false));
     }
-}
-
-/// Simple token estimator: word count (split by whitespace).
-fn estimate_tokens(text: &str) -> usize {
-    text.split_whitespace().count()
 }
 
 /// Whether two adjacent elements can be merged according to the given policy.
@@ -426,10 +450,10 @@ fn is_splittable_element(e: &Element) -> bool {
 }
 
 /// Split text at sentence boundaries (`. `, `! `, `? `, `\n`) into fragments of at most
-/// `max_tokens` words. Greedily accumulates sentences; if a single sentence still exceeds
-/// `max_tokens`, it is emitted as a single fragment (cannot split further without a
-/// semantic break). Never returns an empty Vec.
-fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
+/// `max_tokens` tokens under `counter`. Greedily accumulates sentences; if a single
+/// sentence still exceeds `max_tokens`, it is emitted as a single fragment (cannot split
+/// further without a semantic break). Never returns an empty Vec.
+fn split_by_sentences(text: &str, counter: &dyn TokenCounter, max_tokens: usize) -> Vec<String> {
     // Split into sentences preserving the delimiter as part of the sentence.
     let sentences = split_into_sentences(text);
 
@@ -442,7 +466,7 @@ fn split_by_sentences(text: &str, max_tokens: usize) -> Vec<String> {
         if sentence.is_empty() {
             continue;
         }
-        let sentence_tokens = estimate_tokens(sentence);
+        let sentence_tokens = counter.count(sentence);
 
         if current.is_empty() {
             // Starting a new fragment

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -33,4 +33,6 @@ pub use spi::{
 };
 #[cfg(all(feature = "unstable-spi", feature = "semantic"))]
 pub use spi::{EnrichContext, MetadataEnricher};
+#[cfg(feature = "tiktoken")]
+pub use token_counter::TiktokenCounter;
 pub use token_counter::{TokenCounter, WordProxyCounter};

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -10,6 +10,7 @@ pub mod reading_order;
 pub mod semantic_chunking;
 #[cfg(feature = "unstable-spi")]
 pub mod spi;
+pub mod token_counter;
 
 #[cfg(feature = "language-detection")]
 pub use chunk_metadata::detect_language;
@@ -32,3 +33,4 @@ pub use spi::{
 };
 #[cfg(all(feature = "unstable-spi", feature = "semantic"))]
 pub use spi::{EnrichContext, MetadataEnricher};
+pub use token_counter::{TokenCounter, WordProxyCounter};

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -23,8 +23,9 @@ use serde::{Deserialize, Serialize};
 /// - `full_text`: heading context + text — **use this for embedding generation**
 /// - `token_estimate`: token count under the chunker's active `TokenCounter`
 ///   (word-count proxy by default; a real tokenizer such as cl100k_base when a
-///   counter is injected via `rag_chunks_with_counter`). Query the counter's
-///   `name()` for provenance.
+///   counter is injected via `rag_chunks_with_counter`). `RagChunk` does not
+///   store the counter; query the counter you injected via its `name()` for
+///   provenance.
 /// - `is_oversized`: true when a single element exceeds `max_tokens`
 ///
 /// # Example
@@ -65,8 +66,8 @@ pub struct RagChunk {
     pub heading_context: Option<String>,
     /// Token count under the chunker's active `TokenCounter` (word-count
     /// proxy by default; a real tokenizer such as cl100k_base when a counter
-    /// is injected via `rag_chunks_with_counter`). Query the counter's
-    /// `name()` for provenance.
+    /// is injected via `rag_chunks_with_counter`). `RagChunk` does not store
+    /// the counter; query the counter you injected via its `name()`.
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -21,7 +21,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// - `text`: raw chunk text for display or keyword search
 /// - `full_text`: heading context + text — **use this for embedding generation**
-/// - `token_estimate`: word-count proxy (multiply by ~1.5 for subword tokens)
+/// - `token_estimate`: token count under the chunker's active `TokenCounter`
+///   (word-count proxy by default; a real tokenizer such as cl100k_base when a
+///   counter is injected via `rag_chunks_with_counter`). Query the counter's
+///   `name()` for provenance.
 /// - `is_oversized`: true when a single element exceeds `max_tokens`
 ///
 /// # Example
@@ -60,13 +63,10 @@ pub struct RagChunk {
     pub element_types: Vec<String>,
     /// Heading context inherited from the nearest parent heading.
     pub heading_context: Option<String>,
-    /// Approximate token count (word-count proxy).
-    ///
-    /// Computed as the number of whitespace-separated words. LLM subword
-    /// tokenizers (BPE/WordPiece) typically produce 1.3–1.7x more tokens
-    /// than the raw word count. Size your chunk budget accordingly: a
-    /// `max_tokens: 512` setting corresponds to roughly 300–390 actual
-    /// subword tokens for typical English prose.
+    /// Token count under the chunker's active `TokenCounter` (word-count
+    /// proxy by default; a real tokenizer such as cl100k_base when a counter
+    /// is injected via `rag_chunks_with_counter`). Query the counter's
+    /// `name()` for provenance.
     pub token_estimate: usize,
     /// Whether the chunk exceeds the configured `max_tokens`.
     pub is_oversized: bool,

--- a/oxidize-pdf-core/src/pipeline/semantic_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/semantic_chunking.rs
@@ -1,4 +1,6 @@
+use crate::pipeline::token_counter::{TokenCounter, WordProxyCounter};
 use crate::pipeline::Element;
+use std::sync::Arc;
 
 /// Configuration for semantic chunking.
 #[derive(Debug, Clone)]
@@ -42,6 +44,7 @@ impl SemanticChunkConfig {
 pub struct SemanticChunk {
     elements: Vec<Element>,
     oversized: bool,
+    token_estimate: usize,
 }
 
 impl SemanticChunk {
@@ -59,9 +62,9 @@ impl SemanticChunk {
             .join("\n")
     }
 
-    /// Approximate token count (word count proxy).
+    /// Token count under the counter that produced this chunk.
     pub fn token_estimate(&self) -> usize {
-        estimate_tokens(&self.text())
+        self.token_estimate
     }
 
     /// Page numbers spanned by this chunk.
@@ -81,19 +84,63 @@ impl SemanticChunk {
 /// Semantic chunker that respects element boundaries.
 pub struct SemanticChunker {
     config: SemanticChunkConfig,
+    counter: Arc<dyn TokenCounter>,
 }
 
 impl Default for SemanticChunker {
     fn default() -> Self {
         Self {
             config: SemanticChunkConfig::default(),
+            counter: Arc::new(WordProxyCounter),
         }
     }
 }
 
 impl SemanticChunker {
     pub fn new(config: SemanticChunkConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            counter: Arc::new(WordProxyCounter),
+        }
+    }
+
+    /// Inject a token counter governing split/oversize decisions and the stamped
+    /// per-chunk `token_estimate`. Default is `WordProxyCounter`.
+    pub fn with_token_counter(mut self, counter: Arc<dyn TokenCounter>) -> Self {
+        self.counter = counter;
+        self
+    }
+
+    fn element_tokens(&self, element: &Element) -> usize {
+        self.counter.count(&element.display_text())
+    }
+
+    fn make_chunk(&self, elements: Vec<Element>, oversized: bool) -> SemanticChunk {
+        let text = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let token_estimate = self.counter.count(&text);
+        SemanticChunk {
+            elements,
+            oversized,
+            token_estimate,
+        }
+    }
+
+    fn make_paragraph_chunk(
+        &self,
+        text: &str,
+        meta: &crate::pipeline::ElementMetadata,
+    ) -> SemanticChunk {
+        self.make_chunk(
+            vec![Element::Paragraph(crate::pipeline::ElementData {
+                text: text.to_string(),
+                metadata: meta.clone(),
+            })],
+            false,
+        )
     }
 
     /// Chunk a list of elements into semantic chunks.
@@ -107,7 +154,7 @@ impl SemanticChunker {
         let mut current_tokens = 0usize;
 
         for element in elements {
-            let elem_tokens = element_token_count(element);
+            let elem_tokens = self.element_tokens(element);
 
             // Non-splittable elements (Table, Title, Header, Footer, Image)
             if !is_splittable(element) {
@@ -126,10 +173,7 @@ impl SemanticChunker {
 
                 // If element alone exceeds max_tokens, it gets its own oversized chunk
                 if elem_tokens > self.config.max_tokens && current_elements.is_empty() {
-                    chunks.push(SemanticChunk {
-                        elements: vec![element.clone()],
-                        oversized: true,
-                    });
+                    chunks.push(self.make_chunk(vec![element.clone()], true));
                     continue;
                 }
 
@@ -172,9 +216,9 @@ impl SemanticChunker {
                 let mut buf_tokens = 0;
 
                 for sentence in &sentences {
-                    let s_tokens = estimate_tokens(sentence);
+                    let s_tokens = self.counter.count(sentence);
                     if buf_tokens + s_tokens > self.config.max_tokens && !sentence_buf.is_empty() {
-                        chunks.push(make_paragraph_chunk(&sentence_buf, &meta));
+                        chunks.push(self.make_paragraph_chunk(&sentence_buf, &meta));
                         sentence_buf.clear();
                         buf_tokens = 0;
                     }
@@ -197,10 +241,7 @@ impl SemanticChunker {
 
         // Flush remaining
         if !current_elements.is_empty() {
-            chunks.push(SemanticChunk {
-                elements: current_elements,
-                oversized: false,
-            });
+            chunks.push(self.make_chunk(current_elements, false));
         }
 
         chunks
@@ -215,10 +256,7 @@ impl SemanticChunker {
         oversized: bool,
     ) {
         let flushed = std::mem::take(current_elements);
-        chunks.push(SemanticChunk {
-            elements: flushed.clone(),
-            oversized,
-        });
+        chunks.push(self.make_chunk(flushed.clone(), oversized));
 
         // Apply overlap: carry trailing elements from flushed chunk into the next
         if self.config.overlap_tokens > 0 {
@@ -227,7 +265,7 @@ impl SemanticChunker {
 
             // Walk backwards through flushed elements to collect overlap
             for elem in flushed.iter().rev() {
-                let t = element_token_count(elem);
+                let t = self.element_tokens(elem);
                 if overlap_tokens + t > self.config.overlap_tokens && !overlap_elements.is_empty() {
                     break;
                 }
@@ -250,16 +288,6 @@ fn is_splittable(element: &Element) -> bool {
         element,
         Element::Paragraph(_) | Element::ListItem(_) | Element::CodeBlock(_) | Element::KeyValue(_)
     )
-}
-
-/// Approximate token count for an element.
-fn element_token_count(element: &Element) -> usize {
-    estimate_tokens(&element.display_text())
-}
-
-/// Simple token estimator: word count (split by whitespace).
-fn estimate_tokens(text: &str) -> usize {
-    text.split_whitespace().count()
 }
 
 /// Split text into sentences.
@@ -286,14 +314,4 @@ fn split_sentences(text: &str) -> Vec<String> {
     }
 
     sentences
-}
-
-fn make_paragraph_chunk(text: &str, meta: &crate::pipeline::ElementMetadata) -> SemanticChunk {
-    SemanticChunk {
-        elements: vec![Element::Paragraph(crate::pipeline::ElementData {
-            text: text.to_string(),
-            metadata: meta.clone(),
-        })],
-        oversized: false,
-    }
 }

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -23,6 +23,33 @@ impl TokenCounter for WordProxyCounter {
     }
 }
 
+/// Real token counter backed by tiktoken's cl100k_base BPE (GPT-3.5/4 family).
+#[cfg(feature = "tiktoken")]
+pub struct TiktokenCounter {
+    bpe: tiktoken_rs::CoreBPE,
+}
+
+#[cfg(feature = "tiktoken")]
+impl TiktokenCounter {
+    /// Load the cl100k_base BPE rank tables (embedded in the crate; infallible
+    /// in practice — the tables ship with `tiktoken-rs`).
+    pub fn cl100k_base() -> Self {
+        Self {
+            bpe: tiktoken_rs::cl100k_base().expect("cl100k_base tokenizer tables"),
+        }
+    }
+}
+
+#[cfg(feature = "tiktoken")]
+impl TokenCounter for TiktokenCounter {
+    fn count(&self, text: &str) -> usize {
+        self.bpe.encode_ordinary(text).len()
+    }
+    fn name(&self) -> &'static str {
+        "cl100k_base"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,5 +62,34 @@ mod tests {
         assert_eq!(c.count("  multiple   spaces  "), 2);
         assert_eq!(c.count("punct, and! more?"), 3);
         assert_eq!(c.name(), "word-proxy");
+    }
+}
+
+#[cfg(all(test, feature = "tiktoken"))]
+mod tiktoken_tests {
+    use super::*;
+
+    #[test]
+    fn cl100k_exact_reference_counts() {
+        let c = TiktokenCounter::cl100k_base();
+        // Pinned cl100k_base values (OpenAI reference tokenizer).
+        assert_eq!(c.count(""), 0);
+        assert_eq!(c.count("hello world"), 2);
+        assert_eq!(c.count("The quick brown fox"), 4);
+        assert_eq!(c.name(), "cl100k_base");
+    }
+
+    #[test]
+    fn cl100k_diverges_from_word_proxy_on_subword() {
+        let tk = TiktokenCounter::cl100k_base();
+        let wp = WordProxyCounter;
+        // A URL is one whitespace "word" but many BPE tokens.
+        let url = "https://example.com/verify";
+        assert_eq!(wp.count(url), 1);
+        assert!(
+            tk.count(url) > 1,
+            "tiktoken should split the URL: {}",
+            tk.count(url)
+        );
     }
 }

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -62,6 +62,13 @@ mod tests {
         assert_eq!(c.count("  multiple   spaces  "), 2);
         assert_eq!(c.count("punct, and! more?"), 3);
         assert_eq!(c.name(), "word-proxy");
+
+        // Property: the default counter must stay identical to the historical
+        // `split_whitespace().count()` word-proxy — this is the byte-identity
+        // invariant the whole feature rests on (#377).
+        for s in ["", "a b c", "  x  y ", "line1\nline2\tthree", "único café"] {
+            assert_eq!(c.count(s), s.split_whitespace().count());
+        }
     }
 }
 

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -1,0 +1,39 @@
+//! Pluggable token counting for chunk-size decisions and reported estimates.
+
+/// Counts tokens in a string. Implementations back chunk-size decisions and the
+/// reported `token_estimate` with a real tokenizer.
+pub trait TokenCounter: Send + Sync {
+    /// Number of tokens in `text` under this counter.
+    fn count(&self, text: &str) -> usize;
+    /// Stable provenance identifier, e.g. `"word-proxy"` or `"cl100k_base"`.
+    fn name(&self) -> &'static str;
+}
+
+/// Zero-dependency default: whitespace-separated word count. Reproduces the
+/// historical `estimate_tokens` behaviour exactly.
+#[derive(Debug, Default, Clone)]
+pub struct WordProxyCounter;
+
+impl TokenCounter for WordProxyCounter {
+    fn count(&self, text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+    fn name(&self) -> &'static str {
+        "word-proxy"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_proxy_matches_split_whitespace() {
+        let c = WordProxyCounter;
+        assert_eq!(c.count(""), 0);
+        assert_eq!(c.count("hello world"), 2);
+        assert_eq!(c.count("  multiple   spaces  "), 2);
+        assert_eq!(c.count("punct, and! more?"), 3);
+        assert_eq!(c.name(), "word-proxy");
+    }
+}

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -915,14 +915,11 @@ impl TextExtractor {
                             );
                         }
 
-                        // Update position for next text
-                        last_x = x + text_width;
+                        // Advance the text matrix and track the true post-advance
+                        // pen x (folds in Tz and CTM x-scale, issue #386). `last_y`
+                        // stays the shown-text origin y for line detection.
+                        last_x = advance_pen(&mut state, text_width);
                         last_y = y;
-
-                        // Update text matrix for next show operation
-                        let tx = text_width * state.horizontal_scale / 100.0;
-                        state.text_matrix =
-                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
                     }
                 }
 
@@ -987,15 +984,10 @@ impl TextExtractor {
 
                                     // Keep the pen position in sync so a following
                                     // `Tj`/`TJ` measures its gap from the right origin
-                                    // (issue #381: a stale `last_y` dropped newlines).
-                                    last_x = x + text_width;
+                                    // (issue #381: a stale `last_y` dropped newlines;
+                                    // issue #386: `last_x` must fold in Tz/CTM scale).
+                                    last_x = advance_pen(&mut state, text_width);
                                     last_y = y;
-
-                                    let tx = text_width * state.horizontal_scale / 100.0;
-                                    state.text_matrix = multiply_matrix(
-                                        &[1.0, 0.0, 0.0, 1.0, tx, 0.0],
-                                        &state.text_matrix,
-                                    );
                                 }
                                 TextElement::Spacing(adjustment) => {
                                     // Text position adjustment (negative = move left,
@@ -1103,12 +1095,8 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = x + text_width;
+                        last_x = advance_pen(&mut state, text_width);
                         last_y = y;
-
-                        let tx = text_width * state.horizontal_scale / 100.0;
-                        state.text_matrix =
-                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
                     }
                 }
 
@@ -1164,12 +1152,8 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = x + text_width;
+                        last_x = advance_pen(&mut state, text_width);
                         last_y = y;
-
-                        let tx = text_width * state.horizontal_scale / 100.0;
-                        state.text_matrix =
-                            multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
                     }
                 }
 
@@ -1982,6 +1966,21 @@ fn emit_text_fragment(
 fn text_origin(state: &TextState) -> (f64, f64) {
     let combined = multiply_matrix(&state.text_matrix, &state.ctm);
     transform_point(0.0, 0.0, &combined)
+}
+
+/// Advance the text matrix by one shown glyph run of unscaled width
+/// `text_width` and return the pen's new x in user space.
+///
+/// The advance applied to the text matrix is `text_width * Tz/100`
+/// (`state.horizontal_scale`), and the resulting user-space displacement also
+/// folds in the CTM's x-scale. The caller's `last_x` (used for `dx`-based
+/// space decisions) must therefore come from the post-advance pen origin, not
+/// from `origin_x + text_width`, which ignores both factors and trails the
+/// real pen whenever `Tz != 100` or the CTM scales x (issue #386).
+fn advance_pen(state: &mut TextState, text_width: f64) -> f64 {
+    let tx = text_width * state.horizontal_scale / 100.0;
+    state.text_matrix = multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
+    text_origin(state).0
 }
 
 /// Multiply two transformation matrices

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -937,6 +937,25 @@ impl TextExtractor {
                                     // for Artifact scopes (issue #330).
                                     let skip_text =
                                         skip_artifact_text(&state, self.options.include_artifacts);
+
+                                    // Pen origin in user space = (CTM × text_matrix)(0, 0).
+                                    let (x, y) = text_origin(&state);
+
+                                    // Insert a newline when this TJ piece starts on a
+                                    // different visual line than the previously shown
+                                    // text (issue #381). Only the vertical case is
+                                    // handled here: horizontal word spacing within a
+                                    // line is governed by the `TextElement::Spacing`
+                                    // kern logic below, and adding a dx-based space
+                                    // would wrongly split a single word that a TJ array
+                                    // draws as several positioned pieces.
+                                    if !skip_text
+                                        && !extracted_text.is_empty()
+                                        && (y - last_y).abs() > self.options.newline_threshold
+                                    {
+                                        extracted_text.push('\n');
+                                    }
+
                                     if !skip_text {
                                         extracted_text.push_str(&decoded);
                                     }
@@ -955,7 +974,6 @@ impl TextExtractor {
                                     };
 
                                     if self.options.preserve_layout {
-                                        let (x, y) = text_origin(&state);
                                         emit_text_fragment(
                                             &mut fragments,
                                             &decoded,
@@ -966,6 +984,12 @@ impl TextExtractor {
                                             self.options.include_artifacts,
                                         );
                                     }
+
+                                    // Keep the pen position in sync so a following
+                                    // `Tj`/`TJ` measures its gap from the right origin
+                                    // (issue #381: a stale `last_y` dropped newlines).
+                                    last_x = x + text_width;
+                                    last_y = y;
 
                                     let tx = text_width * state.horizontal_scale / 100.0;
                                     state.text_matrix = multiply_matrix(

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -68,6 +68,14 @@ pub struct ExtractionOptions {
     /// (issue #269 Phase 1). Opt-in by setting `true` when extracting
     /// page furniture matters (e.g. forensic auditing, redaction tools).
     pub include_artifacts: bool,
+    /// Reorder flat-text output by column so per-column tokens stay adjacent in
+    /// multi-column layouts (issue #389). Only affects the flat path
+    /// (`preserve_layout = false`); in layout mode `detect_columns` already
+    /// reorders. Default `false` → the flat path is byte-identical to before.
+    /// When on, `.text` is produced by the fragment pipeline (its shape matches
+    /// the layout path's reconstruction, not stream order); `.fragments` stays
+    /// empty.
+    pub reorder_columns: bool,
 }
 
 impl Default for ExtractionOptions {
@@ -84,6 +92,7 @@ impl Default for ExtractionOptions {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         }
     }
 }
@@ -780,6 +789,22 @@ impl TextExtractor {
             if self.options.preserve_layout && !fragments.is_empty() {
                 extracted_text = self.reconstruct_text_from_fragments(&fragments);
             }
+
+            // Flat path with column reordering (issue #389): fragments were
+            // collected only to reorder. `sort_and_merge_fragments` already ran
+            // at the top of this block (sort_by_position defaults true) and now
+            // applies column clustering via the gate above; call it here too so
+            // the behaviour is independent of `sort_by_position`, then rebuild
+            // the flat text from the reordered fragments and drop them (the
+            // `.fragments` contract only exposes fragments under preserve_layout).
+            if self.options.reorder_columns
+                && !self.options.preserve_layout
+                && !fragments.is_empty()
+            {
+                self.sort_and_merge_fragments(&mut fragments);
+                extracted_text = self.reconstruct_text_from_fragments(&fragments);
+                fragments.clear();
+            }
         }
 
         Ok(ExtractedText {
@@ -910,7 +935,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -985,7 +1010,8 @@ impl TextExtractor {
                                         )
                                     };
 
-                                    if self.options.preserve_layout {
+                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    {
                                         emit_text_fragment(
                                             &mut fragments,
                                             &decoded,
@@ -1098,7 +1124,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1155,7 +1181,7 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout {
+                        if self.options.preserve_layout || self.options.reorder_columns {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1308,7 +1334,9 @@ impl TextExtractor {
                         // If we just closed the scope that opened the pending run, flush it.
                         if pending.stack_depth + 1 == popped_depth {
                             let run = state.pending_actualtext.take().unwrap();
-                            if run.populated && self.options.preserve_layout {
+                            if run.populated
+                                && (self.options.preserve_layout || self.options.reorder_columns)
+                            {
                                 let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
                                 let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
@@ -1504,7 +1532,7 @@ impl TextExtractor {
         });
 
         // Detect columns if requested
-        if self.options.detect_columns {
+        if self.options.detect_columns || self.options.reorder_columns {
             self.detect_and_sort_columns(fragments);
         }
     }
@@ -2476,6 +2504,7 @@ mod tests {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         };
         assert!(options.preserve_layout);
         assert_eq!(options.space_threshold, 0.5);
@@ -2676,6 +2705,7 @@ mod tests {
             track_space_decisions: false,
             reconstruct_paragraphs: false,
             include_artifacts: false,
+            reorder_columns: false,
         };
         let extractor = TextExtractor::with_options(options.clone());
         assert_eq!(extractor.options.preserve_layout, options.preserve_layout);

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1057,7 +1057,8 @@ impl TextExtractor {
                                         // even though no real `Tj` has fired yet. The
                                         // EMC flush will supply the canonical fragment
                                         // text from the override (Phase 1 #269 contract).
-                                        if self.options.preserve_layout
+                                        if (self.options.preserve_layout
+                                            || self.options.reorder_columns)
                                             && state.pending_actualtext.is_none()
                                         {
                                             // Emit a synthetic single-space fragment at the
@@ -1531,8 +1532,13 @@ impl TextExtractor {
             band_a.total_cmp(&band_b).then_with(|| a.x.total_cmp(&b.x))
         });
 
-        // Detect columns if requested
-        if self.options.detect_columns || self.options.reorder_columns {
+        // Detect columns if requested. `reorder_columns` forces column detection
+        // only on the flat path (`!preserve_layout`); in layout mode `detect_columns`
+        // is the intended control, keeping the `reorder_columns` field flat-only as
+        // documented (issue #389).
+        if self.options.detect_columns
+            || (self.options.reorder_columns && !self.options.preserve_layout)
+        {
             self.detect_and_sort_columns(fragments);
         }
     }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -875,7 +875,14 @@ impl TextExtractor {
                             let dx = x - last_x;
                             let dy = (y - last_y).abs();
 
-                            if dy > self.options.newline_threshold {
+                            // A large backward jump in x is a line wrap: the pen
+                            // returns to the left margin on a new line. When the
+                            // line height is below `newline_threshold` the dy check
+                            // alone misses it, so treat a backward dx beyond one
+                            // line-height (2× the threshold, conservative) as a
+                            // newline regardless of dy (issue #390).
+                            let line_wrap = dx < -(self.options.newline_threshold * 2.0);
+                            if dy > self.options.newline_threshold || line_wrap {
                                 extracted_text.push('\n');
                             } else if dx > self.options.space_threshold * state.font_size {
                                 extracted_text.push(' ');
@@ -940,15 +947,23 @@ impl TextExtractor {
 
                                     // Insert a newline when this TJ piece starts on a
                                     // different visual line than the previously shown
-                                    // text (issue #381). Only the vertical case is
-                                    // handled here: horizontal word spacing within a
-                                    // line is governed by the `TextElement::Spacing`
-                                    // kern logic below, and adding a dx-based space
-                                    // would wrongly split a single word that a TJ array
-                                    // draws as several positioned pieces.
+                                    // text (issue #381), or when the pen jumps far back
+                                    // to the left — a line wrap whose line height is
+                                    // below `newline_threshold` (issue #390). Only the
+                                    // newline case is handled here: horizontal word
+                                    // spacing within a line is governed by the
+                                    // `TextElement::Spacing` kern logic below, and a
+                                    // forward dx-based space would wrongly split a single
+                                    // word that a TJ array draws as several positioned
+                                    // pieces. A *backward* dx beyond one line-height
+                                    // (2× the threshold, conservative) is a wrap, not a
+                                    // kern, so it is safe to break there.
+                                    let line_wrap =
+                                        (x - last_x) < -(self.options.newline_threshold * 2.0);
                                     if !skip_text
                                         && !extracted_text.is_empty()
-                                        && (y - last_y).abs() > self.options.newline_threshold
+                                        && ((y - last_y).abs() > self.options.newline_threshold
+                                            || line_wrap)
                                     {
                                         extracted_text.push('\n');
                                     }

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -125,3 +125,72 @@ fn rag_chunks_with_counter_word_proxy_parity() {
         assert_eq!(b.token_estimate, i.token_estimate);
     }
 }
+
+#[cfg(feature = "tiktoken")]
+mod tiktoken_integration {
+    use super::para;
+    use oxidize_pdf::pipeline::{
+        HybridChunkConfig, HybridChunker, TiktokenCounter, TokenCounter, WordProxyCounter,
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn injected_tiktoken_stamps_exact_wholetext_count() {
+        // Single paragraph, subword-heavy. Stamp must equal cl100k count of the
+        // whole chunk text, not the word count.
+        let text = "https://example.com/verify?token=abc123";
+        let elements = vec![para(text)];
+        let chunker = HybridChunker::new(HybridChunkConfig {
+            max_tokens: 10_000, // large: keep it a single chunk
+            ..Default::default()
+        })
+        .with_token_counter(Arc::new(TiktokenCounter::cl100k_base()));
+        let chunks = chunker.chunk(&elements);
+        assert_eq!(chunks.len(), 1);
+
+        let expected = TiktokenCounter::cl100k_base().count(text);
+        assert_eq!(chunks[0].token_estimate(), expected);
+        // And it must differ from the word-proxy (1 word, no whitespace).
+        assert_eq!(WordProxyCounter.count(text), 1);
+        assert!(expected > 1);
+    }
+
+    #[test]
+    fn tiktoken_drives_split_word_proxy_would_not() {
+        // Two subword-heavy paragraphs. Under word-proxy each is 1 "word" → they
+        // stay merged under a tiny budget. Under cl100k each is many tokens → the
+        // summed decision exceeds the budget and they do NOT merge.
+        let a = "https://example.com/alpha/one/two/three";
+        let b = "https://example.com/beta/four/five/six";
+
+        // Precondition guard: the split test only proves what it claims if each
+        // URL individually exceeds max_tokens (5) under cl100k. Confirmed
+        // empirically: cl100k_base().count(a) == 12, count(b) == 12.
+        let count_a = TiktokenCounter::cl100k_base().count(a);
+        let count_b = TiktokenCounter::cl100k_base().count(b);
+        assert!(count_a > 5, "a should exceed max_tokens=5, got {}", count_a);
+        assert!(count_b > 5, "b should exceed max_tokens=5, got {}", count_b);
+
+        let elements = vec![para(a), para(b)];
+        let cfg = HybridChunkConfig {
+            max_tokens: 5,
+            ..Default::default()
+        };
+
+        // Word-proxy: elem_tokens(a)=1, elem_tokens(b)=1, 1+1<=5 → may merge into 1 chunk.
+        let wp_chunks = HybridChunker::new(cfg.clone()).chunk(&elements);
+
+        // Tiktoken: each URL is >5 cl100k tokens → cannot merge; also each single
+        // element exceeds max_tokens → splittable path fires.
+        let tk_chunks = HybridChunker::new(cfg)
+            .with_token_counter(Arc::new(TiktokenCounter::cl100k_base()))
+            .chunk(&elements);
+
+        assert!(
+            tk_chunks.len() > wp_chunks.len(),
+            "tiktoken should produce more chunks: wp={} tk={}",
+            wp_chunks.len(),
+            tk_chunks.len()
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -50,3 +50,78 @@ fn semantic_with_token_counter_builder_exists() {
     let chunks = chunker.chunk(&elements);
     assert_eq!(chunks[0].token_estimate(), 3);
 }
+
+/// Build a small in-memory PDF whose body, chunked with a tight token budget,
+/// yields several chunks. Pattern mirrors `rag_chunk_metadata_test.rs::build_chunks`.
+fn build_test_document() -> oxidize_pdf::parser::PdfDocument<std::io::Cursor<Vec<u8>>> {
+    use oxidize_pdf::parser::{PdfDocument, PdfReader};
+    use oxidize_pdf::text::Font;
+    use oxidize_pdf::{Document, Page};
+    use std::io::Cursor;
+
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    page.text()
+        .set_font(Font::HelveticaBold, 16.0)
+        .at(50.0, 760.0)
+        .write("SECTION ALPHA HEADING")
+        .unwrap();
+
+    let body_lines = [
+        (720.0, "Alpha marker paragraph with several words to fill the first token budget bucket completely."),
+        (700.0, "Bravo marker paragraph with several words to fill the second token budget bucket completely."),
+        (680.0, "Charlie marker paragraph with several words to fill the third token budget bucket completely."),
+        (660.0, "Delta marker paragraph with several words to fill the fourth token budget bucket completely."),
+        (640.0, "Echo marker paragraph with several words to fill the fifth token budget bucket completely."),
+        (620.0, "Foxtrot marker paragraph with several words to fill the sixth token budget bucket completely."),
+    ];
+    for (y, line) in body_lines {
+        page.text()
+            .set_font(Font::Helvetica, 11.0)
+            .at(50.0, y)
+            .write(line)
+            .unwrap();
+    }
+
+    doc.add_page(page);
+    let pdf_bytes = doc.to_bytes().expect("pdf generation should succeed");
+
+    let reader = PdfReader::new(Cursor::new(pdf_bytes)).expect("parse generated PDF");
+    PdfDocument::new(reader)
+}
+
+#[test]
+fn rag_chunks_with_counter_word_proxy_parity() {
+    use oxidize_pdf::pipeline::{HybridChunkConfig, MergePolicy, WordProxyCounter};
+
+    let doc = build_test_document();
+
+    // Tight token budget to force multiple chunks; merge adjacent so paragraphs
+    // accrete into a bucket until the budget overflows.
+    let config = HybridChunkConfig {
+        max_tokens: 12,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: true,
+        merge_policy: MergePolicy::AnyInlineContent,
+    };
+
+    let base = doc.rag_chunks_with(config.clone()).unwrap();
+    let injected = doc
+        .rag_chunks_with_counter(config, Arc::new(WordProxyCounter))
+        .unwrap();
+
+    assert!(
+        base.len() >= 2,
+        "expected at least two chunks to make the parity check meaningful, got {}",
+        base.len()
+    );
+
+    // Same grouping/metadata; word-proxy injection changes nothing.
+    assert_eq!(base.len(), injected.len());
+    for (b, i) in base.iter().zip(&injected) {
+        assert_eq!(b.text, i.text);
+        assert_eq!(b.token_estimate, i.token_estimate);
+    }
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -30,3 +30,23 @@ fn with_token_counter_accepts_word_proxy_explicitly() {
     let chunks = chunker.chunk(&elements);
     assert_eq!(chunks[0].token_estimate(), 3);
 }
+
+#[test]
+fn default_semantic_chunker_stamps_word_count() {
+    use oxidize_pdf::pipeline::{SemanticChunkConfig, SemanticChunker};
+    let elements = vec![para("one two three four five")];
+    let chunker = SemanticChunker::new(SemanticChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].token_estimate(), 5);
+}
+
+#[test]
+fn semantic_with_token_counter_builder_exists() {
+    use oxidize_pdf::pipeline::{SemanticChunkConfig, SemanticChunker, WordProxyCounter};
+    let elements = vec![para("one two three")];
+    let chunker = SemanticChunker::new(SemanticChunkConfig::default())
+        .with_token_counter(Arc::new(WordProxyCounter));
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks[0].token_estimate(), 3);
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -1,0 +1,32 @@
+//! #377 — TokenCounter injection into the chunking path.
+use oxidize_pdf::pipeline::{
+    Element, ElementData, ElementMetadata, HybridChunkConfig, HybridChunker,
+};
+use std::sync::Arc;
+
+fn para(text: &str) -> Element {
+    Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    })
+}
+
+#[test]
+fn default_hybrid_chunker_stamps_word_count() {
+    // No injection → WordProxyCounter → token_estimate == whitespace word count.
+    let elements = vec![para("alpha beta gamma delta")];
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].token_estimate(), 4);
+}
+
+#[test]
+fn with_token_counter_accepts_word_proxy_explicitly() {
+    use oxidize_pdf::pipeline::WordProxyCounter;
+    let elements = vec![para("alpha beta gamma")];
+    let chunker = HybridChunker::new(HybridChunkConfig::default())
+        .with_token_counter(Arc::new(WordProxyCounter));
+    let chunks = chunker.chunk(&elements);
+    assert_eq!(chunks[0].token_estimate(), 3);
+}

--- a/oxidize-pdf-core/tests/issue_381_tj_newline_test.rs
+++ b/oxidize-pdf-core/tests/issue_381_tj_newline_test.rs
@@ -1,0 +1,183 @@
+//! Regression tests for issue #381.
+//!
+//! Flat-text extraction (`preserve_layout = false`) must insert a newline
+//! between `TJ` (`ShowTextArray`) blocks drawn on different visual lines.
+//! Before the fix, the `TextElement::Text` arm of `ShowTextArray` neither
+//! checked the pen origin against `newline_threshold` nor updated
+//! `last_x`/`last_y`, so text on separate lines was glued together and a
+//! following `Tj` measured its gap from a stale position.
+//!
+//! Nuance (also asserted): the fix adds ONLY the vertical (newline) case.
+//! A single word drawn as several positioned pieces inside one `TJ` array on
+//! the same line must NOT gain a spurious newline — horizontal spacing stays
+//! governed by the existing `TextElement::Spacing` kern logic.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false (the affected flat path).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_blocks_on_different_lines_get_a_newline() {
+    // Δy = 700 - 680 = 20 > newline_threshold (10) => a '\n' must separate them.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(user@example.com)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(* footnote text here)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        !text.contains("user@example.com*"),
+        "TJ blocks on different lines were glued together: {text:?}"
+    );
+    assert!(
+        text.contains("user@example.com\n* footnote text here"),
+        "expected a newline between the two TJ lines, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_pieces_of_one_word_on_same_line_are_not_split() {
+    // A single word "example" drawn as three positioned pieces inside ONE TJ
+    // array, all at the same y. Kerning between pieces is expressed as small
+    // negative adjustments (below tj_space_threshold), so nothing should break
+    // the word — and crucially, no newline may appear.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n",
+        "[(ex) -5 (am) -5 (ple)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        text.contains("example"),
+        "same-line TJ pieces of one word were split: {text:?}"
+    );
+    assert!(
+        !text.contains('\n'),
+        "no newline expected within a single visual line, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_then_tj_on_same_line_stay_joined() {
+    // Two TJ blocks at the SAME y (same line) must not get a newline: the fix
+    // is vertical-only.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(Hello)] TJ\n",
+        "1 0 0 1 90 700 Tm\n[(World)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert!(
+        !text.contains('\n'),
+        "no newline expected for TJ blocks on the same line, got: {text:?}"
+    );
+}
+
+#[test]
+fn tj_then_bare_tj_on_different_line_gets_newline() {
+    // Real-world streams mix `Tj` and `TJ`. The TJ arm must keep `last_y` in
+    // sync so a following bare `Tj` (whose newline check reads `last_y`) still
+    // sees the line change — and vice versa. Guards the `last_y` write in the
+    // TJ arm against the read in the `ShowText` (Tj) arm.
+    let tj_then_tj = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(TJ line)] TJ\n",
+        "1 0 0 1 50 680 Tm\n(Tj line) Tj\nET"
+    );
+    assert!(
+        extract_flat(tj_then_tj).contains("TJ line\nTj line"),
+        "TJ→Tj across lines lost the newline: {:?}",
+        extract_flat(tj_then_tj)
+    );
+
+    let tj_then_ta = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n(Tj line) Tj\n",
+        "1 0 0 1 50 680 Tm\n[(TJ line)] TJ\nET"
+    );
+    assert!(
+        extract_flat(tj_then_ta).contains("Tj line\nTJ line"),
+        "Tj→TJ across lines lost the newline: {:?}",
+        extract_flat(tj_then_ta)
+    );
+}
+
+#[test]
+fn tj_updates_position_so_following_tj_measures_correctly() {
+    // TJ on line 1, then TJ on line 2, then TJ back near line 1's y but a full
+    // line below the previous. Each vertical jump > threshold must newline.
+    // This exercises last_y being kept in sync by the TJ arm (stale last_y
+    // would drop the second newline).
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(line one)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(line two)] TJ\n",
+        "1 0 0 1 50 660 Tm\n[(line three)] TJ\nET"
+    );
+    let text = extract_flat(content);
+
+    assert_eq!(
+        text.matches('\n').count(),
+        2,
+        "expected exactly two newlines across three TJ lines, got: {text:?}"
+    );
+    assert!(
+        text.contains("line one\nline two\nline three"),
+        "lines were not separated correctly: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_386_tz_pen_advance_test.rs
+++ b/oxidize-pdf-core/tests/issue_386_tz_pen_advance_test.rs
@@ -1,0 +1,135 @@
+//! Regression tests for issue #386.
+//!
+//! The pen-position tracking used for space/newline decisions in the flat
+//! extraction path recorded `last_x = origin_x + text_width`, which ignores
+//! both the horizontal text scaling operator `Tz` (`state.horizontal_scale`)
+//! and the CTM's x-scale. When either differs from the identity, `last_x`
+//! underestimates the real pen advance, so the next text-showing operator
+//! measures `dx = x - last_x` against a stale position and inserts a spurious
+//! space between text that is actually flush.
+//!
+//! Both tests use the *natural* pen advance (two consecutive `Tj` with no
+//! intervening `Tm`), so the second operator's origin is exactly the pen
+//! position after the first — no hard-coded glyph widths needed. Correct
+//! tracking yields `dx == 0` (no space); the bug yields `dx == text_width`
+//! (a space).
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tz_scaled_flush_text_gets_no_spurious_space() {
+    // `200 Tz` doubles the horizontal advance. Two consecutive `Tj` (no `Tm`
+    // between them) sit flush. Correct tracking => "HiThere". The bug records
+    // last_x = origin + text_width (Tz ignored), so dx = text_width > 0 and a
+    // space is wrongly inserted.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n200 Tz\n",
+        "1 0 0 1 50 700 Tm\n(Hi) Tj\n(There) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("HiThere"),
+        "Tz-scaled flush text got a spurious space: {text:?}"
+    );
+}
+
+#[test]
+fn ctm_scaled_flush_text_gets_no_spurious_space() {
+    // A 2x scaling CTM (`2 0 0 2 0 0 cm`) doubles the user-space advance while
+    // `Tz` stays at 100. `text_width` (computed from font_size, not the CTM)
+    // underestimates the real advance, so the buggy last_x again trails the
+    // real pen and a spurious space appears.
+    let content = concat!(
+        "2 0 0 2 0 0 cm\n",
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 25 350 Tm\n(Hi) Tj\n(There) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("HiThere"),
+        "CTM-scaled flush text got a spurious space: {text:?}"
+    );
+}
+
+#[test]
+fn unscaled_flush_text_still_joins() {
+    // Baseline: with Tz=100 and identity CTM, flush text stays joined (guards
+    // against the fix over-correcting and dropping legitimate advances).
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n(Hi) Tj\n(There) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("HiThere"),
+        "unscaled flush text was split: {text:?}"
+    );
+}
+
+#[test]
+fn tz_scaled_wide_gap_still_spaces() {
+    // Sanity: a genuinely wide gap under Tz must still produce a space. Here
+    // the second Tm is placed far to the right, so dx is unambiguously large
+    // regardless of the tracking fix.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n200 Tz\n",
+        "1 0 0 1 50 700 Tm\n(Hi) Tj\n",
+        "1 0 0 1 400 700 Tm\n(There) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("Hi There"),
+        "a wide gap under Tz should still insert a space: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -102,3 +102,53 @@ fn reorder_columns_preserves_wide_tj_kern_space() {
         "wide TJ kern must stay a space under reorder_columns, not concatenate: {text:?}"
     );
 }
+
+#[test]
+fn default_flat_still_interleaves_columns() {
+    // Documents the pre-fix behaviour and proves the flag is the switch: with
+    // reorder_columns OFF (default), the col1 email is still broken by col2.
+    let text = extract(TWO_COL_EMAILS, ExtractionOptions::default()).text;
+    assert!(
+        !text.contains("user@example.com"),
+        "default flat must remain stream-order (broken email): {text:?}"
+    );
+}
+
+#[test]
+fn reorder_columns_leaves_fragments_empty() {
+    // Contract: reorder_columns fixes only `.text`; `.fragments` stays empty in
+    // flat mode (populated only under preserve_layout).
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let result = extract(TWO_COL_EMAILS, opts);
+    assert!(
+        result.fragments.is_empty(),
+        "flat + reorder_columns must not expose fragments"
+    );
+}
+
+#[test]
+fn single_column_reorder_matches_plain_flat() {
+    // A single-column doc: no column boundary is detected, so reorder_columns
+    // must not split or reorder — the wrapped lines stay in reading order.
+    const ONE_COL: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(alpha beta)] TJ\n",
+        "1 0 0 1 50 680 Tm\n[(gamma delta)] TJ\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(ONE_COL, opts).text;
+    // Both lines present, in reading order, words within each line intact.
+    let a = text.find("alpha").expect("alpha present");
+    let g = text.find("gamma").expect("gamma present");
+    assert!(a < g, "reading order preserved for single column: {text:?}");
+    assert!(
+        text.contains("alpha beta") && text.contains("gamma delta"),
+        "words within each line stay intact: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -1,0 +1,80 @@
+//! Regression tests for issue #389 — flat-text column reordering (opt-in).
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+// Two-column table row: col1 email `user@example`+`.com` (x=50,x=100),
+// col2 email `tel@example`+`.com` (x=200,x=250), interleaved in stream order.
+const TWO_COL_EMAILS: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 50 680 Tm\n[(user@example)] TJ\n",
+    "1 0 0 1 200 680 Tm\n[(tel@example)] TJ\n",
+    "1 0 0 1 100 680 Tm\n[(.com)] TJ\n",
+    "1 0 0 1 250 680 Tm\n[(.com)] TJ\nET"
+);
+
+#[test]
+fn reorder_columns_keeps_column_tokens_adjacent() {
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(TWO_COL_EMAILS, opts).text;
+    assert!(
+        text.contains("user@example.com"),
+        "col1 email must be intact under reorder_columns: {text:?}"
+    );
+    assert!(
+        text.contains("tel@example.com"),
+        "col2 email must be intact under reorder_columns: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
+++ b/oxidize-pdf-core/tests/issue_389_flat_reorder_columns_test.rs
@@ -78,3 +78,27 @@ fn reorder_columns_keeps_column_tokens_adjacent() {
         "col2 email must be intact under reorder_columns: {text:?}"
     );
 }
+
+#[test]
+fn reorder_columns_preserves_wide_tj_kern_space() {
+    // A word break encoded purely as a wide TJ kern (issue #272), with the kern
+    // in the [tj_space_threshold, space_threshold) * font_size band: -250/1000 *
+    // 10pt = 2.5pt, which is > 2.0pt (tj_space_threshold*fs, so the synthetic
+    // space fires) but < 3.0pt (space_threshold*fs, so `reconstruct_text_from_
+    // fragments` would NOT insert a gap-based space). The synthetic-space
+    // fragment must therefore be collected under reorder_columns too, or the two
+    // words concatenate. Single column → no reordering; this isolates the kern.
+    const KERN_BREAK: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(alpha) -250 (beta)] TJ\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(KERN_BREAK, opts).text;
+    assert!(
+        text.contains("alpha beta"),
+        "wide TJ kern must stay a space under reorder_columns, not concatenate: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_390_flat_line_wrap_test.rs
+++ b/oxidize-pdf-core/tests/issue_390_flat_line_wrap_test.rs
@@ -1,0 +1,131 @@
+//! Regression tests for issue #390.
+//!
+//! Flat-text extraction (`preserve_layout = false`) glued the last word of one
+//! visual line to the first word of the next when the line height was smaller
+//! than `newline_threshold` (default 10pt) AND the next line wrapped back to
+//! the left. The newline gate keyed only on `dy > newline_threshold`, so a
+//! Δy of ~9pt produced no newline; and because the pen jumped backward
+//! (negative dx, a line wrap) the space branch didn't fire either — nothing
+//! was inserted.
+//!
+//! Fix: treat a large backward horizontal jump (`dx < -(newline_threshold*2)`)
+//! as a line wrap and insert a newline regardless of the exact Δy. Applied to
+//! both the `Tj` (`ShowText`) and `TJ` (`ShowTextArray`) handlers.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false (the affected flat path).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_line_wrap_below_threshold_gets_newline() {
+    // Δy = 700 - 691 = 9 pt  <  newline_threshold (10). The second line wraps
+    // back to x=50 (a big negative dx). Before the fix the two lines glued into
+    // "...linkhttps://...". A '\n' must now separate them.
+    let content = concat!(
+        "BT\n/F1 8 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(Please scan the QR code at the link)] TJ\n",
+        "1 0 0 1 50 691 Tm\n[(https://example.com/verify)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("link\nhttps://example.com/verify"),
+        "expected a newline between the wrapped lines, got: {text:?}"
+    );
+    assert!(
+        !text.contains("linkhttps"),
+        "last word of line 1 must not touch first word of line 2: {text:?}"
+    );
+}
+
+#[test]
+fn tj_operator_line_wrap_below_threshold_gets_newline() {
+    // Same wrap, but drawn with the `Tj` (ShowText) operator instead of `TJ`.
+    let content = concat!(
+        "BT\n/F1 8 Tf\n",
+        "1 0 0 1 50 700 Tm\n(Please scan the QR code at the link) Tj\n",
+        "1 0 0 1 50 691 Tm\n(https://example.com/verify) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("link\nhttps://example.com/verify"),
+        "Tj path must also break the wrapped line, got: {text:?}"
+    );
+    assert!(
+        !text.contains("linkhttps"),
+        "Tj path glued the wrapped lines: {text:?}"
+    );
+}
+
+#[test]
+fn same_line_forward_pieces_do_not_get_spurious_newline() {
+    // Two TJ pieces on the SAME line (Δy = 0), the second advancing forward
+    // (x=90 > x=50). The line-wrap rule keys on a large *backward* dx, so a
+    // forward advance must never insert a newline — a word drawn in pieces
+    // stays on one line.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n[(Hello)] TJ\n",
+        "1 0 0 1 90 700 Tm\n[(World)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "forward same-line pieces must not gain a newline: {text:?}"
+    );
+    assert!(
+        text.contains("Hello") && text.contains("World"),
+        "both pieces must be present: {text:?}"
+    );
+}


### PR DESCRIPTION
## Release 3.1.0

**MINOR** — additive API + one flat-text bug fix. No breaking changes; MSRV 1.88.

### Added
- **#377** — `TokenCounter` trait (`pipeline::token_counter`): `WordProxyCounter` (zero-dep default) + feature-gated `TiktokenCounter` (cl100k_base, `tiktoken` feature). `HybridChunker`/`SemanticChunker` gain `with_token_counter(..)`; chunks stamp `token_estimate` with the active counter; `PdfDocument::rag_chunks_with_counter`. Default build byte-identical, no new default dep.
- **#389** — `ExtractionOptions.reorder_columns` (opt-in, default off): flat-text path reorders by column so per-column tokens stay adjacent in multi-column tables. Reuses existing column detection; `.fragments` stays empty; default byte-identical.

### Fixed
- **#390** — flat-text no longer glues line-wrapped text when line height < `newline_threshold` (backward horizontal jump now treated as a line break in Tj and TJ handlers).

### Verification
develop CI green on each merged PR (#393/#394/#396, all-OS + MSRV 1.88). Pre-release on develop: lib 6598/0, clippy `--all-features -D warnings` clean, fmt clean, MSRV 1.88 builds with `--features tiktoken`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
