### PR TITLE
feat(#375): RAG table extraction quality + data-loss safety net (4.0 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### BREAKING CHANGES
+
+- `TableElementData` (`oxidize_pdf::pipeline`), and `DetectedTable` / `TableCell`
+  (`oxidize_pdf::text::table_detection`) are now `#[non_exhaustive]` and gained new public
+  fields (rich table structure / cell spans / header rows). External code can no longer
+  construct these with a struct literal or match them exhaustively. Migration: build
+  `TableElementData` via `TableElementData::new(rows, metadata)` (flat) or
+  `TableElementData::from_structure(structure, metadata)` (rich); build `TableCell` via
+  `TableCell::new(..)` and `DetectedTable` via `DetectedTable::new(..)`. (#375)
+
+### Added
+
+- **RAG table extraction quality (#375).** Merged cells (rowspan/colspan) and header rows are
+  now represented by a rich `TableStructure` / `RichCell` model on `TableElementData.structure`,
+  populated from hard signals — drawn-grid dividers (merged cells) and PDF structure tags
+  (header rows). The flat `rows` view is derived from it (spanned values repeated). GFM export
+  collapses multi-level headers (joined with `›`) and repeats merged-cell values; RAG chunk
+  metadata (`table_rows`/`table_cols`) counts the rich geometry. Borderless tables and
+  un-tagged multi-level headers remain flat — see `docs/TABLE_DETECTION_GUIDE.md`.
+
+### Fixed
+
+- **Table detection no longer silently drops page text (#375).** A detected table now claims
+  only fragments it actually placed in a cell (both ruling and spatial detectors); text inside
+  the table bounding box but not in any cell falls back to prose instead of being discarded.
+  Near-empty tables (< 2 populated cells) decompose to prose. Guarded by a text-conservation
+  invariant test.
+
 ## [3.1.1] - 2026-07-07
 
 ### Fixed

--- a/docs/TABLE_DETECTION_GUIDE.md
+++ b/docs/TABLE_DETECTION_GUIDE.md
@@ -596,3 +596,22 @@ https://github.com/BelowZero/oxidize-pdf/issues
 **Version**: 1.6.3
 **Last Updated**: 2025-10-22
 **License**: MIT
+
+## Known limitations (as of #375)
+
+Rich table structure — merged cells and multi-level headers — is only produced when a
+**hard signal** reveals it:
+
+- **Merged cells** are detected from the drawn grid: where an internal dividing line is
+  absent, the adjacent cells are merged. Tables without drawn borders ("borderless") are
+  returned as a flat grid with no merged-cell information.
+- **Multi-level headers** are represented as header rows containing merged cells (e.g. a
+  "Region" header spanning two columns above "Q1"/"Q2"). Header rows are identified from the
+  PDF's structure tags when the document is tagged, otherwise the top row is assumed to be
+  the header. A nested header *hierarchy* is not read from the PDF's internal structure tree.
+- **Borderless-table detection is intrinsically ambiguous** and best-effort; when in doubt
+  the content is preserved as prose rather than forced into a grid (no text is dropped).
+
+For GitHub-Flavored Markdown export, merged-cell values are repeated across every column
+they cover, and multi-level headers are flattened into a single header row joining the
+levels with " › ".

--- a/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
+++ b/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
@@ -275,11 +275,13 @@ git commit -m "fix(#375): spatial tables claim only populated-cell fragments"
 Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add:
 
 ```rust
-                                // #375: a table that captured too few cells is not a
-                                // table — skip it so its fragments become prose.
+                                // #375: a table with fewer than 2 populated cells is not a
+                                // real table — skip it so its fragments become prose.
+                                // (Softened from `populated < rows` after Task 4 review found
+                                // that threshold over-rejected legitimately sparse narrow tables;
+                                // human-approved 2026-07-09.)
                                 let populated = table.cells.iter().filter(|c| !c.text.is_empty()).count();
-                                if populated < table.rows.max(1) {
-                                    // fewer populated cells than rows => no real column structure
+                                if populated < 2 {
                                     continue;
                                 }
 ```
@@ -287,9 +289,10 @@ Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add
 Spatial path — after its confidence gate at ~392, add:
 
 ```rust
+                            // #375: same near-empty guard for the spatial path.
                             let populated = table.rows.iter().flat_map(|r| &r.cells)
                                 .filter(|c| !c.is_empty()).count();
-                            if populated < table.row_count().max(1) {
+                            if populated < 2 {
                                 continue;
                             }
 ```

--- a/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
+++ b/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
@@ -1,0 +1,1157 @@
+# Issue #375 — Table Extraction Quality + Data-Loss Safety Net — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop silent text loss when prose is misdetected as a table, and additively enrich the table model so merged cells and multi-level headers (header rows + merged cells) are represented and exported to GFM.
+
+**Architecture:** Two independent detectors (ruling/vector-grid in `text/table_detection.rs`, spatial/borderless in `text/structured/`) feed one canonical `Element::Table(TableElementData)` in `pipeline/`. We (1) change fragment *claiming* so a table claims only text it actually placed in a cell (leftover flows to prose), guarded by a text-conservation invariant; (2) add an optional rich `TableStructure` alongside the existing flat `rows` (flat derived from rich, no breaking change); (3) rework grid construction to detect absent interior dividers → merged cells; (4) collapse header rows in the Markdown exporter and compute RAG metadata from the rich model.
+
+**Tech Stack:** Rust (edition per workspace), `cargo test`/`clippy`, no new dependencies, no-ML/deterministic.
+
+## Global Constraints
+
+- MSRV **1.88**; verify `cargo +1.88 build --lib --all-features --locked` before PR.
+- **Warnings = errors**: every commit must pass `cargo clippy --lib --all-features -- -D warnings` and `cargo fmt --check`.
+- **Additive only**: no breaking change to public types. `TableElementData.rows` stays public and unchanged in meaning. New fields are `Option`/defaulted.
+- **No-ML, deterministic**: identical input → identical output. No randomness, stable ordering.
+- **Tests verify real content**, never just "no crash" or "non-empty".
+- **TDD**: write the failing test, watch it fail, implement minimally, watch it pass, commit.
+- Branch: `feature/issue-375-table-extraction-quality` (off `develop`). Frequent commits.
+- **quality-rust pass is mandatory before the PR** (final task).
+- SemVer target: **MINOR**.
+
+## File map
+
+- `oxidize-pdf-core/src/pipeline/element.rs` — add `TableStructure`, `RichCell`, `structure` field + `from_structure` constructor; Markdown/metadata read it.
+- `oxidize-pdf-core/src/pipeline/partition.rs` — claim-only-captured (both paths), reject-degenerate, build rich table from ruling detector.
+- `oxidize-pdf-core/src/text/table_detection.rs` — `TableCell` spans, `DetectedTable.header_rows`, grid-segment retention, merged-cell detection.
+- `oxidize-pdf-core/src/pipeline/export.rs` — header-row collapse (multi-level → joined GFM header).
+- `oxidize-pdf-core/src/pipeline/chunk_metadata.rs` — `table_dims` from rich structure.
+- `oxidize-pdf-core/docs/../docs/TABLE_DETECTION_GUIDE.md` (repo `docs/TABLE_DETECTION_GUIDE.md`) + module rustdoc — known-limitation docs.
+- Tests: `tests/issue_375_text_conservation_test.rs`, `tests/issue_375_merged_cells_test.rs`, `tests/issue_375_multi_level_header_test.rs`, plus additions to `tests/partition_table_detection_test.rs`.
+
+---
+
+## Task 1: Reproduce the data-loss bug with a text-conservation invariant (RED)
+
+**Files:**
+- Create: `oxidize-pdf-core/tests/issue_375_text_conservation_test.rs`
+
+**Interfaces:**
+- Consumes: `PdfDocument::partition_with(PartitionConfig) -> ParseResult<Vec<Element>>`; `Element::display_text() -> String`; text extraction to get the page's expected text.
+- Produces: the invariant helper `assert_text_conserved` reused by later tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_text_conservation_test.rs
+//
+// #375 data-loss guard: after partitioning, the union of all element text must
+// cover the page's extracted text. A prose page misdetected as an (empty) table
+// currently drops its text -> this fails RED until the claim fix lands.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{Element, PartitionConfig};
+use oxidize_pdf::text::TextExtractor;
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+/// Non-whitespace tokens of `s`, lowercased, for order-independent containment.
+fn tokens(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|t| t.to_lowercase()).collect()
+}
+
+#[test]
+fn partition_conserves_page_text_default_config() {
+    let doc = PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"));
+
+    // Expected: raw extracted text of every page.
+    let mut extractor = TextExtractor::new();
+    let page_count = doc.page_count().expect("page_count");
+    let mut expected = String::new();
+    for p in 0..page_count {
+        let page_text = extractor
+            .extract_from_page(&doc, p)
+            .expect("extract page")
+            .text;
+        expected.push('\n');
+        expected.push_str(&page_text);
+    }
+
+    // Actual: union of all element display text.
+    let elements = doc.partition_with(PartitionConfig::default()).expect("partition");
+    let actual: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let actual_tokens: std::collections::HashSet<String> = tokens(&actual).into_iter().collect();
+
+    // Every expected token must survive partitioning (allow a small slack for
+    // tokenization artifacts at cell boundaries).
+    let missing: Vec<String> = tokens(&expected)
+        .into_iter()
+        .filter(|t| !actual_tokens.contains(t))
+        .collect();
+
+    let miss_ratio = missing.len() as f64 / tokens(&expected).len().max(1) as f64;
+    assert!(
+        miss_ratio < 0.01,
+        "partition dropped {:.1}% of page tokens ({} missing), e.g. {:?}",
+        miss_ratio * 100.0,
+        missing.len(),
+        &missing.iter().take(15).collect::<Vec<_>>()
+    );
+}
+```
+
+- [ ] **Step 2: Run it and confirm RED**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: FAIL — a meaningful fraction of tokens missing (the #345 empty-table drop). If it unexpectedly PASSES, the fixture doesn't trigger the bug; switch to the alternate reproduction in Step 3 before proceeding.
+
+- [ ] **Step 3 (only if Step 2 passed): synthetic spatial reproduction**
+
+If the fixture no longer triggers it, add this second test that drives the spatial path directly with prose fragments that clear the 0.5 confidence gate yet leave bbox-interior fragments uncelled:
+
+```rust
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(), x, y,
+        width: text.len() as f64 * 6.0, height: 12.0, font_size: 12.0,
+        font_name: None, is_bold: false, is_italic: false, color: None,
+        space_decisions: Vec::new(), mcid: None, struct_tag: None,
+    }
+}
+
+#[test]
+fn spatial_table_does_not_drop_interior_prose() {
+    // A justified prose block: 3 X-columns x 4 Y-rows, but one stray token sits
+    // in a gap between columns (inside the table bbox, outside every cell).
+    let mut frags = Vec::new();
+    for (r, y) in [780.0, 760.0, 740.0, 720.0].iter().enumerate() {
+        for (c, x) in [72.0, 200.0, 330.0].iter().enumerate() {
+            frags.push(frag(&format!("w{r}{c}"), *x, *y));
+        }
+    }
+    frags.push(frag("ORPHAN", 150.0, 730.0)); // in-bbox, between columns
+
+    let elements = Partitioner::new(PartitionConfig::default())
+        .partition_fragments(&frags, 0, 842.0);
+    let all: String = elements.iter().map(|e| e.display_text()).collect::<Vec<_>>().join(" ");
+    assert!(all.contains("ORPHAN"), "interior prose token was dropped: {all}");
+}
+```
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: FAIL on `spatial_table_does_not_drop_interior_prose` (ORPHAN claimed by bbox, never celled, never re-classified).
+
+- [ ] **Step 4: Commit the RED test**
+
+```bash
+git add oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
+git commit -m "test(#375): failing text-conservation invariant reproduces table data loss"
+```
+
+---
+
+## Task 2: Claim only captured text — ruling path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs:348-357` (ruling claim loop)
+
+**Interfaces:**
+- Consumes: `DetectedTable { cells: Vec<TableCell>, .. }` where each `TableCell` has a `bbox` with `contains_point(x, y)`.
+- Produces: unchanged public surface; only claiming behavior changes.
+
+- [ ] **Step 1: Replace bbox-membership claiming with cell-membership claiming**
+
+Current (lines 348–357) claims every fragment inside the table bbox. Replace the inner loop body so a fragment is claimed only if its center lands inside an actual cell of this table:
+
+```rust
+                                // #375: claim only fragments actually placed in a
+                                // cell. Fragments inside the table bbox but in no
+                                // cell (gaps, borders, normalization misses) stay
+                                // unclaimed and fall through to prose classification.
+                                for (i, f) in fragments.iter().enumerate() {
+                                    if claimed[i] {
+                                        continue;
+                                    }
+                                    let cx = f.x + f.width / 2.0;
+                                    let cy = f.y + f.height / 2.0;
+                                    if table.cells.iter().any(|cell| cell.bbox.contains_point(cx, cy)) {
+                                        claimed[i] = true;
+                                    }
+                                }
+```
+
+(Delete the old `let (rx, ry) = ...; let (rr, rt) = ...;` bbox-corner computation above it — it is now unused; clippy will flag it.)
+
+- [ ] **Step 2: Build and lint**
+
+Run: `cargo clippy --lib --all-features -- -D warnings`
+Expected: clean (no unused-variable warning for the removed bbox corners).
+
+- [ ] **Step 3: Run the ruling regression tests**
+
+Run: `cargo test --test ruling_table_partition_test`
+Expected: PASS — genuine bordered tables still capture their cells (fragments are inside cells, so still claimed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): ruling tables claim only celled fragments, not whole bbox"
+```
+
+---
+
+## Task 3: Claim only captured text — spatial path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs:419-428` (spatial claim loop)
+
+**Interfaces:**
+- Consumes: spatial `Table { rows: Vec<Row>, .. }`, `Row { cells: Vec<Cell>, .. }`, `Cell { text, bounding_box, .. }` where `bounding_box` has `contains(x, y)` (structured `BoundingBox`).
+
+- [ ] **Step 1: Replace the spatial claim loop**
+
+Replace lines 419–428 so a fragment is claimed only if its center is inside a non-empty cell of the detected table:
+
+```rust
+                            // #375: claim only fragments inside a populated cell.
+                            for (i, f) in fragments.iter().enumerate() {
+                                if claimed[i] {
+                                    continue;
+                                }
+                                let cx = f.x + f.width / 2.0;
+                                let cy = f.y + f.height / 2.0;
+                                let in_cell = table.rows.iter().flat_map(|r| &r.cells).any(|c| {
+                                    !c.is_empty() && c.bounding_box.contains(cx, cy)
+                                });
+                                if in_cell {
+                                    claimed[i] = true;
+                                }
+                            }
+```
+
+If structured `BoundingBox` exposes containment under a different name, confirm with:
+Run: `grep -n "fn contains" oxidize-pdf-core/src/text/structured/types.rs`
+and use that method name.
+
+- [ ] **Step 2: Lint + spatial regression**
+
+Run: `cargo clippy --lib --all-features -- -D warnings && cargo test --test partition_table_detection_test`
+Expected: PASS.
+
+- [ ] **Step 3: Run the conservation invariant from Task 1**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: the `spatial_...` synthetic test now PASSES (ORPHAN survives). The full-fixture test may still fail if the ruling path or degenerate tables contribute — proceed to Task 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): spatial tables claim only populated-cell fragments"
+```
+
+---
+
+## Task 4: Reject degenerate tables (decompose to prose)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` (ruling accept gate ~324; spatial accept gate ~392)
+
+**Interfaces:**
+- A table that placed almost no text is not emitted at all; its fragments remain unclaimed → prose.
+
+- [ ] **Step 1: Add a degeneracy guard next to each confidence gate**
+
+Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add:
+
+```rust
+                                // #375: a table that captured too few cells is not a
+                                // table — skip it so its fragments become prose.
+                                let populated = table.cells.iter().filter(|c| !c.text.is_empty()).count();
+                                if populated < table.rows.max(1) {
+                                    // fewer populated cells than rows => no real column structure
+                                    continue;
+                                }
+```
+
+Spatial path — after its confidence gate at ~392, add:
+
+```rust
+                            let populated = table.rows.iter().flat_map(|r| &r.cells)
+                                .filter(|c| !c.is_empty()).count();
+                            if populated < table.row_count().max(1) {
+                                continue;
+                            }
+```
+
+- [ ] **Step 2: Run the full conservation invariant**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: PASS (both tests). If the full-fixture test still shows missing tokens, inspect which elements swallowed them (`--nocapture` prints the sample) and tighten the guard; do not raise the slack above 1%.
+
+- [ ] **Step 3: Corpus sanity — no regression on real tables**
+
+Run: `cargo test --test table_integration_test --test ruling_table_partition_test --test advanced_tables_tests`
+Expected: PASS — real tables still detected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): degenerate tables decompose to prose instead of eating text"
+```
+
+---
+
+## Task 5: Additive rich table model (`TableStructure`, `RichCell`, `structure` field)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/element.rs` (add types near `TableElementData`, line 215; add field; add constructor)
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` (two `TableElementData { rows, metadata }` literals at ~334 and ~409 → add `structure: None`)
+
+**Interfaces:**
+- Produces:
+  - `struct RichCell { pub row: usize, pub col: usize, pub row_span: usize, pub col_span: usize, pub text: String, pub is_header: bool }`
+  - `struct TableStructure { pub cells: Vec<RichCell>, pub num_rows: usize, pub num_cols: usize, pub header_rows: usize }`
+  - `TableElementData { pub rows, pub structure: Option<TableStructure>, pub metadata }`
+  - `TableElementData::from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self` — fills `rows` from the structure by expanding spans (repeating each spanning cell's text across every covered `(row, col)`), so the flat view is derived from the rich one.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_merged_cells_test.rs  (create; more tests added in Task 7/9)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+
+#[test]
+fn from_structure_expands_spans_into_flat_rows() {
+    // 2x2 grid; top row is a single cell spanning both columns (a merged header).
+    let structure = TableStructure {
+        num_rows: 2,
+        num_cols: 2,
+        header_rows: 1,
+        cells: vec![
+            RichCell { row: 0, col: 0, row_span: 1, col_span: 2, text: "Region".into(), is_header: true },
+            RichCell { row: 1, col: 0, row_span: 1, col_span: 1, text: "Q1".into(), is_header: false },
+            RichCell { row: 1, col: 1, row_span: 1, col_span: 1, text: "Q2".into(), is_header: false },
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    // Flat view repeats the spanned header value across both covered columns.
+    assert_eq!(data.rows, vec![
+        vec!["Region".to_string(), "Region".to_string()],
+        vec!["Q1".to_string(), "Q2".to_string()],
+    ]);
+    assert_eq!(data.structure.as_ref().unwrap().header_rows, 1);
+}
+```
+
+- [ ] **Step 2: Run it — FAIL to compile (types don't exist)**
+
+Run: `cargo test --test issue_375_merged_cells_test`
+Expected: FAIL — unresolved `RichCell`/`TableStructure`/`from_structure`.
+
+- [ ] **Step 3: Add the types, field, and constructor**
+
+In `src/pipeline/element.rs`, above `TableElementData` (line 215):
+
+```rust
+/// One cell of a table's rich structure. `row`/`col` are the cell's top-left
+/// position in the base grid; `row_span`/`col_span` are >= 1.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct RichCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub text: String,
+    pub is_header: bool,
+}
+
+/// Rich table structure: merged cells and header rows. Present only when a hard
+/// signal (drawn grid / structure tags) revealed it; borderless tables leave it
+/// `None` and use the flat `rows` view only.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct TableStructure {
+    pub cells: Vec<RichCell>,
+    pub num_rows: usize,
+    pub num_cols: usize,
+    /// Number of leading rows that are headers (0 = none, 1 = single header row,
+    /// >1 = multi-level header expressed as header rows + merged cells).
+    pub header_rows: usize,
+}
+```
+
+Change `TableElementData` (line 218) to add the field:
+
+```rust
+pub struct TableElementData {
+    /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
+    /// present this is its expanded (span-repeated) view; otherwise it is the
+    /// primary representation.
+    pub rows: Vec<Vec<String>>,
+    /// Rich structure (merged cells / header rows) when a hard signal revealed it.
+    pub structure: Option<TableStructure>,
+    pub metadata: ElementMetadata,
+}
+```
+
+Add the constructor in an `impl TableElementData` block (create one right after the struct):
+
+```rust
+impl TableElementData {
+    /// Build from rich structure, deriving the flat `rows` view by expanding each
+    /// spanning cell's text across every covered (row, col).
+    pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {
+        let mut rows = vec![vec![String::new(); structure.num_cols]; structure.num_rows];
+        for cell in &structure.cells {
+            for r in cell.row..(cell.row + cell.row_span).min(structure.num_rows) {
+                for c in cell.col..(cell.col + cell.col_span).min(structure.num_cols) {
+                    rows[r][c] = cell.text.clone();
+                }
+            }
+        }
+        Self { rows, structure: Some(structure), metadata }
+    }
+}
+```
+
+- [ ] **Step 4: Export the new types**
+
+In the module's public re-exports (same place `TableElementData` is exported — check `src/pipeline/mod.rs`), add `RichCell, TableStructure`:
+Run: `grep -n "TableElementData" oxidize-pdf-core/src/pipeline/mod.rs`
+Then add `RichCell, TableStructure` to that `pub use` list.
+
+- [ ] **Step 5: Fix the two struct literals in partition.rs**
+
+At `partition.rs` ~334 and ~409, the `Element::Table(TableElementData { rows, metadata: ... })` literals must add `structure: None,`:
+
+```rust
+                                elements.push(Element::Table(TableElementData {
+                                    rows,
+                                    structure: None,
+                                    metadata: ElementMetadata { /* unchanged */ ..Default::default() },
+                                }));
+```
+
+Also fix any other construction sites the compiler reports:
+Run: `cargo build --lib 2>&1 | grep -n "TableElementData"`
+Add `structure: None,` to each.
+
+- [ ] **Step 6: Run test + build**
+
+Run: `cargo test --test issue_375_merged_cells_test && cargo clippy --lib --all-features -- -D warnings`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/element.rs oxidize-pdf-core/src/pipeline/mod.rs oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
+git commit -m "feat(#375): additive rich table model (TableStructure/RichCell), flat rows derived"
+```
+
+---
+
+## Task 6: Add span fields to the ruling detector's cell (additive, no behavior change)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs:161-184` (`TableCell` struct + `new`)
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs:93-119` (`DetectedTable` gains `header_rows`)
+
+**Interfaces:**
+- Produces: `TableCell { .., pub row_span: usize, pub col_span: usize }` (default 1); `DetectedTable { .., pub header_rows: usize }` (default 0). Existing `DetectedTable::new` keeps its signature and sets `header_rows: 0`.
+
+- [ ] **Step 1: Add fields, defaulting to the current (no-span) behavior**
+
+`TableCell` — add fields and default them in `new`:
+
+```rust
+pub struct TableCell {
+    pub row: usize,
+    pub column: usize,
+    pub bbox: BoundingBox,
+    pub text: String,
+    pub has_borders: bool,
+    /// Number of base rows this cell spans (>= 1).
+    pub row_span: usize,
+    /// Number of base columns this cell spans (>= 1).
+    pub col_span: usize,
+}
+```
+```rust
+    pub fn new(row: usize, column: usize, bbox: BoundingBox) -> Self {
+        Self { row, column, bbox, text: String::new(), has_borders: false, row_span: 1, col_span: 1 }
+    }
+```
+
+`DetectedTable` — add `pub header_rows: usize` and set it to `0` in `new` (keep `new`'s signature unchanged):
+
+```rust
+pub struct DetectedTable {
+    pub bbox: BoundingBox,
+    pub cells: Vec<TableCell>,
+    pub rows: usize,
+    pub columns: usize,
+    pub confidence: f64,
+    /// Leading header rows (0 until header detection runs; Task 8).
+    pub header_rows: usize,
+}
+```
+```rust
+    pub fn new(bbox: BoundingBox, cells: Vec<TableCell>, rows: usize, columns: usize) -> Self {
+        let confidence = Self::calculate_confidence(&cells, rows, columns);
+        Self { bbox, cells, rows, columns, confidence, header_rows: 0 }
+    }
+```
+
+- [ ] **Step 2: Fix any other `TableCell`/`DetectedTable` literals**
+
+Run: `cargo build --lib 2>&1 | grep -nE "TableCell|DetectedTable"`
+Update each literal to include the new fields (spans `1`, `header_rows` `0`).
+
+- [ ] **Step 3: Existing detector tests unchanged**
+
+Run: `cargo test --lib text::table_detection && cargo test --test table_integration_test`
+Expected: PASS, byte-identical behavior (spans all 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs
+git commit -m "feat(#375): additive span + header_rows fields on ruling detector (default no-op)"
+```
+
+---
+
+## Task 7: Detect merged cells from drawn grid (retain divider segments) — PRIMARY RISK
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` — `GridPattern` (line 514) retains segments; new `merge_cells_across_absent_dividers`; call it inside `detect_bordered_table` (line 318) after `create_cells_from_grid`.
+- Create: `oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs`
+
+**Interfaces:**
+- Consumes: `VectorLine { x1, y1, x2, y2, .. }` from `graphics.horizontal_lines()/vertical_lines()`; grid `rows: Vec<f64>` (Y gridlines), `columns: Vec<f64>` (X gridlines).
+- Produces: `TableCell`s where merged regions appear once at their top-left with `row_span`/`col_span` > 1, and covered interior positions are omitted. `get_cell` still indexes the base grid; callers that need spans read `cells` directly (Task 9 does).
+
+**Algorithm (deterministic):** two base cells are in the same merged region when the divider segment on their shared edge is *absent*. (a) A vertical divider between base columns `c|c+1` across base row `r` is present if some vertical `VectorLine` at `x ≈ columns[c+1]` covers the row's Y-range `[rows[r], rows[r+1]]` (within `alignment_tolerance`). (b) A horizontal divider between base rows `r|r+1` across base column `c` is present if some horizontal `VectorLine` at `y ≈ rows[r+1]` covers `[columns[c], columns[c+1]]`. Build merged regions by union-find over base cells connected by *absent* dividers; each region becomes one `TableCell` at its min-row/min-col with spans = extent, `has_borders: true`.
+
+- [ ] **Step 1: Write the failing test (fixture with one merged header cell)**
+
+```rust
+// tests/issue_375_merged_cells_detect_test.rs
+//
+// Build a bordered 2-col table whose top row is a single cell spanning both
+// columns (the vertical divider is omitted only in row 0). Detection must yield
+// a top-left cell with col_span == 2.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::text::extraction::TextFragment;
+use oxidize_pdf::text::table_detection::TableDetector;
+
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine { VectorLine { x1, y1: y, x2, y2: y } }
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine { VectorLine { x1: x, y1, x2: x, y2 } }
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment { text: t.into(), x, y, width: 30.0, height: 10.0, font_size: 10.0,
+        font_name: None, is_bold: false, is_italic: false, color: None,
+        space_decisions: Vec::new(), mcid: None, struct_tag: None }
+}
+
+#[test]
+fn merged_header_cell_detected_with_col_span_2() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![hline(100.0, 300.0, 100.0), hline(100.0, 300.0, 150.0), hline(100.0, 300.0, 200.0)];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),           // left border (full height)
+        vline(300.0, 100.0, 200.0),           // right border (full height)
+        vline(200.0, 100.0, 150.0),           // MIDDLE divider only in row 1
+    ];
+    let graphics = ExtractedGraphics::from_lines(h, v); // see Step 3 if constructor differs
+    let frags = vec![
+        frag("Header", 150.0, 170.0),
+        frag("A", 130.0, 120.0), frag("B", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+    let top_left = table.cells.iter().find(|c| c.row == 0 && c.column == 0).expect("cell 0,0");
+    assert_eq!(top_left.col_span, 2, "merged header should span 2 columns");
+    // The non-merged row keeps two single cells.
+    assert!(table.cells.iter().any(|c| c.row == 1 && c.column == 0 && c.col_span == 1));
+    assert!(table.cells.iter().any(|c| c.row == 1 && c.column == 1 && c.col_span == 1));
+}
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test`
+Expected: FAIL — either `from_lines` missing (fix in Step 3) or `col_span == 1` (merge not yet implemented).
+
+- [ ] **Step 3: Confirm the graphics test constructor**
+
+Run: `grep -nE "pub fn |pub struct (ExtractedGraphics|VectorLine)|struct VectorLine" oxidize-pdf-core/src/graphics/extraction.rs | head -40`
+- If there is no public `ExtractedGraphics::from_lines`, add a small test-only constructor next to `ExtractedGraphics` that stores the given H/V lines and reports `has_table_structure()` true when both have ≥2 (mirroring the real fields). If `VectorLine` has fields beyond `x1,y1,x2,y2`, extend the helpers to fill them (defaults). Adjust the test's helpers accordingly. Keep the constructor `#[cfg(any(test, feature = "test-helpers"))]` if the codebase gates test helpers, else `pub`.
+
+- [ ] **Step 4: Implement grid-segment retention**
+
+Change `GridPattern` to also hold the raw segments, and populate it in `detect_grid_pattern`:
+
+```rust
+struct GridPattern {
+    rows: Vec<f64>,
+    columns: Vec<f64>,
+    h_segments: Vec<(f64, f64, f64)>, // (y, x_start, x_end)
+    v_segments: Vec<(f64, f64, f64)>, // (x, y_start, y_end)
+}
+```
+In `detect_grid_pattern`, before returning, collect normalized segments from `h_lines`/`v_lines` (`(line.y1, line.x1.min(line.x2), line.x1.max(line.x2))` for horizontals; symmetric for verticals).
+
+- [ ] **Step 5: Implement `merge_cells_across_absent_dividers`**
+
+Add the method and call it in `detect_bordered_table` right after `create_cells_from_grid` (before `assign_text_to_cells`, so text lands in merged cells):
+
+```rust
+fn divider_present_vertical(&self, grid: &GridPattern, x: f64, y0: f64, y1: f64) -> bool {
+    let (lo, hi) = (y0.min(y1), y0.max(y1));
+    grid.v_segments.iter().any(|&(sx, s0, s1)| {
+        (sx - x).abs() <= self.config.alignment_tolerance
+            && s0 <= lo + self.config.alignment_tolerance
+            && s1 >= hi - self.config.alignment_tolerance
+    })
+}
+// symmetric divider_present_horizontal(grid, y, x0, x1)
+
+fn merge_cells_across_absent_dividers(&self, grid: &GridPattern, cells: Vec<TableCell>) -> Vec<TableCell> {
+    let num_rows = grid.rows.len().saturating_sub(1);
+    let num_cols = grid.columns.len().saturating_sub(1);
+    if num_rows == 0 || num_cols == 0 { return cells; }
+
+    // Union-find over base cells (index = r*num_cols + c).
+    let mut parent: Vec<usize> = (0..num_rows * num_cols).collect();
+    fn find(p: &mut Vec<usize>, i: usize) -> usize {
+        if p[i] != i { let r = find(p, p[i]); p[i] = r; } p[i]
+    }
+    for r in 0..num_rows {
+        for c in 0..num_cols {
+            // merge right if the vertical divider at columns[c+1] is absent over this row band
+            if c + 1 < num_cols {
+                let x = grid.columns[c + 1];
+                if !self.divider_present_vertical(grid, x, grid.rows[r], grid.rows[r + 1]) {
+                    let (a, b) = (find(&mut parent, r * num_cols + c), find(&mut parent, r * num_cols + c + 1));
+                    parent[a] = b;
+                }
+            }
+            // merge down if the horizontal divider at rows[r+1] is absent over this column band
+            if r + 1 < num_rows {
+                let y = grid.rows[r + 1];
+                if !self.divider_present_horizontal(grid, y, grid.columns[c], grid.columns[c + 1]) {
+                    let (a, b) = (find(&mut parent, r * num_cols + c), find(&mut parent, (r + 1) * num_cols + c));
+                    parent[a] = b;
+                }
+            }
+        }
+    }
+
+    // Group base cells by root; each group -> one merged TableCell at its min row/col.
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<usize, Vec<&TableCell>> = BTreeMap::new();
+    for cell in &cells {
+        let root = find(&mut parent, cell.row * num_cols + cell.column);
+        groups.entry(root).or_default().push(cell);
+    }
+    let mut merged = Vec::new();
+    for (_root, group) in groups {
+        let min_r = group.iter().map(|c| c.row).min().unwrap();
+        let min_c = group.iter().map(|c| c.column).min().unwrap();
+        let max_r = group.iter().map(|c| c.row).max().unwrap();
+        let max_c = group.iter().map(|c| c.column).max().unwrap();
+        // Merged bbox = union of member bboxes (use grid extents for determinism).
+        let x = grid.columns[min_c];
+        let y = grid.rows[min_r].min(grid.rows[max_r + 1]);
+        let w = (grid.columns[max_c + 1] - grid.columns[min_c]).abs();
+        let hgt = (grid.rows[max_r + 1] - grid.rows[min_r]).abs();
+        let mut cell = TableCell::new(min_r, min_c, BoundingBox::new(x, y, w, hgt));
+        cell.has_borders = true;
+        cell.row_span = max_r - min_r + 1;
+        cell.col_span = max_c - min_c + 1;
+        merged.push(cell);
+    }
+    merged.sort_by(|a, b| (a.row, a.column).cmp(&(b.row, b.column)));
+    merged
+}
+```
+
+Wire into `detect_bordered_table`:
+
+```rust
+        let cells = self.create_cells_from_grid(&grid);
+        let cells = self.merge_cells_across_absent_dividers(&grid, cells); // #375
+        let cells_with_text = self.assign_text_to_cells(cells, text_fragments);
+```
+
+Note: `DetectedTable.rows`/`columns` remain the **base** grid dimensions; merged cells carry spans. `get_cell`'s flat index no longer matches merged cells — that's acceptable because Task 9 reads `cells` directly; leave `get_cell` as-is for base-grid callers.
+
+- [ ] **Step 6: Iterate against the test**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test -- --nocapture`
+Expected: PASS. Adjust tolerance handling until the merged region is exactly col_span 2 in row 0 and single cells in row 1. Then confirm no regression on full grids:
+Run: `cargo test --lib text::table_detection && cargo test --test table_integration_test --test ruling_table_partition_test`
+Expected: PASS (a fully-ruled table has all dividers present → every region is 1×1 → identical to before).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+git commit -m "feat(#375): detect merged cells from absent grid dividers (union-find over base cells)"
+```
+
+---
+
+## Task 8: Identify header rows (from tags, else top row)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` — set `DetectedTable.header_rows` in `detect_bordered_table` after text assignment.
+
+**Interfaces:**
+- Consumes: `TextFragment.struct_tag: Option<String>` (a marked-content/structure tag name; header cells commonly tagged `"TH"` or containing `"Header"`).
+- Produces: `header_rows` = count of leading rows whose fragments are header-tagged; falls back to `1` (top row) when the table is non-trivial and no tags are present.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// append to tests/issue_375_merged_cells_detect_test.rs
+#[test]
+fn header_row_detected_from_th_tag() {
+    let h = vec![hline(100.0,300.0,100.0), hline(100.0,300.0,150.0), hline(100.0,300.0,200.0)];
+    let v = vec![vline(100.0,100.0,200.0), vline(200.0,100.0,200.0), vline(300.0,100.0,200.0)];
+    let graphics = ExtractedGraphics::from_lines(h, v);
+    let mut th = |t: &str, x: f64, y: f64| {
+        let mut f = frag(t, x, y); f.struct_tag = Some("TH".to_string()); f
+    };
+    let frags = vec![
+        th("H1", 130.0, 170.0), th("H2", 230.0, 170.0), // header row
+        frag("a", 130.0, 120.0), frag("b", 230.0, 120.0),
+    ];
+    let tables = TableDetector::default().detect(&graphics, &frags).expect("detect");
+    assert_eq!(tables.first().unwrap().header_rows, 1);
+}
+```
+
+- [ ] **Step 2: Run — FAIL** (`header_rows` is 0)
+
+Run: `cargo test --test issue_375_merged_cells_detect_test header_row_detected_from_th_tag`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement header-row counting**
+
+After `assign_text_to_cells` in `detect_bordered_table`, before building `DetectedTable`, compute header rows and store it. Since `DetectedTable::new` sets `header_rows: 0`, set the field after construction:
+
+```rust
+        let mut table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        table.header_rows = Self::count_header_rows(&table, text_fragments);
+        Ok(Some(table))
+```
+
+Add helper — a row is a header row if any fragment inside its cells is header-tagged; count only the leading contiguous header rows; if none tagged and the table has ≥2 rows, default to 1:
+
+```rust
+fn count_header_rows(table: &DetectedTable, fragments: &[TextFragment]) -> usize {
+    fn is_header_tag(tag: &str) -> bool {
+        let t = tag.to_ascii_uppercase();
+        t == "TH" || t.contains("HEADER")
+    }
+    let mut tagged_leading = 0usize;
+    for r in 0..table.rows {
+        let row_cells: Vec<&TableCell> = table.cells.iter()
+            .filter(|c| c.row <= r && r < c.row + c.row_span).collect();
+        let has_header = fragments.iter().any(|f| {
+            f.struct_tag.as_deref().map(is_header_tag).unwrap_or(false)
+                && row_cells.iter().any(|c| c.bbox.contains_point(f.x + f.width/2.0, f.y + f.height/2.0))
+        });
+        if has_header { tagged_leading = r + 1; } else { break; }
+    }
+    if tagged_leading > 0 { tagged_leading }
+    else if table.rows >= 2 { 1 } else { 0 }
+}
+```
+
+- [ ] **Step 4: Run — PASS + regression**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test && cargo test --lib text::table_detection`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+git commit -m "feat(#375): count header rows from structure tags, default to top row"
+```
+
+---
+
+## Task 9: Build rich `TableElementData` in the ruling partition path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` — replace `ruling_table_to_rows(table)` usage at ~327/334 with a rich builder that produces `TableStructure`; spatial path keeps `structure: None`.
+
+**Interfaces:**
+- Consumes: `DetectedTable { cells (with spans), rows, columns, header_rows, .. }`.
+- Produces: `Element::Table(TableElementData::from_structure(structure, metadata))` where `structure.cells` mirror the detector's merged cells.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::pipeline::{Element, PartitionConfig, Partitioner};
+use oxidize_pdf::text::extraction::TextFragment;
+
+// (reuse hline/vline/frag helpers — copy the small helpers from the detect test)
+
+#[test]
+fn ruling_partition_emits_rich_structure_with_merged_header() {
+    let h = vec![/* same 3 h-lines as the merged-header fixture */];
+    let v = vec![/* left, right full; middle only in row 1 */];
+    let graphics = ExtractedGraphics::from_lines(h, v);
+    let frags = vec![/* "Region" spanning header row, "Q1"/"Q2" below */];
+
+    let elements = Partitioner::new(PartitionConfig::default())
+        .partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let table = elements.iter().find_map(|e| match e { Element::Table(t) => Some(t), _ => None })
+        .expect("a table element");
+    let st = table.structure.as_ref().expect("rich structure present");
+    assert!(st.cells.iter().any(|c| c.row == 0 && c.col == 0 && c.col_span == 2 && c.is_header));
+    assert_eq!(st.header_rows, 1);
+    // Flat view still complete (spanned value repeated).
+    assert_eq!(table.rows[0].len(), 2);
+}
+```
+
+- [ ] **Step 2: Run — FAIL** (`structure` is None today)
+
+Run: `cargo test --test issue_375_multi_level_header_test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the rich builder and use it in the ruling path**
+
+Replace `ruling_table_to_rows` (partition.rs:761) with a structure builder (keep the name or add a new fn; update the call site):
+
+```rust
+/// Convert a ruling-detected table (with merged cells + header rows) into a
+/// rich `TableStructure`. The flat `rows` view is derived by `from_structure`.
+fn ruling_table_to_structure(table: &crate::text::table_detection::DetectedTable) -> TableStructure {
+    let header_rows = table.header_rows;
+    let cells = table.cells.iter().map(|c| RichCell {
+        row: c.row,
+        col: c.column,
+        row_span: c.row_span.max(1),
+        col_span: c.col_span.max(1),
+        text: c.text.clone(),
+        is_header: c.row < header_rows,
+    }).collect();
+    TableStructure { cells, num_rows: table.rows, num_cols: table.columns, header_rows }
+}
+```
+
+At the ruling emit site (~327–342), replace:
+
+```rust
+                                let structure = ruling_table_to_structure(table);
+                                let bbox = ElementBBox::new(
+                                    table.bbox.x, table.bbox.y, table.bbox.width, table.bbox.height,
+                                );
+                                let mut data = TableElementData::from_structure(
+                                    structure,
+                                    ElementMetadata {
+                                        page,
+                                        bbox,
+                                        confidence: table.confidence,
+                                        ..Default::default()
+                                    },
+                                );
+                                // keep metadata bbox already set above
+                                elements.push(Element::Table(std::mem::take(&mut data).into_table()));
+```
+
+If wrapping helpers feel awkward, simpler: build `data` then `elements.push(Element::Table(data));` — `from_structure` already returns `TableElementData`. Use:
+
+```rust
+                                elements.push(Element::Table(TableElementData::from_structure(
+                                    ruling_table_to_structure(table),
+                                    ElementMetadata { page, bbox, confidence: table.confidence, ..Default::default() },
+                                )));
+```
+
+Import `RichCell, TableStructure` at the top of partition.rs (extend the `use crate::pipeline::{...}` list on line 3–5). Remove the now-unused `ruling_table_to_rows` if nothing else calls it (clippy will flag).
+
+Also update the Task 2 ruling claim loop: it references `table.cells` bboxes — still correct (merged cell bboxes cover their region), no change needed.
+
+- [ ] **Step 4: Run — PASS + conservation still green**
+
+Run: `cargo test --test issue_375_multi_level_header_test --test issue_375_text_conservation_test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): ruling path emits rich TableStructure (merged cells + header rows)"
+```
+
+---
+
+## Task 10: Markdown degradation — collapse multi-level headers, keep repeated spans
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/export.rs:54,66-78` — `table_to_markdown` becomes structure-aware.
+
+**Interfaces:**
+- Consumes: `TableElementData { rows, structure }`.
+- Rendering: when `structure.header_rows > 1`, collapse the first `header_rows` rows into ONE GFM header, joining each column's header texts top-to-bottom with `" › "` (dedup consecutive equal). Body = remaining rows. Merged-cell values are already repeated in `rows`, so body rendering is unchanged. When `structure` absent or `header_rows <= 1`, keep current behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs  (append)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+use oxidize_pdf::pipeline::export::element_to_markdown_for_test; // see Step 3 for exact entry point
+
+#[test]
+fn multi_level_header_flattens_with_separator() {
+    // 3 header-ish rows collapsed: "Region" (span2) over ["Q1","Q2"].
+    let structure = TableStructure {
+        num_rows: 3, num_cols: 2, header_rows: 2,
+        cells: vec![
+            RichCell{row:0,col:0,row_span:1,col_span:2,text:"Region".into(),is_header:true},
+            RichCell{row:1,col:0,row_span:1,col_span:1,text:"Q1".into(),is_header:true},
+            RichCell{row:1,col:1,row_span:1,col_span:1,text:"Q2".into(),is_header:true},
+            RichCell{row:2,col:0,row_span:1,col_span:1,text:"10".into(),is_header:false},
+            RichCell{row:2,col:1,row_span:1,col_span:1,text:"20".into(),is_header:false},
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    let md = oxidize_pdf::pipeline::export::table_to_markdown_data(&data); // exact name per Step 3
+    assert_eq!(md, "| Region › Q1 | Region › Q2 |\n| --- | --- |\n| 10 | 20 |");
+}
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `cargo test --test issue_375_multi_level_header_test multi_level_header_flattens_with_separator`
+Expected: FAIL (function missing / current flat behavior).
+
+- [ ] **Step 3: Implement structure-aware export**
+
+Add a `pub(crate)` (or `pub`) `table_to_markdown_data(&TableElementData) -> String` and route `Element::Table` through it; keep `table_to_markdown(rows)` for the no-structure case:
+
+```rust
+pub fn table_to_markdown_data(data: &TableElementData) -> String {
+    match &data.structure {
+        Some(st) if st.header_rows > 1 && !data.rows.is_empty() => {
+            let ncols = data.rows[0].len();
+            let mut header = Vec::with_capacity(ncols);
+            for c in 0..ncols {
+                let mut parts: Vec<&str> = Vec::new();
+                for r in 0..st.header_rows.min(data.rows.len()) {
+                    let cell = data.rows[r].get(c).map(|s| s.as_str()).unwrap_or("");
+                    if parts.last() != Some(&cell) && !cell.is_empty() {
+                        parts.push(cell);
+                    }
+                }
+                header.push(parts.join(" › "));
+            }
+            let mut lines = vec![
+                format!("| {} |", header.join(" | ")),
+                format!("| {} |", vec!["---"; ncols].join(" | ")),
+            ];
+            for row in &data.rows[st.header_rows.min(data.rows.len())..] {
+                lines.push(format!("| {} |", row.join(" | ")));
+            }
+            lines.join("\n")
+        }
+        _ => table_to_markdown(&data.rows), // single/no header: unchanged
+    }
+}
+```
+
+Change the arm at line 54:
+```rust
+            Element::Table(t) => Some(table_to_markdown_data(t)),
+```
+
+- [ ] **Step 4: Run — PASS + existing export tests**
+
+Run: `cargo test --test issue_375_multi_level_header_test && cargo test --lib pipeline::export && cargo test --test '*export*' 2>/dev/null; cargo test --lib export`
+Expected: PASS; single-header tables unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/export.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): GFM export collapses multi-level headers, repeats merged spans"
+```
+
+---
+
+## Task 11: RAG metadata from the rich model
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/chunk_metadata.rs:262-277` (`table_dims`)
+
+**Interfaces:**
+- `table_dims` reports the rich `(num_rows, num_cols)` when `structure` is present (true geometry), else the flat `rows` dims.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs  (append) — or a chunk_metadata unit test
+#[test]
+fn table_dims_prefer_rich_structure() {
+    use oxidize_pdf::pipeline::chunk_metadata::ChunkMetadata; // if table_dims is private, test via ChunkMetadata
+    // Build a chunk whose only element is the rich merged table; assert table_cols == 2, table_rows == 3.
+    // (Use the same TableElementData as Task 10.)
+}
+```
+
+If `table_dims` is private (`fn table_dims`), assert through the public `ChunkMetadata` that exposes `table_rows`/`table_cols`. Confirm the constructor path:
+Run: `grep -n "pub fn.*ChunkMetadata\|table_dims\|pub struct ChunkMetadata" oxidize-pdf-core/src/pipeline/chunk_metadata.rs`
+
+- [ ] **Step 2: Run — FAIL** (counts come from flat rows, not structure)
+
+- [ ] **Step 3: Implement**
+
+```rust
+fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
+    elements
+        .iter()
+        .filter_map(|e| match e {
+            Element::Table(t) => Some(match &t.structure {
+                Some(st) => (st.num_rows, st.num_cols),
+                None => (t.rows.len(), t.rows.iter().map(|r| r.len()).max().unwrap_or(0)),
+            }),
+            _ => None,
+        })
+        .max_by_key(|(rows, _)| *rows)
+        .map(|(r, c)| (Some(r), Some(c)))
+        .unwrap_or((None, None))
+}
+```
+
+- [ ] **Step 4: Run — PASS + metadata regression**
+
+Run: `cargo test --lib pipeline::chunk_metadata && cargo test --test issue_375_multi_level_header_test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/chunk_metadata.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): RAG table metadata counts rich structure geometry"
+```
+
+---
+
+## Task 12: Document the known limitation
+
+**Files:**
+- Modify: `docs/TABLE_DETECTION_GUIDE.md` (add a "Known limitations" section)
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` (module `//!` header — short note pointing to the guide)
+
+- [ ] **Step 1: Add the guide section**
+
+Append to `docs/TABLE_DETECTION_GUIDE.md`:
+
+```markdown
+## Known limitations (as of #375)
+
+Rich table structure — merged cells and multi-level headers — is only produced when a
+**hard signal** reveals it:
+
+- **Merged cells** are detected from the drawn grid: where an internal dividing line is
+  absent, the adjacent cells are merged. Tables without drawn borders ("borderless") are
+  returned as a flat grid with no merged-cell information.
+- **Multi-level headers** are represented as header rows containing merged cells (e.g. a
+  "Region" header spanning two columns above "Q1"/"Q2"). Header rows are identified from the
+  PDF's structure tags when the document is tagged, otherwise the top row is assumed to be
+  the header. A nested header *hierarchy* is not read from the PDF's internal structure tree.
+- **Borderless-table detection is intrinsically ambiguous** and best-effort; when in doubt
+  the content is preserved as prose rather than forced into a grid (no text is dropped).
+
+For GitHub-Flavored Markdown export, merged-cell values are repeated across every column
+they cover, and multi-level headers are flattened into a single header row joining the
+levels with " › ".
+```
+
+- [ ] **Step 2: Add the module note**
+
+Extend the `//!` header of `table_detection.rs` with one line:
+
+```rust
+//! Merged cells are detected from absent grid dividers; borderless tables and un-tagged
+//! multi-level headers stay flat. See `docs/TABLE_DETECTION_GUIDE.md` for the full limits.
+```
+
+- [ ] **Step 3: Build (rustdoc compiles) + commit**
+
+Run: `cargo build --lib`
+```bash
+git add docs/TABLE_DETECTION_GUIDE.md oxidize-pdf-core/src/text/table_detection.rs
+git commit -m "docs(#375): document borderless + un-tagged-header limitations"
+```
+
+---
+
+## Task 13: Integration sweep, MSRV, and quality-rust
+
+**Files:** none (verification only) — fixes land in the relevant prior task's files if issues surface.
+
+- [ ] **Step 1: Full library + integration suite**
+
+Run: `cargo test --lib && cargo test --test issue_375_text_conservation_test --test issue_375_merged_cells_test --test issue_375_merged_cells_detect_test --test issue_375_multi_level_header_test --test partition_table_detection_test --test ruling_table_partition_test --test table_integration_test --test advanced_tables_tests`
+Expected: all PASS.
+
+- [ ] **Step 2: Corpus text-conservation (real PDFs, no regression)**
+
+Run: `cargo test --test table_extraction_real_pdfs` and the corpus tests `t1`/`t2` per repo convention (see `.private`/CI). Confirm zero character-count regressions vs `develop` on a before/after sweep of a handful of table-bearing fixtures.
+
+- [ ] **Step 3: Lint, format, MSRV**
+
+Run:
+```bash
+cargo clippy --lib --all-features -- -D warnings
+cargo fmt --check
+cargo +1.88 build --lib --all-features --locked
+```
+Expected: all clean.
+
+- [ ] **Step 4: quality-rust pass (mandatory)**
+
+Dispatch the `quality-rust` agent over the #375 diff. Apply verified findings (correctness/security first). Re-run Steps 1 & 3 after any fix.
+
+- [ ] **Step 5: Final commit (if quality-rust produced fixes)**
+
+```bash
+git add -A
+git commit -m "chore(#375): quality-rust findings applied"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** data-loss (Tasks 1–4), additive rich model (Task 5), merged cells from grid (Tasks 6–7), header rows / multi-level (Tasks 8–9), Markdown degradation (Task 10), RAG metadata (Task 11), documentation (Task 12), verification + MSRV + quality-rust (Task 13). All spec sections covered.
+- **Uncertain anchors flagged for the implementer to confirm before coding:** (a) `ExtractedGraphics`/`VectorLine` test constructor (Task 7 Step 3); (b) structured `BoundingBox` containment method name (Task 3 Step 1); (c) the exact export entry-point name and `chunk_metadata` visibility (Tasks 10–11); (d) the header tag string(s) real tagged PDFs use (Task 8 — we match `TH`/`*HEADER*`, widen if corpus shows another). These are grounded to a `grep` step, not left as prose placeholders.
+- **Type consistency:** `RichCell`/`TableStructure` field names identical across Tasks 5, 9, 10, 11; `TableCell.row_span/col_span` and `DetectedTable.header_rows` identical across Tasks 6–9.

--- a/docs/superpowers/specs/2026-07-09-issue-375-table-extraction-quality-design.md
+++ b/docs/superpowers/specs/2026-07-09-issue-375-table-extraction-quality-design.md
@@ -1,0 +1,162 @@
+# Design — Issue #375: Table extraction quality + prose-as-empty-table data loss
+
+**Date:** 2026-07-09
+**Issue:** #375 (enhancement, RAG)
+**Branch:** `feature/issue-375-table-extraction-quality` (off `develop`)
+**SemVer:** MINOR (additive; no breaking change to the public table model)
+
+## Summary
+
+Issue #375 bundles three concerns, delivered as a single block:
+
+1. **Data-loss bug (priority):** pages of single-column prose can be misclassified as an
+   empty/sparse table, discarding the page text. Silent data loss in the RAG path.
+2. **Merged cells** (rowspan/colspan) are not preserved — spans collapse.
+3. **Multi-level (nested) headers** are flattened, losing column semantics.
+
+The fix is a correctness fix (concern 1) plus an additive enrichment of the table data
+model (concerns 2 & 3), populated only from hard structural signals. Borderless-table
+structure inference is explicitly out of scope and documented as a known limitation.
+
+## Background — current architecture
+
+Two independent table detectors feed one shared, flat table representation:
+
+- **Ruling-based detector:** reads the horizontal/vertical vector lines the PDF draws as
+  borders, derives a grid from the line crossings, and assigns text to cells.
+- **Spatial/borderless detector:** with no drawn borders, clusters text by X/Y position to
+  infer an implicit grid.
+
+Both produce the same shape: a flat grid of plain-text strings (rows, each a list of
+strings). There is **no representation** for merged cells or header rows today; those
+features are structurally unrepresentable, not merely unimplemented.
+
+Detected tables become a canonical pipeline element, flow into RAG chunks (with
+row/column-count metadata), and are exported to GitHub-Flavored Markdown (GFM).
+
+### Root cause of the data-loss bug
+
+When a region is accepted as a table, the partitioner marks **every text fragment whose
+position falls inside the table's bounding box as "claimed"** — independently of whether
+that fragment's text was actually placed into a cell. The prose classifier only processes
+*unclaimed* fragments. So text inside the bounding box but not inside any cell (gaps,
+border zones, coordinate-normalization misses) is claimed and never re-classified as prose
+→ its text is silently dropped. A prose page with as few as two horizontal and two vertical
+drawn lines (a frame, a box, header/footer rules) can trip the detector, claim the whole
+page, and emit a near-empty table.
+
+The earlier #345 work only exposed a config switch to turn table detection off — a
+workaround. The underlying claim-without-capture defect was never fixed.
+
+## Goals
+
+- No page loses text to an empty/sparse-table misclassification. Zero character-count
+  regression across the corpus.
+- Merged cells and multi-level headers are represented when a hard signal reveals them, and
+  round-trip to correct GFM.
+- Additive change only: existing consumers of the flat table view keep working unchanged.
+- No-ML, deterministic throughout.
+
+## Non-goals
+
+- Inferring merged cells or header hierarchy from borderless (whitespace-only) tables.
+  Documented as a known limitation.
+- Reading the PDF's deep structure tree to recover a nested-header hierarchy (parent/child
+  header grouping). That data does not reach the text/partition layer today — only a flat
+  per-fragment tag name does — and plumbing the full structure tree is a much larger change
+  reserved for a separate block. Multi-level headers are instead represented as header rows
+  containing merged cells (see Design §3).
+- Any breaking change to the public table model.
+
+## Design
+
+### 1. Data-loss safety net (concern 1, always on)
+
+- **Claim only what you capture.** A table may claim only the text it actually placed into a
+  cell. Text inside the bounding box but not in any cell stays unclaimed and flows to the
+  prose classifier as paragraphs. This removes the silent drop at its source.
+- **Reject degenerate tables.** A candidate table that captured almost no text decomposes
+  back to prose rather than being accepted.
+- **Text-conservation invariant.** After partitioning, the union of all element text must
+  cover the page's extracted text. This becomes a hard test (absent today) and the safety
+  net that catches any future leak.
+- Delivered automatically to everyone with detection enabled — a data-loss fix is not
+  hidden behind opt-in. The existing "disable detection" switch remains for compatibility
+  but is demoted from a data-safety necessity to a plain preference.
+
+### 2. Additive rich table model (concerns 2 & 3, representation)
+
+- The rich structure — cells with their row/column span, and which rows are headers — is
+  built internally as the source of truth.
+- The existing flat grid stays public and is **derived** from the rich structure, so the two
+  never desynchronize.
+- Consumers of the flat view are unaffected; consumers wanting structure use the new layer.
+- SemVer: MINOR (additive).
+
+### 3. Sources of rich structure (hard signals only)
+
+**Merged cells (the central, highest-risk task).** From the drawn grid. Today the grid
+detector keeps only the *positions* of gridlines (the Y of each horizontal rule, the X of
+each vertical rule) and then assumes a complete, perfect grid — it does **not** record which
+dividing segments are actually drawn. A merged cell is precisely a *missing* internal
+divider, which is invisible under that representation. So this task reworks grid construction
+to remember which dividers actually exist (the raw line segments are available upstream and
+are currently discarded during clustering) and, where an internal divider is absent, merges
+the adjacent cells into one spanning cell. This is the hardest part of the block; everything
+else is straightforward on top of it.
+
+**Header rows.** Identify which rows are header rows: from the per-fragment structure tag
+when the PDF is tagged (a fragment carrying a "header cell" tag), otherwise fall back to the
+existing convention that the top row is the header.
+
+**Multi-level headers = header rows + merged cells.** We do not read a nested-header
+hierarchy from anywhere; that grouping is not exposed at this layer (see Non-goals). A
+multi-level header is represented as header rows that contain merged cells — e.g. a "Region"
+header spanning two columns above "Q1"/"Q2". The merged-cell detection above is what makes it
+representable. Where there is neither a drawn header span nor a tag, we keep a single header
+row.
+
+**Borderless tables:** flat grid, best effort. No span/header inference.
+
+### 4. Outputs — Markdown degradation and RAG metadata
+
+GFM cannot express merged cells or multi-level headers. Deterministic degradation:
+
+- **Merged cell → repeat its value in every covered cell.** A query landing on any covered
+  column then sees the value instead of a gap (avoids the "disconnected numbers" failure).
+- **Multi-level header → flatten by joining levels** (e.g. `Region › Q1`) so each column
+  keeps its full semantic path.
+
+RAG metadata (row/column counts, has-table flag) is computed from the rich model, counting
+the real geometry of the spans.
+
+### 5. Documentation of the known limitation
+
+- Public table-detection guide (`docs/TABLE_DETECTION_GUIDE.md`): explanation with an
+  example — borderless tables get no rich structure and their detection is intrinsically
+  ambiguous; multi-level headers require a tagged PDF.
+- Library module-level docs (rustdoc header of the table-detection module): short note
+  pointing to the guide. Single source of truth in the guide; the module note just refers to
+  it.
+
+### 6. Testing
+
+- **Reproduce first (TDD red):** a real corpus fixture where a prose page is currently eaten
+  by an empty table; assert its text survives → then fix.
+- **Text-conservation invariant** over the corpus: zero character-count regression.
+- **Merged-cell fixture:** round-trips to correct GFM (spanned value repeated).
+- **Multi-level-header fixture (tagged PDF):** round-trips to correct flattened GFM header.
+- Every test verifies real content, not absence of crash.
+
+## Risks / known limitations
+
+- **Primary risk — merged-cell detection.** Requires reworking grid construction to retain
+  per-segment divider presence (§3). Higher effort and risk than the rest of the block; must
+  not regress existing full-grid table detection (guarded by the corpus/ruling tests).
+- Borderless-table structure and un-tagged multi-level headers remain flat — documented.
+- Changing the claim logic shifts some pages from (empty) table output to prose output. This
+  is the intended correction; corpus before/after sweep confirms text is preserved, not lost.
+
+## Rollout
+
+- MINOR release once merged to `develop` and validated. Quality-rust pass before PR.

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -265,14 +265,17 @@ fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
     elements
         .iter()
         .filter_map(|e| match e {
-            Element::Table(t) => Some(&t.rows),
+            Element::Table(t) => Some(match &t.structure {
+                Some(st) => (st.num_rows, st.num_cols),
+                None => (
+                    t.rows.len(),
+                    t.rows.iter().map(|r| r.len()).max().unwrap_or(0),
+                ),
+            }),
             _ => None,
         })
-        .max_by_key(|rows| rows.len())
-        .map(|rows| {
-            let cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-            (Some(rows.len()), Some(cols))
-        })
+        .max_by_key(|(rows, _)| *rows)
+        .map(|(r, c)| (Some(r), Some(c)))
         .unwrap_or((None, None))
 }
 
@@ -406,7 +409,7 @@ pub(crate) fn sentence_count(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+    use crate::pipeline::element::{Element, ElementData, ElementMetadata, TableStructure};
 
     fn table_el() -> Element {
         Element::Table(crate::pipeline::element::TableElementData {
@@ -663,6 +666,24 @@ mod tests {
         let m = ChunkMetadata::from_elements(&els, "just prose", "just prose", 0, None);
         assert_eq!(m.table_rows, None);
         assert_eq!(m.table_cols, None);
+    }
+
+    #[test]
+    fn table_dims_prefers_rich_structure() {
+        // Flat `rows` says 1x1; rich `structure` says 3x4 (e.g. a merged-cell
+        // table where the flat fallback under-counts). table_dims must read
+        // the structure geometry, not the flat rows, when structure is present.
+        let el = Element::Table(crate::pipeline::element::TableElementData {
+            rows: vec![vec!["x".to_string()]],
+            structure: Some(TableStructure {
+                cells: vec![],
+                num_rows: 3,
+                num_cols: 4,
+                header_rows: 1,
+            }),
+            metadata: ElementMetadata::default(),
+        });
+        assert_eq!(table_dims(&[el]), (Some(3), Some(4)));
     }
 
     #[cfg(feature = "semantic")]

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -411,6 +411,7 @@ mod tests {
     fn table_el() -> Element {
         Element::Table(crate::pipeline::element::TableElementData {
             rows: vec![],
+            structure: None,
             metadata: crate::pipeline::element::ElementMetadata::default(),
         })
     }
@@ -631,6 +632,7 @@ mod tests {
                 .into_iter()
                 .map(|r| r.into_iter().map(String::from).collect())
                 .collect(),
+            structure: None,
             metadata: ElementMetadata::default(),
         })
     }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -412,11 +412,10 @@ mod tests {
     use crate::pipeline::element::{Element, ElementData, ElementMetadata, TableStructure};
 
     fn table_el() -> Element {
-        Element::Table(crate::pipeline::element::TableElementData {
-            rows: vec![],
-            structure: None,
-            metadata: crate::pipeline::element::ElementMetadata::default(),
-        })
+        Element::Table(crate::pipeline::element::TableElementData::new(
+            vec![],
+            crate::pipeline::element::ElementMetadata::default(),
+        ))
     }
 
     #[test]
@@ -630,14 +629,12 @@ mod tests {
     }
 
     fn table_with(rows: Vec<Vec<&str>>) -> Element {
-        Element::Table(crate::pipeline::element::TableElementData {
-            rows: rows
-                .into_iter()
+        Element::Table(crate::pipeline::element::TableElementData::new(
+            rows.into_iter()
                 .map(|r| r.into_iter().map(String::from).collect())
                 .collect(),
-            structure: None,
-            metadata: ElementMetadata::default(),
-        })
+            ElementMetadata::default(),
+        ))
     }
 
     #[test]
@@ -673,6 +670,12 @@ mod tests {
         // Flat `rows` says 1x1; rich `structure` says 3x4 (e.g. a merged-cell
         // table where the flat fallback under-counts). table_dims must read
         // the structure geometry, not the flat rows, when structure is present.
+        // Deliberately construct rows/structure out of sync (1x1 flat rows vs
+        // 3x4 structure) to prove table_dims reads structure geometry, not the
+        // flat rows view. `from_structure` would derive rows FROM structure and
+        // erase this mismatch, so this stays a same-crate struct literal
+        // (unaffected by #[non_exhaustive], which only gates cross-crate
+        // construction).
         let el = Element::Table(crate::pipeline::element::TableElementData {
             rows: vec![vec!["x".to_string()]],
             structure: Some(TableStructure {

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -242,6 +242,7 @@ pub struct TableStructure {
 /// Data specific to table elements.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct TableElementData {
     /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
     /// present this is its expanded (span-repeated) view; otherwise it is the
@@ -253,6 +254,16 @@ pub struct TableElementData {
 }
 
 impl TableElementData {
+    /// Build a plain (non-rich) table from flat row-major cells. `structure` is
+    /// `None`; use `from_structure` when merged cells / header rows are known.
+    pub fn new(rows: Vec<Vec<String>>, metadata: ElementMetadata) -> Self {
+        Self {
+            rows,
+            structure: None,
+            metadata,
+        }
+    }
+
     /// Build from rich structure, deriving the flat `rows` view by expanding each
     /// spanning cell's text across every covered (row, col).
     pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -212,13 +212,64 @@ pub struct ElementData {
     pub metadata: ElementMetadata,
 }
 
+/// One cell of a table's rich structure. `row`/`col` are the cell's top-left
+/// position in the base grid; `row_span`/`col_span` are >= 1.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct RichCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub text: String,
+    pub is_header: bool,
+}
+
+/// Rich table structure: merged cells and header rows. Present only when a hard
+/// signal (drawn grid / structure tags) revealed it; borderless tables leave it
+/// `None` and use the flat `rows` view only.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct TableStructure {
+    pub cells: Vec<RichCell>,
+    pub num_rows: usize,
+    pub num_cols: usize,
+    /// Number of leading rows that are headers (0 = none, 1 = single header row,
+    /// >1 = multi-level header expressed as header rows + merged cells).
+    pub header_rows: usize,
+}
+
 /// Data specific to table elements.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
 pub struct TableElementData {
-    /// Row-major cell data. Each inner Vec is one row.
+    /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
+    /// present this is its expanded (span-repeated) view; otherwise it is the
+    /// primary representation.
     pub rows: Vec<Vec<String>>,
+    /// Rich structure (merged cells / header rows) when a hard signal revealed it.
+    pub structure: Option<TableStructure>,
     pub metadata: ElementMetadata,
+}
+
+impl TableElementData {
+    /// Build from rich structure, deriving the flat `rows` view by expanding each
+    /// spanning cell's text across every covered (row, col).
+    pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {
+        let mut rows = vec![vec![String::new(); structure.num_cols]; structure.num_rows];
+        for cell in &structure.cells {
+            for r in cell.row..(cell.row + cell.row_span).min(structure.num_rows) {
+                for c in cell.col..(cell.col + cell.col_span).min(structure.num_cols) {
+                    rows[r][c] = cell.text.clone();
+                }
+            }
+        }
+        Self {
+            rows,
+            structure: Some(structure),
+            metadata,
+        }
+    }
 }
 
 /// Data specific to image elements.

--- a/oxidize-pdf-core/src/pipeline/export.rs
+++ b/oxidize-pdf-core/src/pipeline/export.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::Element;
+use crate::pipeline::{Element, TableElementData};
 
 /// Configuration for element-aware markdown export.
 #[derive(Debug, Clone)]
@@ -51,7 +51,7 @@ impl ElementMarkdownExporter {
                 let alt = img.alt_text.as_deref().unwrap_or("");
                 Some(format!("![{}]()", alt))
             }
-            Element::Table(t) => Some(table_to_markdown(&t.rows)),
+            Element::Table(t) => Some(table_to_markdown_data(t)),
             Element::Header(_) | Element::Footer(_) => {
                 if self.config.include_headers_footers {
                     Some(element.display_text())
@@ -75,4 +75,174 @@ fn table_to_markdown(rows: &[Vec<String>]) -> String {
         lines.push(format!("| {} |", row.join(" | ")));
     }
     lines.join("\n")
+}
+
+/// Structure-aware table export: when `data.structure` reveals a multi-level
+/// header (`header_rows > 1`), collapse the first `header_rows` rows into a
+/// single GFM header row, joining each column's header texts top-to-bottom
+/// with " › " (skipping empties and consecutive duplicates so a vertically-
+/// or horizontally-merged header cell that is already repeated across the
+/// flat `rows` view doesn't render as "X › X"). Body rows start right after
+/// the header rows; merged body cells are already repeated in `rows`, so
+/// their rendering is unchanged.
+///
+/// When `structure` is absent or `header_rows <= 1`, delegates to
+/// [`table_to_markdown`] — behavior for single/no-header tables is unchanged.
+fn table_to_markdown_data(data: &TableElementData) -> String {
+    match &data.structure {
+        Some(st) if st.header_rows > 1 && !data.rows.is_empty() => {
+            let ncols = st.num_cols;
+            let header_rows = st.header_rows.min(data.rows.len());
+            let mut header = Vec::with_capacity(ncols);
+            for c in 0..ncols {
+                let mut parts: Vec<&str> = Vec::new();
+                for row in &data.rows[..header_rows] {
+                    let cell = row.get(c).map(|s| s.as_str()).unwrap_or("");
+                    if !cell.is_empty() && parts.last() != Some(&cell) {
+                        parts.push(cell);
+                    }
+                }
+                header.push(parts.join(" › "));
+            }
+            let mut lines = vec![
+                format!("| {} |", header.join(" | ")),
+                format!("| {} |", vec!["---"; ncols].join(" | ")),
+            ];
+            for row in &data.rows[header_rows..] {
+                lines.push(format!("| {} |", row.join(" | ")));
+            }
+            lines.join("\n")
+        }
+        _ => table_to_markdown(&data.rows),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::{ElementMetadata, RichCell, TableStructure};
+
+    #[test]
+    fn multi_level_header_flattens_with_separator() {
+        // "Region" spans both columns over row 0; row 1 sub-headers "Q1"/"Q2".
+        // Dedup must prevent "Region › Region" leaking through.
+        let structure = TableStructure {
+            num_rows: 3,
+            num_cols: 2,
+            header_rows: 2,
+            cells: vec![
+                RichCell {
+                    row: 0,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 2,
+                    text: "Region".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "Q1".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "Q2".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 2,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "10".into(),
+                    is_header: false,
+                },
+                RichCell {
+                    row: 2,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "20".into(),
+                    is_header: false,
+                },
+            ],
+        };
+        let data = TableElementData::from_structure(structure, ElementMetadata::default());
+        let md = table_to_markdown_data(&data);
+        assert_eq!(
+            md,
+            "| Region › Q1 | Region › Q2 |\n| --- | --- |\n| 10 | 20 |"
+        );
+    }
+
+    #[test]
+    fn no_structure_table_unchanged() {
+        let metadata = ElementMetadata::default();
+        let data = TableElementData {
+            rows: vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["1".to_string(), "2".to_string()],
+            ],
+            structure: None,
+            metadata,
+        };
+        let expected = table_to_markdown(&data.rows);
+        assert_eq!(table_to_markdown_data(&data), expected);
+        assert_eq!(expected, "| a | b |\n| --- | --- |\n| 1 | 2 |");
+    }
+
+    #[test]
+    fn single_header_row_structure_unchanged() {
+        // header_rows == 1: same behavior as the plain no-structure path.
+        let structure = TableStructure {
+            num_rows: 2,
+            num_cols: 2,
+            header_rows: 1,
+            cells: vec![
+                RichCell {
+                    row: 0,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "a".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 0,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "b".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "1".into(),
+                    is_header: false,
+                },
+                RichCell {
+                    row: 1,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "2".into(),
+                    is_header: false,
+                },
+            ],
+        };
+        let data = TableElementData::from_structure(structure, ElementMetadata::default());
+        assert_eq!(
+            table_to_markdown_data(&data),
+            "| a | b |\n| --- | --- |\n| 1 | 2 |"
+        );
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/export.rs
+++ b/oxidize-pdf-core/src/pipeline/export.rs
@@ -184,14 +184,13 @@ mod tests {
     #[test]
     fn no_structure_table_unchanged() {
         let metadata = ElementMetadata::default();
-        let data = TableElementData {
-            rows: vec![
+        let data = TableElementData::new(
+            vec![
                 vec!["a".to_string(), "b".to_string()],
                 vec!["1".to_string(), "2".to_string()],
             ],
-            structure: None,
             metadata,
-        };
+        );
         let expected = table_to_markdown(&data.rows);
         assert_eq!(table_to_markdown_data(&data), expected);
         assert_eq!(expected, "| a | b |\n| --- | --- |\n| 1 | 2 |");

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -17,7 +17,7 @@ pub use chunk_metadata::detect_language;
 pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource, PageRegion};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,
-    KeyValueElementData, TableElementData,
+    KeyValueElementData, RichCell, TableElementData, TableStructure,
 };
 pub use export::{ElementMarkdownExporter, ExportConfig};
 pub use graph::ElementGraph;

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -340,6 +340,7 @@ impl Partitioner {
                                 );
                                 elements.push(Element::Table(TableElementData {
                                     rows,
+                                    structure: None,
                                     metadata: ElementMetadata {
                                         page,
                                         bbox,
@@ -432,6 +433,7 @@ impl Partitioner {
 
                             elements.push(Element::Table(TableElementData {
                                 rows,
+                                structure: None,
                                 metadata: ElementMetadata {
                                     page,
                                     bbox,

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -324,6 +324,14 @@ impl Partitioner {
                                 if table.confidence < self.config.min_table_confidence {
                                     continue;
                                 }
+                                // #375: a table that captured too few cells is not a
+                                // table — skip it so its fragments become prose.
+                                let populated =
+                                    table.cells.iter().filter(|c| !c.text.is_empty()).count();
+                                if populated < table.rows.max(1) {
+                                    // fewer populated cells than rows => no real column structure
+                                    continue;
+                                }
                                 let rows = ruling_table_to_rows(table);
                                 let bbox = ElementBBox::new(
                                     table.bbox.x,
@@ -395,6 +403,18 @@ impl Partitioner {
                         for table in &result.tables {
                             // Apply minimum confidence filter.
                             if table.confidence < self.config.min_table_confidence {
+                                continue;
+                            }
+
+                            // #375: a table that captured too few cells is not a
+                            // table — skip it so its fragments become prose.
+                            let populated = table
+                                .rows
+                                .iter()
+                                .flat_map(|r| &r.cells)
+                                .filter(|c| !c.is_empty())
+                                .count();
+                            if populated < table.row_count().max(1) {
                                 continue;
                             }
 

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -1,7 +1,8 @@
 use crate::graphics::extraction::ExtractedGraphics;
 use crate::pipeline::reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 use crate::pipeline::{
-    Element, ElementBBox, ElementData, ElementMetadata, KeyValueElementData, TableElementData,
+    Element, ElementBBox, ElementData, ElementMetadata, KeyValueElementData, RichCell,
+    TableElementData, TableStructure,
 };
 use crate::text::extraction::TextFragment;
 
@@ -331,23 +332,21 @@ impl Partitioner {
                                 if populated < 2 {
                                     continue;
                                 }
-                                let rows = ruling_table_to_rows(table);
                                 let bbox = ElementBBox::new(
                                     table.bbox.x,
                                     table.bbox.y,
                                     table.bbox.width,
                                     table.bbox.height,
                                 );
-                                elements.push(Element::Table(TableElementData {
-                                    rows,
-                                    structure: None,
-                                    metadata: ElementMetadata {
+                                elements.push(Element::Table(TableElementData::from_structure(
+                                    ruling_table_to_structure(table),
+                                    ElementMetadata {
                                         page,
                                         bbox,
                                         confidence: table.confidence,
                                         ..Default::default()
                                     },
-                                }));
+                                )));
                                 // #375: claim only fragments actually placed in a
                                 // cell. Fragments inside the table bbox but in no
                                 // cell (gaps, borders, normalization misses) stay
@@ -785,16 +784,31 @@ fn is_list_item(text: &str) -> bool {
     false
 }
 
-/// Flatten a ruling-detected table into row-major `Vec<Vec<String>>`, filling
-/// absent cells with empty strings.
-fn ruling_table_to_rows(table: &crate::text::table_detection::DetectedTable) -> Vec<Vec<String>> {
-    let mut grid = vec![vec![String::new(); table.columns]; table.rows];
-    for cell in &table.cells {
-        if cell.row < table.rows && cell.column < table.columns {
-            grid[cell.row][cell.column] = cell.text.clone();
-        }
+/// Convert a ruling-detected table (with merged cells + header rows) into a
+/// rich `TableStructure`. The flat `rows` view is derived by
+/// `TableElementData::from_structure`.
+fn ruling_table_to_structure(
+    table: &crate::text::table_detection::DetectedTable,
+) -> TableStructure {
+    let header_rows = table.header_rows;
+    let cells = table
+        .cells
+        .iter()
+        .map(|c| RichCell {
+            row: c.row,
+            col: c.column,
+            row_span: c.row_span.max(1),
+            col_span: c.col_span.max(1),
+            text: c.text.clone(),
+            is_header: c.row < header_rows,
+        })
+        .collect();
+    TableStructure {
+        cells,
+        num_rows: table.rows,
+        num_cols: table.columns,
+        header_rows,
     }
-    grid
 }
 
 /// Splits unclaimed fragments into Y-separated table candidate regions.

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -340,17 +340,20 @@ impl Partitioner {
                                         ..Default::default()
                                     },
                                 }));
-                                let (rx, ry) = (table.bbox.x, table.bbox.y);
-                                let (rr, rt) = (
-                                    table.bbox.x + table.bbox.width,
-                                    table.bbox.y + table.bbox.height,
-                                );
+                                // #375: claim only fragments actually placed in a
+                                // cell. Fragments inside the table bbox but in no
+                                // cell (gaps, borders, normalization misses) stay
+                                // unclaimed and fall through to prose classification.
                                 for (i, f) in fragments.iter().enumerate() {
-                                    if !claimed[i]
-                                        && f.x >= rx - 1.0
-                                        && f.x <= rr + 1.0
-                                        && f.y >= ry - 1.0
-                                        && f.y <= rt + 1.0
+                                    if claimed[i] {
+                                        continue;
+                                    }
+                                    let cx = f.x + f.width / 2.0;
+                                    let cy = f.y + f.height / 2.0;
+                                    if table
+                                        .cells
+                                        .iter()
+                                        .any(|cell| cell.bbox.contains_point(cx, cy))
                                     {
                                         claimed[i] = true;
                                     }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -430,16 +430,15 @@ impl Partitioner {
                                 table.bounding_box.height,
                             );
 
-                            elements.push(Element::Table(TableElementData {
+                            elements.push(Element::Table(TableElementData::new(
                                 rows,
-                                structure: None,
-                                metadata: ElementMetadata {
+                                ElementMetadata {
                                     page,
                                     bbox,
                                     confidence: table.confidence,
                                     ..Default::default()
                                 },
-                            }));
+                            )));
 
                             // #375: claim only fragments inside a populated cell.
                             for (i, f) in fragments.iter().enumerate() {

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -421,14 +421,19 @@ impl Partitioner {
                                 },
                             }));
 
-                            // Claim fragments that fall within this table's bounding box.
+                            // #375: claim only fragments inside a populated cell.
                             for (i, f) in fragments.iter().enumerate() {
-                                if !claimed[i]
-                                    && f.x >= table.bounding_box.x - 1.0
-                                    && f.x <= table.bounding_box.right() + 1.0
-                                    && f.y >= table.bounding_box.y - 1.0
-                                    && f.y <= table.bounding_box.top() + 1.0
-                                {
+                                if claimed[i] {
+                                    continue;
+                                }
+                                let cx = f.x + f.width / 2.0;
+                                let cy = f.y + f.height / 2.0;
+                                let in_cell = table
+                                    .rows
+                                    .iter()
+                                    .flat_map(|r| &r.cells)
+                                    .any(|c| !c.is_empty() && c.bounding_box.contains(cx, cy));
+                                if in_cell {
                                     claimed[i] = true;
                                 }
                             }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -324,12 +324,11 @@ impl Partitioner {
                                 if table.confidence < self.config.min_table_confidence {
                                     continue;
                                 }
-                                // #375: a table that captured too few cells is not a
-                                // table — skip it so its fragments become prose.
+                                // #375: a table with fewer than 2 populated cells is not
+                                // a real table — skip it so its fragments become prose.
                                 let populated =
                                     table.cells.iter().filter(|c| !c.text.is_empty()).count();
-                                if populated < table.rows.max(1) {
-                                    // fewer populated cells than rows => no real column structure
+                                if populated < 2 {
                                     continue;
                                 }
                                 let rows = ruling_table_to_rows(table);
@@ -406,15 +405,15 @@ impl Partitioner {
                                 continue;
                             }
 
-                            // #375: a table that captured too few cells is not a
-                            // table — skip it so its fragments become prose.
+                            // #375: a table with fewer than 2 populated cells is not
+                            // a real table — skip it so its fragments become prose.
                             let populated = table
                                 .rows
                                 .iter()
                                 .flat_map(|r| &r.cells)
                                 .filter(|c| !c.is_empty())
                                 .count();
-                            if populated < table.row_count().max(1) {
+                            if populated < 2 {
                                 continue;
                             }
 

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -346,9 +346,59 @@ impl TableDetector {
         let num_rows = grid.rows.len().saturating_sub(1);
         let num_cols = grid.columns.len().saturating_sub(1);
 
-        let table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        let mut table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        table.header_rows = Self::count_header_rows(&table, text_fragments);
 
         Ok(Some(table))
+    }
+
+    /// Counts the leading contiguous header rows of a detected table
+    /// (issue #375, Task 8).
+    ///
+    /// A row is a header row when at least one text fragment landing inside
+    /// one of its cells carries a header structure tag (`"TH"`, or any tag
+    /// containing `"HEADER"`, case-insensitively — e.g. PDF/UA `"TH"` cells
+    /// or a custom `"TableHeader"` role). Only *leading* tagged rows count:
+    /// counting stops at the first row without a header-tagged fragment, so
+    /// a tagged row that is not contiguous with the top does not count.
+    ///
+    /// When no rows carry a header tag, a bordered table with at least two
+    /// rows falls back to treating the top row as the header (the common
+    /// convention for ruled tables without structure information).
+    fn count_header_rows(table: &DetectedTable, fragments: &[TextFragment]) -> usize {
+        fn is_header_tag(tag: &str) -> bool {
+            let t = tag.to_ascii_uppercase();
+            t == "TH" || t.contains("HEADER")
+        }
+
+        let mut tagged_leading = 0usize;
+        for r in 0..table.rows {
+            let row_cells: Vec<&TableCell> = table
+                .cells
+                .iter()
+                .filter(|c| c.row <= r && r < c.row + c.row_span)
+                .collect();
+            let has_header = fragments.iter().any(|f| {
+                f.struct_tag.as_deref().map(is_header_tag).unwrap_or(false)
+                    && row_cells.iter().any(|c| {
+                        c.bbox
+                            .contains_point(f.x + f.width / 2.0, f.y + f.height / 2.0)
+                    })
+            });
+            if has_header {
+                tagged_leading = r + 1;
+            } else {
+                break;
+            }
+        }
+
+        if tagged_leading > 0 {
+            tagged_leading
+        } else if table.rows >= 2 {
+            1
+        } else {
+            0
+        }
     }
 
     /// Detects a grid pattern from horizontal and vertical lines.

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -96,6 +96,7 @@ impl Default for TableDetectionConfig {
 
 /// A detected table with cells, rows, and columns.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct DetectedTable {
     /// Bounding box of the entire table
     pub bbox: BoundingBox,
@@ -165,6 +166,7 @@ impl DetectedTable {
 
 /// A single cell in a detected table.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct TableCell {
     /// Row index (0-based)
     pub row: usize,

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -45,6 +45,7 @@
 
 use crate::graphics::extraction::{ExtractedGraphics, LineOrientation, VectorLine};
 use crate::text::extraction::TextFragment;
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 /// Errors that can occur during table detection.
@@ -326,6 +327,10 @@ impl TableDetector {
         // Calculate cell boundaries
         let cells = self.create_cells_from_grid(&grid);
 
+        // Merge base cells across absent interior dividers before text assignment
+        // so text lands in the merged (spanning) cells (issue #375).
+        let cells = self.merge_cells_across_absent_dividers(&grid, cells);
+
         // Assign text to cells
         let cells_with_text = self.assign_text_to_cells(cells, text_fragments);
 
@@ -361,7 +366,23 @@ impl TableDetector {
         // Reverse rows so row 0 is at the top (highest Y) for intuitive indexing
         rows.reverse();
 
-        Ok(GridPattern { rows, columns })
+        // Retain the raw divider segments (normalized) so absent interior
+        // dividers can be detected for merged-cell reconstruction (issue #375).
+        let h_segments: Vec<(f64, f64, f64)> = h_lines
+            .iter()
+            .map(|line| (line.y1, line.x1.min(line.x2), line.x1.max(line.x2)))
+            .collect();
+        let v_segments: Vec<(f64, f64, f64)> = v_lines
+            .iter()
+            .map(|line| (line.x1, line.y1.min(line.y2), line.y1.max(line.y2)))
+            .collect();
+
+        Ok(GridPattern {
+            rows,
+            columns,
+            h_segments,
+            v_segments,
+        })
     }
 
     /// Clusters lines by their primary position (Y for horizontal, X for vertical).
@@ -453,6 +474,116 @@ impl TableDetector {
         cells
     }
 
+    /// Returns true if a vertical divider is drawn at `x` covering the Y-range
+    /// `[y0, y1]` (within `alignment_tolerance`) — i.e. some retained vertical
+    /// segment sits at that column and spans the given row band (issue #375).
+    fn divider_present_vertical(&self, grid: &GridPattern, x: f64, y0: f64, y1: f64) -> bool {
+        let tol = self.config.alignment_tolerance;
+        let (lo, hi) = (y0.min(y1), y0.max(y1));
+        grid.v_segments
+            .iter()
+            .any(|&(sx, s0, s1)| (sx - x).abs() <= tol && s0 <= lo + tol && s1 >= hi - tol)
+    }
+
+    /// Returns true if a horizontal divider is drawn at `y` covering the
+    /// X-range `[x0, x1]` (within `alignment_tolerance`) (issue #375).
+    fn divider_present_horizontal(&self, grid: &GridPattern, y: f64, x0: f64, x1: f64) -> bool {
+        let tol = self.config.alignment_tolerance;
+        let (lo, hi) = (x0.min(x1), x0.max(x1));
+        grid.h_segments
+            .iter()
+            .any(|&(sy, s0, s1)| (sy - y).abs() <= tol && s0 <= lo + tol && s1 >= hi - tol)
+    }
+
+    /// Merges base cells across *absent* interior dividers into spanning cells.
+    ///
+    /// Two adjacent base cells belong to the same merged region when the divider
+    /// on their shared edge is not drawn. Union-find groups connected base cells;
+    /// each region becomes one [`TableCell`] positioned at its top-left base
+    /// index with `row_span`/`col_span` equal to its extent (issue #375).
+    ///
+    /// A fully-ruled table (every divider present) yields all-`1` spans, i.e.
+    /// output identical to the base grid.
+    fn merge_cells_across_absent_dividers(
+        &self,
+        grid: &GridPattern,
+        cells: Vec<TableCell>,
+    ) -> Vec<TableCell> {
+        let num_rows = grid.rows.len().saturating_sub(1);
+        let num_cols = grid.columns.len().saturating_sub(1);
+        if num_rows == 0 || num_cols == 0 {
+            return cells;
+        }
+
+        // Union-find over base cells (flat index = r * num_cols + c).
+        fn find(parent: &mut [usize], i: usize) -> usize {
+            if parent[i] != i {
+                let root = find(parent, parent[i]);
+                parent[i] = root;
+            }
+            parent[i]
+        }
+
+        let mut parent: Vec<usize> = (0..num_rows * num_cols).collect();
+        for r in 0..num_rows {
+            for c in 0..num_cols {
+                // Merge right across an absent vertical divider at columns[c+1].
+                if c + 1 < num_cols {
+                    let x = grid.columns[c + 1];
+                    if !self.divider_present_vertical(grid, x, grid.rows[r], grid.rows[r + 1]) {
+                        let a = find(&mut parent, r * num_cols + c);
+                        let b = find(&mut parent, r * num_cols + c + 1);
+                        parent[a] = b;
+                    }
+                }
+                // Merge down across an absent horizontal divider at rows[r+1].
+                if r + 1 < num_rows {
+                    let y = grid.rows[r + 1];
+                    if !self.divider_present_horizontal(
+                        grid,
+                        y,
+                        grid.columns[c],
+                        grid.columns[c + 1],
+                    ) {
+                        let a = find(&mut parent, r * num_cols + c);
+                        let b = find(&mut parent, (r + 1) * num_cols + c);
+                        parent[a] = b;
+                    }
+                }
+            }
+        }
+
+        // Group base cells by root. BTreeMap keeps the output deterministic.
+        let mut groups: BTreeMap<usize, Vec<&TableCell>> = BTreeMap::new();
+        for cell in &cells {
+            let root = find(&mut parent, cell.row * num_cols + cell.column);
+            groups.entry(root).or_default().push(cell);
+        }
+
+        let mut merged = Vec::with_capacity(groups.len());
+        for group in groups.into_values() {
+            let min_r = group.iter().map(|c| c.row).min().unwrap_or(0);
+            let min_c = group.iter().map(|c| c.column).min().unwrap_or(0);
+            let max_r = group.iter().map(|c| c.row).max().unwrap_or(0);
+            let max_c = group.iter().map(|c| c.column).max().unwrap_or(0);
+
+            // Merged bbox spans the grid extents of the region (deterministic).
+            let x = grid.columns[min_c];
+            let y = grid.rows[min_r].min(grid.rows[max_r + 1]);
+            let w = (grid.columns[max_c + 1] - grid.columns[min_c]).abs();
+            let h = (grid.rows[max_r + 1] - grid.rows[min_r]).abs();
+
+            let mut cell = TableCell::new(min_r, min_c, BoundingBox::new(x, y, w, h));
+            cell.has_borders = true;
+            cell.row_span = max_r - min_r + 1;
+            cell.col_span = max_c - min_c + 1;
+            merged.push(cell);
+        }
+
+        merged.sort_by_key(|c| (c.row, c.column));
+        merged
+    }
+
     /// Assigns text fragments to cells based on spatial containment.
     ///
     /// **Coordinate Space Normalization**:
@@ -525,6 +656,13 @@ struct GridPattern {
     rows: Vec<f64>,
     /// Column X coordinates (sorted)
     columns: Vec<f64>,
+    /// Raw horizontal divider segments as `(y, x_start, x_end)` with
+    /// `x_start <= x_end`. Retained so absent interior dividers (merged cells)
+    /// can be detected instead of assuming a fully dense grid (issue #375).
+    h_segments: Vec<(f64, f64, f64)>,
+    /// Raw vertical divider segments as `(x, y_start, y_end)` with
+    /// `y_start <= y_end` (issue #375).
+    v_segments: Vec<(f64, f64, f64)>,
 }
 
 impl Default for TableDetector {

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -103,6 +103,8 @@ pub struct DetectedTable {
     pub columns: usize,
     /// Confidence score (0.0 to 1.0)
     pub confidence: f64,
+    /// Leading header rows (0 until header detection runs; Task 8).
+    pub header_rows: usize,
 }
 
 impl DetectedTable {
@@ -115,6 +117,7 @@ impl DetectedTable {
             rows,
             columns,
             confidence,
+            header_rows: 0,
         }
     }
 
@@ -169,6 +172,10 @@ pub struct TableCell {
     pub text: String,
     /// Whether this cell has borders
     pub has_borders: bool,
+    /// Number of base rows this cell spans (>= 1).
+    pub row_span: usize,
+    /// Number of base columns this cell spans (>= 1).
+    pub col_span: usize,
 }
 
 impl TableCell {
@@ -180,6 +187,8 @@ impl TableCell {
             bbox,
             text: String::new(),
             has_borders: false,
+            row_span: 1,
+            col_span: 1,
         }
     }
 

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -42,6 +42,9 @@
 //! }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//!
+//! Merged cells are detected from absent grid dividers; borderless tables and un-tagged
+//! multi-level headers stay flat. See `docs/TABLE_DETECTION_GUIDE.md` for the full limits.
 
 use crate::graphics::extraction::{ExtractedGraphics, LineOrientation, VectorLine};
 use crate::text::extraction::TextFragment;

--- a/oxidize-pdf-core/tests/element_types_test.rs
+++ b/oxidize-pdf-core/tests/element_types_test.rs
@@ -35,18 +35,17 @@ fn test_element_paragraph_creation() {
 fn test_element_table_creation() {
     use oxidize_pdf::pipeline::TableElementData;
 
-    let table = Element::Table(TableElementData {
-        rows: vec![
+    let table = Element::Table(TableElementData::new(
+        vec![
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
             vec!["1".to_string(), "2".to_string(), "3".to_string()],
             vec!["X".to_string(), "Y".to_string(), "Z".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 1,
             ..Default::default()
         },
-    });
+    ));
 
     assert!(matches!(table, Element::Table(_)));
     assert_eq!(table.row_count(), Some(3));
@@ -66,11 +65,7 @@ fn test_element_variants_exhaustive() {
     let elements = vec![
         Element::Title(data()),
         Element::Paragraph(data()),
-        Element::Table(TableElementData {
-            rows: vec![],
-            structure: None,
-            metadata: ElementMetadata::default(),
-        }),
+        Element::Table(TableElementData::new(vec![], ElementMetadata::default())),
         Element::Header(data()),
         Element::Footer(data()),
         Element::ListItem(data()),
@@ -207,14 +202,13 @@ fn test_element_sort_by_reading_order() {
 fn test_element_display_text_table() {
     use oxidize_pdf::pipeline::TableElementData;
 
-    let table = Element::Table(TableElementData {
-        rows: vec![
+    let table = Element::Table(TableElementData::new(
+        vec![
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata::default(),
-    });
+        ElementMetadata::default(),
+    ));
 
     let display = table.display_text();
     assert!(display.contains("Name"));

--- a/oxidize-pdf-core/tests/element_types_test.rs
+++ b/oxidize-pdf-core/tests/element_types_test.rs
@@ -41,6 +41,7 @@ fn test_element_table_creation() {
             vec!["1".to_string(), "2".to_string(), "3".to_string()],
             vec!["X".to_string(), "Y".to_string(), "Z".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata {
             page: 1,
             ..Default::default()
@@ -67,6 +68,7 @@ fn test_element_variants_exhaustive() {
         Element::Paragraph(data()),
         Element::Table(TableElementData {
             rows: vec![],
+            structure: None,
             metadata: ElementMetadata::default(),
         }),
         Element::Header(data()),
@@ -210,6 +212,7 @@ fn test_element_display_text_table() {
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata::default(),
     });
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -198,15 +198,14 @@ fn test_oversized_table_gets_own_oversized_chunk() {
 
     let elements = vec![
         para_with_heading("Before table.", 0, 750.0, None),
-        Element::Table(TableElementData {
-            rows: big_rows,
-            structure: None,
-            metadata: ElementMetadata {
+        Element::Table(TableElementData::new(
+            big_rows,
+            ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),
                 ..Default::default()
             },
-        }),
+        )),
         para_with_heading("After table.", 0, 100.0, None),
     ];
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -200,6 +200,7 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         para_with_heading("Before table.", 0, 750.0, None),
         Element::Table(TableElementData {
             rows: big_rows,
+            structure: None,
             metadata: ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -38,19 +38,18 @@ fn title_elem(text: &str, page: u32, y: f64) -> Element {
 }
 
 fn make_small_table() -> Element {
-    Element::Table(TableElementData {
-        rows: vec![
+    Element::Table(TableElementData::new(
+        vec![
             vec!["Header A".to_string(), "Header B".to_string()],
             vec!["Row 1A".to_string(), "Row 1B".to_string()],
             vec!["Row 2A".to_string(), "Row 2B".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 400.0, 400.0, 100.0),
             ..Default::default()
         },
-    })
+    ))
 }
 
 fn frag(text: &str, x: f64, y: f64, font_size: f64) -> TextFragment {
@@ -227,15 +226,14 @@ fn test_table_oversized_remains_atomic_not_split() {
     let big_rows: Vec<Vec<String>> = (0..100)
         .map(|i| vec![format!("key_{}", i), format!("value_{}", i)])
         .collect();
-    let elements = vec![Element::Table(TableElementData {
-        rows: big_rows,
-        structure: None,
-        metadata: ElementMetadata {
+    let elements = vec![Element::Table(TableElementData::new(
+        big_rows,
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),
             ..Default::default()
         },
-    })];
+    ))];
     let chunker = HybridChunker::new(HybridChunkConfig {
         max_tokens: 20,
         overlap_tokens: 0,

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -44,6 +44,7 @@ fn make_small_table() -> Element {
             vec!["Row 1A".to_string(), "Row 1B".to_string()],
             vec!["Row 2A".to_string(), "Row 2B".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 400.0, 400.0, 100.0),
@@ -228,6 +229,7 @@ fn test_table_oversized_remains_atomic_not_split() {
         .collect();
     let elements = vec![Element::Table(TableElementData {
         rows: big_rows,
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -106,3 +106,71 @@ fn merged_header_cell_detected_with_col_span_2() {
         "bottom-right single cell"
     );
 }
+
+/// Same fragment as `frag`, but tagged as a table-header structure element.
+fn th(t: &str, x: f64, y: f64) -> TextFragment {
+    let mut f = frag(t, x, y);
+    f.struct_tag = Some("TH".to_string());
+    f
+}
+
+/// Issue #375 Task 8: a fully-ruled 2x2 table whose top row is tagged `TH`
+/// must report `header_rows == 1`; the untagged bottom row must not count.
+#[test]
+fn header_row_detected_from_th_tag() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),
+        vline(200.0, 100.0, 200.0),
+        vline(300.0, 100.0, 200.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        th("H1", 130.0, 170.0),
+        th("H2", 230.0, 170.0),
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(table.header_rows, 1, "top row tagged TH must be the header");
+}
+
+/// Issue #375 Task 8: with no structure tags at all, a >=2-row bordered
+/// table still defaults `header_rows` to 1 (top row fallback).
+#[test]
+fn header_row_defaults_to_top_row_without_tags() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),
+        vline(200.0, 100.0, 200.0),
+        vline(300.0, 100.0, 200.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("H1", 130.0, 170.0),
+        frag("H2", 230.0, 170.0),
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(
+        table.header_rows, 1,
+        "no tags present: must default to top-row fallback"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -215,3 +215,142 @@ fn header_rows_two_when_top_two_of_three_rows_tagged() {
         "top two tagged rows must both count as header rows"
     );
 }
+
+/// Issue #375 Task 7 (final-review I2/T7d): vertical merge coverage.
+///
+/// Grid: X gridlines 100/200/300 (2 cols); Y gridlines 100/150/200 (2 row
+/// bands, row 0 = top). The middle horizontal divider at y=150 is drawn only
+/// over the RIGHT column (x 200..300); it is absent over the LEFT column
+/// (x 100..200). `divider_present_horizontal` therefore reports the divider
+/// missing on the left, so the two left-column base cells merge vertically
+/// into one `row_span == 2` cell, while the right column — where the divider
+/// is present — keeps two separate `row_span == 1` cells.
+#[test]
+fn merged_cell_detected_with_row_span_2() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0), // bottom border
+        hline(200.0, 300.0, 150.0), // middle divider, RIGHT column only
+        hline(100.0, 300.0, 200.0), // top border
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(200.0, 100.0, 200.0), // middle vertical (full height, both rows)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Left", 130.0, 150.0),
+        frag("TopRight", 230.0, 170.0),
+        frag("BottomRight", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x2.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 2, "base grid columns");
+
+    let left = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(left.row_span, 2, "left column should span 2 rows");
+    assert_eq!(left.col_span, 1, "left merged cell spans a single column");
+
+    // The vertical merge must not leave a separate cell at (1,0).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 1 && c.column == 0),
+        "interior position of a vertically merged cell must be omitted"
+    );
+
+    // The right column keeps two single (unmerged) cells.
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 0 && c.column == 1 && c.row_span == 1 && c.col_span == 1),
+        "top-right single cell"
+    );
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 1 && c.row_span == 1 && c.col_span == 1),
+        "bottom-right single cell"
+    );
+}
+
+/// Issue #375 Task 7 (final-review I2/T7d): transitive multi-cell merge
+/// coverage.
+///
+/// Grid: X gridlines 100/200/300/400 (3 cols); Y gridlines 100/150/200 (2 row
+/// bands). In the TOP row band (y 150..200) BOTH interior verticals (x=200
+/// and x=300) are absent — each is drawn only over the BOTTOM band
+/// (y 100..150) — so all three top-row base cells merge transitively
+/// (0-1 absent, 1-2 absent -> union-find connects all three) into one
+/// `col_span == 3` cell. The bottom row keeps both interior verticals, so it
+/// stays as three separate `col_span == 1` cells.
+#[test]
+fn transitive_merge_across_three_columns_detected() {
+    let h = vec![
+        hline(100.0, 400.0, 100.0), // bottom border
+        hline(100.0, 400.0, 150.0), // middle divider, full width
+        hline(100.0, 400.0, 200.0), // top border
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(400.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // interior divider 1, BOTTOM band only
+        vline(300.0, 100.0, 150.0), // interior divider 2, BOTTOM band only
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Top", 250.0, 170.0),
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+        frag("C", 330.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x3.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 3, "base grid columns");
+
+    let top = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(
+        top.col_span, 3,
+        "top row should transitively merge 3 columns"
+    );
+    assert_eq!(top.row_span, 1, "top merged cell spans a single row");
+
+    // The transitive merge must not leave separate cells at (0,1) or (0,2).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 1),
+        "interior position (0,1) of the merged cell must be omitted"
+    );
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 2),
+        "interior position (0,2) of the merged cell must be omitted"
+    );
+
+    // The bottom row keeps three single (unmerged) cells.
+    for col in 0..3 {
+        assert!(
+            table
+                .cells
+                .iter()
+                .any(|c| { c.row == 1 && c.column == col && c.row_span == 1 && c.col_span == 1 }),
+            "bottom row cell at column {col} should remain unmerged"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -174,3 +174,44 @@ fn header_row_defaults_to_top_row_without_tags() {
         "no tags present: must default to top-row fallback"
     );
 }
+
+/// Issue #375 Task 8: a fully-ruled 3x2 table with the TOP TWO rows tagged
+/// `TH` must report `header_rows == 2`. This is discriminating from the
+/// untagged `rows >= 2 -> 1` fallback: a broken tag-matching path can only
+/// ever produce 1 here, never 2.
+#[test]
+fn header_rows_two_when_top_two_of_three_rows_tagged() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 140.0),
+        hline(100.0, 300.0, 180.0),
+        hline(100.0, 300.0, 220.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 220.0),
+        vline(200.0, 100.0, 220.0),
+        vline(300.0, 100.0, 220.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        // Top row (row 0), tagged.
+        th("H1", 130.0, 200.0),
+        th("H2", 230.0, 200.0),
+        // Middle row (row 1), tagged.
+        th("H3", 130.0, 160.0),
+        th("H4", 230.0, 160.0),
+        // Bottom row (row 2), plain.
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(table.rows, 3, "base grid rows");
+    assert_eq!(
+        table.header_rows, 2,
+        "top two tagged rows must both count as header rows"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -1,0 +1,108 @@
+//! Issue #375 Task 7: detect merged cells from a drawn grid by retaining which
+//! divider line-segments are actually present.
+//!
+//! Fixture: a bordered 2-column table whose TOP row omits the middle vertical
+//! divider (a single spanning header cell) while the BOTTOM row keeps it (two
+//! cells). Detection must yield a top-left cell with `col_span == 2` and two
+//! `col_span == 1` cells in the bottom row.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::text::extraction::TextFragment;
+use oxidize_pdf::text::table_detection::TableDetector;
+
+/// Horizontal line at height `y` from `x1` to `x2`.
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+
+/// Vertical line at `x` from `y1` to `y2`.
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: t.into(),
+        x,
+        y,
+        width: 30.0,
+        height: 10.0,
+        font_size: 10.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
+    let mut g = ExtractedGraphics::new();
+    for line in h.into_iter().chain(v.into_iter()) {
+        g.add_line(line);
+    }
+    g
+}
+
+#[test]
+fn merged_header_cell_detected_with_col_span_2() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // MIDDLE divider only in row 1
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Header", 150.0, 170.0),
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x2.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 2, "base grid columns");
+
+    let top_left = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(top_left.col_span, 2, "merged header should span 2 columns");
+    assert_eq!(top_left.row_span, 1, "merged header spans a single row");
+
+    // The merged header must NOT leave a separate cell at (0,1).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 1),
+        "interior position of a merged cell must be omitted"
+    );
+
+    // The non-merged bottom row keeps two single cells.
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 0 && c.col_span == 1 && c.row_span == 1),
+        "bottom-left single cell"
+    );
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 1 && c.col_span == 1 && c.row_span == 1),
+        "bottom-right single cell"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
@@ -1,0 +1,48 @@
+// tests/issue_375_merged_cells_test.rs  (create; more tests added in Task 7/9)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+
+#[test]
+fn from_structure_expands_spans_into_flat_rows() {
+    // 2x2 grid; top row is a single cell spanning both columns (a merged header).
+    let structure = TableStructure {
+        num_rows: 2,
+        num_cols: 2,
+        header_rows: 1,
+        cells: vec![
+            RichCell {
+                row: 0,
+                col: 0,
+                row_span: 1,
+                col_span: 2,
+                text: "Region".into(),
+                is_header: true,
+            },
+            RichCell {
+                row: 1,
+                col: 0,
+                row_span: 1,
+                col_span: 1,
+                text: "Q1".into(),
+                is_header: false,
+            },
+            RichCell {
+                row: 1,
+                col: 1,
+                row_span: 1,
+                col_span: 1,
+                text: "Q2".into(),
+                is_header: false,
+            },
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    // Flat view repeats the spanned header value across both covered columns.
+    assert_eq!(
+        data.rows,
+        vec![
+            vec!["Region".to_string(), "Region".to_string()],
+            vec!["Q1".to_string(), "Q2".to_string()],
+        ]
+    );
+    assert_eq!(data.structure.as_ref().unwrap().header_rows, 1);
+}

--- a/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
@@ -1,0 +1,99 @@
+//! Issue #375 Task 9: the ruling-detector partition path must emit the RICH
+//! `TableStructure` (merged cells + header rows), with the flat `rows` view
+//! derived from it via `TableElementData::from_structure`. The spatial path
+//! keeps `structure: None` (unchanged, not exercised here).
+//!
+//! Fixture: same merged-header grid as the Task 7 detect test (a 2-col table
+//! whose top row omits the middle vertical divider, producing one spanning
+//! header cell with `col_span == 2`), run through the full partition path.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::pipeline::{Element, PartitionConfig, Partitioner};
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: t.into(),
+        x,
+        y,
+        width: 30.0,
+        height: 10.0,
+        font_size: 10.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
+    let mut g = ExtractedGraphics::new();
+    for line in h.into_iter().chain(v.into_iter()) {
+        g.add_line(line);
+    }
+    g
+}
+
+#[test]
+fn ruling_partition_emits_rich_structure_with_merged_header() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // MIDDLE divider only in row 1
+    ];
+    let graphics = build_graphics(h, v);
+
+    let mut header_frag = frag("Header", 150.0, 170.0);
+    header_frag.struct_tag = Some("TH".to_string());
+    let frags = vec![
+        header_frag,
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+    ];
+
+    let elements = Partitioner::new(PartitionConfig::default()).partition_fragments_with_graphics(
+        &frags,
+        Some(&graphics),
+        0,
+        842.0,
+    );
+
+    let table = elements
+        .iter()
+        .find_map(|e| match e {
+            Element::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("a table element");
+
+    let st = table.structure.as_ref().expect("rich structure present");
+    assert!(
+        st.cells
+            .iter()
+            .any(|c| c.row == 0 && c.col == 0 && c.col_span == 2 && c.is_header),
+        "expected a spanning header cell at row 0, col 0 with col_span == 2"
+    );
+    assert_eq!(st.header_rows, 1, "single header row expected");
+
+    // Flat view still complete (spanned value repeated across both columns).
+    assert_eq!(table.rows[0].len(), 2);
+}

--- a/oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
@@ -1,0 +1,165 @@
+// tests/issue_375_text_conservation_test.rs
+//
+// #375 data-loss guard: after partitioning, the union of all element text must
+// cover the page's extracted text. A prose page misdetected as an (empty) table
+// currently drops its text -> this fails RED until the claim fix lands.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::PartitionConfig;
+use oxidize_pdf::text::TextExtractor;
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+/// Non-whitespace tokens of `s`, lowercased, for order-independent containment.
+fn tokens(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|t| t.to_lowercase()).collect()
+}
+
+#[test]
+fn partition_conserves_page_text_default_config() {
+    let doc = PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"));
+
+    // Expected: raw extracted text of every page.
+    let mut extractor = TextExtractor::new();
+    let page_count = doc.page_count().expect("page_count");
+    let mut expected = String::new();
+    for p in 0..page_count {
+        let page_text = extractor
+            .extract_from_page(&doc, p)
+            .expect("extract page")
+            .text;
+        expected.push('\n');
+        expected.push_str(&page_text);
+    }
+
+    // Actual: union of all element display text.
+    let elements = doc
+        .partition_with(PartitionConfig::default())
+        .expect("partition");
+    let actual: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let actual_tokens: std::collections::HashSet<String> = tokens(&actual).into_iter().collect();
+
+    // Every expected token must survive partitioning (allow a small slack for
+    // tokenization artifacts at cell boundaries).
+    let missing: Vec<String> = tokens(&expected)
+        .into_iter()
+        .filter(|t| !actual_tokens.contains(t))
+        .collect();
+
+    let miss_ratio = missing.len() as f64 / tokens(&expected).len().max(1) as f64;
+    assert!(
+        miss_ratio < 0.01,
+        "partition dropped {:.1}% of page tokens ({} missing), e.g. {:?}",
+        miss_ratio * 100.0,
+        missing.len(),
+        &missing.iter().take(15).collect::<Vec<_>>()
+    );
+}
+
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x,
+        y,
+        width: text.len() as f64 * 6.0,
+        height: 12.0,
+        font_size: 12.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn spatial_table_does_not_drop_interior_prose() {
+    // A justified prose block: 3 X-columns x 4 Y-rows, but one stray token sits
+    // in a gap between columns (inside the table bbox, outside every cell).
+    //
+    // NOTE: with the current spatial-cluster detector, an isolated in-gap point
+    // like this becomes its own singleton column (any point far enough from its
+    // neighbors starts a new cluster) and so is captured, not dropped. This test
+    // currently passes; it is kept as a durable guard for that shape of
+    // regression. The actual data-loss reproduction is
+    // `spatial_table_drops_column_jitter_outliers` below.
+    let mut frags = Vec::new();
+    for (r, y) in [780.0, 760.0, 740.0, 720.0].iter().enumerate() {
+        for (c, x) in [72.0, 200.0, 330.0].iter().enumerate() {
+            frags.push(frag(&format!("w{r}{c}"), *x, *y));
+        }
+    }
+    frags.push(frag("ORPHAN", 150.0, 730.0)); // in-bbox, between columns
+
+    let elements =
+        Partitioner::new(PartitionConfig::default()).partition_fragments(&frags, 0, 842.0);
+    let all: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all.contains("ORPHAN"),
+        "interior prose token was dropped: {all}"
+    );
+}
+
+/// #375 root-cause reproduction: a column whose X positions drift within the
+/// spatial detector's clustering tolerance (5.0pt) still forms a single column
+/// cluster, but `find_cell_for_fragment` only accepts a fragment into a cell
+/// when it is within `2 * column_alignment_tolerance` (10.0pt) of the
+/// *cluster mean* — not the raw point. A cluster built from a chain of small
+/// (<=5pt) steps can have a mean far enough from its own extreme members that
+/// those members fail the cell-assignment check and are placed in no cell.
+///
+/// The bounding box used to *claim* fragments is computed from the column's
+/// full raw extent (`min`/`max`, padded to a 50pt minimum width), which is
+/// wide enough to still cover those extreme members. So they get claimed by
+/// the table (removed from consideration for prose) but never appear in any
+/// cell's text: the fragment's text is silently dropped, matching the #375
+/// root cause ("claim without capture") described for the ruling-detector
+/// case in the design doc, reproduced here via the spatial detector.
+#[test]
+fn spatial_table_drops_column_jitter_outliers() {
+    let mut frags = Vec::new();
+    // A tight, well-behaved column (x == 250.0 for every row).
+    let ys = [700.0, 680.0, 660.0, 640.0, 620.0, 600.0, 580.0, 560.0];
+    // A second column whose x drifts by 4.5pt per row (each step <= the 5.0pt
+    // column_alignment_tolerance, so cluster_columns still merges all 8 points
+    // into one cluster), spanning 31.5pt total -- enough for the two extreme
+    // rows on each end to fall outside `2 * tolerance` (10.0pt) of the
+    // resulting cluster mean.
+    let drift_xs = [100.0, 104.5, 109.0, 113.5, 118.0, 122.5, 127.0, 131.5];
+    for (i, (&y, &x)) in ys.iter().zip(drift_xs.iter()).enumerate() {
+        frags.push(frag(&format!("A{i}"), 250.0, y));
+        frags.push(frag(&format!("B{i}"), x, y));
+    }
+
+    let elements =
+        Partitioner::new(PartitionConfig::default()).partition_fragments(&frags, 0, 842.0);
+    let all: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let missing: Vec<String> = (0..8)
+        .map(|i| format!("B{i}"))
+        .filter(|tok| !all.contains(tok.as_str()))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "column-jitter outliers were claimed by the table but dropped from every cell: {missing:?}\nfull output: {all}"
+    );
+}

--- a/oxidize-pdf-core/tests/partition_confidence_test.rs
+++ b/oxidize-pdf-core/tests/partition_confidence_test.rs
@@ -210,13 +210,12 @@ fn test_kv_confidence_minimum_is_0_5() {
 // Cycle 2.5
 #[test]
 fn test_table_element_confidence_is_not_overridden() {
-    let table = Element::Table(TableElementData {
-        rows: vec![vec!["A".to_string(), "B".to_string()]],
-        structure: None,
-        metadata: ElementMetadata {
+    let table = Element::Table(TableElementData::new(
+        vec![vec!["A".to_string(), "B".to_string()]],
+        ElementMetadata {
             confidence: 0.7,
             ..Default::default()
         },
-    });
+    ));
     assert!((table.metadata().confidence - 0.7).abs() < f64::EPSILON);
 }

--- a/oxidize-pdf-core/tests/partition_confidence_test.rs
+++ b/oxidize-pdf-core/tests/partition_confidence_test.rs
@@ -212,6 +212,7 @@ fn test_kv_confidence_minimum_is_0_5() {
 fn test_table_element_confidence_is_not_overridden() {
     let table = Element::Table(TableElementData {
         rows: vec![vec!["A".to_string(), "B".to_string()]],
+        structure: None,
         metadata: ElementMetadata {
             confidence: 0.7,
             ..Default::default()

--- a/oxidize-pdf-core/tests/pipeline_export_test.rs
+++ b/oxidize-pdf-core/tests/pipeline_export_test.rs
@@ -62,6 +62,7 @@ fn test_export_table_pipe_format() {
             vec!["Alice".to_string(), "30".to_string()],
             vec!["Bob".to_string(), "25".to_string()],
         ],
+        structure: None,
         metadata: meta(),
     })];
     let output = exporter.export(&elements);

--- a/oxidize-pdf-core/tests/pipeline_export_test.rs
+++ b/oxidize-pdf-core/tests/pipeline_export_test.rs
@@ -56,15 +56,14 @@ fn test_export_paragraph_produces_plain_text() {
 #[test]
 fn test_export_table_pipe_format() {
     let exporter = ElementMarkdownExporter::default();
-    let elements = vec![Element::Table(TableElementData {
-        rows: vec![
+    let elements = vec![Element::Table(TableElementData::new(
+        vec![
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
             vec!["Bob".to_string(), "25".to_string()],
         ],
-        structure: None,
-        metadata: meta(),
-    })];
+        meta(),
+    ))];
     let output = exporter.export(&elements);
     assert!(output.contains("| Name | Age |"));
     assert!(output.contains("| --- | --- |"));

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -398,6 +398,7 @@ fn test_element_type_names_for_all_variants() {
             "table",
             Element::Table(TableElementData {
                 rows: vec![vec!["a".into()]],
+                structure: None,
                 metadata: md.clone(),
             }),
         ),

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -396,11 +396,7 @@ fn test_element_type_names_for_all_variants() {
         ),
         (
             "table",
-            Element::Table(TableElementData {
-                rows: vec![vec!["a".into()]],
-                structure: None,
-                metadata: md.clone(),
-            }),
+            Element::Table(TableElementData::new(vec![vec!["a".into()]], md.clone())),
         ),
     ];
 

--- a/oxidize-pdf-core/tests/semantic_chunking_test.rs
+++ b/oxidize-pdf-core/tests/semantic_chunking_test.rs
@@ -69,6 +69,7 @@ fn test_semantic_chunk_table_stays_whole() {
                 vec!["1".into(), "2".into()],
                 vec!["3".into(), "4".into()],
             ],
+            structure: None,
             metadata: ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 600.0, 400.0, 100.0),
@@ -95,6 +96,7 @@ fn test_semantic_chunk_large_table_allowed_to_overflow() {
         rows: (0..50)
             .map(|i| vec![format!("cell_{}_0", i), format!("cell_{}_1", i)])
             .collect(),
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 100.0, 400.0, 500.0),

--- a/oxidize-pdf-core/tests/semantic_chunking_test.rs
+++ b/oxidize-pdf-core/tests/semantic_chunking_test.rs
@@ -63,19 +63,18 @@ fn test_semantic_chunk_title_not_split() {
 fn test_semantic_chunk_table_stays_whole() {
     let elements = vec![
         para("Before table.", 0, 750.0),
-        Element::Table(TableElementData {
-            rows: vec![
+        Element::Table(TableElementData::new(
+            vec![
                 vec!["A".into(), "B".into()],
                 vec!["1".into(), "2".into()],
                 vec!["3".into(), "4".into()],
             ],
-            structure: None,
-            metadata: ElementMetadata {
+            ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 600.0, 400.0, 100.0),
                 ..Default::default()
             },
-        }),
+        )),
         para("After table.", 0, 450.0),
     ];
 
@@ -92,17 +91,16 @@ fn test_semantic_chunk_table_stays_whole() {
 
 #[test]
 fn test_semantic_chunk_large_table_allowed_to_overflow() {
-    let big_table = Element::Table(TableElementData {
-        rows: (0..50)
+    let big_table = Element::Table(TableElementData::new(
+        (0..50)
             .map(|i| vec![format!("cell_{}_0", i), format!("cell_{}_1", i)])
             .collect(),
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 100.0, 400.0, 500.0),
             ..Default::default()
         },
-    });
+    ));
 
     let chunks =
         SemanticChunker::new(SemanticChunkConfig::new(20).with_overlap(0)).chunk(&[big_table]);


### PR DESCRIPTION
Addresses #375. **First PR of the 4.0.0 major cycle** (target: `develop`).

## What

RAG table extraction quality + a data-loss safety net, delivered as one block:

1. **Data-loss safety net (priority).** A detected table now claims only the fragments it actually placed in a cell (both ruling and spatial detectors); text inside the table bounding box but not in any cell falls back to prose instead of being silently dropped. Near-empty tables (< 2 populated cells) decompose to prose. Guarded by a new **text-conservation invariant** test.
2. **Rich table model (additive at the value level).** Merged cells (rowspan/colspan) and header rows are represented via a new `TableStructure` / `RichCell` model on `TableElementData.structure`, populated from **hard signals only**: drawn-grid dividers (merged cells, union-find over base cells) and PDF structure tags (header rows). Multi-level headers = header rows + merged cells. The flat `rows` view is derived from it (spanned values repeated).
3. **Outputs.** GFM export collapses multi-level headers (joined with `›`) and repeats merged-cell values; RAG chunk metadata (`table_rows`/`table_cols`) counts the rich geometry.

Borderless tables and un-tagged multi-level headers stay flat — documented in `docs/TABLE_DETECTION_GUIDE.md` and the module rustdoc.

## ⚠️ BREAKING — why this is 4.0.0

`TableElementData` (`pipeline`) and `DetectedTable` / `TableCell` (`text::table_detection`) gain public fields and are now `#[non_exhaustive]`. External struct-literal construction / exhaustive matching no longer compiles — same change (and migration) the project shipped for `CidMapping` in v3.0.0. **Migration:** construct via `TableElementData::new(rows, metadata)` / `TableElementData::from_structure(structure, metadata)`, `TableCell::new(..)`, `DetectedTable::new(..)`. `RichCell` / `TableStructure` are new and intentionally left freely constructible.

## Verification

- Full lib suite **6613/0**; #375 + table integration targets all green; MSRV **1.88** `--all-features --locked` clean; clippy `-D warnings` + fmt clean.
- Design + plan: `docs/superpowers/specs/2026-07-09-issue-375-table-extraction-quality-design.md`, `docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md`.
- Reviewed task-by-task + final whole-branch quality-rust pass (verdict READY, no Critical/Important after fixes) + Kripteia test-quality (all files 87–100).

## Part of the 4.0.0 bundle

Follow-up branches to land on `develop` before the release: `#[non_exhaustive]` blindaje sweep of remaining public output structs, #408 (reorder_columns double-sort corruption), #382 (extract_from_page memory bound), #376 (RAG contextual chunks). Version bump to 4.0.0 at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
