### PR TITLE
Release v3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1545,68 +1545,139 @@ impl TextExtractor {
 
     /// Detect columns and re-sort fragments accordingly
     fn detect_and_sort_columns(&self, fragments: &mut [TextFragment]) {
-        // Group fragments by approximate Y position
-        let mut lines: Vec<Vec<&mut TextFragment>> = Vec::new();
-        let mut current_line: Vec<&mut TextFragment> = Vec::new();
-        let mut last_y = f64::INFINITY;
+        // `fragments` arrives pre-sorted by `sort_and_merge_fragments` in reading
+        // order: top-to-bottom by Y band, left-to-right by X within a band.
+        //
+        // Column boundaries are scoped to the row-span of the block that produced
+        // them (issue #403). A page that mixes a small table with unrelated
+        // full-width prose must not apply the table's column gaps to the
+        // paragraph: doing so bucketed the paragraph's per-glyph fragments into
+        // different "columns" by x-position and shredded any token that straddled
+        // a boundary. We therefore only reorder fragments inside a *columnar
+        // block* — a maximal run of consecutive lines that each exhibit an
+        // internal gap wider than `column_threshold` — and leave full-width
+        // "flow" lines in their natural reading order.
 
-        for fragment in fragments.iter_mut() {
-            let fragment_y = fragment.y;
-            if (last_y - fragment_y).abs() > self.options.newline_threshold
+        // Group fragment indices into lines by Y band. Indices (not `&mut`) so we
+        // can later reorder the slice by a computed permutation.
+        let mut lines: Vec<Vec<usize>> = Vec::new();
+        let mut current_line: Vec<usize> = Vec::new();
+        let mut last_y = f64::INFINITY;
+        for (i, fragment) in fragments.iter().enumerate() {
+            if (last_y - fragment.y).abs() > self.options.newline_threshold
                 && !current_line.is_empty()
             {
-                lines.push(current_line);
-                current_line = Vec::new();
+                lines.push(std::mem::take(&mut current_line));
             }
-            current_line.push(fragment);
-            last_y = fragment_y;
+            current_line.push(i);
+            last_y = fragment.y;
         }
         if !current_line.is_empty() {
             lines.push(current_line);
         }
 
-        // Detect column boundaries
-        let mut column_boundaries = vec![0.0];
-        for line in &lines {
-            if line.len() > 1 {
-                for i in 0..line.len() - 1 {
-                    let gap = line[i + 1].x - (line[i].x + line[i].width);
+        // A line is "columnar" when it has at least one internal gap wider than
+        // `column_threshold`.
+        let line_is_columnar = |line: &[usize]| -> bool {
+            line.windows(2).any(|w| {
+                let (a, b) = (&fragments[w[0]], &fragments[w[1]]);
+                b.x - (a.x + a.width) > self.options.column_threshold
+            })
+        };
+
+        // Segment lines into blocks: consecutive columnar lines share one segment
+        // id (a multi-line column block); every other line is its own segment.
+        // Segment ids are monotonic top-to-bottom, so a later stable sort keyed on
+        // (segment, column) keeps regions in their original vertical order.
+        let n = fragments.len();
+        let mut segment_of = vec![0usize; n];
+        let mut column_of = vec![0usize; n];
+        let mut has_columnar_block = false;
+        let mut seg_id = 0usize;
+        let mut prev_columnar = false;
+
+        for (li, line) in lines.iter().enumerate() {
+            let columnar = line_is_columnar(line);
+            if li > 0 && !(columnar && prev_columnar) {
+                seg_id += 1;
+            }
+            for &i in line {
+                segment_of[i] = seg_id;
+            }
+            prev_columnar = columnar;
+        }
+
+        // For each columnar block (a segment whose lines are columnar), derive
+        // boundaries from that block's lines only and assign each fragment its
+        // column. Flow segments keep column 0, so the stable sort preserves their
+        // left-to-right reading order untouched.
+        let mut block_start = 0usize;
+        while block_start < lines.len() {
+            if !line_is_columnar(&lines[block_start]) {
+                block_start += 1;
+                continue;
+            }
+            let seg = segment_of[lines[block_start][0]];
+            let mut block_end = block_start;
+            while block_end < lines.len() && segment_of[lines[block_end][0]] == seg {
+                block_end += 1;
+            }
+
+            // Collect boundaries from every line in this block.
+            let mut boundaries = vec![0.0];
+            for line in &lines[block_start..block_end] {
+                for w in line.windows(2) {
+                    let (a, b) = (&fragments[w[0]], &fragments[w[1]]);
+                    let gap = b.x - (a.x + a.width);
                     if gap > self.options.column_threshold {
-                        let boundary = line[i].x + line[i].width + gap / 2.0;
-                        if !column_boundaries
-                            .iter()
-                            .any(|&b| (b - boundary).abs() < 10.0)
-                        {
-                            column_boundaries.push(boundary);
+                        let boundary = a.x + a.width + gap / 2.0;
+                        if !boundaries.iter().any(|&x| (x - boundary).abs() < 10.0) {
+                            boundaries.push(boundary);
                         }
                     }
                 }
             }
-        }
-        column_boundaries.sort_by(|a, b| a.total_cmp(b));
+            boundaries.sort_by(|a, b| a.total_cmp(b));
 
-        // Re-sort fragments by column then Y position
-        if column_boundaries.len() > 1 {
-            fragments.sort_by(|a, b| {
-                // Determine column for each fragment
-                let col_a = column_boundaries
-                    .iter()
-                    .position(|&boundary| a.x < boundary)
-                    .unwrap_or(column_boundaries.len())
-                    - 1;
-                let col_b = column_boundaries
-                    .iter()
-                    .position(|&boundary| b.x < boundary)
-                    .unwrap_or(column_boundaries.len())
-                    - 1;
-
-                if col_a != col_b {
-                    col_a.cmp(&col_b)
-                } else {
-                    // Same column, sort by Y position
-                    b.y.total_cmp(&a.y)
+            if boundaries.len() > 1 {
+                has_columnar_block = true;
+                for line in &lines[block_start..block_end] {
+                    for &i in line {
+                        // Column = index of the last boundary not exceeding x.
+                        // `boundaries[0]` is 0.0; a fragment drawn off-page-left
+                        // (x < 0) saturates to column 0 rather than underflowing.
+                        let col = boundaries
+                            .iter()
+                            .position(|&boundary| fragments[i].x < boundary)
+                            .map_or(boundaries.len() - 1, |p| p.saturating_sub(1));
+                        column_of[i] = col;
+                    }
                 }
-            });
+            }
+            block_start = block_end;
+        }
+
+        // No columnar block → nothing to reorder; the reading-order sort stands.
+        if !has_columnar_block {
+            return;
+        }
+
+        // Stable permutation by (segment, column), tie-broken by original index so
+        // reading order is preserved within each (segment, column) — top-to-bottom
+        // then left-to-right, i.e. column-major within a block.
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|&i, &j| {
+            segment_of[i]
+                .cmp(&segment_of[j])
+                .then(column_of[i].cmp(&column_of[j]))
+                .then(i.cmp(&j))
+        });
+
+        // Materialize the permuted order once (one clone per fragment), then move
+        // each element back into place — avoids a second full-slice clone.
+        let reordered: Vec<TextFragment> = order.iter().map(|&i| fragments[i].clone()).collect();
+        for (slot, frag) in fragments.iter_mut().zip(reordered) {
+            *slot = frag;
         }
     }
 

--- a/oxidize-pdf-core/tests/issue_392_unicode_keyed_cyrillic_test.rs
+++ b/oxidize-pdf-core/tests/issue_392_unicode_keyed_cyrillic_test.rs
@@ -1,0 +1,114 @@
+//! Regression guard for issue #392 — the Unicode-keyed font path
+//! (`add_font*` + `Font::Custom` + write) must render/extract non-Latin text
+//! (Cyrillic here) instead of silently degrading to a single-byte encoding that
+//! substitutes `?`.
+//!
+//! The bug was real on the Python wheel 0.14.0 (a core predating #240): the text
+//! path emitted single-byte WinAnsi codes, so any character outside that range
+//! became `?`. Since #240 the `Font::Custom` path emits UTF-16BE hex strings and
+//! the writer emits a Type0/CIDFontType2 font with Identity-H and a CIDToGIDMap
+//! that maps Unicode code points to glyph IDs via the font's own cmap. These
+//! tests lock that contract so it cannot silently regress.
+//!
+//! Fixture: `../test-pdfs/Roboto-Regular.ttf` (has full Cyrillic coverage).
+//! Skips gracefully if the fixture is missing.
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::{Document, Font, Page};
+use std::io::Cursor;
+
+const ROBOTO_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+
+// Cyrillic string outside the single-byte Latin range (U+044D, U+0447, U+0433,
+// U+0444, U+0433). Exactly the failing input class from the issue.
+const CYRILLIC: &str = "эчгфг";
+
+fn load_fixture() -> Option<Vec<u8>> {
+    std::fs::read(ROBOTO_PATH)
+        .map_err(|_| eprintln!("SKIPPED: {ROBOTO_PATH} not found"))
+        .ok()
+}
+
+/// Build a one-page PDF that writes `CYRILLIC` via the Unicode-keyed path and
+/// return the serialized bytes.
+fn build_pdf_with_cyrillic(font_data: Vec<u8>) -> Vec<u8> {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes should succeed");
+
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 40.0)
+        .at(60.0, 700.0)
+        .write(CYRILLIC)
+        .expect("writing Cyrillic via Unicode-keyed path should succeed");
+    doc.add_page(page);
+
+    doc.to_bytes().expect("PDF generation should succeed")
+}
+
+#[test]
+fn unicode_keyed_font_roundtrips_cyrillic() {
+    let font_data = match load_fixture() {
+        Some(d) => d,
+        None => return,
+    };
+    let pdf_bytes = build_pdf_with_cyrillic(font_data);
+
+    let reader =
+        PdfReader::new(Cursor::new(&pdf_bytes)).expect("generated PDF must be re-parseable");
+    let extracted = PdfDocument::new(reader)
+        .extract_text_from_page(0)
+        .expect("text extraction must succeed");
+
+    assert!(
+        extracted.text.contains(CYRILLIC),
+        "Unicode-keyed path must round-trip Cyrillic, not degrade to '?': {:?}",
+        extracted.text
+    );
+    assert!(
+        !extracted.text.contains('?'),
+        "no character may degrade to '?': {:?}",
+        extracted.text
+    );
+}
+
+#[test]
+fn unicode_keyed_font_emits_type0_not_single_byte() {
+    // The distinguishing artifact of the fix: a Type0 composite font with
+    // Identity-H, not a simple single-byte font. The font dictionaries are not
+    // compressed, so a raw-byte scan is a reliable check.
+    let font_data = match load_fixture() {
+        Some(d) => d,
+        None => return,
+    };
+    let pdf_bytes = build_pdf_with_cyrillic(font_data);
+    let haystack = String::from_utf8_lossy(&pdf_bytes);
+
+    for marker in ["/Type0", "/CIDFontType2", "Identity-H", "CIDToGIDMap"] {
+        assert!(
+            haystack.contains(marker),
+            "Unicode-keyed Cyrillic font must be emitted as a Type0/CIDFontType2 \
+             composite font (missing marker {marker:?})"
+        );
+    }
+}
+
+#[test]
+fn font_missing_glyphs_matches_renderability() {
+    // Issue request #3: `font_missing_glyphs` must not give a false all-clear
+    // that contradicts what the font actually paints. Roboto covers the
+    // Cyrillic, so it reports none missing AND the text round-trips — consistent.
+    let font_data = match load_fixture() {
+        Some(d) => d,
+        None => return,
+    };
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", font_data)
+        .expect("add_font_from_bytes should succeed");
+
+    assert_eq!(
+        doc.font_missing_glyphs("Roboto", CYRILLIC),
+        Vec::<char>::new(),
+        "Roboto covers this Cyrillic, so no glyph is missing"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_403_column_scope_test.rs
+++ b/oxidize-pdf-core/tests/issue_403_column_scope_test.rs
@@ -1,0 +1,156 @@
+//! Regression tests for issue #403 — `reorder_columns` must scope column
+//! boundaries to the row-span of the block that produced them (direction A),
+//! instead of applying page-wide boundaries to unrelated full-width prose.
+//!
+//! Before the fix, a small table's column gaps produced boundaries that fell
+//! in the middle of an unrelated paragraph below it; because CID-font PDFs emit
+//! one glyph per fragment, the paragraph's characters were bucketed into
+//! different "columns" by x-position and re-sorted, shredding any token that
+//! straddled the boundary.
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+/// A 3-column header row (wide gaps → real column boundaries) at y=700, then a
+/// full-width paragraph at y=670 emitted glyph-by-glyph (matches the per-glyph
+/// TextFragment granularity of real CID-font PDFs). The paragraph's token
+/// `ID-99887766-55` spans an x-range that crosses the table's column boundary.
+fn build_mixed_table_and_prose() -> String {
+    let mut c = String::new();
+    // 3-column table row: gaps of ~96pt >> column_threshold (50).
+    c.push_str("BT\n/F1 10 Tf\n");
+    c.push_str("1 0 0 1 100 700 Tm\n(Col1) Tj\n");
+    c.push_str("1 0 0 1 220 700 Tm\n(Col2) Tj\n");
+    c.push_str("1 0 0 1 340 700 Tm\n(Col3) Tj\n");
+    c.push_str("ET\n");
+
+    // Full-width paragraph, one glyph per fragment. Adjacent glyphs are 6pt
+    // apart (no gap > column_threshold), so the line is not columnar.
+    let text = "Test doc ID-99887766-55 has more filler content after it to pad the line.";
+    let start_x = 60.0_f64;
+    let y = 670.0_f64;
+    let advance = 6.0_f64;
+    for (i, ch) in text.chars().enumerate() {
+        let x = start_x + advance * i as f64;
+        // Escape the space glyph as a literal space inside ( ) — Helvetica.
+        c.push_str(&format!(
+            "BT\n/F1 10 Tf\n1 0 0 1 {x:.2} {y:.2} Tm\n({ch}) Tj\nET\n"
+        ));
+    }
+    c
+}
+
+#[test]
+fn mixed_table_and_prose_keeps_prose_token_intact() {
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(&build_mixed_table_and_prose(), opts).text;
+    assert!(
+        text.contains("ID-99887766-55"),
+        "prose token must survive: the table's column boundary must not be \
+         applied to the unrelated full-width paragraph below it: {text:?}"
+    );
+}
+
+#[test]
+fn multiline_columns_still_reflow_column_major() {
+    // Guard against a per-line-only fix (direction B): a true two-column,
+    // two-line layout must still reflow column-major — all of column 1 (both
+    // lines) before column 2 — which is the reason #389's reorder_columns
+    // exists. Column 1 at x=50, column 2 at x=300 (gap ~245 >> threshold).
+    // Stream order interleaves the columns.
+    const TWO_COL_TWO_LINE: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 50 700 Tm\n(AAAA) Tj\n",
+        "1 0 0 1 300 700 Tm\n(CCCC) Tj\n",
+        "1 0 0 1 50 680 Tm\n(BBBB) Tj\n",
+        "1 0 0 1 300 680 Tm\n(DDDD) Tj\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(TWO_COL_TWO_LINE, opts).text;
+    let a = text.find("AAAA").expect("AAAA present");
+    let b = text.find("BBBB").expect("BBBB present");
+    let cc = text.find("CCCC").expect("CCCC present");
+    let d = text.find("DDDD").expect("DDDD present");
+    assert!(
+        a < b && b < cc && cc < d,
+        "column-major reflow: column 1 (AAAA,BBBB) must precede column 2 \
+         (CCCC,DDDD): {text:?}"
+    );
+}
+
+#[test]
+fn negative_x_fragment_in_columnar_block_does_not_panic() {
+    // A columnar line whose leftmost fragment is drawn off-page-left (x < 0).
+    // Column assignment counts boundaries not exceeding x; boundaries[0] is 0.0,
+    // so a negative-x fragment must saturate to column 0 instead of underflowing
+    // the `usize` column index (which panics in debug builds).
+    const NEG_X: &str = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 -10 700 Tm\n(L) Tj\n",
+        "1 0 0 1 200 700 Tm\n(R) Tj\nET"
+    );
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    // Must not panic; both glyphs survive with L (column 0) before R (column 1).
+    let text = extract(NEG_X, opts).text;
+    let l = text.find('L').expect("L present");
+    let r = text.find('R').expect("R present");
+    assert!(l < r, "off-page-left fragment lands in column 0: {text:?}");
+}


### PR DESCRIPTION
## Release v3.1.2 (PATCH)

- **#403** — `fix(extraction)`: scope `reorder_columns` column boundaries to row-span blocks. A small table's column gaps no longer bucket unrelated full-width prose into columns and shred tokens that straddle a boundary. (PR #404)
- **#392** — `test(fonts)`: regression guard for Unicode-keyed non-Latin (Cyrillic) rendering; core already emits Type0/CIDFontType2 Identity-H with a Unicode→GID CIDToGIDMap (fixed by #240). (PR #405)

No breaking changes. MSRV 1.88. quality-rust reviewed the #403 fix; all CI green on the feature PRs (all-OS + MSRV).