### PR TITLE
fix(parser): reconstruct missing/corrupt xref tables, fail-safe for encryption (#374)

### DIFF
--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -496,8 +496,14 @@ impl PdfObject {
         }
     }
 
-    /// Parse the inner dictionary with custom options
-    fn parse_dictionary_inner_with_options<R: Read + std::io::Seek>(
+    /// Parse the inner dictionary with custom options.
+    ///
+    /// Assumes the opening `<<` token has already been consumed and parses key/
+    /// value pairs up to the closing `>>`, WITHOUT attempting to read any
+    /// following `stream` body. `pub(crate)` so xref recovery (Issue #374) can
+    /// extract `/Encrypt`/`/ID` from a cross-reference stream object's dict
+    /// without risking a stream-body parse failure discarding the dictionary.
+    pub(crate) fn parse_dictionary_inner_with_options<R: Read + std::io::Seek>(
         lexer: &mut Lexer<R>,
         options: &super::ParseOptions,
     ) -> ParseResult<PdfDictionary> {

--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -559,6 +559,27 @@ impl PdfObject {
                 if *len == -1 {
                     // Special marker for missing length - we need to search for endstream
                     usize::MAX // We'll handle this specially below
+                } else if *len < 0 {
+                    // A present-but-negative /Length is invalid (ISO 32000-1
+                    // §7.3.8.2: Length is a non-negative integer). Casting it to
+                    // usize would request an astronomically large buffer and
+                    // abort the process with a capacity overflow. Fall back to
+                    // the bounded endstream search in lenient mode; fail cleanly
+                    // otherwise. (Regression guard: exposed once xref recovery
+                    // began reaching such streams by default — see #374.)
+                    if options.lenient_streams {
+                        if options.collect_warnings {
+                            tracing::debug!(
+                                "Warning: negative stream /Length {len}; searching for endstream marker"
+                            );
+                        }
+                        usize::MAX
+                    } else {
+                        return Err(ParseError::SyntaxError {
+                            position: lexer.position(),
+                            message: format!("Invalid negative stream length: {len}"),
+                        });
+                    }
                 } else {
                     *len as usize
                 }

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -3747,11 +3747,22 @@ startxref
 %%EOF"
             .to_vec();
 
+        // Issue #374: a corrupt xref table is reconstructed by scanning object
+        // headers (default options allow recovery). The scan finds object 1 and
+        // resolves the catalog.
+        let cursor = Cursor::new(corrupt_pdf.clone());
+        let mut reader = PdfReader::new(cursor).expect("corrupt xref is reconstructed by scan");
+        let catalog = reader
+            .catalog()
+            .expect("catalog resolves after reconstruction");
+        assert_eq!(
+            catalog.get("Type"),
+            Some(&PdfObject::Name(PdfName("Catalog".to_string()))),
+        );
+
+        // strict() disables recovery: the corrupt xref must still fail loudly.
         let cursor = Cursor::new(corrupt_pdf);
-        let result = PdfReader::new(cursor);
-        // Even with lenient parsing, completely corrupted xref table cannot be recovered
-        // Note: XRef recovery for corrupted tables is a potential future enhancement
-        assert!(result.is_err());
+        assert!(PdfReader::new_with_options(cursor, ParseOptions::strict()).is_err());
     }
 
     #[test]
@@ -3769,11 +3780,22 @@ startxref
 %%EOF"
             .to_vec();
 
+        // Issue #374: without a trailer, recovery locates the catalog by
+        // scanning objects for /Type /Catalog and synthesizes the trailer's
+        // /Root, so default parsing succeeds.
+        let cursor = Cursor::new(pdf_no_trailer.clone());
+        let mut reader = PdfReader::new(cursor).expect("missing trailer recovered by object scan");
+        let catalog = reader
+            .catalog()
+            .expect("catalog resolved from scanned /Root");
+        assert_eq!(
+            catalog.get("Type"),
+            Some(&PdfObject::Name(PdfName("Catalog".to_string()))),
+        );
+
+        // strict() disables recovery: a missing trailer must still fail.
         let cursor = Cursor::new(pdf_no_trailer);
-        let result = PdfReader::new(cursor);
-        // PDFs without trailer cannot be parsed even with lenient mode
-        // The trailer is essential for locating the catalog
-        assert!(result.is_err());
+        assert!(PdfReader::new_with_options(cursor, ParseOptions::strict()).is_err());
     }
 
     #[test]
@@ -3940,11 +3962,22 @@ startxref
 %%EOF"
             .to_vec();
 
+        // Issue #374: a trailer without /Root triggers recovery, which locates
+        // the catalog by content scan and synthesizes /Root, so default parsing
+        // succeeds and resolves the catalog.
+        let cursor = Cursor::new(bad_pdf.clone());
+        let mut reader = PdfReader::new(cursor).expect("missing /Root recovered by object scan");
+        let catalog = reader
+            .catalog()
+            .expect("catalog resolved from scanned /Root");
+        assert_eq!(
+            catalog.get("Type"),
+            Some(&PdfObject::Name(PdfName("Catalog".to_string()))),
+        );
+
+        // strict() disables recovery: a trailer without /Root must still fail.
         let cursor = Cursor::new(bad_pdf);
-        let result = PdfReader::new(cursor);
-        // Trailer missing required /Root entry cannot be recovered
-        // This is a fundamental requirement for PDF structure
-        assert!(result.is_err());
+        assert!(PdfReader::new_with_options(cursor, ParseOptions::strict()).is_err());
     }
 
     #[test]
@@ -4000,14 +4033,23 @@ startxref
         // The PDF is malformed (incomplete xref), so even basic parsing fails
         assert!(strict_reader.is_err());
 
-        // Test lenient mode - even lenient mode cannot parse PDFs with incomplete xref
+        // Issue #374: default options allow recovery, so a PDF with a mismatched
+        // xref (caused here by the incorrect stream /Length) is reconstructed by
+        // scanning objects, and the catalog resolves.
         let cursor = Cursor::new(pdf_data);
         let mut options = ParseOptions::default();
         options.lenient_streams = true;
         options.max_recovery_bytes = 1000;
         options.collect_warnings = false;
-        let lenient_reader = PdfReader::new_with_options(cursor, options);
-        assert!(lenient_reader.is_err());
+        let mut reader =
+            PdfReader::new_with_options(cursor, options).expect("mismatched xref reconstructed");
+        let catalog = reader
+            .catalog()
+            .expect("catalog resolves after reconstruction");
+        assert_eq!(
+            catalog.get("Type"),
+            Some(&PdfObject::Name(PdfName("Catalog".to_string()))),
+        );
     }
 
     #[test]
@@ -4086,12 +4128,22 @@ startxref
         assert!(!reader.is_encrypted());
         assert!(reader.is_unlocked()); // Unencrypted PDFs are always "unlocked"
 
-        // Test encrypted PDF - this will fail during construction due to encryption
+        // Test encrypted PDF. Its xref offsets don't match, so it goes through
+        // reconstruction (Issue #374). The recovery must preserve /Encrypt so
+        // the document opens as ENCRYPTED and LOCKED (fail-safe), never silently
+        // as plaintext. It is not unlockable with the empty password here
+        // because /O and /U are placeholders.
         let encrypted_pdf = create_pdf_with_encryption();
         let cursor = Cursor::new(encrypted_pdf);
-        let result = PdfReader::new(cursor);
-        // Should fail because we don't support reading encrypted PDFs yet in construction
-        assert!(result.is_err());
+        let reader = PdfReader::new(cursor).expect("encrypted PDF opens as locked, not rejected");
+        assert!(
+            reader.is_encrypted(),
+            "must report encrypted, not plaintext"
+        );
+        assert!(
+            !reader.is_unlocked(),
+            "must stay locked without a valid password"
+        );
     }
 
     #[test]
@@ -4169,21 +4221,23 @@ startxref
 
     #[test]
     fn test_reader_encryption_error_handling() {
-        // This test verifies that encrypted PDFs are properly rejected during construction
+        // Fail-safe (Issue #374): an encrypted PDF whose xref must be rebuilt
+        // must never be opened as plaintext. Two outcomes are safe: rejected
+        // during construction, or opened while still reporting encrypted+locked.
+        // Opening it as an unlocked/unencrypted document is a fail-open bug.
         let encrypted_pdf = create_pdf_with_encryption();
         let cursor = Cursor::new(encrypted_pdf);
 
-        // Should fail during construction due to unsupported encryption
-        let result = PdfReader::new(cursor);
-        match result {
-            Err(ParseError::EncryptionNotSupported) => {
-                // Expected - encryption detected but not supported in current flow
-            }
-            Err(_) => {
-                // Other errors are also acceptable as encryption detection may fail parsing
-            }
-            Ok(_) => {
-                panic!("Should not successfully create reader for encrypted PDF without password");
+        match PdfReader::new(cursor) {
+            // Rejecting the encrypted document is safe.
+            Err(_) => {}
+            // Opening it is only safe if encryption is still recognized and the
+            // document remains locked (no valid password was supplied).
+            Ok(reader) => {
+                assert!(
+                    reader.is_encrypted() && !reader.is_unlocked(),
+                    "recovered encrypted PDF must stay encrypted+locked, not open as plaintext"
+                );
             }
         }
     }

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -470,7 +470,16 @@ impl XRefTable {
         match Self::parse_with_incremental_updates_options(reader, options) {
             Ok(table) => Ok(table),
             Err(e) => {
-                if options.lenient_syntax {
+                // Reconstructing a missing/corrupt cross-reference table by
+                // scanning object headers is standard robustness behaviour for
+                // a PDF reader (poppler/pdf.js/qpdf all do it), NOT a syntax
+                // tolerance. Issue #374: files without a `startxref`/`xref`
+                // (e.g. poppler fuzzing fixtures) must still be recoverable via
+                // `PdfReader::new`. Gate recovery on `max_recovery_attempts > 0`
+                // — the semantic "recovery allowed" knob — so `default()`
+                // (attempts = 3) and `tolerant()` (attempts = 5) reconstruct,
+                // while `strict()` (attempts = 0) keeps failing loudly.
+                if options.max_recovery_attempts > 0 {
                     tracing::warn!("Primary XRef parsing failed: {e:?}, attempting recovery");
 
                     // Reset reader position and try recovery
@@ -1054,7 +1063,7 @@ impl XRefTable {
     /// Parse XRef table using recovery mode with options
     fn parse_with_recovery_options<R: Read + Seek>(
         reader: &mut BufReader<R>,
-        _options: &super::ParseOptions,
+        options: &super::ParseOptions,
     ) -> ParseResult<Self> {
         // Bounded-memory recovery (Issue #339): scan object headers in fixed-size
         // chunks and resolve the catalog through per-object / file-tail windows,
@@ -1097,6 +1106,19 @@ impl XRefTable {
             "Size".to_string(),
             super::objects::PdfObject::Integer(table.len() as i64),
         );
+
+        // 3b) Preserve `/Encrypt` and `/ID` from the original classic trailer so
+        //     a reconstructed ENCRYPTED document is not silently opened as
+        //     plaintext (Issue #374 fail-safe). Dropping `/Encrypt` here would
+        //     make `EncryptionHandler::detect_encryption` return false and the
+        //     reader would treat ciphertext as cleartext.
+        let (encrypt, id) = extract_encrypt_and_id_from_trailer(&root_tail, options);
+        if let Some(encrypt) = encrypt {
+            trailer.insert("Encrypt".to_string(), encrypt);
+        }
+        if let Some(id) = id {
+            trailer.insert("ID".to_string(), id);
+        }
 
         // 4) Resolve the catalog object.
         let mut catalog_candidate = None;
@@ -2483,17 +2505,25 @@ mod tests {
 
     #[test]
     fn test_xref_parse_with_fallback() {
-        // Test that fallback works when primary parsing fails
+        // Issue #374: a PDF with no xref structure at all is reconstructed by
+        // scanning object headers when recovery is allowed
+        // (max_recovery_attempts > 0, the case for default options).
         let pdf_content =
             b"1 0 obj\n<< /Type /Catalog >>\nendobj\n2 0 obj\n<< /Type /Page >>\nendobj\n";
-        let mut reader = BufReader::new(Cursor::new(pdf_content));
 
-        // PDF without any xref structure cannot be parsed by XRefTable::parse
-        // This would need a higher-level recovery mechanism
-        let result = XRefTable::parse(&mut reader);
-        assert!(result.is_err());
-        if let Err(e) = result {
-            assert!(matches!(e, ParseError::InvalidXRef));
+        // Default options allow recovery: the table is rebuilt from the scan.
+        let mut reader = BufReader::new(Cursor::new(pdf_content.to_vec()));
+        let table = XRefTable::parse(&mut reader).expect("recovery rebuilds xref from object scan");
+        assert!(table.get_entry(1).is_some(), "object 1 indexed by scan");
+        assert!(table.get_entry(2).is_some(), "object 2 indexed by scan");
+
+        // strict() disables recovery (max_recovery_attempts == 0): a missing
+        // xref must still fail loudly with InvalidXRef.
+        let mut reader = BufReader::new(Cursor::new(pdf_content.to_vec()));
+        match XRefTable::parse_with_options(&mut reader, &ParseOptions::strict()) {
+            Err(ParseError::InvalidXRef) => {}
+            Ok(_) => panic!("strict() must fail on missing xref, not recover"),
+            Err(other) => panic!("strict() must fail with InvalidXRef, got: {other:?}"),
         }
     }
 
@@ -3174,6 +3204,96 @@ startxref\n\
         let result = XRefTable::parse(&mut reader);
         // Should handle incomplete subsection
         assert!(result.is_err() || result.is_ok());
+    }
+}
+
+type EncryptAndId = (
+    Option<super::objects::PdfObject>,
+    Option<super::objects::PdfObject>,
+);
+
+/// Extract `/Encrypt` and `/ID` from the original trailer found in a bounded
+/// file tail (Issue #374), covering BOTH classic trailers and cross-reference
+/// streams.
+///
+/// XRef reconstruction builds a synthetic trailer; without carrying the
+/// original `/Encrypt` forward, an encrypted document whose xref had to be
+/// rebuilt would be treated as unencrypted (fail-open). `/ID` is preserved too
+/// because the standard security handler mixes it into the encryption key.
+///
+/// Both branches parse with the real object parser (binary-safe: handles
+/// hex/literal strings, arrays, refs) and honour the caller's `ParseOptions`
+/// so lenient tokenizing (e.g. a stray byte before `<<`) is applied when the
+/// caller asked for it — not silently reverted to strict.
+///
+/// 1. Classic `trailer` keyword (PDF ≤1.4 and hybrid files).
+/// 2. Cross-reference stream (PDF 1.5+): `/Encrypt` lives in the xref-stream
+///    object's own dict, which is uncompressed text even when the stream data
+///    is filtered, so it can be parsed straight from the tail.
+fn extract_encrypt_and_id_from_trailer(tail: &[u8], options: &ParseOptions) -> EncryptAndId {
+    // 1) Classic trailer.
+    if let Some(pos) = rfind_byte_pattern(tail, b"trailer") {
+        let after = &tail[pos + b"trailer".len()..];
+        let mut lexer =
+            super::lexer::Lexer::new_with_options(std::io::Cursor::new(after), options.clone());
+        if let Ok(super::objects::PdfObject::Dictionary(dict)) =
+            super::objects::PdfObject::parse_with_options(&mut lexer, options)
+        {
+            let encrypt = dict.get("Encrypt").cloned();
+            let id = dict.get("ID").cloned();
+            if encrypt.is_some() || id.is_some() {
+                return (encrypt, id);
+            }
+        }
+    }
+
+    // 2) Cross-reference stream dict.
+    extract_encrypt_and_id_from_xref_stream(tail, options)
+}
+
+/// Extract `/Encrypt` and `/ID` from a cross-reference stream object's dict in
+/// the tail (Issue #374, fail-safe for PDF 1.5+ encrypted files).
+///
+/// Anchors on the xref stream object header (`N G obj`) that precedes
+/// `/Type /XRef`, then parses the dictionary that opens after it — truncating
+/// the region at the `stream` keyword so the parser sees a plain dictionary
+/// (never attempting to consume the filtered stream body).
+fn extract_encrypt_and_id_from_xref_stream(tail: &[u8], options: &ParseOptions) -> EncryptAndId {
+    let type_pos = match rfind_byte_pattern(tail, b"/Type/XRef")
+        .or_else(|| rfind_byte_pattern(tail, b"/Type /XRef"))
+    {
+        Some(p) => p,
+        None => return (None, None),
+    };
+
+    // Anchor on the object header so a nested `<<` before `/Type` can't be
+    // mistaken for the dict opening.
+    let Some(obj_pos) = rfind_byte_pattern(&tail[..type_pos], b"obj") else {
+        return (None, None);
+    };
+    let Some(rel) = find_byte_pattern(&tail[obj_pos..type_pos], b"<<") else {
+        return (None, None);
+    };
+    let dict_start = obj_pos + rel;
+
+    // Parse ONLY the inner dictionary (up to `>>`). We must not let the object
+    // parser attempt the following `stream` body: its /Length may be an
+    // indirect reference or otherwise unparseable in a recovery scenario, and a
+    // body-parse failure would discard the dictionary (and thus /Encrypt) —
+    // reopening the fail-open hole. Truncating at a raw `stream` substring is
+    // also wrong, since a value before /Encrypt (e.g. `/Producer (streamlined)`)
+    // can contain those bytes. The inner-dict parser respects string/nesting
+    // boundaries, so neither problem applies.
+    let region = &tail[dict_start..];
+    let mut lexer =
+        super::lexer::Lexer::new_with_options(std::io::Cursor::new(region), options.clone());
+    // Consume the opening `<<` before parsing the dictionary body.
+    if !matches!(lexer.next_token(), Ok(super::lexer::Token::DictStart)) {
+        return (None, None);
+    }
+    match super::objects::PdfObject::parse_dictionary_inner_with_options(&mut lexer, options) {
+        Ok(dict) => (dict.get("Encrypt").cloned(), dict.get("ID").cloned()),
+        Err(_) => (None, None),
     }
 }
 

--- a/oxidize-pdf-core/tests/issue_374_xref_reconstruction_test.rs
+++ b/oxidize-pdf-core/tests/issue_374_xref_reconstruction_test.rs
@@ -1,0 +1,230 @@
+//! Regression tests for issue #374.
+//!
+//! `poppler-85140-0.pdf` is a poppler fuzzing fixture that has NO `xref`
+//! table and NO `startxref` marker — the trailer directly follows the last
+//! `endobj`. A robust PDF reader must reconstruct the cross-reference table by
+//! scanning object headers (as poppler/pdf.js/qpdf do), instead of failing at
+//! parse stage with `Invalid xref table`.
+//!
+//! Before the fix, `PdfReader::new` (strict-by-default, `lenient_syntax=false`)
+//! propagated `ParseError::InvalidXRef`; only the explicitly-lenient paths
+//! (`PdfReader::open`, `ParseOptions::tolerant()`) recovered. This coupled
+//! xref reconstruction to `lenient_syntax`, which is a syntax-tolerance knob,
+//! not a recovery knob. The fix gates reconstruction on
+//! `max_recovery_attempts > 0` instead, so `new()`/`default()` recover while
+//! `strict()` (attempts = 0) still fails loudly.
+
+use oxidize_pdf::parser::{ParseError, ParseOptions, PdfName, PdfObject, PdfReader};
+use std::io::Cursor;
+
+const FIXTURE: &str = "tests/fixtures/poppler-85140-0.pdf";
+
+/// `PdfReader::new` (default options, in-memory reader — the path used on
+/// wasm32) must reconstruct the missing xref and resolve the real catalog
+/// object recovered by the object-header scan.
+#[test]
+fn pdfreader_new_reconstructs_missing_xref_and_resolves_catalog() {
+    let bytes = std::fs::read(FIXTURE).expect("read fixture");
+    let mut reader =
+        PdfReader::new(Cursor::new(bytes)).expect("new() must reconstruct the missing xref table");
+
+    // Not a smoke check: prove the reconstruction found the real objects by
+    // resolving the catalog (object 1) and confirming its /Type is /Catalog.
+    let catalog = reader
+        .catalog()
+        .expect("catalog must resolve after reconstruction");
+    let ty = catalog.get("Type").expect("catalog has /Type");
+    assert_eq!(
+        ty,
+        &PdfObject::Name(PdfName("Catalog".to_string())),
+        "recovered catalog must be /Type /Catalog"
+    );
+
+    // The catalog references /Pages 2 0 R; the scan must have indexed object 2
+    // as well, and it must resolve to a /Pages node.
+    let pages = reader
+        .get_object(2, 0)
+        .expect("object 2 indexed by scan")
+        .clone();
+    let pages_dict = pages.as_dict().expect("object 2 is a dictionary");
+    assert_eq!(
+        pages_dict.get("Type"),
+        Some(&PdfObject::Name(PdfName("Pages".to_string()))),
+        "recovered object 2 must be /Type /Pages"
+    );
+}
+
+/// Security guard (fail-safe): an ENCRYPTED PDF whose xref must be
+/// reconstructed must NOT be silently opened as plaintext. The recovered
+/// synthetic trailer must preserve `/Encrypt` (and `/ID`) so the encryption
+/// flow still runs. Before the fix the recovery trailer carried only
+/// `/Size`+`/Root`, dropping `/Encrypt`, so a recovered encrypted document
+/// looked unencrypted — a fail-open regression once `new()` gained recovery.
+#[test]
+fn recovered_encrypted_pdf_is_not_opened_as_plaintext() {
+    // Standard-security encrypted PDF (V1/R2) with NO xref and NO startxref,
+    // forcing xref reconstruction. The trailer declares /Encrypt and /ID.
+    let pdf = b"%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+5 0 obj
+<< /Filter /Standard /V 1 /R 2 /O (0123456789abcdef0123456789abcdef) /U (0123456789abcdef0123456789abcdef) /P -4 >>
+endobj
+trailer
+<< /Size 6 /Root 1 0 R /Encrypt 5 0 R /ID [(0123456789abcdef) (0123456789abcdef)] >>
+%%EOF"
+        .to_vec();
+
+    match PdfReader::new(Cursor::new(pdf)) {
+        // Rejecting the encrypted document is safe.
+        Err(_) => {}
+        // Opening it is only acceptable if encryption is still recognized and
+        // the document stays locked; being opened as plaintext/unlocked is a
+        // fail-open bug.
+        Ok(reader) => assert!(
+            reader.is_encrypted() && !reader.is_unlocked(),
+            "encrypted PDF recovered via xref reconstruction must stay \
+             encrypted+locked, not be opened as plaintext"
+        ),
+    }
+}
+
+/// Fail-safe for PDF 1.5+ encrypted files that use a cross-reference STREAM
+/// (no classic `trailer` keyword — `/Encrypt` lives in the xref-stream dict).
+/// When the xref stream can't be used and recovery kicks in, `/Encrypt` must
+/// still be carried into the synthetic trailer, or the document would open as
+/// plaintext. Modern (AES) encrypted PDFs commonly use xref streams.
+#[test]
+fn recovered_encrypted_xref_stream_pdf_is_not_opened_as_plaintext() {
+    // Encrypted document whose only cross-reference is a stream object
+    // (object 6, /Type /XRef ... /Encrypt 5 0 R). No `startxref`, forcing
+    // reconstruction; the xref-stream dict is the only place /Encrypt appears.
+    let pdf = b"%PDF-1.5
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+5 0 obj
+<< /Filter /Standard /V 1 /R 2 /O (0123456789abcdef0123456789abcdef) /U (0123456789abcdef0123456789abcdef) /P -4 >>
+endobj
+6 0 obj
+<< /Type /XRef /Size 7 /Root 1 0 R /Encrypt 5 0 R /ID [(0123456789abcdef) (0123456789abcdef)] /W [1 1 1] /Length 4 >>
+stream
+\x00\x00\x00\x00
+endstream
+endobj
+%%EOF"
+        .to_vec();
+
+    match PdfReader::new(Cursor::new(pdf)) {
+        Err(_) => {}
+        Ok(reader) => assert!(
+            reader.is_encrypted() && !reader.is_unlocked(),
+            "encrypted xref-stream PDF recovered via reconstruction must stay \
+             encrypted+locked, not be opened as plaintext"
+        ),
+    }
+}
+
+/// Fail-safe regression guard: a value BEFORE `/Encrypt` in the xref-stream
+/// dict that contains the ASCII bytes `stream` (e.g. `/Producer (streamlined)`)
+/// must not truncate the dict and cause `/Encrypt` to be dropped. The dict must
+/// be parsed with a real lexer that respects string boundaries, not truncated
+/// at a raw `stream` substring.
+#[test]
+fn recovered_encrypted_xref_stream_with_stream_substring_before_encrypt() {
+    let pdf = b"%PDF-1.5
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+5 0 obj
+<< /Filter /Standard /V 1 /R 2 /O (0123456789abcdef0123456789abcdef) /U (0123456789abcdef0123456789abcdef) /P -4 >>
+endobj
+6 0 obj
+<< /Type /XRef /Producer (a streamlined pdf tool) /Size 7 /Root 1 0 R /Encrypt 5 0 R /ID [(0123456789abcdef) (0123456789abcdef)] /W [1 1 1] /Length 4 >>
+stream
+\x00\x00\x00\x00
+endstream
+endobj
+%%EOF"
+        .to_vec();
+
+    match PdfReader::new(Cursor::new(pdf)) {
+        Err(_) => {}
+        Ok(reader) => assert!(
+            reader.is_encrypted() && !reader.is_unlocked(),
+            "a `stream` substring in a value before /Encrypt must not drop /Encrypt (fail-open)"
+        ),
+    }
+}
+
+/// Fail-safe under lenient/tolerant options: the recovery trailer parser must
+/// honour the caller's ParseOptions. A stray byte between `trailer` and its
+/// `<<` (plausible in exactly the corrupted files recovery exists for) must be
+/// tolerated under `tolerant()` so `/Encrypt` is still recovered — not dropped
+/// because an internal lexer silently reverted to strict tokenizing.
+#[test]
+fn recovered_encrypted_pdf_with_stray_trailer_byte_preserves_encrypt_under_tolerant() {
+    // Classic trailer preceded by a stray '`' before `<<`; no xref/startxref
+    // forces recovery.
+    let pdf = b"%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+5 0 obj
+<< /Filter /Standard /V 1 /R 2 /O (0123456789abcdef0123456789abcdef) /U (0123456789abcdef0123456789abcdef) /P -4 >>
+endobj
+trailer
+` << /Size 6 /Root 1 0 R /Encrypt 5 0 R /ID [(0123456789abcdef) (0123456789abcdef)] >>
+%%EOF"
+        .to_vec();
+
+    match PdfReader::new_with_options(Cursor::new(pdf), ParseOptions::tolerant()) {
+        Err(_) => {}
+        Ok(reader) => assert!(
+            reader.is_encrypted() && !reader.is_unlocked(),
+            "under tolerant(), a stray byte before the trailer dict must not \
+             cause /Encrypt to be dropped (fail-open)"
+        ),
+    }
+}
+
+/// Guard: `strict()` disables recovery (`max_recovery_attempts == 0`), so the
+/// missing xref must still fail loudly with `InvalidXRef`. This preserves the
+/// project's fail-loud-by-default contract for callers that opt into strict
+/// parsing.
+#[test]
+fn strict_mode_still_fails_loudly_on_missing_xref() {
+    let bytes = std::fs::read(FIXTURE).expect("read fixture");
+    // PdfReader does not implement Debug, so match on the Result directly
+    // instead of using expect_err.
+    match PdfReader::new_with_options(Cursor::new(bytes), ParseOptions::strict()) {
+        Ok(_) => panic!("strict() must NOT reconstruct a missing xref"),
+        Err(ParseError::InvalidXRef) => {}
+        Err(other) => panic!("strict() must fail with InvalidXRef, got: {other:?}"),
+    }
+}

--- a/oxidize-pdf-core/tests/parser_edge_cases_integration.rs
+++ b/oxidize-pdf-core/tests/parser_edge_cases_integration.rs
@@ -235,7 +235,12 @@ fn test_memory_exhaustion_protection() {
             Ok(_) => println!("  Large object handled"),
             Err(error) => {
                 println!("  Error (may be expected): {error}");
-                // Should get a proper error, not run out of memory
+                // Should get a proper error, not run out of memory.
+                // Since #374 (recover-by-default), a wrong startxref no longer
+                // fails at xref parsing: the xref is reconstructed and parsing
+                // proceeds until the missing catalog is detected. These synthetic
+                // PDFs have no /Root in the trailer, so "Missing required key: Root"
+                // is the correct graceful terminal error.
                 assert!(
                     error.to_string().contains("too large")
                         || error.to_string().contains("memory")
@@ -245,6 +250,8 @@ fn test_memory_exhaustion_protection() {
                         || error.to_string().contains("Syntax")
                         || error.to_string().contains("xref")
                         || error.to_string().contains("keyword")
+                        || error.to_string().contains("Missing required key"),
+                    "unexpected error kind: {error}"
                 );
             }
         }

--- a/oxidize-pdf-core/tests/parser_malformed_comprehensive_test.rs
+++ b/oxidize-pdf-core/tests/parser_malformed_comprehensive_test.rs
@@ -60,6 +60,34 @@ endobj
     }
 }
 
+/// Regression for the negative-`/Length` capacity-overflow: a present-but-
+/// negative `/Length` must not abort with a giant allocation. In lenient mode
+/// (the default) the parser falls back to the bounded endstream search and
+/// recovers the actual stream bytes verbatim.
+#[test]
+fn test_stream_negative_length_recovers_data_lenient() {
+    let content =
+        "1 0 obj\n<</Length -100>>\nstream\nThis is some stream data\nendstream\nendobj\n";
+    let pdf = create_pdf_with_content(content);
+    let cursor = Cursor::new(pdf);
+
+    let doc = PdfReader::new(cursor)
+        .map(PdfDocument::new)
+        .expect("lenient parse of a negative-length stream must not fail at load");
+    let obj = doc
+        .get_object(1, 0)
+        .expect("object 1 must be retrievable without panicking");
+
+    let stream = obj
+        .as_stream()
+        .expect("object 1 must parse as a stream despite the invalid /Length");
+    let recovered = String::from_utf8_lossy(&stream.data);
+    assert!(
+        recovered.contains("This is some stream data"),
+        "endstream-search fallback must recover the real stream bytes; got {recovered:?}"
+    );
+}
+
 /// Test 2: Stream with length larger than file size
 #[test]
 fn test_stream_excessive_length() {

--- a/oxidize-pdf-core/tests/parser_reader_coverage.rs
+++ b/oxidize-pdf-core/tests/parser_reader_coverage.rs
@@ -341,21 +341,30 @@ fn test_resolve_stream_length_on_non_stream() {
     let pdf_data = create_minimal_valid_pdf();
     let cursor = Cursor::new(pdf_data);
 
-    if let Ok(mut reader) = PdfReader::new(cursor) {
-        use oxidize_pdf::parser::objects::PdfObject;
+    let mut reader = PdfReader::new(cursor).expect("minimal PDF must parse");
+    use oxidize_pdf::parser::objects::PdfObject;
 
-        let int_obj = PdfObject::Integer(42);
-        let result = reader.resolve_stream_length(&int_obj);
-
-        // Non-stream object should return None
-        if let Ok(None) = result {
-            // Expected
-        } else if result.is_err() {
-            // Also acceptable - exercises error path
-        } else {
-            panic!("Expected None or error, got {:?}", result);
-        }
-    }
+    // A direct non-negative integer IS a valid /Length value.
+    assert_eq!(
+        reader
+            .resolve_stream_length(&PdfObject::Integer(42))
+            .unwrap(),
+        Some(42)
+    );
+    // A negative integer is not a valid length.
+    assert_eq!(
+        reader
+            .resolve_stream_length(&PdfObject::Integer(-5))
+            .unwrap(),
+        None
+    );
+    // A non-numeric object is not a length at all.
+    assert_eq!(
+        reader
+            .resolve_stream_length(&PdfObject::Boolean(true))
+            .unwrap(),
+        None
+    );
 }
 
 // ============================================================================
@@ -738,11 +747,20 @@ startxref
 50
 %%EOF
 ";
+    // #374 recover-by-default: a corrupt xref table is reconstructed by the
+    // object-header scan, so the default reader opens the document. Strict mode
+    // (max_recovery_attempts = 0) still fails loudly.
     let cursor = Cursor::new(malformed_xref);
-    let result = PdfReader::new(cursor);
+    assert!(
+        PdfReader::new(cursor).is_ok(),
+        "default reader must reconstruct a malformed xref"
+    );
 
-    // Should fail with XRef parsing error
-    assert!(result.is_err());
+    let cursor = Cursor::new(malformed_xref);
+    assert!(
+        PdfReader::new_with_options(cursor, ParseOptions::strict()).is_err(),
+        "strict mode must still reject a malformed xref"
+    );
 }
 
 #[test]
@@ -757,11 +775,20 @@ xref
 0000000000 65535 f
 0000000009 00000 n
 ";
+    // #374 recover-by-default: a missing trailer is synthesized from the
+    // reconstructed xref, so the default reader opens the document. Strict mode
+    // still fails loudly.
     let cursor = Cursor::new(no_trailer);
-    let result = PdfReader::new(cursor);
+    assert!(
+        PdfReader::new(cursor).is_ok(),
+        "default reader must synthesize a missing trailer"
+    );
 
-    // Should fail due to missing trailer
-    assert!(result.is_err());
+    let cursor = Cursor::new(no_trailer);
+    assert!(
+        PdfReader::new_with_options(cursor, ParseOptions::strict()).is_err(),
+        "strict mode must still reject a missing trailer"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`PdfReader::new` failed with `Invalid xref table` on PDFs lacking a `startxref`/`xref` table (e.g. `poppler-85140-0.pdf`, the only hard parse failure in the oxidize-wasm e2e corpus besides encryption) or with a corrupt xref. The object-header scan recovery already existed but was gated on `lenient_syntax`. Reconstructing a missing/corrupt xref is standard reader robustness (poppler/pdf.js/qpdf), not syntax tolerance.

Addresses #374. Target: `develop` (3.1.1, bundled with #380). Not for release yet.

## Changes

- **Gate recovery on `max_recovery_attempts > 0`** instead of `lenient_syntax`. Effect: `default()` (used by `PdfReader::new`, incl. wasm32 in-memory path) and `tolerant()` reconstruct; `strict()` (attempts = 0) still fails loudly with `InvalidXRef`.
- **Fail-safe for encrypted PDFs (seguro por defecto):** the recovery path built a synthetic trailer that dropped `/Encrypt`, so an encrypted document whose xref had to be rebuilt would open as **plaintext**. Now `/Encrypt` and `/ID` are preserved:
  - classic `trailer` keyword — parsed with the real object parser;
  - cross-reference stream (PDF 1.5+) — `/Encrypt` lives in the xref-stream object dict, parsed via `parse_dictionary_inner_with_options` (dict only, never the stream body; immune to `stream`-substring truncation).
  - Both honour the caller's `ParseOptions`.
- `parse_dictionary_inner_with_options`: `fn` → `pub(crate) fn` (visibility only).

## Tests

- New `issue_374_xref_reconstruction_test.rs` (6): reconstruction + catalog resolve, 3 encryption fail-safe guards (classic, xref-stream, `stream`-substring-before-`/Encrypt`, stray-byte under tolerant), strict fail-loud.
- 7 preexisting `reader.rs`/`xref.rs` tests updated to the recover-by-default contract (verify real content, not inverted asserts).

## Verification

- lib 6598/0; encryption suite (owner/pwd/r5/r6/real) full pass; recovery/stress tests pass; corpus `t2_realworld` 23/0.
- clippy `--lib --all-features` clean; fmt clean; MSRV 1.88 `build --all-features --locked` clean.
- 3 QR passes (quality-rust); 3 fail-open security gaps found and closed iteratively; final pass clean, 0 residual.

## Follow-up (not in this PR)

`max_recovery_attempts` is now consumed as a boolean gate, not a retry count — rename/redocument or implement bounded retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)