### PR TITLE
feat(#382): bound per-page peak memory in extract_from_page

### DIFF
--- a/oxidize-pdf-core/src/operations/source_highlighter.rs
+++ b/oxidize-pdf-core/src/operations/source_highlighter.rs
@@ -339,7 +339,11 @@ mod tests {
             .map(|f| f.text.as_str())
             .collect::<Vec<_>>()
             .join(" ");
-        ExtractedText { text, fragments }
+        ExtractedText {
+            text,
+            fragments,
+            truncated: false,
+        }
     }
 
     #[test]
@@ -347,6 +351,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -367,6 +372,7 @@ mod tests {
                 make_fragment("World", 160.0, 700.0, 55.0, 12.0),
                 make_fragment("Test", 225.0, 700.0, 40.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -383,10 +389,12 @@ mod tests {
         let page1 = ExtractedText {
             text: "Page one".to_string(),
             fragments: vec![make_fragment("Page one", 72.0, 700.0, 80.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "Page two".to_string(),
             fragments: vec![make_fragment("Page two", 72.0, 700.0, 80.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2]);
 
@@ -405,6 +413,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -417,6 +426,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -434,6 +444,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -477,6 +488,7 @@ mod tests {
         let page1 = ExtractedText {
             text: "AAA".to_string(),
             fragments: vec![make_fragment("AAA", 72.0, 700.0, 30.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "BBB CCC".to_string(),
@@ -484,6 +496,7 @@ mod tests {
                 make_fragment("BBB", 72.0, 700.0, 30.0, 12.0),
                 make_fragment("CCC", 110.0, 700.0, 30.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2]);
 
@@ -502,14 +515,17 @@ mod tests {
         let page1 = ExtractedText {
             text: "ABCDE".to_string(), // 5 chars
             fragments: vec![make_fragment("ABCDE", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "FGHIJ".to_string(), // 5 chars
             fragments: vec![make_fragment("FGHIJ", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let page3 = ExtractedText {
             text: "KLMNO".to_string(), // 5 chars
             fragments: vec![make_fragment("KLMNO", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2, page3]);
 
@@ -532,6 +548,7 @@ mod tests {
                 make_fragment("", 130.0, 700.0, 10.0, 12.0), // empty fragment
                 make_fragment("World", 145.0, 700.0, 55.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -551,6 +568,7 @@ mod tests {
                 make_fragment("CCC", 150.0, 700.0, 30.0, 12.0),
                 make_fragment("DDD", 190.0, 700.0, 30.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -76,6 +76,30 @@ pub struct ExtractionOptions {
     /// the layout path's reconstruction, not stream order); `.fragments` stays
     /// empty.
     pub reorder_columns: bool,
+    /// Stop accumulating decoded text for a page once this many bytes have been
+    /// collected, bounding the per-page peak memory of extraction. The limit is
+    /// enforced *during* accumulation, not by truncating the finished string, so
+    /// a single page with a huge or adversarially inflated content stream cannot
+    /// materialise an unbounded `String` before the caller sees it (issue #382).
+    ///
+    /// Semantics are *undershoot*: extraction stops before the fragment that
+    /// would push the accumulated bytes past the limit, so the returned
+    /// `text.len() <= max_extracted_bytes` and a multi-byte UTF-8 character is
+    /// never split. When the limit cuts extraction short,
+    /// [`ExtractedText::truncated`] is set to `true`.
+    ///
+    /// `None` (default) means no limit — output is byte-identical to before.
+    /// The `text.len() <= max_extracted_bytes` invariant holds on **every** path
+    /// (flat, `reorder_columns`, `preserve_layout`): the layout paths rebuild
+    /// `.text` from the already-bounded fragment set and are then clamped to the
+    /// limit at a UTF-8 char boundary as a final safety net.
+    ///
+    /// Because whole decoded runs are the unit of truncation, a page whose text
+    /// is a single run larger than the whole budget (e.g. one huge `Tj`, or an
+    /// `/ActualText` override) comes back with `text == ""` and
+    /// `truncated == true` rather than a partial run — the limit is never
+    /// satisfied by splitting a run mid-character.
+    pub max_extracted_bytes: Option<usize>,
 }
 
 impl Default for ExtractionOptions {
@@ -93,6 +117,7 @@ impl Default for ExtractionOptions {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         }
     }
 }
@@ -104,6 +129,11 @@ pub struct ExtractedText {
     pub text: String,
     /// Text fragments with position information (if preserve_layout is true)
     pub fragments: Vec<TextFragment>,
+    /// `true` when extraction stopped early because
+    /// [`ExtractionOptions::max_extracted_bytes`] was reached, so `text` is a
+    /// bounded prefix of the page's full text rather than the whole page
+    /// (issue #382). Always `false` when no limit is set.
+    pub truncated: bool,
 }
 
 /// Metadata about a space insertion decision during text extraction.
@@ -275,6 +305,10 @@ struct OpRunState {
     last_y: f64,
     extracted_text: String,
     fragments: Vec<TextFragment>,
+    /// Set once the per-page byte budget (`max_extracted_bytes`) has cut text
+    /// accumulation short. Propagates through Form XObject recursion and into
+    /// [`ExtractedText::truncated`] (issue #382).
+    truncated: bool,
 }
 
 impl Default for TextState {
@@ -707,6 +741,7 @@ impl TextExtractor {
             last_y,
             extracted_text,
             fragments,
+            truncated: false,
         };
 
         // Process each content stream
@@ -749,11 +784,18 @@ impl TextExtractor {
                 page_index,
                 0,
             )?;
+
+            // Per-page byte budget reached (issue #382): don't decode the
+            // remaining content streams — the text is already at the limit.
+            if run.truncated {
+                break;
+            }
         }
 
         let OpRunState {
             mut extracted_text,
             mut fragments,
+            mut truncated,
             ..
         } = run;
         {
@@ -805,11 +847,22 @@ impl TextExtractor {
                 extracted_text = self.reconstruct_text_from_fragments(&fragments);
                 fragments.clear();
             }
+
+            // Final safety net (issue #382): the layout/reorder reconstruction
+            // above rebuilds `.text` with its own separators, so guarantee the
+            // `text.len() <= max_extracted_bytes` invariant for every path here.
+            // No-op for the flat path (already bounded) and when no limit is set.
+            clamp_to_budget(
+                &mut extracted_text,
+                self.options.max_extracted_bytes,
+                &mut truncated,
+            );
         }
 
         Ok(ExtractedText {
             text: extracted_text,
             fragments,
+            truncated,
         })
     }
 
@@ -832,6 +885,7 @@ impl TextExtractor {
             mut last_y,
             mut extracted_text,
             mut fragments,
+            mut truncated,
         } = run;
 
         let page_properties: Option<&crate::parser::objects::PdfDictionary> =
@@ -842,6 +896,12 @@ impl TextExtractor {
 
         let _ops_span = tracing::info_span!("text_ops_loop").entered();
         for op in operations {
+            // Per-page byte budget reached (issue #382): stop processing further
+            // operators. Show-text arms also `break` mid-run, but a state-only
+            // op between two show ops would otherwise keep the loop alive.
+            if truncated {
+                break;
+            }
             match op {
                 ContentOperation::BeginText => {
                     in_text_object = true;
@@ -896,26 +956,42 @@ impl TextExtractor {
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
 
                         // Add spacing based on position change
-                        if !skip_text && !extracted_text.is_empty() {
-                            let dx = x - last_x;
-                            let dy = (y - last_y).abs();
-
-                            // A large backward jump in x is a line wrap: the pen
-                            // returns to the left margin on a new line. When the
-                            // line height is below `newline_threshold` the dy check
-                            // alone misses it, so treat a backward dx beyond one
-                            // line-height (2× the threshold, conservative) as a
-                            // newline regardless of dy (issue #390).
-                            let line_wrap = dx < -(self.options.newline_threshold * 2.0);
-                            if dy > self.options.newline_threshold || line_wrap {
-                                extracted_text.push('\n');
-                            } else if dx > self.options.space_threshold * state.font_size {
-                                extracted_text.push(' ');
-                            }
-                        }
-
                         if !skip_text {
-                            extracted_text.push_str(&decoded);
+                            let separator = if !extracted_text.is_empty() {
+                                let dx = x - last_x;
+                                let dy = (y - last_y).abs();
+
+                                // A large backward jump in x is a line wrap: the
+                                // pen returns to the left margin on a new line.
+                                // When the line height is below `newline_threshold`
+                                // the dy check alone misses it, so treat a backward
+                                // dx beyond one line-height (2× the threshold,
+                                // conservative) as a newline regardless of dy
+                                // (issue #390).
+                                let line_wrap = dx < -(self.options.newline_threshold * 2.0);
+                                if dy > self.options.newline_threshold || line_wrap {
+                                    Some('\n')
+                                } else if dx > self.options.space_threshold * state.font_size {
+                                    Some(' ')
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
+
+                            // Per-page byte budget (issue #382): stop before the
+                            // run that would overshoot; the outer loop guard ends
+                            // extraction on the next iteration.
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
+                            }
                         }
 
                         // Get font info for accurate width calculation.
@@ -985,16 +1061,26 @@ impl TextExtractor {
                                     // kern, so it is safe to break there.
                                     let line_wrap =
                                         (x - last_x) < -(self.options.newline_threshold * 2.0);
-                                    if !skip_text
-                                        && !extracted_text.is_empty()
-                                        && ((y - last_y).abs() > self.options.newline_threshold
-                                            || line_wrap)
-                                    {
-                                        extracted_text.push('\n');
-                                    }
-
                                     if !skip_text {
-                                        extracted_text.push_str(&decoded);
+                                        let separator = if !extracted_text.is_empty()
+                                            && ((y - last_y).abs() > self.options.newline_threshold
+                                                || line_wrap)
+                                        {
+                                            Some('\n')
+                                        } else {
+                                            None
+                                        };
+
+                                        // Per-page byte budget (issue #382).
+                                        if !append_bounded(
+                                            &mut extracted_text,
+                                            separator,
+                                            &decoded,
+                                            self.options.max_extracted_bytes,
+                                            &mut truncated,
+                                        ) {
+                                            break;
+                                        }
                                     }
 
                                     let text_width = {
@@ -1046,7 +1132,18 @@ impl TextExtractor {
                                         && !extracted_text.is_empty()
                                         && !extracted_text.ends_with(' ')
                                     {
-                                        extracted_text.push(' ');
+                                        // Per-page byte budget (issue #382): even
+                                        // the synthesised space counts, so the
+                                        // `text.len() <= limit` invariant holds.
+                                        if !append_bounded(
+                                            &mut extracted_text,
+                                            Some(' '),
+                                            "",
+                                            self.options.max_extracted_bytes,
+                                            &mut truncated,
+                                        ) {
+                                            break;
+                                        }
 
                                         // Skip the fragment-level emission while an
                                         // ActualText scope is pending: the synthesised
@@ -1106,10 +1203,21 @@ impl TextExtractor {
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
                         if !skip_text {
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
+                            let separator = if extracted_text.is_empty() {
+                                None
+                            } else {
+                                Some('\n')
+                            };
+                            // Per-page byte budget (issue #382).
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
                             }
-                            extracted_text.push_str(&decoded);
                         }
 
                         let text_width = {
@@ -1163,10 +1271,21 @@ impl TextExtractor {
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
                         if !skip_text {
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
+                            let separator = if extracted_text.is_empty() {
+                                None
+                            } else {
+                                Some('\n')
+                            };
+                            // Per-page byte budget (issue #382).
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
                             }
-                            extracted_text.push_str(&decoded);
                         }
 
                         let text_width = {
@@ -1341,6 +1460,25 @@ impl TextExtractor {
                                 let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
                                 let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
+                                    // Per-page byte budget (issue #382): the
+                                    // `/ActualText` override is this scope's
+                                    // canonical text and can be arbitrarily
+                                    // large. It bypasses the per-`Tj`
+                                    // `append_bounded` gate, so account it here
+                                    // against the same ledger (`extracted_text`,
+                                    // which these paths rebuild from `fragments`).
+                                    // If it would overshoot, drop the fragment and
+                                    // stop — a huge override must not escape the
+                                    // cap while reporting `truncated = false`.
+                                    if !append_bounded(
+                                        &mut extracted_text,
+                                        None,
+                                        &run.text,
+                                        self.options.max_extracted_bytes,
+                                        &mut truncated,
+                                    ) {
+                                        break;
+                                    }
                                     fragments.push(TextFragment {
                                         text: run.text,
                                         x: run.first_x,
@@ -1402,6 +1540,7 @@ impl TextExtractor {
                                 last_y,
                                 extracted_text,
                                 fragments,
+                                truncated,
                             };
                             let mut out = self.process_operations(
                                 xobj_ops,
@@ -1422,6 +1561,7 @@ impl TextExtractor {
                             last_y = out.last_y;
                             extracted_text = out.extracted_text;
                             fragments = out.fragments;
+                            truncated = out.truncated;
                         }
                     }
                 }
@@ -1438,6 +1578,7 @@ impl TextExtractor {
             last_y,
             extracted_text,
             fragments,
+            truncated,
         })
     }
 
@@ -2022,6 +2163,65 @@ fn skip_artifact_text(state: &TextState, include_artifacts: bool) -> bool {
     !include_artifacts && state.mc_stack.iter().any(|e| e.is_artifact)
 }
 
+/// Append an optional `separator` plus `decoded` to `acc`, honouring the
+/// per-page byte budget `limit` (issue #382).
+///
+/// Returns `true` when the run was appended. Returns `false` — appending
+/// nothing and setting `*truncated` — when the combined bytes would exceed
+/// `limit`. The separator is counted against the budget so the invariant
+/// `acc.len() <= limit` holds *exactly*, and because whole runs are the unit of
+/// truncation a multi-byte UTF-8 character is never split (undershoot
+/// semantics). A `None` limit always appends and never truncates, keeping the
+/// no-limit path byte-identical to before. Once `*truncated` is set the helper
+/// is a no-op, so a caller that keeps calling it after the budget is reached
+/// simply accumulates nothing further.
+fn append_bounded(
+    acc: &mut String,
+    separator: Option<char>,
+    decoded: &str,
+    limit: Option<usize>,
+    truncated: &mut bool,
+) -> bool {
+    if *truncated {
+        return false;
+    }
+    if let Some(max) = limit {
+        let add = separator.map_or(0, char::len_utf8) + decoded.len();
+        if acc.len() + add > max {
+            *truncated = true;
+            return false;
+        }
+    }
+    if let Some(sep) = separator {
+        acc.push(sep);
+    }
+    acc.push_str(decoded);
+    true
+}
+
+/// Defensive final clamp of a page's text to the byte budget (issue #382).
+///
+/// The `preserve_layout` / `reorder_columns` paths rebuild `.text` from the
+/// already-bounded fragment set via `reconstruct_text_from_fragments`, which
+/// reorders fragments and inserts its own separators — so the reconstructed
+/// length is not provably `<= limit` from the accumulation-time accounting
+/// alone. This clamps the result to `limit` at a UTF-8 char boundary (never
+/// splitting a character) and sets `*truncated` if it had to cut, making the
+/// `text.len() <= max_extracted_bytes` invariant hold for *every* path. A no-op
+/// when there is no limit or the text already fits.
+fn clamp_to_budget(text: &mut String, limit: Option<usize>, truncated: &mut bool) {
+    if let Some(max) = limit {
+        if text.len() > max {
+            let mut cut = max;
+            while cut > 0 && !text.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            text.truncate(cut);
+            *truncated = true;
+        }
+    }
+}
+
 fn emit_text_fragment(
     fragments: &mut Vec<TextFragment>,
     decoded: &str,
@@ -2559,6 +2759,99 @@ fn standard_14_space_width(base_font: &str) -> Option<f64> {
 mod tests {
     use super::*;
 
+    // ── issue #382: per-page byte-budget helper ──────────────────────────────
+
+    #[test]
+    fn test_append_bounded_no_limit_always_appends() {
+        let mut s = String::new();
+        let mut trunc = false;
+        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc));
+        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc));
+        assert_eq!(s, "hello world");
+        assert!(!trunc, "no limit never truncates");
+    }
+
+    #[test]
+    fn test_append_bounded_undershoot_counts_separator() {
+        // "abcd" (4) is at budget 5; a Some('\n') + "x" would need 2 more → over.
+        let mut s = String::from("abcd");
+        let mut trunc = false;
+        assert!(!append_bounded(
+            &mut s,
+            Some('\n'),
+            "x",
+            Some(5),
+            &mut trunc
+        ));
+        assert_eq!(s, "abcd", "nothing appended when it would overshoot");
+        assert!(trunc, "budget hit sets truncated");
+        // Exactly-fits case: "e" alone (1 byte, no separator) reaches 5.
+        let mut s2 = String::from("abcd");
+        let mut t2 = false;
+        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2));
+        assert_eq!(s2, "abcde");
+        assert!(!t2);
+        assert!(s2.len() <= 5, "invariant: len <= limit exactly");
+    }
+
+    #[test]
+    fn test_append_bounded_zero_limit_truncates_immediately() {
+        let mut s = String::new();
+        let mut trunc = false;
+        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc));
+        assert!(s.is_empty());
+        assert!(trunc);
+    }
+
+    #[test]
+    fn test_append_bounded_is_noop_once_truncated() {
+        let mut s = String::from("kept");
+        let mut trunc = true; // already truncated
+        assert!(!append_bounded(
+            &mut s,
+            None,
+            "more",
+            Some(1_000),
+            &mut trunc
+        ));
+        assert_eq!(s, "kept", "no further accumulation after truncation");
+    }
+
+    #[test]
+    fn test_clamp_to_budget_no_limit_or_fits_is_noop() {
+        let mut a = String::from("hello");
+        let mut t = false;
+        clamp_to_budget(&mut a, None, &mut t);
+        assert_eq!(a, "hello");
+        assert!(!t, "no limit never truncates");
+
+        let mut b = String::from("hi");
+        clamp_to_budget(&mut b, Some(10), &mut t);
+        assert_eq!(b, "hi", "already fits");
+        assert!(!t);
+    }
+
+    #[test]
+    fn test_clamp_to_budget_cuts_and_flags() {
+        let mut s = String::from("abcdefgh");
+        let mut t = false;
+        clamp_to_budget(&mut s, Some(3), &mut t);
+        assert_eq!(s, "abc");
+        assert!(t, "clamp that cut must set truncated");
+    }
+
+    #[test]
+    fn test_clamp_to_budget_never_splits_utf8() {
+        // "é" is 2 bytes (0xC3 0xA9). A 3-byte budget on "éé" (4 bytes) must cut
+        // back to the char boundary at 2, keeping one whole "é".
+        let mut s = String::from("éé");
+        let mut t = false;
+        clamp_to_budget(&mut s, Some(3), &mut t);
+        assert_eq!(s, "é", "must retreat to a char boundary, not split 'é'");
+        assert!(s.len() <= 3);
+        assert!(t);
+    }
+
     #[test]
     fn test_matrix_multiplication() {
         let identity = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -2606,6 +2899,7 @@ mod tests {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         };
         assert!(options.preserve_layout);
         assert_eq!(options.space_threshold, 0.5);
@@ -2734,6 +3028,7 @@ mod tests {
         let extracted = ExtractedText {
             text: "Hello World".to_string(),
             fragments: fragments,
+            truncated: false,
         };
 
         assert_eq!(extracted.text, "Hello World");
@@ -2807,6 +3102,7 @@ mod tests {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         };
         let extractor = TextExtractor::with_options(options.clone());
         assert_eq!(extractor.options.preserve_layout, options.preserve_layout);

--- a/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
+++ b/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
@@ -1,0 +1,412 @@
+//! Regression / feature tests for issue #382 — `extract_from_page` had no
+//! per-page text-length limit, so a single page with a huge content stream
+//! materialised the whole decoded string in RAM before the caller saw it.
+//!
+//! `ExtractionOptions::max_extracted_bytes` caps the bytes of decoded text
+//! accumulated for one page. The cap is enforced *during* accumulation (not by
+//! truncating the finished string), so it bounds peak RAM. When the cap cuts
+//! extraction short, `ExtractedText::truncated` is `true`.
+//!
+//! Semantics are *undershoot*: extraction stops before the fragment that would
+//! push the accumulated bytes over the limit, so `text.len() <= limit` and a
+//! multi-byte UTF-8 character is never split.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractedText, ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid single-page PDF whose content stream is `content`.
+/// `/F1` maps to Helvetica (Type1) so decoding is trivial (1 byte → 1 char).
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+/// A page with `lines` separate `Tj` show operators, each drawing `chunk`
+/// (ASCII, so one byte of content stream = one byte of decoded text). Each
+/// operator is its own text fragment, so the undershoot boundary is exercised
+/// at fragment granularity.
+fn build_repeated_text(chunk: &str, lines: usize) -> String {
+    let mut c = String::new();
+    let mut y = 760.0_f64;
+    for _ in 0..lines {
+        c.push_str(&format!(
+            "BT\n/F1 12 Tf\n1 0 0 1 72 {y:.2} Tm\n({chunk}) Tj\nET\n"
+        ));
+        y -= 14.0;
+        if y < 20.0 {
+            y = 760.0;
+        }
+    }
+    c
+}
+
+// ── Cycle 1: cap bounds the flat (default) path and sets the flag ────────────
+
+#[test]
+fn test_bounds_flat_text_and_sets_flag() {
+    // 40 fragments × 50 chars ≈ 2 KB of decoded text (plus newlines the
+    // extractor inserts between fragments on separate lines).
+    let content = build_repeated_text(&"A".repeat(50), 40);
+
+    // No limit: full text, not truncated.
+    let full = extract(&content, ExtractionOptions::default());
+    assert!(
+        full.text.len() >= 40 * 50,
+        "unbounded extraction should contain all {} chars, got {}",
+        40 * 50,
+        full.text.len()
+    );
+    assert!(
+        !full.truncated,
+        "unbounded extraction must not be truncated"
+    );
+
+    // With a 500-byte cap: bounded and flagged.
+    let opts = ExtractionOptions {
+        max_extracted_bytes: Some(500),
+        ..Default::default()
+    };
+    let capped = extract(&content, opts);
+    assert!(
+        capped.text.len() <= 500,
+        "capped text must be <= 500 bytes, got {}",
+        capped.text.len()
+    );
+    assert!(
+        capped.truncated,
+        "capped extraction must set truncated = true"
+    );
+    // Content check (not just length): the kept text is a genuine prefix of the
+    // full extraction — extraction stopped early, it did not reorder or mangle.
+    assert!(
+        full.text.starts_with(&capped.text),
+        "capped text must be a prefix of the full text"
+    );
+    assert!(!capped.text.is_empty(), "a 500-byte cap keeps some text");
+}
+
+// ── Cycle 2: the cap flows through the reorder / preserve-layout paths ────────
+
+#[test]
+fn test_bounds_reorder_and_preserve_layout() {
+    let content = build_repeated_text(&"B".repeat(40), 40);
+
+    for (label, mut opts) in [
+        ("reorder_columns", ExtractionOptions::default()),
+        ("preserve_layout", ExtractionOptions::default()),
+    ] {
+        match label {
+            "reorder_columns" => opts.reorder_columns = true,
+            _ => opts.preserve_layout = true,
+        }
+
+        let full = extract(&content, opts.clone());
+        assert!(!full.truncated, "{label}: unbounded must not be truncated");
+
+        opts.max_extracted_bytes = Some(400);
+        let capped = extract(&content, opts);
+
+        // The flag is authoritative for every path.
+        assert!(
+            capped.truncated,
+            "{label}: capped extraction must set truncated"
+        );
+        // These paths rebuild `.text` from the already-bounded fragment set and
+        // insert their own separators, but the final `clamp_to_budget` safety
+        // net guarantees the hard invariant on every path, not just the flat one.
+        assert!(
+            capped.text.len() <= 400,
+            "{label}: capped text ({}) must respect the 400-byte cap",
+            capped.text.len()
+        );
+        assert!(
+            capped.text.len() < full.text.len(),
+            "{label}: capped text ({}) must be shorter than full ({})",
+            capped.text.len(),
+            full.text.len()
+        );
+        assert!(
+            !capped.text.is_empty(),
+            "{label}: a 400-byte cap keeps text"
+        );
+    }
+}
+
+// ── Cycle 3: the cap never splits a multi-byte UTF-8 character ────────────────
+
+/// `build_pdf`, but the content stream is raw bytes so we can embed WinAnsi
+/// high bytes (e.g. `0xE9` → `é`) that decode to multi-byte UTF-8.
+fn build_pdf_bytes(content: &[u8]) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+              /Encoding /WinAnsiEncoding >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(format!("5 0 obj\n<< /Length {clen} >>\nstream\n").as_bytes());
+    buf.extend_from_slice(content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_bytes(content: &[u8], opts: ExtractionOptions) -> ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf_bytes(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+#[test]
+fn test_never_splits_utf8() {
+    // Each `Tj` draws 10 × `0xE9` (WinAnsi 'é', 2 UTF-8 bytes each → 20 bytes of
+    // decoded text per fragment). A 45-byte cap lands *inside* the third
+    // fragment; undershoot must drop that whole fragment, never half a 'é'.
+    let mut content = Vec::<u8>::new();
+    let mut y = 760.0_f64;
+    for _ in 0..20 {
+        content.extend_from_slice(format!("BT\n/F1 12 Tf\n1 0 0 1 72 {y:.2} Tm\n(").as_bytes());
+        content.extend(std::iter::repeat_n(0xE9u8, 10));
+        content.extend_from_slice(b") Tj\nET\n");
+        y -= 14.0;
+    }
+
+    // Sanity: unbounded decode really produced multi-byte 'é'.
+    let full = extract_bytes(&content, ExtractionOptions::default());
+    assert!(
+        full.text.contains('é'),
+        "fixture must decode WinAnsi 0xE9 to 'é', got {:?}",
+        full.text.chars().take(8).collect::<String>()
+    );
+    assert!(!full.truncated);
+
+    let opts = ExtractionOptions {
+        max_extracted_bytes: Some(45),
+        ..Default::default()
+    };
+    let capped = extract_bytes(&content, opts);
+
+    // No panic, valid UTF-8 (String guarantees it), and bounded.
+    assert!(
+        capped.truncated,
+        "45-byte cap on 20-byte fragments must truncate"
+    );
+    assert!(
+        capped.text.len() <= 45,
+        "flat path holds text.len() <= limit"
+    );
+    // Undershoot at fragment granularity: the kept text is a whole number of
+    // fragments, so every 'é' is complete — assert no lone continuation byte.
+    assert!(
+        std::str::from_utf8(capped.text.as_bytes()).is_ok(),
+        "text must be valid UTF-8"
+    );
+    assert!(
+        full.text.starts_with(&capped.text),
+        "capped text is a clean prefix, no split char"
+    );
+}
+
+// ── Cycle 4: zero budget and empty page ──────────────────────────────────────
+
+#[test]
+fn test_zero_budget_and_empty_page() {
+    // Some(0): a page with text yields empty output, flagged truncated.
+    let content = build_repeated_text(&"C".repeat(20), 5);
+    let zero = extract(
+        &content,
+        ExtractionOptions {
+            max_extracted_bytes: Some(0),
+            ..Default::default()
+        },
+    );
+    assert!(
+        zero.text.is_empty(),
+        "Some(0) keeps no text, got {:?}",
+        zero.text
+    );
+    assert!(zero.truncated, "Some(0) on a non-empty page is truncated");
+
+    // Empty page (no show-text ops): never truncated, whatever the limit.
+    let empty_page = "BT\n/F1 12 Tf\n1 0 0 1 72 700 Tm\nET\n";
+    let empty = extract(
+        empty_page,
+        ExtractionOptions {
+            max_extracted_bytes: Some(100),
+            ..Default::default()
+        },
+    );
+    assert!(empty.text.is_empty(), "no show-text → no text");
+    assert!(!empty.truncated, "a page with no text is never truncated");
+}
+
+// ── Cycle 5: composes with a document-level output budget (the issue's loop) ──
+
+#[test]
+fn test_composes_with_document_budget() {
+    // The issue's motivating loop: a per-page cap bounds each page's peak, while
+    // the caller keeps its own document-level output budget. Here we drive one
+    // page repeatedly (a stand-in for a multi-page document) and confirm every
+    // page is individually bounded and correctly flagged.
+    let content = build_repeated_text(&"D".repeat(60), 30);
+    let per_page_cap = 300usize;
+
+    let mut doc_budget = 1000usize;
+    let mut out = String::new();
+    let mut any_page_truncated = false;
+
+    for _ in 0..5 {
+        let page = extract(
+            &content,
+            ExtractionOptions {
+                max_extracted_bytes: Some(per_page_cap),
+                ..Default::default()
+            },
+        );
+        // Per-page peak is bounded regardless of the document budget.
+        assert!(
+            page.text.len() <= per_page_cap,
+            "each page must respect the per-page cap"
+        );
+        assert!(page.truncated, "each dense page hits the per-page cap");
+        any_page_truncated |= page.truncated;
+
+        // Caller's document-level truncation still composes on top.
+        let take = page.text.len().min(doc_budget);
+        out.push_str(&page.text[..take]);
+        doc_budget -= take;
+        if doc_budget == 0 {
+            break;
+        }
+    }
+
+    assert!(any_page_truncated);
+    assert!(out.len() <= 1000, "document output budget is respected");
+    assert!(!out.is_empty());
+}
+
+// ── Cycle 6: /ActualText override cannot bypass the budget (QR critical #1) ────
+
+#[test]
+fn test_actualtext_scope_respects_budget() {
+    // A single marked-content scope declaring an inline `/ActualText` string of
+    // 4000 bytes, populated by one tiny `Tj`. On the layout / reorder paths the
+    // scope's fragment text is the *declared* string, and `.text` is rebuilt
+    // from fragments — so without budgeting this leaks the whole 4000 bytes with
+    // `truncated == false`. This is the adversarial single-operator case #382
+    // exists to defend against.
+    let big = "Z".repeat(4000);
+    let content = format!(
+        "BT\n/F1 12 Tf\n1 0 0 1 72 700 Tm\n\
+         /Span << /ActualText ({big}) >> BDC\n(x) Tj\nEMC\nET\n"
+    );
+
+    for (label, base) in [
+        ("preserve_layout", {
+            let mut o = ExtractionOptions::default();
+            o.preserve_layout = true;
+            o
+        }),
+        ("reorder_columns", {
+            let mut o = ExtractionOptions::default();
+            o.reorder_columns = true;
+            o
+        }),
+    ] {
+        // Unbounded: the ActualText override does surface (sanity that the
+        // fixture exercises the ActualText path at all).
+        let full = extract(&content, base.clone());
+        assert!(
+            full.text.len() >= 4000,
+            "{label}: fixture must exercise ActualText (got {} bytes)",
+            full.text.len()
+        );
+        assert!(!full.truncated, "{label}: unbounded not truncated");
+
+        // Bounded: the override must NOT escape the cap, and the flag must tell
+        // the truth.
+        let mut opts = base;
+        opts.max_extracted_bytes = Some(50);
+        let capped = extract(&content, opts);
+        assert!(
+            capped.text.len() <= 50,
+            "{label}: ActualText must not bypass the 50-byte cap, got {}",
+            capped.text.len()
+        );
+        assert!(
+            capped.truncated,
+            "{label}: a bypassed budget must still report truncated"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ExtractionOptions.max_extracted_bytes: Option<usize>` and `ExtractedText.truncated: bool` so callers can bound the per-page **peak** memory of text extraction (issue #382, reporter @oshtivi).

The cap is enforced **during** accumulation (helper `append_bounded` at the four show-text operator arms + the TJ synthetic space), not by truncating the finished string — so a page with a huge or adversarially inflated content stream cannot materialise an unbounded `String` before the caller sees it.

- **Undershoot semantics**: extraction stops *before* the run that would overshoot → `text.len() <= max_extracted_bytes`, and a multi-byte UTF-8 char is never split.
- `truncated` propagates through Form XObject recursion and into **every** path (flat / `reorder_columns` / `preserve_layout` / `reconstruct_paragraphs`).
- Once truncated, the remaining content streams are not decoded (extra CPU/memory saving).
- `None` (default) is **byte-identical** to prior behaviour.

## QR (quality-rust) hardening — found via adversarial review

- **Critical**: an inline `/ActualText` marked-content override bypassed the budget — the declared string (arbitrarily large) was pushed straight to `fragments` at the EMC flush and, on the layout/reorder paths where `.text` is rebuilt from fragments, leaked unbounded with `truncated == false`. Now routed through `append_bounded`.
- **Important**: the layout/reorder reconstruction inserts its own separators, so `text.len() <= limit` was not provable from accumulation accounting alone. Added a char-boundary-safe `clamp_to_budget` safety net after reconstruction — the invariant now holds on every path.

## Tests (TDD, RED → GREEN)

`tests/issue_382_extract_page_byte_limit.rs`: flat bound+flag, reorder/preserve_layout, multi-byte UTF-8 non-split, `Some(0)` + empty page, document-budget composition, and the ActualText-bypass regression. Plus unit tests for `append_bounded` and `clamp_to_budget`.

## Verification

- lib 6618/0, no regression on issue_408 / issue_389 / issue_403 / two_column
- `clippy --all -- -D warnings`, `fmt`, MSRV 1.88 `--all-features --locked`

## Notes

- Public struct field additions → **4.0.0 MAJOR** (bundle step 2 of 4; `#[non_exhaustive]` blindaje lands at the end of the bundle).
- Addresses #382 (external reporter closes the issue).