### PR TITLE
fix(writer): collision-only preserved-font disambiguation (#395)

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -151,6 +151,13 @@ pub struct Page {
     /// Populated by `Page::a4_with_metrics` and friends, or injected by
     /// `Document::add_page()` in Task 11.
     pub(crate) font_metrics_store: Option<FontMetricsStore>,
+    /// Collision-only rename map for preserved fonts (issue #395), stamped by
+    /// the writer just before content generation. Maps an original preserved
+    /// `/Font` key to its disambiguated key when (and only when) that key
+    /// collided with a writer-injected/overlay font. Empty for pages with no
+    /// preserved fonts or no collisions — in which case the preserved content
+    /// is emitted verbatim.
+    pub(crate) preserved_font_rewrite_map: HashMap<String, String>,
 }
 
 impl Page {
@@ -180,6 +187,7 @@ impl Page {
             preserved_resources: None,
             page_ops: Vec::new(),
             font_metrics_store: None,
+            preserved_font_rewrite_map: HashMap::new(),
         }
     }
 
@@ -1624,34 +1632,17 @@ impl Page {
         let text_tail = self.text_context.generate_operations()?;
         final_content.extend_from_slice(&text_tail);
 
-        // Add any content that was added via add_text_flow
-        // Phase 2.3: Rewrite font references in preserved content if fonts were renamed
-        let content_to_add = if let Some(ref preserved_res) = self.preserved_resources {
-            // Check if we have preserved fonts that need renaming
-            if let Some(fonts_dict) = preserved_res.get("Font") {
-                if let crate::pdf_objects::Object::Dictionary(ref fonts) = fonts_dict {
-                    // Build font mapping (F1 → OrigF1, Arial → OrigArial, etc.)
-                    let mut font_mapping = std::collections::HashMap::new();
-                    for (original_name, _) in fonts.iter() {
-                        let new_name = format!("Orig{}", original_name.as_str());
-                        font_mapping.insert(original_name.as_str().to_string(), new_name);
-                    }
-
-                    // Rewrite font references in preserved content
-                    if !font_mapping.is_empty() && !self.content.is_empty() {
-                        use crate::writer::rewrite_font_references;
-                        rewrite_font_references(&self.content, &font_mapping)
-                    } else {
-                        self.content.clone()
-                    }
-                } else {
-                    self.content.clone()
-                }
-            } else {
-                self.content.clone()
-            }
-        } else {
+        // Add preserved original content. Issue #395: rewrite only the font
+        // references the writer disambiguated (collision-only). When no font
+        // collided, `preserved_font_rewrite_map` is empty and the preserved
+        // content is emitted verbatim — the common case (incl. all-non-base-14
+        // inputs like `testi.pdf`), which avoids ever touching the stream.
+        let content_to_add = if self.preserved_font_rewrite_map.is_empty()
+            || self.content.is_empty()
+        {
             self.content.clone()
+        } else {
+            crate::writer::rewrite_font_references(&self.content, &self.preserved_font_rewrite_map)
         };
 
         final_content.extend_from_slice(&content_to_add);

--- a/oxidize-pdf-core/src/writer/content_stream_utils.rs
+++ b/oxidize-pdf-core/src/writer/content_stream_utils.rs
@@ -126,56 +126,303 @@ pub fn rename_preserved_fonts(fonts: &crate::objects::Dictionary) -> crate::obje
 /// let rewritten = rewrite_font_references(content, &mappings);
 /// // Result: b"BT /OrigF1 12 Tf (Hello) Tj ET"
 /// ```
-#[allow(dead_code)] // Will be used in Phase 2.3
 pub fn rewrite_font_references(content: &[u8], mappings: &HashMap<String, String>) -> Vec<u8> {
-    let content_str = String::from_utf8_lossy(content);
-    let mut result = String::new();
+    if mappings.is_empty() {
+        return content.to_vec();
+    }
 
-    for line in content_str.lines() {
-        let tokens: Vec<&str> = line.split_whitespace().collect();
-        let mut rewritten_line = String::new();
+    // Tokenize into raw byte spans. Only the bytes of a font name that sits in
+    // the operand position of a `Tf` operator are replaced; every other byte
+    // (whitespace, comments, string/hex literals, inline binary) is copied
+    // verbatim. This is robust to layout the previous line-based rewriter
+    // failed on — e.g. a font operator split across a newline
+    // (`/F1\n12 Tf`) — and never corrupts string/comment content that merely
+    // happens to contain a `/name`.
+    let tokens = tokenize_content(content);
 
-        let mut i = 0;
-        while i < tokens.len() {
-            let token = tokens[i];
-
-            // Check if this is a font name (starts with /) followed by size and Tf
-            if token.starts_with('/') && i + 2 < tokens.len() && tokens[i + 2] == "Tf" {
-                // Extract font name (without leading /)
-                let font_name = &token[1..];
-
-                // Check if we have a mapping for this font
-                if let Some(new_name) = mappings.get(font_name) {
-                    // Write renamed font
-                    rewritten_line.push('/');
-                    rewritten_line.push_str(new_name);
-                } else {
-                    // Keep original font name
-                    rewritten_line.push_str(token);
-                }
-            } else {
-                // Not a font reference, keep as-is
-                rewritten_line.push_str(token);
-            }
-
-            // Add space after token (except for last token)
-            if i < tokens.len() - 1 {
-                rewritten_line.push(' ');
-            }
-
-            i += 1;
+    // Mark the name tokens to rewrite: a Name whose value is in `mappings` and
+    // that is immediately followed (ignoring whitespace/comments) by a Number
+    // and the keyword `Tf`.
+    let mut rewrite: Vec<Option<&String>> = vec![None; tokens.len()];
+    for i in 0..tokens.len() {
+        let tok = &tokens[i];
+        if tok.kind != TokenKind::Name {
+            continue;
         }
-
-        result.push_str(&rewritten_line);
-        result.push('\n');
+        // Name bytes include the leading '/'; strip it for the map lookup.
+        let name = &content[tok.start + 1..tok.end];
+        let Ok(name) = std::str::from_utf8(name) else {
+            continue;
+        };
+        let Some(new_name) = mappings.get(name) else {
+            continue;
+        };
+        let is_size = tokens
+            .get(i + 1)
+            .is_some_and(|t| t.kind == TokenKind::Number);
+        let is_tf = tokens
+            .get(i + 2)
+            .is_some_and(|t| t.kind == TokenKind::Keyword && &content[t.start..t.end] == b"Tf");
+        if is_size && is_tf {
+            rewrite[i] = Some(new_name);
+        }
     }
 
-    // Remove trailing newline if original didn't have it
-    if !content.ends_with(b"\n") && result.ends_with('\n') {
-        result.pop();
+    // Reassemble, preserving all inter-token bytes verbatim.
+    let mut out = Vec::with_capacity(content.len());
+    let mut pos = 0usize;
+    for (i, tok) in tokens.iter().enumerate() {
+        out.extend_from_slice(&content[pos..tok.start]);
+        match rewrite[i] {
+            Some(new_name) => {
+                out.push(b'/');
+                out.extend_from_slice(new_name.as_bytes());
+            }
+            None => out.extend_from_slice(&content[tok.start..tok.end]),
+        }
+        pos = tok.end;
     }
+    out.extend_from_slice(&content[pos..]);
+    out
+}
 
-    result.into_bytes()
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum TokenKind {
+    Name,
+    Number,
+    Keyword,
+    /// String/hex literal, array/dict delimiter, or any other token that breaks
+    /// a `/name <size> Tf` run.
+    Other,
+}
+
+struct Token {
+    start: usize,
+    end: usize,
+    kind: TokenKind,
+}
+
+/// True for PDF whitespace (ISO 32000-1 Table 1).
+fn is_pdf_whitespace(b: u8) -> bool {
+    matches!(b, b'\0' | b'\t' | b'\n' | b'\x0c' | b'\r' | b' ')
+}
+
+/// True for PDF delimiter characters (ISO 32000-1 Table 2).
+fn is_pdf_delimiter(b: u8) -> bool {
+    matches!(
+        b,
+        b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'
+    )
+}
+
+fn is_regular(b: u8) -> bool {
+    !is_pdf_whitespace(b) && !is_pdf_delimiter(b)
+}
+
+/// Split a content stream into significant tokens, recording each token's byte
+/// span. Whitespace and comments are not emitted as tokens (they are the gaps
+/// between tokens). String and hex literals are consumed whole as `Other` so a
+/// `/name` inside them is never treated as a font reference.
+fn tokenize_content(content: &[u8]) -> Vec<Token> {
+    let n = content.len();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < n {
+        let c = content[i];
+        if is_pdf_whitespace(c) {
+            i += 1;
+            continue;
+        }
+        match c {
+            b'%' => {
+                // Comment: skip to end of line (gap, not a token).
+                while i < n && content[i] != b'\n' && content[i] != b'\r' {
+                    i += 1;
+                }
+            }
+            b'(' => {
+                // Literal string: balanced parens honouring backslash escapes.
+                let start = i;
+                i += 1;
+                let mut depth = 1;
+                while i < n && depth > 0 {
+                    match content[i] {
+                        b'\\' => i += 1, // skip the escaped byte too
+                        b'(' => depth += 1,
+                        b')' => depth -= 1,
+                        _ => {}
+                    }
+                    i += 1;
+                }
+                tokens.push(Token {
+                    start,
+                    end: i,
+                    kind: TokenKind::Other,
+                });
+            }
+            b'<' => {
+                if i + 1 < n && content[i + 1] == b'<' {
+                    tokens.push(Token {
+                        start: i,
+                        end: i + 2,
+                        kind: TokenKind::Other,
+                    });
+                    i += 2;
+                } else {
+                    // Hex string up to '>'.
+                    let start = i;
+                    i += 1;
+                    while i < n && content[i] != b'>' {
+                        i += 1;
+                    }
+                    if i < n {
+                        i += 1; // consume '>'
+                    }
+                    tokens.push(Token {
+                        start,
+                        end: i,
+                        kind: TokenKind::Other,
+                    });
+                }
+            }
+            b'>' => {
+                let end = if i + 1 < n && content[i + 1] == b'>' {
+                    i + 2
+                } else {
+                    i + 1
+                };
+                tokens.push(Token {
+                    start: i,
+                    end,
+                    kind: TokenKind::Other,
+                });
+                i = end;
+            }
+            b'[' | b']' | b'{' | b'}' | b')' => {
+                tokens.push(Token {
+                    start: i,
+                    end: i + 1,
+                    kind: TokenKind::Other,
+                });
+                i += 1;
+            }
+            b'/' => {
+                let start = i;
+                i += 1;
+                while i < n && is_regular(content[i]) {
+                    i += 1;
+                }
+                tokens.push(Token {
+                    start,
+                    end: i,
+                    kind: TokenKind::Name,
+                });
+            }
+            _ => {
+                let start = i;
+                while i < n && is_regular(content[i]) {
+                    i += 1;
+                }
+                let kind = if is_pdf_number(&content[start..i]) {
+                    TokenKind::Number
+                } else {
+                    TokenKind::Keyword
+                };
+                tokens.push(Token {
+                    start,
+                    end: i,
+                    kind,
+                });
+            }
+        }
+    }
+    tokens
+}
+
+/// True if `bytes` is a PDF numeric token (integer or real, optional sign).
+fn is_pdf_number(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut seen_digit = false;
+    for (idx, &b) in bytes.iter().enumerate() {
+        match b {
+            b'+' | b'-' if idx == 0 => {}
+            b'0'..=b'9' => seen_digit = true,
+            b'.' => {}
+            _ => return false,
+        }
+    }
+    seen_digit
+}
+
+/// Resource keys of the standard Type1 fonts that `write_page_with_fonts`
+/// injects into every page `/Font` dictionary. A preserved font whose resource
+/// key equals one of these is shadowed by the injected stub unless it is
+/// disambiguated (issue #395).
+pub(crate) const INJECTED_BASE_FONT_KEYS: [&str; 12] = [
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-Oblique",
+    "Helvetica-BoldOblique",
+    "Times-Roman",
+    "Times-Bold",
+    "Times-Italic",
+    "Times-BoldItalic",
+    "Courier",
+    "Courier-Bold",
+    "Courier-Oblique",
+    "Courier-BoldOblique",
+];
+
+/// Build a rename map for preserved fonts, disambiguating ONLY the keys that
+/// collide with `reserved` (the keys already present in the destination page
+/// `/Font` dictionary: the injected base fonts plus any overlay fonts).
+///
+/// Non-colliding keys are absent from the map and keep their original name, so
+/// no content rewrite is performed for them — which is what makes inputs like
+/// `testi.pdf` (all non-base-14 font names) safe. The disambiguated name is
+/// guaranteed unique against both `reserved` and every preserved key, so it can
+/// never introduce a fresh collision.
+pub fn collision_font_mapping<'a>(
+    preserved_keys: impl IntoIterator<Item = &'a str>,
+    reserved: &HashSet<String>,
+) -> HashMap<String, String> {
+    let preserved: Vec<String> = preserved_keys.into_iter().map(|s| s.to_string()).collect();
+    let preserved_set: HashSet<&str> = preserved.iter().map(|s| s.as_str()).collect();
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    for key in &preserved {
+        if !reserved.contains(key) {
+            continue;
+        }
+        let mut candidate = format!("Orig{key}");
+        let mut suffix = 1u32;
+        while reserved.contains(&candidate)
+            || preserved_set.contains(candidate.as_str())
+            || map.values().any(|v| v == &candidate)
+        {
+            candidate = format!("Orig{key}_{suffix}");
+            suffix += 1;
+        }
+        map.insert(key.clone(), candidate);
+    }
+    map
+}
+
+/// Apply a font rename `map` to a preserved font dictionary: keys present in the
+/// map are renamed to their mapped value; every other key (and all values) are
+/// carried over unchanged.
+pub fn apply_font_rename_map(
+    fonts: &crate::objects::Dictionary,
+    map: &HashMap<String, String>,
+) -> crate::objects::Dictionary {
+    let mut out = crate::objects::Dictionary::new();
+    for (key, value) in fonts.iter() {
+        let new_key = map.get(key).cloned().unwrap_or_else(|| key.clone());
+        out.set(new_key, value.clone());
+    }
+    out
 }
 
 /// Check if a font has embedded font data (FontFile/FontFile2/FontFile3)
@@ -533,11 +780,12 @@ mod tests {
         assert!(result.contains("(Text) Tj"));
     }
 
-    // Edge case tests - documenting known limitations
+    // Edge case tests
 
     #[test]
-    fn test_rewrite_font_references_normalizes_whitespace() {
-        // DOCUMENTED LIMITATION: Whitespace is normalized
+    fn test_rewrite_font_references_preserves_whitespace() {
+        // The structure-preserving rewriter (issue #395) only replaces the font
+        // name bytes; all surrounding whitespace is kept verbatim.
         let content = b"BT  /F1   12  Tf  (Text)  Tj  ET"; // Multiple spaces
         let mut mappings = HashMap::new();
         mappings.insert("F1".to_string(), "OrigF1".to_string());
@@ -545,16 +793,13 @@ mod tests {
         let rewritten = rewrite_font_references(content, &mappings);
         let result = String::from_utf8(rewritten).unwrap();
 
-        // Font renamed correctly
-        assert!(result.contains("/OrigF1 12 Tf"));
-        // Whitespace normalized (not "  /OrigF1   12")
-        assert!(!result.contains("  /OrigF1"));
-        // PDF is still valid (single spaces are sufficient)
+        // Only the name changed; the original spacing is preserved exactly.
+        assert_eq!(result, "BT  /OrigF1   12  Tf  (Text)  Tj  ET");
     }
 
     #[test]
     fn test_rewrite_font_references_with_indentation() {
-        // DOCUMENTED LIMITATION: Indentation is lost
+        // Indentation and newlines are preserved (only the name is rewritten).
         let content = b"BT\n  /F1 12 Tf\n  100 700 Td\n  (Text) Tj\nET";
         let mut mappings = HashMap::new();
         mappings.insert("F1".to_string(), "OrigF1".to_string());
@@ -562,10 +807,51 @@ mod tests {
         let rewritten = rewrite_font_references(content, &mappings);
         let result = String::from_utf8(rewritten).unwrap();
 
-        // Font renamed
-        assert!(result.contains("/OrigF1 12 Tf"));
-        // Original indentation lost (becomes single line tokens)
-        // This is acceptable - PDF readers don't care about formatting
+        assert_eq!(result, "BT\n  /OrigF1 12 Tf\n  100 700 Td\n  (Text) Tj\nET");
+    }
+
+    #[test]
+    fn test_rewrite_font_references_cross_line_operator() {
+        // Regression for issue #395: the font name and its size on separate
+        // lines. The old line-based rewriter missed this; the tokenizer-based
+        // one rewrites it and keeps the newline.
+        let content = b"BT\n/F1\n12 Tf (Text) Tj ET";
+        let mut mappings = HashMap::new();
+        mappings.insert("F1".to_string(), "OrigF1".to_string());
+
+        let rewritten = rewrite_font_references(content, &mappings);
+        let result = String::from_utf8(rewritten).unwrap();
+
+        assert_eq!(result, "BT\n/OrigF1\n12 Tf (Text) Tj ET");
+    }
+
+    #[test]
+    fn test_rewrite_font_references_ignores_name_inside_string() {
+        // A `/F1 12 Tf` sequence appearing INSIDE a literal string must not be
+        // rewritten — it is text content, not an operator.
+        let content = b"BT /F1 12 Tf (/F1 12 Tf literal) Tj ET";
+        let mut mappings = HashMap::new();
+        mappings.insert("F1".to_string(), "OrigF1".to_string());
+
+        let rewritten = rewrite_font_references(content, &mappings);
+        let result = String::from_utf8(rewritten).unwrap();
+
+        // The operator is rewritten; the string literal is untouched.
+        assert_eq!(result, "BT /OrigF1 12 Tf (/F1 12 Tf literal) Tj ET");
+    }
+
+    #[test]
+    fn test_rewrite_font_references_real_size_and_negative() {
+        // Font sizes may be reals or signed; both are valid Number operands.
+        let content = b"/F1 12.5 Tf /F2 -8 Tf";
+        let mut mappings = HashMap::new();
+        mappings.insert("F1".to_string(), "OrigF1".to_string());
+        mappings.insert("F2".to_string(), "OrigF2".to_string());
+
+        let rewritten = rewrite_font_references(content, &mappings);
+        let result = String::from_utf8(rewritten).unwrap();
+
+        assert_eq!(result, "/OrigF1 12.5 Tf /OrigF2 -8 Tf");
     }
 
     #[test]
@@ -589,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_font_references_with_tabs() {
-        // Tabs are normalized to spaces
+        // Tab separators are valid PDF whitespace and are preserved verbatim.
         let content = b"BT\t/F1\t12\tTf\t(Text)\tTj\tET";
         let mut mappings = HashMap::new();
         mappings.insert("F1".to_string(), "OrigF1".to_string());
@@ -597,8 +883,89 @@ mod tests {
         let rewritten = rewrite_font_references(content, &mappings);
         let result = String::from_utf8(rewritten).unwrap();
 
-        // Font renamed correctly despite tabs
-        assert!(result.contains("/OrigF1 12 Tf"));
+        // Font renamed correctly; tabs kept.
+        assert_eq!(result, "BT\t/OrigF1\t12\tTf\t(Text)\tTj\tET");
+    }
+
+    // Tests for collision_font_mapping (issue #395)
+
+    fn reserved_set(keys: &[&str]) -> HashSet<String> {
+        keys.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_collision_mapping_renames_only_colliding_keys() {
+        // /Helvetica collides with the injected base font; /F1 and /Arial do not.
+        let reserved = reserved_set(&INJECTED_BASE_FONT_KEYS);
+        let map = collision_font_mapping(["Helvetica", "F1", "Arial"], &reserved);
+
+        assert_eq!(
+            map.get("Helvetica").map(String::as_str),
+            Some("OrigHelvetica")
+        );
+        assert!(
+            !map.contains_key("F1"),
+            "non-colliding key must not be renamed"
+        );
+        assert!(
+            !map.contains_key("Arial"),
+            "non-colliding key must not be renamed"
+        );
+    }
+
+    #[test]
+    fn test_collision_mapping_empty_when_no_collision() {
+        // The `testi.pdf` class: all font names are non-base-14 → no rename.
+        let reserved = reserved_set(&INJECTED_BASE_FONT_KEYS);
+        let map = collision_font_mapping(["ArialMT", "Arial-BoldMT", "TT0"], &reserved);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_collision_mapping_disambiguates_against_reserved_and_preserved() {
+        // Reserved already contains the naive candidate `OrigHelvetica`, and the
+        // preserved set contains `OrigHelvetica_1`; the mapping must skip both.
+        let mut reserved = reserved_set(&["Helvetica", "OrigHelvetica"]);
+        reserved.insert("Helvetica".to_string());
+        let map = collision_font_mapping(["Helvetica", "OrigHelvetica_1"], &reserved);
+
+        let new_name = map.get("Helvetica").expect("colliding key must be renamed");
+        assert_ne!(new_name, "OrigHelvetica");
+        assert_ne!(new_name, "OrigHelvetica_1");
+        assert!(!reserved.contains(new_name));
+        // `OrigHelvetica_1` is not reserved, so it is not renamed.
+        assert!(!map.contains_key("OrigHelvetica_1"));
+    }
+
+    #[test]
+    fn test_collision_mapping_overlay_font_key() {
+        // A preserved key colliding with an overlay (non-base-14) key is renamed.
+        let reserved = reserved_set(&["CustomOverlay"]);
+        let map = collision_font_mapping(["CustomOverlay"], &reserved);
+        assert_eq!(
+            map.get("CustomOverlay").map(String::as_str),
+            Some("OrigCustomOverlay")
+        );
+    }
+
+    #[test]
+    fn test_apply_font_rename_map_renames_only_mapped_keys() {
+        use crate::objects::{Dictionary, Object};
+
+        let mut fonts = Dictionary::new();
+        fonts.set("Helvetica", Object::Integer(1));
+        fonts.set("F1", Object::Integer(2));
+
+        let mut map = HashMap::new();
+        map.insert("Helvetica".to_string(), "OrigHelvetica".to_string());
+
+        let out = apply_font_rename_map(&fonts, &map);
+
+        assert!(out.contains_key("OrigHelvetica"));
+        assert!(!out.contains_key("Helvetica"));
+        assert!(out.contains_key("F1"), "unmapped key must be kept as-is");
+        assert_eq!(out.get("OrigHelvetica"), Some(&Object::Integer(1)));
+        assert_eq!(out.get("F1"), Some(&Object::Integer(2)));
     }
 
     #[test]

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -8,7 +8,9 @@ mod signature;
 mod xref_stream_writer;
 
 // Phase 2 utilities for font preservation
-pub(crate) use content_stream_utils::{rename_preserved_fonts, rewrite_font_references};
+pub(crate) use content_stream_utils::{
+    apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
+};
 pub use incremental_form_fill::IncrementalFormFiller;
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1073,8 +1073,49 @@ impl<W: Write> PdfWriter<W> {
         Ok(())
     }
 
-    fn write_page_content(&mut self, content_id: ObjectId, page: &crate::page::Page) -> Result<()> {
+    /// Issue #395: build the collision-only rename map for a page's preserved
+    /// fonts. A preserved `/Font` key is disambiguated only when it collides
+    /// with a key already present in the page `/Font` dict the writer builds —
+    /// i.e. one of the unconditionally injected base fonts
+    /// ([`INJECTED_BASE_FONT_KEYS`]) or an overlay/custom font (`font_refs`).
+    /// Returns an empty map when the page has no preserved fonts or none
+    /// collide, so no content rewrite happens in the common case.
+    fn preserved_font_disambiguation_map(
+        page: &crate::page::Page,
+        font_refs: &HashMap<String, ObjectId>,
+    ) -> HashMap<String, String> {
+        let preserved_fonts = match page
+            .get_preserved_resources()
+            .and_then(|res| res.get("Font"))
+        {
+            Some(crate::pdf_objects::Object::Dictionary(fonts)) => fonts,
+            _ => return HashMap::new(),
+        };
+
+        let mut reserved: std::collections::HashSet<String> =
+            crate::writer::INJECTED_BASE_FONT_KEYS
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+        reserved.extend(font_refs.keys().cloned());
+
+        let preserved_keys: Vec<String> = preserved_fonts
+            .keys()
+            .map(|k| k.as_str().to_string())
+            .collect();
+        crate::writer::collision_font_mapping(preserved_keys.iter().map(|s| s.as_str()), &reserved)
+    }
+
+    fn write_page_content(
+        &mut self,
+        content_id: ObjectId,
+        page: &crate::page::Page,
+        preserved_font_map: &HashMap<String, String>,
+    ) -> Result<()> {
         let mut page_copy = page.clone();
+        // Issue #395: drive the preserved-content font rewrite from the same
+        // collision-only map used for the resource-dict rename.
+        page_copy.preserved_font_rewrite_map = preserved_font_map.clone();
         let content = page_copy.generate_content()?;
 
         // Create stream with compression if enabled
@@ -2505,8 +2546,21 @@ impl<W: Write> PdfWriter<W> {
             let page_id = page_ids[i];
             let content_id = content_ids[i];
 
-            self.write_page_with_fonts(page_id, pages_id, content_id, page, document, font_refs)?;
-            self.write_page_content(content_id, page)?;
+            // Issue #395: compute the collision-only preserved-font rename map
+            // once and drive BOTH the resource-dict rename (write_page_with_fonts)
+            // and the content-stream rewrite (write_page_content) from it, so the
+            // two stay consistent by construction.
+            let preserved_font_map = Self::preserved_font_disambiguation_map(page, font_refs);
+            self.write_page_with_fonts(
+                page_id,
+                pages_id,
+                content_id,
+                page,
+                document,
+                font_refs,
+                &preserved_font_map,
+            )?;
+            self.write_page_content(content_id, page, &preserved_font_map)?;
         }
 
         Ok(())
@@ -2530,6 +2584,7 @@ impl<W: Write> PdfWriter<W> {
         page: &crate::page::Page,
         _document: &Document,
         font_refs: &HashMap<String, ObjectId>,
+        preserved_font_map: &HashMap<String, String>,
     ) -> Result<()> {
         // Start with the page's dictionary which includes annotations
         let mut page_dict = page.to_dict();
@@ -2913,12 +2968,12 @@ impl<W: Write> PdfWriter<W> {
             // Convert pdf_objects::Dictionary to writer Dictionary FIRST
             let mut preserved_writer_dict = self.convert_pdf_objects_dict_to_writer(preserved_res);
 
-            // Step 1: Rename preserved fonts (F1 → OrigF1)
+            // Step 1: Issue #395 — collision-only rename. Only preserved font
+            // keys that collide with an injected/overlay key are renamed (per
+            // `preserved_font_map`); every other key is kept, so non-colliding
+            // fonts are never disturbed and their content is never rewritten.
             if let Some(Object::Dictionary(fonts)) = preserved_writer_dict.get("Font") {
-                // Rename font dictionary keys using our utility function
-                let renamed_fonts = crate::writer::rename_preserved_fonts(fonts);
-
-                // Replace Font dictionary with renamed version
+                let renamed_fonts = crate::writer::apply_font_rename_map(fonts, preserved_font_map);
                 preserved_writer_dict.set("Font", Object::Dictionary(renamed_fonts));
             }
 

--- a/oxidize-pdf-core/tests/issue_395_font_collision_test.rs
+++ b/oxidize-pdf-core/tests/issue_395_font_collision_test.rs
@@ -1,0 +1,229 @@
+//! Acceptance tests for issue #395: a preserved embedded font must not be
+//! silently dropped or de-referenced when its `/Font` resource key collides
+//! with a writer-injected base-14 font, and the preserved content that
+//! references it must keep resolving to the embedded font.
+//!
+//! Root cause (see the issue): `write_page_with_fonts` injects all base-14
+//! fonts into every page `/Font` dict keyed by their PostScript names
+//! (`Helvetica`, `Times-Roman`, …). Preserved resources are merged
+//! overlay-wins-on-collision, so a preserved font keyed `/Helvetica` is
+//! discarded in favour of the non-embedded injected stub.
+//!
+//! The pre-fix mitigation renamed EVERY preserved font unconditionally
+//! (`/F1` → `/OrigF1`) and rewrote the content. That is wrong two ways:
+//!   * `rewrite_font_references` is line-based, so a font operator split
+//!     across a newline (`/Helvetica\n12 Tf`) is NOT rewritten — the dict key
+//!     becomes `/OrigHelvetica` but the content still says `/Helvetica`, which
+//!     then resolves to the injected stub (or, for a non-base-14 key, to
+//!     nothing). This is the class of failure reported on `testi.pdf`.
+//!   * renaming non-colliding fonts is pure risk with no benefit.
+//!
+//! The fix is collision-only disambiguation (rename a preserved font only when
+//! its key collides with the injected/reserved set, rewriting only those
+//! references) plus a whitespace-robust content rewrite.
+
+use oxidize_pdf::parser::objects::{PdfDictionary, PdfObject};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+
+/// The distinctive BaseFont of the preserved embedded font. It differs from any
+/// injected stub's BaseFont so we can find it unambiguously in the output.
+const EMBEDDED_BASE_FONT: &str = "ABCDEF+CustomEmbed";
+
+/// Build a minimal, valid PDF whose page `/Resources /Font /<font_key>` maps to
+/// an embedded TrueType font (distinctive BaseFont, FontDescriptor, FontFile2),
+/// and whose content selects it with a `<size> Tf` operator. When `cross_line`
+/// is true the font name and size are placed on separate content lines — a
+/// layout the pre-fix line-based rewriter fails to handle.
+fn build_pdf(font_key: &str, cross_line: bool) -> Vec<u8> {
+    let content = if cross_line {
+        format!("BT\n/{font_key}\n12 Tf 72 720 Td (Hi) Tj ET")
+    } else {
+        format!("BT /{font_key} 12 Tf 72 720 Td (Hi) Tj ET")
+    };
+    let obj4 = format!(
+        "<< /Length {} >>\nstream\n{}\nendstream",
+        content.len(),
+        content
+    );
+
+    // A dummy embedded font program. `from_parsed_with_content` copies the
+    // stream bytes verbatim (it does not parse the TTF), so arbitrary bytes work
+    // for a preservation round-trip.
+    let fontfile = "\x00\x01\x00\x00dummy-truetype-program";
+    let obj7 = format!(
+        "<< /Length {} /Length1 {} >>\nstream\n{}\nendstream",
+        fontfile.len(),
+        fontfile.len(),
+        fontfile
+    );
+
+    let objects: Vec<String> = vec![
+        // 1: Catalog.
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        // 2: Page tree root.
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        // 3: Page — the /Font key is `font_key`.
+        format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /{font_key} 5 0 R >> >> /Contents 4 0 R >>"
+        ),
+        // 4: Content stream.
+        obj4,
+        // 5: The embedded font dictionary (distinctive BaseFont).
+        format!(
+            "<< /Type /Font /Subtype /TrueType /BaseFont /{EMBEDDED_BASE_FONT} \
+             /FirstChar 32 /LastChar 32 /Widths [500] /Encoding /WinAnsiEncoding \
+             /FontDescriptor 6 0 R >>"
+        ),
+        // 6: FontDescriptor referencing the embedded program.
+        format!(
+            "<< /Type /FontDescriptor /FontName /{EMBEDDED_BASE_FONT} /Flags 4 \
+             /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 700 /Descent -200 \
+             /CapHeight 700 /StemV 80 /FontFile2 7 0 R >>"
+        ),
+        // 7: FontFile2 embedded font program stream.
+        obj7,
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+
+    let xref_offset = pdf.len();
+    let size = objects.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {}\n", size).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            size, xref_offset
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
+/// Resolve `obj` to a dictionary, following one level of indirection.
+fn resolve_dict<R: std::io::Read + std::io::Seek>(
+    doc: &PdfDocument<R>,
+    obj: &PdfObject,
+) -> Option<PdfDictionary> {
+    match obj {
+        PdfObject::Dictionary(d) => Some(d.clone()),
+        PdfObject::Reference(num, gen) => match doc.get_object(*num, *gen) {
+            Ok(PdfObject::Dictionary(d)) => Some(d),
+            Ok(PdfObject::Stream(s)) => Some(s.dict.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Whitespace-tolerant check: does the content select `key` via a
+/// `/key <size> Tf` operator anywhere (across any whitespace, incl. newlines)?
+fn content_selects_font(content: &[u8], key: &str) -> bool {
+    let s = String::from_utf8_lossy(content);
+    let tokens: Vec<&str> = s.split_whitespace().collect();
+    let want = format!("/{key}");
+    tokens.windows(3).any(|w| w[0] == want && w[2] == "Tf")
+}
+
+/// Round-trip the source PDF through `from_parsed_with_content` → write →
+/// re-parse, then assert the embedded font survives in the output `/Font` dict
+/// AND the preserved content still selects it.
+fn assert_embedded_font_survives(font_key: &str, cross_line: bool) {
+    let pdf_bytes = build_pdf(font_key, cross_line);
+
+    let reader =
+        PdfReader::new(Cursor::new(&pdf_bytes)).expect("hand-built PDF must be re-parseable");
+    let document = PdfDocument::new(reader);
+    let parsed_page = document.get_page(0).expect("page 0 must parse");
+    let page = Page::from_parsed_with_content(&parsed_page, &document)
+        .expect("from_parsed_with_content must succeed");
+
+    let mut out_doc = Document::new();
+    out_doc.add_page(page);
+    let out_bytes = out_doc.to_bytes().expect("writing output must succeed");
+
+    let out_reader =
+        PdfReader::new(Cursor::new(&out_bytes)).expect("output PDF must be re-parseable");
+    let out_document = PdfDocument::new(out_reader);
+    let out_page = out_document.get_page(0).expect("output page 0 must parse");
+
+    let resources = out_page
+        .get_resources()
+        .expect("output page must have /Resources");
+    let fonts = resources
+        .get("Font")
+        .and_then(|o| o.as_dict())
+        .expect("output /Font must be an inline dictionary");
+
+    // (1) The embedded font must survive under SOME key.
+    let embedded_key = fonts
+        .0
+        .iter()
+        .find_map(|(name, value)| {
+            let dict = resolve_dict(&out_document, value)?;
+            let base = dict.get("BaseFont").and_then(|o| o.as_name())?;
+            (base.as_str() == EMBEDDED_BASE_FONT).then(|| name.as_str().to_string())
+        })
+        .unwrap_or_else(|| {
+            let keys: Vec<_> = fonts.0.keys().map(|k| k.as_str().to_string()).collect();
+            panic!(
+                "embedded font (BaseFont /{EMBEDDED_BASE_FONT}) was dropped from the output \
+                 /Font dict; keys present: {keys:?}"
+            )
+        });
+
+    // (2) The preserved content must select the embedded font's key, so the
+    // text resolves to the embedded font — not the injected stub, and not a
+    // dangling key.
+    let streams = out_page
+        .content_streams_with_document(&out_document)
+        .expect("output content streams must resolve");
+    let content: Vec<u8> = streams.into_iter().flatten().collect();
+    assert!(
+        content_selects_font(&content, &embedded_key),
+        "preserved content must select the embedded font via `/{embedded_key} <size> Tf`; \
+         got content: {:?}",
+        String::from_utf8_lossy(&content)
+    );
+}
+
+/// Simple base-14 collision: `/Helvetica` on a single content line. This case
+/// already works with the pre-fix unconditional rename; it is a guard against
+/// the #391 regression (removing the mechanism drops the embedded font).
+#[test]
+fn base14_key_collision_simple_content() {
+    assert_embedded_font_survives("Helvetica", false);
+}
+
+/// Base-14 collision with the font operator split across a newline. The pre-fix
+/// line-based rewrite leaves the content pointing at `/Helvetica` (the injected
+/// stub) while the embedded font sits under `/OrigHelvetica`. Requires both the
+/// collision-only rename and a whitespace-robust content rewrite.
+#[test]
+fn base14_key_collision_cross_line_content() {
+    assert_embedded_font_survives("Helvetica", true);
+}
+
+/// Non-base-14 key with the font operator split across a newline — the
+/// `testi.pdf` failure class. The pre-fix code renames `/DistinctFont` →
+/// `/OrigDistinctFont` but fails to rewrite the cross-line reference, leaving
+/// `/DistinctFont` dangling (no injected stub to fall back on). Collision-only
+/// disambiguation fixes it by not renaming a non-colliding font at all.
+#[test]
+fn non_base14_key_cross_line_content_not_corrupted() {
+    assert_embedded_font_survives("DistinctFont", true);
+}


### PR DESCRIPTION
## Summary

A preserved (embedded) font whose `/Font` resource key collides with a writer-injected base-14 font (e.g. `/Helvetica`) was **silently dropped**, and the preserved content that referenced that key rendered with the wrong (non-embedded stub) font.

Root cause: `write_page_with_fonts` injects all base-14 fonts into every page `/Font` dict keyed by their PostScript names, and preserved resources merge **overlay-wins-on-collision** — so a preserved `/Helvetica` loses to the injected stub. The prior mitigation renamed **every** preserved font unconditionally (`/F1` → `/OrigF1`) and rewrote the content with a **line-based** rewriter that missed operators split across a newline, leaving the dict key renamed but the content still pointing at the old key (the `testi.pdf` failure class).

Addresses #395. Target: `develop`.

## Changes

- **Collision-only rename** — a preserved font key is disambiguated *only* when it collides with an injected base-14 or overlay (`font_refs`) key. A single map, computed once per page in `write_pages`, drives **both** the resource-dict rename (`apply_font_rename_map`) and the content rewrite, so the two stay consistent by construction. Non-colliding fonts are never touched — which is what makes all-non-base-14 inputs (`testi.pdf`) safe (no rewrite runs at all).
- **Robust `rewrite_font_references`** — replaced the line-based, whitespace-normalizing rewriter with a byte-level, structure-preserving tokenizer. It rewrites only a `/name` in `Tf` operand position, preserves all whitespace and inline binary verbatim, handles cross-line operators, and ignores a `/name` inside a string/hex literal or comment.

## Tests (TDD)

- `issue_395_font_collision_test.rs`: base-14 simple + cross-line, and non-base-14 cross-line — each round-tripped through `from_parsed_with_content` → write → re-parse, asserting the embedded font (distinctive BaseFont) survives in the output `/Font` dict **and** the preserved content resolves to it. The two cross-line cases were RED before the fix, GREEN after.
- Unit tests for `collision_font_mapping` / `apply_font_rename_map` and the tokenizer edge cases (string-literal safety, real/negative sizes, tabs, indentation preservation).
- Existing `overlay` / `merge_font_mapping` / `page_font_reference_resolve` suites stay green.

## Verification

- lib 6606/0; full `cargo test --no-fail-fast` green (default features).
- `cargo clippy --all -- -D warnings` clean; `cargo fmt --check` clean.

## Notes

- The `testi.pdf` acceptance bullet is addressed by root cause: collision-only stops rewriting non-base-14 fonts entirely. `testi.pdf` was not in the repo, so this class is reproduced via synthetic cross-line inputs rather than that specific file.
- Supersedes PR #391 (correct diagnosis, but removed the collision guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)