### PR TITLE
feat(#376): first-class deterministic contextual RAG chunks (no-ML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ let config = HybridChunkConfig {
 let chunks = doc.rag_chunks_with(config)?;
 ```
 
+### Contextual Retrieval (no-ML)
+
+Prepend a deterministic context snippet to each chunk's `full_text` before
+embedding — the no-ML analogue of [Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)
+/ Late Chunking, which cut retrieval failures substantially by situating each
+chunk in its document. No LLM, no GPU: the prefix is a pure function of the
+document metadata and the chunk's heading breadcrumb, so it is fully
+reproducible (stable `chunk_id`). The display `text` field stays context-free.
+
+```rust
+use oxidize_pdf::pipeline::{ContextFormat, ContextMode, DocumentSource, HybridChunkConfig};
+
+let config = HybridChunkConfig {
+    context_mode: ContextMode::Contextual(ContextFormat::Labeled),
+    ..HybridChunkConfig::default()
+};
+let source = DocumentSource::with_file(Some("annual.pdf".into()), Some("sha256-…".into()));
+let chunks = doc.rag_chunks_with_source_and_config(source, config)?;
+
+// chunk.full_text now reads, e.g.:
+//   Document: Annual Report — Acme Corp
+//   Section: 1 Introduction › 1.2 Scope (p. 3–4)
+//
+//   <chunk text>
+```
+
+`ContextFormat::Prose` renders the same facts as one natural-language sentence.
+Modes: `ContextMode::None` (bare text), `Heading` (leaf heading only, the
+default), `Contextual(_)` (document + section prefix).
+
 ### JSON for Vector Store Ingestion
 
 ```rust

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1409,9 +1409,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Extract and chunk with a custom [`TokenCounter`](crate::pipeline::TokenCounter).
@@ -1431,9 +1432,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         counter: std::sync::Arc<dyn crate::pipeline::TokenCounter>,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config).with_token_counter(counter);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Build RAG chunks stamped with source-document metadata.
@@ -1490,9 +1492,10 @@ impl<R: Read + Seek> PdfDocument<R> {
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         self.autofill_source(&mut source);
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
+        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source), context_mode))
     }
 
     /// Fill `title`/`author`/`creation_date`/`total_pages` from the info
@@ -1605,7 +1608,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         // `mut` is needed only for the enricher pass below (gated `semantic`);
         // without that feature the binding is never mutated — silence the warning.
         #[allow(unused_mut)]
-        let mut chunks = self.build_rag_chunks(&hybrid, source);
+        let mut chunks = self.build_rag_chunks(&hybrid, source, pipeline.context_mode);
         #[cfg(feature = "semantic")]
         if !pipeline.enrichers.is_empty() {
             // Enrich each chunk's `extra` bag. The hybrid chunk (kept alongside)
@@ -1634,17 +1637,27 @@ impl<R: Read + Seek> PdfDocument<R> {
         &self,
         hybrid_chunks: &[crate::pipeline::HybridChunk],
         source: Option<crate::pipeline::DocumentSource>,
+        context_mode: crate::pipeline::ContextMode,
     ) -> Vec<crate::pipeline::RagChunk> {
         let mut chunks: Vec<crate::pipeline::RagChunk> = match &source {
             Some(s) => hybrid_chunks
                 .iter()
                 .enumerate()
-                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk_with_source(i, hc, s))
+                .map(|(i, hc)| {
+                    crate::pipeline::RagChunk::from_hybrid_chunk_with_source_and_mode(
+                        i,
+                        hc,
+                        s,
+                        context_mode,
+                    )
+                })
                 .collect(),
             None => hybrid_chunks
                 .iter()
                 .enumerate()
-                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(i, hc))
+                .map(|(i, hc)| {
+                    crate::pipeline::RagChunk::from_hybrid_chunk_with_mode(i, hc, context_mode)
+                })
                 .collect(),
         };
         crate::pipeline::chunk_metadata::link_chunks(&mut chunks);
@@ -1676,7 +1689,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         let elements = self.partition_with_profile(profile)?;
         let chunker = crate::pipeline::HybridChunker::default();
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, crate::pipeline::ContextMode::Heading))
     }
 
     /// Combine a pre-configured extraction profile with a custom chunking config.
@@ -1701,9 +1714,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition_with_profile(profile)?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Extract chunks as a JSON string ready for vector store ingestion.

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -75,8 +75,16 @@ impl Aggregates {
 }
 
 /// Boolean flags describing the kinds of content present in a chunk.
+///
+/// Pipeline output: the chunker derives these from a chunk's element types;
+/// external consumers read them off [`ChunkMetadata::content_types`]. Like the
+/// enclosing [`ChunkMetadata`], this is `#[non_exhaustive]` so future content
+/// flags (e.g. `has_formula`, `has_footnote`) can be added without a breaking
+/// change. To build one outside the crate (e.g. in a test), start from
+/// [`ContentTypeFlags::default`] and set the fields you need.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct ContentTypeFlags {
     /// The chunk contains at least one table element.
     pub has_table: bool,

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -46,6 +46,7 @@ pub enum MergePolicy {
 ///     merge_adjacent: true,
 ///     propagate_headings: true,
 ///     merge_policy: MergePolicy::AnyInlineContent,
+///     ..Default::default()
 /// };
 /// assert_eq!(config.max_tokens, 256);
 /// ```
@@ -69,6 +70,11 @@ pub struct HybridChunkConfig {
     pub propagate_headings: bool,
     /// Merge policy for adjacent elements. Default: `MergePolicy::AnyInlineContent`.
     pub merge_policy: MergePolicy,
+    /// How each chunk's `full_text` is contextualized for RAG embedding
+    /// (issue #376). Default [`ContextMode::Heading`] — byte-identical to the
+    /// pre-#376 behavior. Set [`ContextMode::Contextual`] for deterministic,
+    /// no-ML document+section context prefixes.
+    pub context_mode: ContextMode,
 }
 
 impl Default for HybridChunkConfig {
@@ -79,8 +85,40 @@ impl Default for HybridChunkConfig {
             merge_adjacent: true,
             propagate_headings: true,
             merge_policy: MergePolicy::AnyInlineContent,
+            context_mode: ContextMode::Heading,
         }
     }
+}
+
+/// How each chunk's `full_text` (the text used for RAG embedding) is
+/// contextualized (issue #376). Contextualization is deterministic and no-ML —
+/// the no-ML analogue of Contextual Retrieval / Late Chunking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContextMode {
+    /// No context prefix — `full_text == text`.
+    None,
+    /// Prepend only the leaf heading context (the pre-#376 behavior, and the
+    /// default so existing callers see byte-identical output).
+    #[default]
+    Heading,
+    /// Prepend a deterministic document + section context snippet in the given
+    /// [`ContextFormat`], situating the chunk in its document (title/author or
+    /// filename, full heading breadcrumb, optional page span).
+    Contextual(ContextFormat),
+}
+
+/// Deterministic, no-ML context-prefix format for [`ContextMode::Contextual`].
+///
+/// `#[non_exhaustive]` so future formats (e.g. structured JSON/YAML) can be
+/// added without a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContextFormat {
+    /// Labeled lines, e.g. `Document: <title> — <author>` / `Section: <breadcrumb> (p. N–M)`.
+    Labeled,
+    /// A single natural-language sentence, e.g.
+    /// `This chunk is from "<title>" by <author>, section "<breadcrumb>" (p. N–M).`
+    Prose,
 }
 
 /// A hybrid chunk: a group of elements with heading context.

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -21,7 +21,9 @@ pub use element::{
 };
 pub use export::{ElementMarkdownExporter, ExportConfig};
 pub use graph::ElementGraph;
-pub use hybrid_chunking::{HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy};
+pub use hybrid_chunking::{
+    ContextFormat, ContextMode, HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy,
+};
 pub use partition::{PartitionConfig, Partitioner, ReadingOrderStrategy};
 pub use profile::{ExtractionProfile, ProfileConfig};
 pub use rag::RagChunk;

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::pipeline::chunk_metadata::ChunkMetadata;
 use crate::pipeline::element::Element;
-use crate::pipeline::hybrid_chunking::HybridChunk;
+use crate::pipeline::hybrid_chunking::{ContextFormat, ContextMode, HybridChunk};
 use crate::pipeline::{DocumentSource, ElementBBox};
 
 #[cfg(feature = "semantic")]
@@ -54,7 +54,11 @@ pub struct RagChunk {
     pub chunk_index: usize,
     /// Chunk text content (elements joined by newlines).
     pub text: String,
-    /// Text with heading context prepended — use this for embedding generation.
+    /// Text for embedding generation, contextualized per the chunker's
+    /// [`ContextMode`](crate::pipeline::ContextMode): the bare `text`
+    /// (`None`), the leaf heading prepended (`Heading`, the default), or a
+    /// deterministic document + section prefix (`Contextual`). The display
+    /// `text` field is always context-free.
     pub full_text: String,
     /// Page numbers where this chunk's elements appear (deduplicated, sorted numerically).
     pub page_numbers: Vec<u32>,
@@ -76,30 +80,65 @@ pub struct RagChunk {
 }
 
 impl RagChunk {
-    /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its elements.
+    /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its
+    /// elements. Uses [`ContextMode::Heading`] for `full_text` (the pre-#376
+    /// behavior); use [`from_hybrid_chunk_with_mode`](Self::from_hybrid_chunk_with_mode)
+    /// to select a different [`ContextMode`].
     pub fn from_hybrid_chunk(chunk_index: usize, chunk: &HybridChunk) -> Self {
-        Self::from_hybrid_chunk_inner(chunk_index, chunk, None)
+        Self::from_hybrid_chunk_inner(chunk_index, chunk, None, ContextMode::Heading)
     }
 
     /// Like [`from_hybrid_chunk`](Self::from_hybrid_chunk) but stamping source
     /// metadata and using `source.doc_hash` for the chunk_id prefix when set.
+    /// Uses [`ContextMode::Heading`]; see
+    /// [`from_hybrid_chunk_with_source_and_mode`](Self::from_hybrid_chunk_with_source_and_mode).
     pub fn from_hybrid_chunk_with_source(
         chunk_index: usize,
         chunk: &HybridChunk,
         source: &DocumentSource,
     ) -> Self {
-        let mut c = Self::from_hybrid_chunk_inner(chunk_index, chunk, Some(source));
+        Self::from_hybrid_chunk_with_source_and_mode(
+            chunk_index,
+            chunk,
+            source,
+            ContextMode::Heading,
+        )
+    }
+
+    /// Build a `RagChunk` selecting how `full_text` is contextualized (issue #376).
+    /// No source is stamped, so `Contextual` prefixes carry section context only.
+    pub fn from_hybrid_chunk_with_mode(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        context_mode: ContextMode,
+    ) -> Self {
+        Self::from_hybrid_chunk_inner(chunk_index, chunk, None, context_mode)
+    }
+
+    /// Build a source-stamped `RagChunk` selecting how `full_text` is
+    /// contextualized (issue #376). `Contextual` prefixes draw the document
+    /// name/author from `source` and the section breadcrumb from the chunk's
+    /// elements.
+    pub fn from_hybrid_chunk_with_source_and_mode(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        source: &DocumentSource,
+        context_mode: ContextMode,
+    ) -> Self {
+        let mut c = Self::from_hybrid_chunk_inner(chunk_index, chunk, Some(source), context_mode);
         c.metadata.source = Some(source.clone());
         c
     }
 
     /// Shared constructor. `source` (when `Some`) supplies the `doc_hash` used
     /// as the chunk_id prefix, so the id is computed exactly once — callers that
-    /// also want the full source stamped do that themselves.
+    /// also want the full source stamped do that themselves. `context_mode`
+    /// selects how `full_text` is built (issue #376).
     fn from_hybrid_chunk_inner(
         chunk_index: usize,
         chunk: &HybridChunk,
         source: Option<&DocumentSource>,
+        context_mode: ContextMode,
     ) -> Self {
         let elements = chunk.elements();
         let page_numbers = collect_pages(elements);
@@ -107,7 +146,25 @@ impl RagChunk {
         let element_types: Vec<String> =
             elements.iter().map(|e| e.type_name().to_string()).collect();
         let text = chunk.text();
-        let full_text = chunk.full_text();
+        // `full_text` (the embedding text) is contextualized per `context_mode`.
+        // It is built before metadata because `ChunkMetadata::from_elements`
+        // hashes it for the content-derived `chunk_id`.
+        let full_text = match context_mode {
+            ContextMode::None => text.clone(),
+            ContextMode::Heading => chunk.full_text(),
+            ContextMode::Contextual(format) => {
+                let heading_path = elements
+                    .first()
+                    .map(|e| e.metadata().heading_path.clone())
+                    .unwrap_or_default();
+                let page_span = (!page_numbers.is_empty())
+                    .then(|| (page_numbers[0], page_numbers[page_numbers.len() - 1]));
+                match build_context_prefix(format, source, &heading_path, page_span) {
+                    Some(prefix) => format!("{prefix}\n\n{text}"),
+                    None => text.clone(),
+                }
+            }
+        };
         let doc_hash = source.and_then(|s| s.doc_hash.as_deref());
         let metadata =
             ChunkMetadata::from_elements(elements, &text, &full_text, chunk_index, doc_hash);
@@ -154,4 +211,200 @@ fn collect_pages(elements: &[Element]) -> Vec<u32> {
     }
     pages.sort_unstable();
     pages
+}
+
+/// Render a page span as `p. N` (single page) or `p. N–M` (range, en dash).
+fn render_page(span: (u32, u32)) -> String {
+    if span.0 == span.1 {
+        format!("p. {}", span.0)
+    } else {
+        format!("p. {}\u{2013}{}", span.0, span.1)
+    }
+}
+
+/// Build the deterministic, no-ML context prefix for a chunk (issue #376).
+///
+/// Pure function of its inputs (document source fields, heading breadcrumb, page
+/// span) → reproducible across runs. Returns `None` when there is neither a
+/// document name nor a section to anchor on (a page alone is not enough
+/// context); the caller then leaves `full_text == text`.
+///
+/// `author` is deliberately only rendered alongside a document name (title or
+/// filename) — an authored *section* reads oddly and adds no retrieval signal —
+/// so a source with only an `author` set and no title/filename contributes
+/// nothing to a section-only prefix.
+fn build_context_prefix(
+    format: ContextFormat,
+    source: Option<&DocumentSource>,
+    heading_path: &[String],
+    page_span: Option<(u32, u32)>,
+) -> Option<String> {
+    // `title` wins; `filename` is the fallback document name.
+    let doc_name = source.and_then(|s| s.title.clone().or_else(|| s.filename.clone()));
+    let author = source.and_then(|s| s.author.clone());
+    let section = (!heading_path.is_empty()).then(|| heading_path.join(" \u{203A} "));
+    let page = page_span.map(render_page);
+
+    // No document or section anchor → no prefix at all.
+    if doc_name.is_none() && section.is_none() {
+        return None;
+    }
+
+    let prefix = match format {
+        ContextFormat::Labeled => {
+            let mut lines: Vec<String> = Vec::new();
+            if let Some(name) = &doc_name {
+                lines.push(match &author {
+                    Some(a) => format!("Document: {name} — {a}"),
+                    None => format!("Document: {name}"),
+                });
+            }
+            if let Some(sec) = &section {
+                lines.push(format!("Section: {sec}"));
+            }
+            // The page span attaches to the last (most specific) context line.
+            if let (Some(pg), Some(last)) = (&page, lines.last_mut()) {
+                last.push_str(&format!(" ({pg})"));
+            }
+            lines.join("\n")
+        }
+        ContextFormat::Prose => {
+            let mut s = String::from("This chunk is from ");
+            if let Some(name) = &doc_name {
+                s.push_str(&format!("\"{name}\""));
+                if let Some(a) = &author {
+                    s.push_str(&format!(" by {a}"));
+                }
+                if let Some(sec) = &section {
+                    s.push_str(&format!(", section \"{sec}\""));
+                }
+            } else if let Some(sec) = &section {
+                s.push_str(&format!("section \"{sec}\""));
+            }
+            if let Some(pg) = &page {
+                s.push_str(&format!(" ({pg})"));
+            }
+            s.push('.');
+            s
+        }
+    };
+    Some(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::{ContextFormat, DocumentSource};
+
+    fn src(title: Option<&str>, author: Option<&str>, filename: Option<&str>) -> DocumentSource {
+        DocumentSource {
+            title: title.map(str::to_string),
+            author: author.map(str::to_string),
+            filename: filename.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn hp(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── issue #376: Labeled prefix ───────────────────────────────────────────
+
+    #[test]
+    fn labeled_full_fields() {
+        let s = src(Some("Annual Report"), Some("Acme Corp"), None);
+        let p = build_context_prefix(
+            ContextFormat::Labeled,
+            Some(&s),
+            &hp(&["1 Intro", "1.2 Scope"]),
+            Some((3, 4)),
+        );
+        assert_eq!(
+            p.as_deref(),
+            Some("Document: Annual Report — Acme Corp\nSection: 1 Intro › 1.2 Scope (p. 3–4)")
+        );
+    }
+
+    #[test]
+    fn labeled_title_only() {
+        let s = src(Some("Doc"), None, None);
+        let p = build_context_prefix(ContextFormat::Labeled, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("Document: Doc"));
+    }
+
+    #[test]
+    fn labeled_filename_fallback_when_no_title() {
+        let s = src(None, None, Some("report.pdf"));
+        let p = build_context_prefix(ContextFormat::Labeled, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("Document: report.pdf"));
+    }
+
+    #[test]
+    fn labeled_section_only_without_source() {
+        let p = build_context_prefix(ContextFormat::Labeled, None, &hp(&["A", "B"]), None);
+        assert_eq!(p.as_deref(), Some("Section: A › B"));
+    }
+
+    #[test]
+    fn labeled_single_page() {
+        let p = build_context_prefix(ContextFormat::Labeled, None, &hp(&["A"]), Some((7, 7)));
+        assert_eq!(p.as_deref(), Some("Section: A (p. 7)"));
+    }
+
+    #[test]
+    fn labeled_nothing_is_none() {
+        let s = src(None, None, None);
+        assert!(
+            build_context_prefix(ContextFormat::Labeled, Some(&s), &[], Some((3, 3))).is_none()
+        );
+        assert!(build_context_prefix(ContextFormat::Labeled, None, &[], None).is_none());
+    }
+
+    // ── issue #376: Prose prefix ─────────────────────────────────────────────
+
+    #[test]
+    fn prose_full_fields() {
+        let s = src(Some("Annual Report"), Some("Acme Corp"), None);
+        let p = build_context_prefix(
+            ContextFormat::Prose,
+            Some(&s),
+            &hp(&["1 Intro", "1.2 Scope"]),
+            Some((3, 4)),
+        );
+        assert_eq!(
+            p.as_deref(),
+            Some(
+                "This chunk is from \"Annual Report\" by Acme Corp, section \"1 Intro › 1.2 Scope\" (p. 3–4)."
+            )
+        );
+    }
+
+    #[test]
+    fn prose_title_only() {
+        let s = src(Some("Doc"), None, None);
+        let p = build_context_prefix(ContextFormat::Prose, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("This chunk is from \"Doc\"."));
+    }
+
+    #[test]
+    fn prose_section_only_without_source() {
+        let p = build_context_prefix(ContextFormat::Prose, None, &hp(&["A", "B"]), Some((5, 5)));
+        assert_eq!(
+            p.as_deref(),
+            Some("This chunk is from section \"A › B\" (p. 5).")
+        );
+    }
+
+    #[test]
+    fn prose_filename_fallback_and_no_section() {
+        let s = src(None, Some("Ann"), Some("f.pdf"));
+        let p = build_context_prefix(ContextFormat::Prose, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("This chunk is from \"f.pdf\" by Ann."));
+    }
+
+    #[test]
+    fn prose_nothing_is_none() {
+        assert!(build_context_prefix(ContextFormat::Prose, None, &[], Some((1, 2))).is_none());
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -135,7 +135,7 @@ pub trait MetadataEnricher: Send + Sync {
     fn enrich(&self, ctx: &EnrichContext, meta: &mut crate::pipeline::ChunkMetadata);
 }
 
-use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
+use crate::pipeline::hybrid_chunking::{ContextMode, HybridChunkConfig, HybridChunker};
 use crate::pipeline::{DocumentSource, PartitionConfig};
 
 /// Configures the analysis pipeline: which chunking strategy to run, the token
@@ -149,6 +149,12 @@ pub struct AnalysisPipeline {
     pub(crate) source: Option<DocumentSource>,
     pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
     pub(crate) partition_config: PartitionConfig,
+    /// How each chunk's `full_text` is contextualized (issue #376). Carried on
+    /// the pipeline because the chunking `Box<dyn ChunkingStrategy>` produces
+    /// `ChunkGroup`s and cannot expose a `HybridChunkConfig` to read the mode
+    /// back from — so a custom strategy's `context_mode` would otherwise be
+    /// lost. Defaults to [`ContextMode::Heading`].
+    pub(crate) context_mode: ContextMode,
     #[cfg(feature = "semantic")]
     pub(crate) enrichers: Vec<Box<dyn MetadataEnricher>>,
 }
@@ -166,6 +172,7 @@ impl AnalysisPipeline {
         let config = HybridChunkConfig::default();
         Self {
             max_tokens: config.max_tokens,
+            context_mode: config.context_mode,
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
             classifier: None,
@@ -173,6 +180,20 @@ impl AnalysisPipeline {
             #[cfg(feature = "semantic")]
             enrichers: Vec::new(),
         }
+    }
+
+    /// Set how each chunk's `full_text` is contextualized (issue #376).
+    ///
+    /// Needed on the pipeline because a custom chunking strategy (`Box<dyn
+    /// ChunkingStrategy>`) yields `ChunkGroup`s and carries no
+    /// `HybridChunkConfig`, so a `context_mode` set on a `HybridChunker` wired
+    /// via [`with_chunking`](Self::with_chunking) cannot be read back — set it
+    /// here instead. When the strategy *is* the built-in `HybridChunker`, this
+    /// takes precedence over any `context_mode` on its config.
+    #[must_use]
+    pub fn with_context_mode(mut self, context_mode: ContextMode) -> Self {
+        self.context_mode = context_mode;
+        self
     }
 
     /// Replace the chunking strategy.

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -45,6 +45,7 @@ fn hybrid_chunker_is_the_default_strategy() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     // Inherent API: Vec<HybridChunk>.
@@ -172,6 +173,7 @@ fn decorator_wraps_default_and_refines() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let base_count = ChunkingStrategy::chunk(&inner, &elements).len();
     assert_eq!(base_count, 4, "default emits one group per element here");
@@ -548,5 +550,41 @@ fn pipeline_owns_oversized_flag_regardless_of_strategy() {
     assert!(
         none_over.iter().all(|c| !c.is_oversized),
         "generous budget → no chunk is oversized"
+    );
+}
+
+/// Issue #376 (QR critical): `context_mode` set on the pipeline must reach
+/// `full_text` through the SPI path, not be silently dropped to `Heading`.
+#[test]
+fn pipeline_context_mode_threads_through_spi_path() {
+    use oxidize_pdf::pipeline::{ContextFormat, ContextMode, DocumentSource};
+    let bytes = build_two_section_doc();
+
+    // Default pipeline (Heading): no contextual `Document:`/`Section:` prefix.
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let heading = parsed
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("rag_chunks_with_pipeline");
+    assert!(
+        !heading.iter().any(|c| c.full_text.contains("Document:")),
+        "default pipeline must not add a contextual prefix"
+    );
+
+    // Contextual mode set on the pipeline must reach every chunk's full_text.
+    let mut source = DocumentSource::with_file(Some("two.pdf".into()), Some("h".into()));
+    source.title = Some("Two Section Doc".into());
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let pipeline = AnalysisPipeline::new()
+        .with_source(source)
+        .with_context_mode(ContextMode::Contextual(ContextFormat::Labeled));
+    let ctx = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+    assert!(!ctx.is_empty(), "fixture must produce chunks");
+    assert!(
+        ctx.iter()
+            .all(|c| c.full_text.starts_with("Document: Two Section Doc")),
+        "context_mode must thread through the SPI path: {:?}",
+        ctx.iter().map(|c| c.full_text.clone()).collect::<Vec<_>>()
     );
 }

--- a/oxidize-pdf-core/tests/common/rag_helpers.rs
+++ b/oxidize-pdf-core/tests/common/rag_helpers.rs
@@ -28,6 +28,7 @@ pub fn make_rag_chunk(
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
         text: text.to_string(),

--- a/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
@@ -168,6 +168,7 @@ fn synthetic_overflow_flushes_emit_disjoint_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -206,6 +207,7 @@ fn synthetic_merge_disabled_with_overlap_still_disjoint() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -57,6 +57,7 @@ fn test_heading_context_propagated_to_chunks() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -79,6 +80,7 @@ fn test_no_heading_before_first_title() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -103,6 +105,7 @@ fn test_heading_context_changes_on_new_title() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -133,6 +136,7 @@ fn test_merge_adjacent_paragraphs_within_budget() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -157,6 +161,7 @@ fn test_no_merge_different_element_types() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -185,6 +190,7 @@ fn test_merge_disabled_one_chunk_per_element() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     assert_eq!(chunker.chunk(&elements).len(), 3);
 }
@@ -215,6 +221,7 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -249,6 +256,7 @@ fn test_overlap_chunks_preserve_heading_context() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -332,6 +340,7 @@ fn test_list_items_merge_with_list_items_not_paragraphs() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -88,6 +88,7 @@ fn test_merge_paragraph_and_list_item_under_same_heading() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -113,6 +114,7 @@ fn test_same_type_only_policy_preserves_legacy_behavior() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     assert_eq!(
@@ -134,6 +136,7 @@ fn test_title_never_merges_with_adjacent_paragraph() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // Title must be its own chunk — it is structural, not inline.
@@ -163,6 +166,7 @@ fn test_table_never_merges_with_adjacent_paragraph() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // Table must be isolated in its own chunk.
@@ -193,6 +197,7 @@ fn test_oversized_paragraph_splits_at_sentence_boundary() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -240,6 +245,7 @@ fn test_table_oversized_remains_atomic_not_split() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -266,6 +272,7 @@ fn test_single_very_long_sentence_stays_in_one_chunk() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // No sentence boundaries → entire text is one "sentence" → one chunk.
@@ -286,6 +293,7 @@ fn test_sentence_split_preserves_parent_heading_metadata() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -379,6 +387,7 @@ fn test_hybrid_chunker_v2_end_to_end_with_partition() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     let graph = ElementGraph::build(&elements);

--- a/oxidize-pdf-core/tests/issue_376_contextual_chunks.rs
+++ b/oxidize-pdf-core/tests/issue_376_contextual_chunks.rs
@@ -1,0 +1,182 @@
+//! Feature tests for issue #376 — first-class deterministic contextual RAG
+//! chunks (no-ML Contextual Retrieval).
+//!
+//! `ContextMode` on `HybridChunkConfig` selects how each chunk's `full_text`
+//! (the embedding text) is contextualized: `None` (== text), `Heading` (the
+//! pre-#376 leaf-heading behavior, default), or `Contextual(ContextFormat)`
+//! which prepends a deterministic document + section snippet. The display
+//! `text` field always stays context-free.
+
+use oxidize_pdf::pipeline::{
+    ContextFormat, ContextMode, DocumentSource, Element, ElementData, ElementMetadata, HybridChunk,
+    HybridChunkConfig, HybridChunker, RagChunk,
+};
+
+/// A paragraph on page 3 under the breadcrumb `1 Intro › 1.2 Scope`.
+fn para(text: &str) -> Element {
+    let mut e = Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    });
+    e.metadata_mut().page = 3;
+    e.set_parent_heading(Some("1.2 Scope".to_string()));
+    e.set_heading_path(vec!["1 Intro".to_string(), "1.2 Scope".to_string()]);
+    e
+}
+
+fn one_chunk() -> Vec<HybridChunk> {
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    chunker.chunk(&[para("Alpha beta gamma."), para("Delta epsilon.")])
+}
+
+fn source() -> DocumentSource {
+    let mut s = DocumentSource::with_file(Some("annual.pdf".to_string()), Some("h123".to_string()));
+    s.title = Some("Annual Report".to_string());
+    s.author = Some("Acme".to_string());
+    s
+}
+
+#[test]
+fn mode_none_full_text_equals_text() {
+    let hcs = one_chunk();
+    let c =
+        RagChunk::from_hybrid_chunk_with_source_and_mode(0, &hcs[0], &source(), ContextMode::None);
+    assert_eq!(c.full_text, c.text, "None mode: full_text is the bare text");
+}
+
+#[test]
+fn mode_heading_matches_legacy_behavior() {
+    let hcs = one_chunk();
+    let legacy = RagChunk::from_hybrid_chunk_with_source(0, &hcs[0], &source());
+    let heading = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Heading,
+    );
+    assert_eq!(
+        heading.full_text, legacy.full_text,
+        "Heading mode must be byte-identical to the pre-#376 constructor"
+    );
+}
+
+#[test]
+fn mode_contextual_labeled_prefix_and_clean_text() {
+    let hcs = one_chunk();
+    let c = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert!(
+        c.full_text
+            .starts_with("Document: Annual Report — Acme\nSection: 1 Intro › 1.2 Scope (p. 3)\n\n"),
+        "labeled prefix missing/wrong: {:?}",
+        c.full_text
+    );
+    assert!(
+        c.full_text.ends_with(&c.text),
+        "full_text must end with the bare chunk text"
+    );
+    assert!(
+        !c.text.contains("Document:") && !c.text.contains("Section:"),
+        "display text must stay context-free: {:?}",
+        c.text
+    );
+}
+
+#[test]
+fn mode_contextual_prose_prefix() {
+    let hcs = one_chunk();
+    let c = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Prose),
+    );
+    assert!(
+        c.full_text.starts_with(
+            "This chunk is from \"Annual Report\" by Acme, section \"1 Intro › 1.2 Scope\" (p. 3).\n\n"
+        ),
+        "prose prefix missing/wrong: {:?}",
+        c.full_text
+    );
+    assert!(c.full_text.ends_with(&c.text));
+}
+
+#[test]
+fn contextual_is_deterministic() {
+    let hcs = one_chunk();
+    let mk = || {
+        RagChunk::from_hybrid_chunk_with_source_and_mode(
+            0,
+            &hcs[0],
+            &source(),
+            ContextMode::Contextual(ContextFormat::Labeled),
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert_eq!(a.full_text, b.full_text, "prefix is a pure function");
+    assert_eq!(
+        a.metadata.chunk_id, b.metadata.chunk_id,
+        "chunk_id reproducible"
+    );
+}
+
+#[test]
+fn contextual_without_source_is_section_only() {
+    let hcs = one_chunk();
+    // No `DocumentSource`: the prefix carries the section breadcrumb only.
+    let labeled = RagChunk::from_hybrid_chunk_with_mode(
+        0,
+        &hcs[0],
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert!(
+        labeled
+            .full_text
+            .starts_with("Section: 1 Intro › 1.2 Scope (p. 3)\n\n"),
+        "no-source labeled prefix should be section-only: {:?}",
+        labeled.full_text
+    );
+    assert!(
+        !labeled.full_text.contains("Document:"),
+        "no source → no Document line"
+    );
+
+    let prose = RagChunk::from_hybrid_chunk_with_mode(
+        0,
+        &hcs[0],
+        ContextMode::Contextual(ContextFormat::Prose),
+    );
+    assert!(
+        prose
+            .full_text
+            .starts_with("This chunk is from section \"1 Intro › 1.2 Scope\" (p. 3).\n\n"),
+        "no-source prose prefix should be section-only: {:?}",
+        prose.full_text
+    );
+}
+
+#[test]
+fn chunk_id_is_mode_independent_when_doc_hash_set() {
+    let hcs = one_chunk();
+    let heading = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Heading,
+    );
+    let contextual = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert_eq!(
+        heading.metadata.chunk_id, contextual.metadata.chunk_id,
+        "with doc_hash set, chunk_id is derived from the hash, not full_text"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -105,6 +105,7 @@ fn rag_chunks_with_counter_word_proxy_parity() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
 
     let base = doc.rag_chunks_with(config.clone()).unwrap();

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -56,6 +56,7 @@ fn build_chunks() -> Vec<RagChunk> {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     parsed
         .rag_chunks_with(config)
@@ -464,6 +465,7 @@ fn rag_chunks_with_source_and_config_applies_both() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     let tight_source = DocumentSource::with_file(None, Some("h".to_string()));
     let tight_chunks = parsed

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -490,3 +490,43 @@ fn rag_chunks_with_source_and_config_applies_both() {
     // doc_hash drives the chunk_id prefix here too.
     assert!(tight_chunks[0].metadata.chunk_id.starts_with("h:"));
 }
+
+/// `ContentTypeFlags` is pipeline output: readable off `ChunkMetadata`, and
+/// `#[non_exhaustive]` so future content flags cannot break external consumers.
+///
+/// This verifies the blindaje contract from an external crate (the integration
+/// test crate is compiled separately, so `#[non_exhaustive]` is in force here):
+///   1. the flags are readable and reflect the real document — `build_chunks`
+///      produces a table/list/code-free doc, so every chunk reports all three
+///      absent;
+///   2. the only cross-crate construction path is `default()` + field mutation.
+///      A struct literal `ContentTypeFlags { has_table: .., .. }` here would
+///      fail to compile (E0639) — that is precisely what the attribute buys.
+#[test]
+fn content_type_flags_are_output_and_non_exhaustive() {
+    use oxidize_pdf::pipeline::ContentTypeFlags;
+
+    let chunks = build_chunks();
+    assert!(!chunks.is_empty(), "expected chunks to read flags from");
+
+    // (1) Real content: the fixture has no tables, lists, or code blocks, so no
+    // chunk may claim them. Read through the non_exhaustive type from outside.
+    for (i, c) in chunks.iter().enumerate() {
+        let f = c.metadata.content_types;
+        assert!(!f.has_table, "chunk[{i}] wrongly flagged has_table");
+        assert!(!f.has_list, "chunk[{i}] wrongly flagged has_list");
+        assert!(!f.has_code, "chunk[{i}] wrongly flagged has_code");
+    }
+
+    // (2) Supported cross-crate construction: start from Default, set fields.
+    // The struct literal form is rejected by #[non_exhaustive].
+    let mut flags = ContentTypeFlags::default();
+    assert_eq!(flags, ContentTypeFlags::default());
+    flags.has_table = true;
+    assert!(flags.has_table);
+    assert_ne!(
+        flags,
+        ContentTypeFlags::default(),
+        "mutating a field must diverge from the default value"
+    );
+}

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -69,6 +69,7 @@ fn test_rag_chunk_from_hybrid_chunk() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     assert_eq!(hybrid_chunks.len(), 1);
@@ -103,6 +104,7 @@ fn test_rag_chunk_collects_pages_from_multi_page_elements() {
         merge_adjacent: true,
         merge_policy: MergePolicy::AnyInlineContent,
         propagate_headings: false,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
@@ -181,6 +183,7 @@ fn test_rag_chunks_indices_are_sequential() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag_chunks: Vec<RagChunk> = hybrid_chunks
@@ -216,6 +219,7 @@ fn test_rag_chunks_with_custom_config_produces_more_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     let large_config = HybridChunkConfig {
         max_tokens: 512,
@@ -223,6 +227,7 @@ fn test_rag_chunks_with_custom_config_produces_more_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
 
     let small_chunks: Vec<RagChunk> = HybridChunker::new(small_config)
@@ -275,6 +280,7 @@ fn test_rag_chunks_json_serializes_vec_as_array() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     let rag_chunks: Vec<RagChunk> = chunker
@@ -305,6 +311,7 @@ fn test_rag_chunk_page_numbers_are_sorted() {
         merge_adjacent: true,
         merge_policy: MergePolicy::AnyInlineContent,
         propagate_headings: false,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
@@ -329,6 +336,7 @@ fn test_element_type_names_for_all_variants() {
             merge_adjacent: false,
             propagate_headings: false,
             merge_policy: MergePolicy::AnyInlineContent,
+            context_mode: Default::default(),
         });
         let chunks = chunker.chunk(&[element]);
         RagChunk::from_hybrid_chunk(0, &chunks[0])


### PR DESCRIPTION
## Summary

Opt-in **Contextual Retrieval (no-ML)** for the RAG chunking path (issue #376). New `ContextMode { None, Heading, Contextual(ContextFormat) }` + `#[non_exhaustive] ContextFormat { Labeled, Prose }`, and `HybridChunkConfig.context_mode` (default `Heading` → **byte-identical** to pre-#376).

`Contextual` prepends a deterministic document + section snippet to each chunk's `full_text` (the embedding text); the display `text` field stays context-free. The prefix is a **pure function** of the `DocumentSource` fields, the heading breadcrumb and the page span → reproducible, so `chunk_id` stays deterministic.

- `Labeled`: `Document: <title> — <author>` / `Section: <breadcrumb> (p. N–M)` lines.
- `Prose`: one natural-language sentence.
- Field degradation (title→filename fallback, optional author/section/page, "no anchor → bare text") is exhaustive and documented.

Applied at `RagChunk` construction (the only point with source + heading_path + page_span). New public `from_hybrid_chunk_with_mode` / `from_hybrid_chunk_with_source_and_mode`; every `rag_chunks_with*` entry threads `config.context_mode`.

## QR (quality-rust) hardening

- **Critical**: the `unstable-spi` pipeline path (`rag_chunks_with_pipeline` / `rag_chunks_from_elements`) hardcoded `Heading`, silently dropping a user's `context_mode` — a `Box<dyn ChunkingStrategy>` can't expose a `HybridChunkConfig` to read it back. Added `AnalysisPipeline::with_context_mode` and threaded it, with a regression test over the SPI path.
- **Doc**: relocated the enums after `HybridChunkConfig` so its docblock + doctest reattach to the struct (they had merged onto `ContextMode`).
- **Minor**: honest `page_span` (dropped unreachable fallback); documented that `author` renders only with a document name.

## Tests (TDD, RED → GREEN)

`tests/issue_376_contextual_chunks.rs` (mode wiring, both formats, determinism, `chunk_id` mode-independence, no-source section-only) + inline unit tests for `build_context_prefix` (both formats × full degradation matrix) + SPI threading regression in `analysis_spi_test.rs`.

## Verification

- lib 6629/0, no regression on chunking/rag suites
- `clippy --all -- -D warnings` (default + `unstable-spi`), `fmt`, MSRV 1.88 `--all-features --locked`, doctests

## Notes

- Public API additions → **4.0.0 MAJOR** (bundle step 3 of 4; `#[non_exhaustive]` blindaje lands at the end).
- Docs: README "Contextual Retrieval (no-ML)" section + rustdoc.
- Addresses #376 (author bzsanti — closed after merge).