### PR TITLE
Release 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,16 @@ jobs:
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        # Drive rustfmt directly in xargs-chunked batches instead of `cargo fmt`.
+        # `cargo fmt --all` passes every workspace target root (~400+ examples/tests)
+        # to a single rustfmt invocation; on windows-latest that command line exceeds
+        # the ~32 KiB CreateProcess limit and fails with `os error 206` (ERROR_FILENAME_
+        # EXCED_RANGE) before checking anything. xargs splits into bounded batches, so
+        # this stays correct as the target count grows. bash runs on all three runners.
+        shell: bash
+        run: >
+          find oxidize-pdf-core -name '*.rs' -not -path '*/target/*' -not -path '*/benches.disabled/*' -print0
+          | xargs -0 -r -n 60 rustfmt --edition 2021 --check
 
       - name: Check for backup files
         if: matrix.os != 'windows-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-10
+
 ### BREAKING CHANGES
 
 - `TableElementData` (`oxidize_pdf::pipeline`), and `DetectedTable` / `TableCell`
@@ -17,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TableElementData` via `TableElementData::new(rows, metadata)` (flat) or
   `TableElementData::from_structure(structure, metadata)` (rich); build `TableCell` via
   `TableCell::new(..)` and `DetectedTable` via `DetectedTable::new(..)`. (#375)
+- **Contextual chunking API (#376).** `HybridChunkConfig` gained a `context_mode` field
+  (`ContextMode`), so full struct-literal construction now requires it — use
+  `HybridChunkConfig { max_tokens, ..Default::default() }`. The default (`ContextMode::Heading`)
+  is byte-identical to previous output. New enum `ContextFormat` is `#[non_exhaustive]`.
+- **Bounded extraction fields (#382).** `ExtractionOptions` gained `max_extracted_bytes:
+  Option<usize>` and `ExtractedText` gained `truncated: bool`, so full struct-literal
+  construction of `ExtractionOptions` now requires the new field — use
+  `ExtractionOptions { ..Default::default() }`.
+- **Output-type hardening.** `ExtractedText` (`oxidize_pdf::text`) and `ContentTypeFlags`
+  (`oxidize_pdf::pipeline`) are now `#[non_exhaustive]`, so future fields can be added without a
+  breaking change. External code can no longer construct them with a struct literal: build
+  `ExtractedText` via `ExtractedText::new(text, fragments)`, and `ContentTypeFlags` via
+  `ContentTypeFlags::default()` + field assignment.
 
 ### Added
 
@@ -27,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapses multi-level headers (joined with `›`) and repeats merged-cell values; RAG chunk
   metadata (`table_rows`/`table_cols`) counts the rich geometry. Borderless tables and
   un-tagged multi-level headers remain flat — see `docs/TABLE_DETECTION_GUIDE.md`.
+- **Contextual Retrieval (no-ML) for RAG chunks (#376).** Opt-in `ContextMode::Contextual`
+  prepends a deterministic document + section snippet (title/author or filename, heading
+  breadcrumb, optional page span) to each chunk's `full_text` (the embedding text) while the
+  display `text` stays context-free. Two formats — `ContextFormat::Labeled` and `Prose`. The
+  prefix is a pure function of the source, breadcrumb and page span, so `chunk_id` stays
+  deterministic. Threaded through every `rag_chunks_with*` entry and the `unstable-spi`
+  pipeline (`AnalysisPipeline::with_context_mode`).
+- **Per-page extraction memory bound (#382).** `ExtractionOptions::max_extracted_bytes` caps
+  decoded-text accumulation *during* a page run (across the show-text arms, TJ spacing, Form
+  XObject recursion, and `/ActualText` overrides), so an adversarially inflated content stream
+  cannot materialise an unbounded `String`. Undershoot semantics: extraction stops before the
+  run that would overshoot (never splits a UTF-8 char); `ExtractedText::truncated` reports it.
+  `None` (default) is byte-identical to before.
 
 ### Fixed
 
@@ -35,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the table bounding box but not in any cell falls back to prose instead of being discarded.
   Near-empty tables (< 2 populated cells) decompose to prose. Guarded by a text-conservation
   invariant test.
+- **Dense prose no longer shredded under column reorder (#408).** `reorder_columns` /
+  `preserve_layout` fragmented dense paragraphs character-by-character because
+  `sort_and_merge_fragments` ran twice; the double pass is removed. A `NaN` Y anchor now
+  breaks the line instead of swallowing the rest of the page.
 
 ## [3.1.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### BREAKING CHANGES
+
+- `TableElementData` (`oxidize_pdf::pipeline`), and `DetectedTable` / `TableCell`
+  (`oxidize_pdf::text::table_detection`) are now `#[non_exhaustive]` and gained new public
+  fields (rich table structure / cell spans / header rows). External code can no longer
+  construct these with a struct literal or match them exhaustively. Migration: build
+  `TableElementData` via `TableElementData::new(rows, metadata)` (flat) or
+  `TableElementData::from_structure(structure, metadata)` (rich); build `TableCell` via
+  `TableCell::new(..)` and `DetectedTable` via `DetectedTable::new(..)`. (#375)
+
+### Added
+
+- **RAG table extraction quality (#375).** Merged cells (rowspan/colspan) and header rows are
+  now represented by a rich `TableStructure` / `RichCell` model on `TableElementData.structure`,
+  populated from hard signals — drawn-grid dividers (merged cells) and PDF structure tags
+  (header rows). The flat `rows` view is derived from it (spanned values repeated). GFM export
+  collapses multi-level headers (joined with `›`) and repeats merged-cell values; RAG chunk
+  metadata (`table_rows`/`table_cols`) counts the rich geometry. Borderless tables and
+  un-tagged multi-level headers remain flat — see `docs/TABLE_DETECTION_GUIDE.md`.
+
+### Fixed
+
+- **Table detection no longer silently drops page text (#375).** A detected table now claims
+  only fragments it actually placed in a cell (both ruling and spatial detectors); text inside
+  the table bounding box but not in any cell falls back to prose instead of being discarded.
+  Near-empty tables (< 2 populated cells) decompose to prose. Guarded by a text-conservation
+  invariant test.
+
 ## [3.1.1] - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.2"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most PDF libraries give you a wall of text. oxidize-pdf gives you **structured, 
 
 ```toml
 [dependencies]
-oxidize-pdf = "3.1"
+oxidize-pdf = "4.0"
 ```
 
 ### RAG Pipeline -- One Liner

--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ let config = HybridChunkConfig {
 let chunks = doc.rag_chunks_with(config)?;
 ```
 
+### Contextual Retrieval (no-ML)
+
+Prepend a deterministic context snippet to each chunk's `full_text` before
+embedding — the no-ML analogue of [Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)
+/ Late Chunking, which cut retrieval failures substantially by situating each
+chunk in its document. No LLM, no GPU: the prefix is a pure function of the
+document metadata and the chunk's heading breadcrumb, so it is fully
+reproducible (stable `chunk_id`). The display `text` field stays context-free.
+
+```rust
+use oxidize_pdf::pipeline::{ContextFormat, ContextMode, DocumentSource, HybridChunkConfig};
+
+let config = HybridChunkConfig {
+    context_mode: ContextMode::Contextual(ContextFormat::Labeled),
+    ..HybridChunkConfig::default()
+};
+let source = DocumentSource::with_file(Some("annual.pdf".into()), Some("sha256-…".into()));
+let chunks = doc.rag_chunks_with_source_and_config(source, config)?;
+
+// chunk.full_text now reads, e.g.:
+//   Document: Annual Report — Acme Corp
+//   Section: 1 Introduction › 1.2 Scope (p. 3–4)
+//
+//   <chunk text>
+```
+
+`ContextFormat::Prose` renders the same facts as one natural-language sentence.
+Modes: `ContextMode::None` (bare text), `Heading` (leaf heading only, the
+default), `Contextual(_)` (document + section prefix).
+
 ### JSON for Vector Store Ingestion
 
 ```rust

--- a/docs/TABLE_DETECTION_GUIDE.md
+++ b/docs/TABLE_DETECTION_GUIDE.md
@@ -596,3 +596,22 @@ https://github.com/BelowZero/oxidize-pdf/issues
 **Version**: 1.6.3
 **Last Updated**: 2025-10-22
 **License**: MIT
+
+## Known limitations (as of #375)
+
+Rich table structure — merged cells and multi-level headers — is only produced when a
+**hard signal** reveals it:
+
+- **Merged cells** are detected from the drawn grid: where an internal dividing line is
+  absent, the adjacent cells are merged. Tables without drawn borders ("borderless") are
+  returned as a flat grid with no merged-cell information.
+- **Multi-level headers** are represented as header rows containing merged cells (e.g. a
+  "Region" header spanning two columns above "Q1"/"Q2"). Header rows are identified from the
+  PDF's structure tags when the document is tagged, otherwise the top row is assumed to be
+  the header. A nested header *hierarchy* is not read from the PDF's internal structure tree.
+- **Borderless-table detection is intrinsically ambiguous** and best-effort; when in doubt
+  the content is preserved as prose rather than forced into a grid (no text is dropped).
+
+For GitHub-Flavored Markdown export, merged-cell values are repeated across every column
+they cover, and multi-level headers are flattened into a single header row joining the
+levels with " › ".

--- a/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
+++ b/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
@@ -275,11 +275,13 @@ git commit -m "fix(#375): spatial tables claim only populated-cell fragments"
 Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add:
 
 ```rust
-                                // #375: a table that captured too few cells is not a
-                                // table — skip it so its fragments become prose.
+                                // #375: a table with fewer than 2 populated cells is not a
+                                // real table — skip it so its fragments become prose.
+                                // (Softened from `populated < rows` after Task 4 review found
+                                // that threshold over-rejected legitimately sparse narrow tables;
+                                // human-approved 2026-07-09.)
                                 let populated = table.cells.iter().filter(|c| !c.text.is_empty()).count();
-                                if populated < table.rows.max(1) {
-                                    // fewer populated cells than rows => no real column structure
+                                if populated < 2 {
                                     continue;
                                 }
 ```
@@ -287,9 +289,10 @@ Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add
 Spatial path — after its confidence gate at ~392, add:
 
 ```rust
+                            // #375: same near-empty guard for the spatial path.
                             let populated = table.rows.iter().flat_map(|r| &r.cells)
                                 .filter(|c| !c.is_empty()).count();
-                            if populated < table.row_count().max(1) {
+                            if populated < 2 {
                                 continue;
                             }
 ```

--- a/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
+++ b/docs/superpowers/plans/2026-07-09-issue-375-table-extraction-quality.md
@@ -1,0 +1,1157 @@
+# Issue #375 — Table Extraction Quality + Data-Loss Safety Net — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop silent text loss when prose is misdetected as a table, and additively enrich the table model so merged cells and multi-level headers (header rows + merged cells) are represented and exported to GFM.
+
+**Architecture:** Two independent detectors (ruling/vector-grid in `text/table_detection.rs`, spatial/borderless in `text/structured/`) feed one canonical `Element::Table(TableElementData)` in `pipeline/`. We (1) change fragment *claiming* so a table claims only text it actually placed in a cell (leftover flows to prose), guarded by a text-conservation invariant; (2) add an optional rich `TableStructure` alongside the existing flat `rows` (flat derived from rich, no breaking change); (3) rework grid construction to detect absent interior dividers → merged cells; (4) collapse header rows in the Markdown exporter and compute RAG metadata from the rich model.
+
+**Tech Stack:** Rust (edition per workspace), `cargo test`/`clippy`, no new dependencies, no-ML/deterministic.
+
+## Global Constraints
+
+- MSRV **1.88**; verify `cargo +1.88 build --lib --all-features --locked` before PR.
+- **Warnings = errors**: every commit must pass `cargo clippy --lib --all-features -- -D warnings` and `cargo fmt --check`.
+- **Additive only**: no breaking change to public types. `TableElementData.rows` stays public and unchanged in meaning. New fields are `Option`/defaulted.
+- **No-ML, deterministic**: identical input → identical output. No randomness, stable ordering.
+- **Tests verify real content**, never just "no crash" or "non-empty".
+- **TDD**: write the failing test, watch it fail, implement minimally, watch it pass, commit.
+- Branch: `feature/issue-375-table-extraction-quality` (off `develop`). Frequent commits.
+- **quality-rust pass is mandatory before the PR** (final task).
+- SemVer target: **MINOR**.
+
+## File map
+
+- `oxidize-pdf-core/src/pipeline/element.rs` — add `TableStructure`, `RichCell`, `structure` field + `from_structure` constructor; Markdown/metadata read it.
+- `oxidize-pdf-core/src/pipeline/partition.rs` — claim-only-captured (both paths), reject-degenerate, build rich table from ruling detector.
+- `oxidize-pdf-core/src/text/table_detection.rs` — `TableCell` spans, `DetectedTable.header_rows`, grid-segment retention, merged-cell detection.
+- `oxidize-pdf-core/src/pipeline/export.rs` — header-row collapse (multi-level → joined GFM header).
+- `oxidize-pdf-core/src/pipeline/chunk_metadata.rs` — `table_dims` from rich structure.
+- `oxidize-pdf-core/docs/../docs/TABLE_DETECTION_GUIDE.md` (repo `docs/TABLE_DETECTION_GUIDE.md`) + module rustdoc — known-limitation docs.
+- Tests: `tests/issue_375_text_conservation_test.rs`, `tests/issue_375_merged_cells_test.rs`, `tests/issue_375_multi_level_header_test.rs`, plus additions to `tests/partition_table_detection_test.rs`.
+
+---
+
+## Task 1: Reproduce the data-loss bug with a text-conservation invariant (RED)
+
+**Files:**
+- Create: `oxidize-pdf-core/tests/issue_375_text_conservation_test.rs`
+
+**Interfaces:**
+- Consumes: `PdfDocument::partition_with(PartitionConfig) -> ParseResult<Vec<Element>>`; `Element::display_text() -> String`; text extraction to get the page's expected text.
+- Produces: the invariant helper `assert_text_conserved` reused by later tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_text_conservation_test.rs
+//
+// #375 data-loss guard: after partitioning, the union of all element text must
+// cover the page's extracted text. A prose page misdetected as an (empty) table
+// currently drops its text -> this fails RED until the claim fix lands.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::{Element, PartitionConfig};
+use oxidize_pdf::text::TextExtractor;
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+/// Non-whitespace tokens of `s`, lowercased, for order-independent containment.
+fn tokens(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|t| t.to_lowercase()).collect()
+}
+
+#[test]
+fn partition_conserves_page_text_default_config() {
+    let doc = PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"));
+
+    // Expected: raw extracted text of every page.
+    let mut extractor = TextExtractor::new();
+    let page_count = doc.page_count().expect("page_count");
+    let mut expected = String::new();
+    for p in 0..page_count {
+        let page_text = extractor
+            .extract_from_page(&doc, p)
+            .expect("extract page")
+            .text;
+        expected.push('\n');
+        expected.push_str(&page_text);
+    }
+
+    // Actual: union of all element display text.
+    let elements = doc.partition_with(PartitionConfig::default()).expect("partition");
+    let actual: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let actual_tokens: std::collections::HashSet<String> = tokens(&actual).into_iter().collect();
+
+    // Every expected token must survive partitioning (allow a small slack for
+    // tokenization artifacts at cell boundaries).
+    let missing: Vec<String> = tokens(&expected)
+        .into_iter()
+        .filter(|t| !actual_tokens.contains(t))
+        .collect();
+
+    let miss_ratio = missing.len() as f64 / tokens(&expected).len().max(1) as f64;
+    assert!(
+        miss_ratio < 0.01,
+        "partition dropped {:.1}% of page tokens ({} missing), e.g. {:?}",
+        miss_ratio * 100.0,
+        missing.len(),
+        &missing.iter().take(15).collect::<Vec<_>>()
+    );
+}
+```
+
+- [ ] **Step 2: Run it and confirm RED**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: FAIL — a meaningful fraction of tokens missing (the #345 empty-table drop). If it unexpectedly PASSES, the fixture doesn't trigger the bug; switch to the alternate reproduction in Step 3 before proceeding.
+
+- [ ] **Step 3 (only if Step 2 passed): synthetic spatial reproduction**
+
+If the fixture no longer triggers it, add this second test that drives the spatial path directly with prose fragments that clear the 0.5 confidence gate yet leave bbox-interior fragments uncelled:
+
+```rust
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(), x, y,
+        width: text.len() as f64 * 6.0, height: 12.0, font_size: 12.0,
+        font_name: None, is_bold: false, is_italic: false, color: None,
+        space_decisions: Vec::new(), mcid: None, struct_tag: None,
+    }
+}
+
+#[test]
+fn spatial_table_does_not_drop_interior_prose() {
+    // A justified prose block: 3 X-columns x 4 Y-rows, but one stray token sits
+    // in a gap between columns (inside the table bbox, outside every cell).
+    let mut frags = Vec::new();
+    for (r, y) in [780.0, 760.0, 740.0, 720.0].iter().enumerate() {
+        for (c, x) in [72.0, 200.0, 330.0].iter().enumerate() {
+            frags.push(frag(&format!("w{r}{c}"), *x, *y));
+        }
+    }
+    frags.push(frag("ORPHAN", 150.0, 730.0)); // in-bbox, between columns
+
+    let elements = Partitioner::new(PartitionConfig::default())
+        .partition_fragments(&frags, 0, 842.0);
+    let all: String = elements.iter().map(|e| e.display_text()).collect::<Vec<_>>().join(" ");
+    assert!(all.contains("ORPHAN"), "interior prose token was dropped: {all}");
+}
+```
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: FAIL on `spatial_table_does_not_drop_interior_prose` (ORPHAN claimed by bbox, never celled, never re-classified).
+
+- [ ] **Step 4: Commit the RED test**
+
+```bash
+git add oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
+git commit -m "test(#375): failing text-conservation invariant reproduces table data loss"
+```
+
+---
+
+## Task 2: Claim only captured text — ruling path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs:348-357` (ruling claim loop)
+
+**Interfaces:**
+- Consumes: `DetectedTable { cells: Vec<TableCell>, .. }` where each `TableCell` has a `bbox` with `contains_point(x, y)`.
+- Produces: unchanged public surface; only claiming behavior changes.
+
+- [ ] **Step 1: Replace bbox-membership claiming with cell-membership claiming**
+
+Current (lines 348–357) claims every fragment inside the table bbox. Replace the inner loop body so a fragment is claimed only if its center lands inside an actual cell of this table:
+
+```rust
+                                // #375: claim only fragments actually placed in a
+                                // cell. Fragments inside the table bbox but in no
+                                // cell (gaps, borders, normalization misses) stay
+                                // unclaimed and fall through to prose classification.
+                                for (i, f) in fragments.iter().enumerate() {
+                                    if claimed[i] {
+                                        continue;
+                                    }
+                                    let cx = f.x + f.width / 2.0;
+                                    let cy = f.y + f.height / 2.0;
+                                    if table.cells.iter().any(|cell| cell.bbox.contains_point(cx, cy)) {
+                                        claimed[i] = true;
+                                    }
+                                }
+```
+
+(Delete the old `let (rx, ry) = ...; let (rr, rt) = ...;` bbox-corner computation above it — it is now unused; clippy will flag it.)
+
+- [ ] **Step 2: Build and lint**
+
+Run: `cargo clippy --lib --all-features -- -D warnings`
+Expected: clean (no unused-variable warning for the removed bbox corners).
+
+- [ ] **Step 3: Run the ruling regression tests**
+
+Run: `cargo test --test ruling_table_partition_test`
+Expected: PASS — genuine bordered tables still capture their cells (fragments are inside cells, so still claimed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): ruling tables claim only celled fragments, not whole bbox"
+```
+
+---
+
+## Task 3: Claim only captured text — spatial path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs:419-428` (spatial claim loop)
+
+**Interfaces:**
+- Consumes: spatial `Table { rows: Vec<Row>, .. }`, `Row { cells: Vec<Cell>, .. }`, `Cell { text, bounding_box, .. }` where `bounding_box` has `contains(x, y)` (structured `BoundingBox`).
+
+- [ ] **Step 1: Replace the spatial claim loop**
+
+Replace lines 419–428 so a fragment is claimed only if its center is inside a non-empty cell of the detected table:
+
+```rust
+                            // #375: claim only fragments inside a populated cell.
+                            for (i, f) in fragments.iter().enumerate() {
+                                if claimed[i] {
+                                    continue;
+                                }
+                                let cx = f.x + f.width / 2.0;
+                                let cy = f.y + f.height / 2.0;
+                                let in_cell = table.rows.iter().flat_map(|r| &r.cells).any(|c| {
+                                    !c.is_empty() && c.bounding_box.contains(cx, cy)
+                                });
+                                if in_cell {
+                                    claimed[i] = true;
+                                }
+                            }
+```
+
+If structured `BoundingBox` exposes containment under a different name, confirm with:
+Run: `grep -n "fn contains" oxidize-pdf-core/src/text/structured/types.rs`
+and use that method name.
+
+- [ ] **Step 2: Lint + spatial regression**
+
+Run: `cargo clippy --lib --all-features -- -D warnings && cargo test --test partition_table_detection_test`
+Expected: PASS.
+
+- [ ] **Step 3: Run the conservation invariant from Task 1**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: the `spatial_...` synthetic test now PASSES (ORPHAN survives). The full-fixture test may still fail if the ruling path or degenerate tables contribute — proceed to Task 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): spatial tables claim only populated-cell fragments"
+```
+
+---
+
+## Task 4: Reject degenerate tables (decompose to prose)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` (ruling accept gate ~324; spatial accept gate ~392)
+
+**Interfaces:**
+- A table that placed almost no text is not emitted at all; its fragments remain unclaimed → prose.
+
+- [ ] **Step 1: Add a degeneracy guard next to each confidence gate**
+
+Ruling path — after the `if table.confidence < ... { continue; }` at ~324, add:
+
+```rust
+                                // #375: a table that captured too few cells is not a
+                                // table — skip it so its fragments become prose.
+                                let populated = table.cells.iter().filter(|c| !c.text.is_empty()).count();
+                                if populated < table.rows.max(1) {
+                                    // fewer populated cells than rows => no real column structure
+                                    continue;
+                                }
+```
+
+Spatial path — after its confidence gate at ~392, add:
+
+```rust
+                            let populated = table.rows.iter().flat_map(|r| &r.cells)
+                                .filter(|c| !c.is_empty()).count();
+                            if populated < table.row_count().max(1) {
+                                continue;
+                            }
+```
+
+- [ ] **Step 2: Run the full conservation invariant**
+
+Run: `cargo test --test issue_375_text_conservation_test -- --nocapture`
+Expected: PASS (both tests). If the full-fixture test still shows missing tokens, inspect which elements swallowed them (`--nocapture` prints the sample) and tighten the guard; do not raise the slack above 1%.
+
+- [ ] **Step 3: Corpus sanity — no regression on real tables**
+
+Run: `cargo test --test table_integration_test --test ruling_table_partition_test --test advanced_tables_tests`
+Expected: PASS — real tables still detected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs
+git commit -m "fix(#375): degenerate tables decompose to prose instead of eating text"
+```
+
+---
+
+## Task 5: Additive rich table model (`TableStructure`, `RichCell`, `structure` field)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/element.rs` (add types near `TableElementData`, line 215; add field; add constructor)
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` (two `TableElementData { rows, metadata }` literals at ~334 and ~409 → add `structure: None`)
+
+**Interfaces:**
+- Produces:
+  - `struct RichCell { pub row: usize, pub col: usize, pub row_span: usize, pub col_span: usize, pub text: String, pub is_header: bool }`
+  - `struct TableStructure { pub cells: Vec<RichCell>, pub num_rows: usize, pub num_cols: usize, pub header_rows: usize }`
+  - `TableElementData { pub rows, pub structure: Option<TableStructure>, pub metadata }`
+  - `TableElementData::from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self` — fills `rows` from the structure by expanding spans (repeating each spanning cell's text across every covered `(row, col)`), so the flat view is derived from the rich one.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_merged_cells_test.rs  (create; more tests added in Task 7/9)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+
+#[test]
+fn from_structure_expands_spans_into_flat_rows() {
+    // 2x2 grid; top row is a single cell spanning both columns (a merged header).
+    let structure = TableStructure {
+        num_rows: 2,
+        num_cols: 2,
+        header_rows: 1,
+        cells: vec![
+            RichCell { row: 0, col: 0, row_span: 1, col_span: 2, text: "Region".into(), is_header: true },
+            RichCell { row: 1, col: 0, row_span: 1, col_span: 1, text: "Q1".into(), is_header: false },
+            RichCell { row: 1, col: 1, row_span: 1, col_span: 1, text: "Q2".into(), is_header: false },
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    // Flat view repeats the spanned header value across both covered columns.
+    assert_eq!(data.rows, vec![
+        vec!["Region".to_string(), "Region".to_string()],
+        vec!["Q1".to_string(), "Q2".to_string()],
+    ]);
+    assert_eq!(data.structure.as_ref().unwrap().header_rows, 1);
+}
+```
+
+- [ ] **Step 2: Run it — FAIL to compile (types don't exist)**
+
+Run: `cargo test --test issue_375_merged_cells_test`
+Expected: FAIL — unresolved `RichCell`/`TableStructure`/`from_structure`.
+
+- [ ] **Step 3: Add the types, field, and constructor**
+
+In `src/pipeline/element.rs`, above `TableElementData` (line 215):
+
+```rust
+/// One cell of a table's rich structure. `row`/`col` are the cell's top-left
+/// position in the base grid; `row_span`/`col_span` are >= 1.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct RichCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub text: String,
+    pub is_header: bool,
+}
+
+/// Rich table structure: merged cells and header rows. Present only when a hard
+/// signal (drawn grid / structure tags) revealed it; borderless tables leave it
+/// `None` and use the flat `rows` view only.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct TableStructure {
+    pub cells: Vec<RichCell>,
+    pub num_rows: usize,
+    pub num_cols: usize,
+    /// Number of leading rows that are headers (0 = none, 1 = single header row,
+    /// >1 = multi-level header expressed as header rows + merged cells).
+    pub header_rows: usize,
+}
+```
+
+Change `TableElementData` (line 218) to add the field:
+
+```rust
+pub struct TableElementData {
+    /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
+    /// present this is its expanded (span-repeated) view; otherwise it is the
+    /// primary representation.
+    pub rows: Vec<Vec<String>>,
+    /// Rich structure (merged cells / header rows) when a hard signal revealed it.
+    pub structure: Option<TableStructure>,
+    pub metadata: ElementMetadata,
+}
+```
+
+Add the constructor in an `impl TableElementData` block (create one right after the struct):
+
+```rust
+impl TableElementData {
+    /// Build from rich structure, deriving the flat `rows` view by expanding each
+    /// spanning cell's text across every covered (row, col).
+    pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {
+        let mut rows = vec![vec![String::new(); structure.num_cols]; structure.num_rows];
+        for cell in &structure.cells {
+            for r in cell.row..(cell.row + cell.row_span).min(structure.num_rows) {
+                for c in cell.col..(cell.col + cell.col_span).min(structure.num_cols) {
+                    rows[r][c] = cell.text.clone();
+                }
+            }
+        }
+        Self { rows, structure: Some(structure), metadata }
+    }
+}
+```
+
+- [ ] **Step 4: Export the new types**
+
+In the module's public re-exports (same place `TableElementData` is exported — check `src/pipeline/mod.rs`), add `RichCell, TableStructure`:
+Run: `grep -n "TableElementData" oxidize-pdf-core/src/pipeline/mod.rs`
+Then add `RichCell, TableStructure` to that `pub use` list.
+
+- [ ] **Step 5: Fix the two struct literals in partition.rs**
+
+At `partition.rs` ~334 and ~409, the `Element::Table(TableElementData { rows, metadata: ... })` literals must add `structure: None,`:
+
+```rust
+                                elements.push(Element::Table(TableElementData {
+                                    rows,
+                                    structure: None,
+                                    metadata: ElementMetadata { /* unchanged */ ..Default::default() },
+                                }));
+```
+
+Also fix any other construction sites the compiler reports:
+Run: `cargo build --lib 2>&1 | grep -n "TableElementData"`
+Add `structure: None,` to each.
+
+- [ ] **Step 6: Run test + build**
+
+Run: `cargo test --test issue_375_merged_cells_test && cargo clippy --lib --all-features -- -D warnings`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/element.rs oxidize-pdf-core/src/pipeline/mod.rs oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
+git commit -m "feat(#375): additive rich table model (TableStructure/RichCell), flat rows derived"
+```
+
+---
+
+## Task 6: Add span fields to the ruling detector's cell (additive, no behavior change)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs:161-184` (`TableCell` struct + `new`)
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs:93-119` (`DetectedTable` gains `header_rows`)
+
+**Interfaces:**
+- Produces: `TableCell { .., pub row_span: usize, pub col_span: usize }` (default 1); `DetectedTable { .., pub header_rows: usize }` (default 0). Existing `DetectedTable::new` keeps its signature and sets `header_rows: 0`.
+
+- [ ] **Step 1: Add fields, defaulting to the current (no-span) behavior**
+
+`TableCell` — add fields and default them in `new`:
+
+```rust
+pub struct TableCell {
+    pub row: usize,
+    pub column: usize,
+    pub bbox: BoundingBox,
+    pub text: String,
+    pub has_borders: bool,
+    /// Number of base rows this cell spans (>= 1).
+    pub row_span: usize,
+    /// Number of base columns this cell spans (>= 1).
+    pub col_span: usize,
+}
+```
+```rust
+    pub fn new(row: usize, column: usize, bbox: BoundingBox) -> Self {
+        Self { row, column, bbox, text: String::new(), has_borders: false, row_span: 1, col_span: 1 }
+    }
+```
+
+`DetectedTable` — add `pub header_rows: usize` and set it to `0` in `new` (keep `new`'s signature unchanged):
+
+```rust
+pub struct DetectedTable {
+    pub bbox: BoundingBox,
+    pub cells: Vec<TableCell>,
+    pub rows: usize,
+    pub columns: usize,
+    pub confidence: f64,
+    /// Leading header rows (0 until header detection runs; Task 8).
+    pub header_rows: usize,
+}
+```
+```rust
+    pub fn new(bbox: BoundingBox, cells: Vec<TableCell>, rows: usize, columns: usize) -> Self {
+        let confidence = Self::calculate_confidence(&cells, rows, columns);
+        Self { bbox, cells, rows, columns, confidence, header_rows: 0 }
+    }
+```
+
+- [ ] **Step 2: Fix any other `TableCell`/`DetectedTable` literals**
+
+Run: `cargo build --lib 2>&1 | grep -nE "TableCell|DetectedTable"`
+Update each literal to include the new fields (spans `1`, `header_rows` `0`).
+
+- [ ] **Step 3: Existing detector tests unchanged**
+
+Run: `cargo test --lib text::table_detection && cargo test --test table_integration_test`
+Expected: PASS, byte-identical behavior (spans all 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs
+git commit -m "feat(#375): additive span + header_rows fields on ruling detector (default no-op)"
+```
+
+---
+
+## Task 7: Detect merged cells from drawn grid (retain divider segments) — PRIMARY RISK
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` — `GridPattern` (line 514) retains segments; new `merge_cells_across_absent_dividers`; call it inside `detect_bordered_table` (line 318) after `create_cells_from_grid`.
+- Create: `oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs`
+
+**Interfaces:**
+- Consumes: `VectorLine { x1, y1, x2, y2, .. }` from `graphics.horizontal_lines()/vertical_lines()`; grid `rows: Vec<f64>` (Y gridlines), `columns: Vec<f64>` (X gridlines).
+- Produces: `TableCell`s where merged regions appear once at their top-left with `row_span`/`col_span` > 1, and covered interior positions are omitted. `get_cell` still indexes the base grid; callers that need spans read `cells` directly (Task 9 does).
+
+**Algorithm (deterministic):** two base cells are in the same merged region when the divider segment on their shared edge is *absent*. (a) A vertical divider between base columns `c|c+1` across base row `r` is present if some vertical `VectorLine` at `x ≈ columns[c+1]` covers the row's Y-range `[rows[r], rows[r+1]]` (within `alignment_tolerance`). (b) A horizontal divider between base rows `r|r+1` across base column `c` is present if some horizontal `VectorLine` at `y ≈ rows[r+1]` covers `[columns[c], columns[c+1]]`. Build merged regions by union-find over base cells connected by *absent* dividers; each region becomes one `TableCell` at its min-row/min-col with spans = extent, `has_borders: true`.
+
+- [ ] **Step 1: Write the failing test (fixture with one merged header cell)**
+
+```rust
+// tests/issue_375_merged_cells_detect_test.rs
+//
+// Build a bordered 2-col table whose top row is a single cell spanning both
+// columns (the vertical divider is omitted only in row 0). Detection must yield
+// a top-left cell with col_span == 2.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::text::extraction::TextFragment;
+use oxidize_pdf::text::table_detection::TableDetector;
+
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine { VectorLine { x1, y1: y, x2, y2: y } }
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine { VectorLine { x1: x, y1, x2: x, y2 } }
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment { text: t.into(), x, y, width: 30.0, height: 10.0, font_size: 10.0,
+        font_name: None, is_bold: false, is_italic: false, color: None,
+        space_decisions: Vec::new(), mcid: None, struct_tag: None }
+}
+
+#[test]
+fn merged_header_cell_detected_with_col_span_2() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![hline(100.0, 300.0, 100.0), hline(100.0, 300.0, 150.0), hline(100.0, 300.0, 200.0)];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),           // left border (full height)
+        vline(300.0, 100.0, 200.0),           // right border (full height)
+        vline(200.0, 100.0, 150.0),           // MIDDLE divider only in row 1
+    ];
+    let graphics = ExtractedGraphics::from_lines(h, v); // see Step 3 if constructor differs
+    let frags = vec![
+        frag("Header", 150.0, 170.0),
+        frag("A", 130.0, 120.0), frag("B", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+    let top_left = table.cells.iter().find(|c| c.row == 0 && c.column == 0).expect("cell 0,0");
+    assert_eq!(top_left.col_span, 2, "merged header should span 2 columns");
+    // The non-merged row keeps two single cells.
+    assert!(table.cells.iter().any(|c| c.row == 1 && c.column == 0 && c.col_span == 1));
+    assert!(table.cells.iter().any(|c| c.row == 1 && c.column == 1 && c.col_span == 1));
+}
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test`
+Expected: FAIL — either `from_lines` missing (fix in Step 3) or `col_span == 1` (merge not yet implemented).
+
+- [ ] **Step 3: Confirm the graphics test constructor**
+
+Run: `grep -nE "pub fn |pub struct (ExtractedGraphics|VectorLine)|struct VectorLine" oxidize-pdf-core/src/graphics/extraction.rs | head -40`
+- If there is no public `ExtractedGraphics::from_lines`, add a small test-only constructor next to `ExtractedGraphics` that stores the given H/V lines and reports `has_table_structure()` true when both have ≥2 (mirroring the real fields). If `VectorLine` has fields beyond `x1,y1,x2,y2`, extend the helpers to fill them (defaults). Adjust the test's helpers accordingly. Keep the constructor `#[cfg(any(test, feature = "test-helpers"))]` if the codebase gates test helpers, else `pub`.
+
+- [ ] **Step 4: Implement grid-segment retention**
+
+Change `GridPattern` to also hold the raw segments, and populate it in `detect_grid_pattern`:
+
+```rust
+struct GridPattern {
+    rows: Vec<f64>,
+    columns: Vec<f64>,
+    h_segments: Vec<(f64, f64, f64)>, // (y, x_start, x_end)
+    v_segments: Vec<(f64, f64, f64)>, // (x, y_start, y_end)
+}
+```
+In `detect_grid_pattern`, before returning, collect normalized segments from `h_lines`/`v_lines` (`(line.y1, line.x1.min(line.x2), line.x1.max(line.x2))` for horizontals; symmetric for verticals).
+
+- [ ] **Step 5: Implement `merge_cells_across_absent_dividers`**
+
+Add the method and call it in `detect_bordered_table` right after `create_cells_from_grid` (before `assign_text_to_cells`, so text lands in merged cells):
+
+```rust
+fn divider_present_vertical(&self, grid: &GridPattern, x: f64, y0: f64, y1: f64) -> bool {
+    let (lo, hi) = (y0.min(y1), y0.max(y1));
+    grid.v_segments.iter().any(|&(sx, s0, s1)| {
+        (sx - x).abs() <= self.config.alignment_tolerance
+            && s0 <= lo + self.config.alignment_tolerance
+            && s1 >= hi - self.config.alignment_tolerance
+    })
+}
+// symmetric divider_present_horizontal(grid, y, x0, x1)
+
+fn merge_cells_across_absent_dividers(&self, grid: &GridPattern, cells: Vec<TableCell>) -> Vec<TableCell> {
+    let num_rows = grid.rows.len().saturating_sub(1);
+    let num_cols = grid.columns.len().saturating_sub(1);
+    if num_rows == 0 || num_cols == 0 { return cells; }
+
+    // Union-find over base cells (index = r*num_cols + c).
+    let mut parent: Vec<usize> = (0..num_rows * num_cols).collect();
+    fn find(p: &mut Vec<usize>, i: usize) -> usize {
+        if p[i] != i { let r = find(p, p[i]); p[i] = r; } p[i]
+    }
+    for r in 0..num_rows {
+        for c in 0..num_cols {
+            // merge right if the vertical divider at columns[c+1] is absent over this row band
+            if c + 1 < num_cols {
+                let x = grid.columns[c + 1];
+                if !self.divider_present_vertical(grid, x, grid.rows[r], grid.rows[r + 1]) {
+                    let (a, b) = (find(&mut parent, r * num_cols + c), find(&mut parent, r * num_cols + c + 1));
+                    parent[a] = b;
+                }
+            }
+            // merge down if the horizontal divider at rows[r+1] is absent over this column band
+            if r + 1 < num_rows {
+                let y = grid.rows[r + 1];
+                if !self.divider_present_horizontal(grid, y, grid.columns[c], grid.columns[c + 1]) {
+                    let (a, b) = (find(&mut parent, r * num_cols + c), find(&mut parent, (r + 1) * num_cols + c));
+                    parent[a] = b;
+                }
+            }
+        }
+    }
+
+    // Group base cells by root; each group -> one merged TableCell at its min row/col.
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<usize, Vec<&TableCell>> = BTreeMap::new();
+    for cell in &cells {
+        let root = find(&mut parent, cell.row * num_cols + cell.column);
+        groups.entry(root).or_default().push(cell);
+    }
+    let mut merged = Vec::new();
+    for (_root, group) in groups {
+        let min_r = group.iter().map(|c| c.row).min().unwrap();
+        let min_c = group.iter().map(|c| c.column).min().unwrap();
+        let max_r = group.iter().map(|c| c.row).max().unwrap();
+        let max_c = group.iter().map(|c| c.column).max().unwrap();
+        // Merged bbox = union of member bboxes (use grid extents for determinism).
+        let x = grid.columns[min_c];
+        let y = grid.rows[min_r].min(grid.rows[max_r + 1]);
+        let w = (grid.columns[max_c + 1] - grid.columns[min_c]).abs();
+        let hgt = (grid.rows[max_r + 1] - grid.rows[min_r]).abs();
+        let mut cell = TableCell::new(min_r, min_c, BoundingBox::new(x, y, w, hgt));
+        cell.has_borders = true;
+        cell.row_span = max_r - min_r + 1;
+        cell.col_span = max_c - min_c + 1;
+        merged.push(cell);
+    }
+    merged.sort_by(|a, b| (a.row, a.column).cmp(&(b.row, b.column)));
+    merged
+}
+```
+
+Wire into `detect_bordered_table`:
+
+```rust
+        let cells = self.create_cells_from_grid(&grid);
+        let cells = self.merge_cells_across_absent_dividers(&grid, cells); // #375
+        let cells_with_text = self.assign_text_to_cells(cells, text_fragments);
+```
+
+Note: `DetectedTable.rows`/`columns` remain the **base** grid dimensions; merged cells carry spans. `get_cell`'s flat index no longer matches merged cells — that's acceptable because Task 9 reads `cells` directly; leave `get_cell` as-is for base-grid callers.
+
+- [ ] **Step 6: Iterate against the test**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test -- --nocapture`
+Expected: PASS. Adjust tolerance handling until the merged region is exactly col_span 2 in row 0 and single cells in row 1. Then confirm no regression on full grids:
+Run: `cargo test --lib text::table_detection && cargo test --test table_integration_test --test ruling_table_partition_test`
+Expected: PASS (a fully-ruled table has all dividers present → every region is 1×1 → identical to before).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+git commit -m "feat(#375): detect merged cells from absent grid dividers (union-find over base cells)"
+```
+
+---
+
+## Task 8: Identify header rows (from tags, else top row)
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` — set `DetectedTable.header_rows` in `detect_bordered_table` after text assignment.
+
+**Interfaces:**
+- Consumes: `TextFragment.struct_tag: Option<String>` (a marked-content/structure tag name; header cells commonly tagged `"TH"` or containing `"Header"`).
+- Produces: `header_rows` = count of leading rows whose fragments are header-tagged; falls back to `1` (top row) when the table is non-trivial and no tags are present.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// append to tests/issue_375_merged_cells_detect_test.rs
+#[test]
+fn header_row_detected_from_th_tag() {
+    let h = vec![hline(100.0,300.0,100.0), hline(100.0,300.0,150.0), hline(100.0,300.0,200.0)];
+    let v = vec![vline(100.0,100.0,200.0), vline(200.0,100.0,200.0), vline(300.0,100.0,200.0)];
+    let graphics = ExtractedGraphics::from_lines(h, v);
+    let mut th = |t: &str, x: f64, y: f64| {
+        let mut f = frag(t, x, y); f.struct_tag = Some("TH".to_string()); f
+    };
+    let frags = vec![
+        th("H1", 130.0, 170.0), th("H2", 230.0, 170.0), // header row
+        frag("a", 130.0, 120.0), frag("b", 230.0, 120.0),
+    ];
+    let tables = TableDetector::default().detect(&graphics, &frags).expect("detect");
+    assert_eq!(tables.first().unwrap().header_rows, 1);
+}
+```
+
+- [ ] **Step 2: Run — FAIL** (`header_rows` is 0)
+
+Run: `cargo test --test issue_375_merged_cells_detect_test header_row_detected_from_th_tag`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement header-row counting**
+
+After `assign_text_to_cells` in `detect_bordered_table`, before building `DetectedTable`, compute header rows and store it. Since `DetectedTable::new` sets `header_rows: 0`, set the field after construction:
+
+```rust
+        let mut table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        table.header_rows = Self::count_header_rows(&table, text_fragments);
+        Ok(Some(table))
+```
+
+Add helper — a row is a header row if any fragment inside its cells is header-tagged; count only the leading contiguous header rows; if none tagged and the table has ≥2 rows, default to 1:
+
+```rust
+fn count_header_rows(table: &DetectedTable, fragments: &[TextFragment]) -> usize {
+    fn is_header_tag(tag: &str) -> bool {
+        let t = tag.to_ascii_uppercase();
+        t == "TH" || t.contains("HEADER")
+    }
+    let mut tagged_leading = 0usize;
+    for r in 0..table.rows {
+        let row_cells: Vec<&TableCell> = table.cells.iter()
+            .filter(|c| c.row <= r && r < c.row + c.row_span).collect();
+        let has_header = fragments.iter().any(|f| {
+            f.struct_tag.as_deref().map(is_header_tag).unwrap_or(false)
+                && row_cells.iter().any(|c| c.bbox.contains_point(f.x + f.width/2.0, f.y + f.height/2.0))
+        });
+        if has_header { tagged_leading = r + 1; } else { break; }
+    }
+    if tagged_leading > 0 { tagged_leading }
+    else if table.rows >= 2 { 1 } else { 0 }
+}
+```
+
+- [ ] **Step 4: Run — PASS + regression**
+
+Run: `cargo test --test issue_375_merged_cells_detect_test && cargo test --lib text::table_detection`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/text/table_detection.rs oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+git commit -m "feat(#375): count header rows from structure tags, default to top row"
+```
+
+---
+
+## Task 9: Build rich `TableElementData` in the ruling partition path
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/partition.rs` — replace `ruling_table_to_rows(table)` usage at ~327/334 with a rich builder that produces `TableStructure`; spatial path keeps `structure: None`.
+
+**Interfaces:**
+- Consumes: `DetectedTable { cells (with spans), rows, columns, header_rows, .. }`.
+- Produces: `Element::Table(TableElementData::from_structure(structure, metadata))` where `structure.cells` mirror the detector's merged cells.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::pipeline::{Element, PartitionConfig, Partitioner};
+use oxidize_pdf::text::extraction::TextFragment;
+
+// (reuse hline/vline/frag helpers — copy the small helpers from the detect test)
+
+#[test]
+fn ruling_partition_emits_rich_structure_with_merged_header() {
+    let h = vec![/* same 3 h-lines as the merged-header fixture */];
+    let v = vec![/* left, right full; middle only in row 1 */];
+    let graphics = ExtractedGraphics::from_lines(h, v);
+    let frags = vec![/* "Region" spanning header row, "Q1"/"Q2" below */];
+
+    let elements = Partitioner::new(PartitionConfig::default())
+        .partition_fragments_with_graphics(&frags, Some(&graphics), 0, 842.0);
+    let table = elements.iter().find_map(|e| match e { Element::Table(t) => Some(t), _ => None })
+        .expect("a table element");
+    let st = table.structure.as_ref().expect("rich structure present");
+    assert!(st.cells.iter().any(|c| c.row == 0 && c.col == 0 && c.col_span == 2 && c.is_header));
+    assert_eq!(st.header_rows, 1);
+    // Flat view still complete (spanned value repeated).
+    assert_eq!(table.rows[0].len(), 2);
+}
+```
+
+- [ ] **Step 2: Run — FAIL** (`structure` is None today)
+
+Run: `cargo test --test issue_375_multi_level_header_test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the rich builder and use it in the ruling path**
+
+Replace `ruling_table_to_rows` (partition.rs:761) with a structure builder (keep the name or add a new fn; update the call site):
+
+```rust
+/// Convert a ruling-detected table (with merged cells + header rows) into a
+/// rich `TableStructure`. The flat `rows` view is derived by `from_structure`.
+fn ruling_table_to_structure(table: &crate::text::table_detection::DetectedTable) -> TableStructure {
+    let header_rows = table.header_rows;
+    let cells = table.cells.iter().map(|c| RichCell {
+        row: c.row,
+        col: c.column,
+        row_span: c.row_span.max(1),
+        col_span: c.col_span.max(1),
+        text: c.text.clone(),
+        is_header: c.row < header_rows,
+    }).collect();
+    TableStructure { cells, num_rows: table.rows, num_cols: table.columns, header_rows }
+}
+```
+
+At the ruling emit site (~327–342), replace:
+
+```rust
+                                let structure = ruling_table_to_structure(table);
+                                let bbox = ElementBBox::new(
+                                    table.bbox.x, table.bbox.y, table.bbox.width, table.bbox.height,
+                                );
+                                let mut data = TableElementData::from_structure(
+                                    structure,
+                                    ElementMetadata {
+                                        page,
+                                        bbox,
+                                        confidence: table.confidence,
+                                        ..Default::default()
+                                    },
+                                );
+                                // keep metadata bbox already set above
+                                elements.push(Element::Table(std::mem::take(&mut data).into_table()));
+```
+
+If wrapping helpers feel awkward, simpler: build `data` then `elements.push(Element::Table(data));` — `from_structure` already returns `TableElementData`. Use:
+
+```rust
+                                elements.push(Element::Table(TableElementData::from_structure(
+                                    ruling_table_to_structure(table),
+                                    ElementMetadata { page, bbox, confidence: table.confidence, ..Default::default() },
+                                )));
+```
+
+Import `RichCell, TableStructure` at the top of partition.rs (extend the `use crate::pipeline::{...}` list on line 3–5). Remove the now-unused `ruling_table_to_rows` if nothing else calls it (clippy will flag).
+
+Also update the Task 2 ruling claim loop: it references `table.cells` bboxes — still correct (merged cell bboxes cover their region), no change needed.
+
+- [ ] **Step 4: Run — PASS + conservation still green**
+
+Run: `cargo test --test issue_375_multi_level_header_test --test issue_375_text_conservation_test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/partition.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): ruling path emits rich TableStructure (merged cells + header rows)"
+```
+
+---
+
+## Task 10: Markdown degradation — collapse multi-level headers, keep repeated spans
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/export.rs:54,66-78` — `table_to_markdown` becomes structure-aware.
+
+**Interfaces:**
+- Consumes: `TableElementData { rows, structure }`.
+- Rendering: when `structure.header_rows > 1`, collapse the first `header_rows` rows into ONE GFM header, joining each column's header texts top-to-bottom with `" › "` (dedup consecutive equal). Body = remaining rows. Merged-cell values are already repeated in `rows`, so body rendering is unchanged. When `structure` absent or `header_rows <= 1`, keep current behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs  (append)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+use oxidize_pdf::pipeline::export::element_to_markdown_for_test; // see Step 3 for exact entry point
+
+#[test]
+fn multi_level_header_flattens_with_separator() {
+    // 3 header-ish rows collapsed: "Region" (span2) over ["Q1","Q2"].
+    let structure = TableStructure {
+        num_rows: 3, num_cols: 2, header_rows: 2,
+        cells: vec![
+            RichCell{row:0,col:0,row_span:1,col_span:2,text:"Region".into(),is_header:true},
+            RichCell{row:1,col:0,row_span:1,col_span:1,text:"Q1".into(),is_header:true},
+            RichCell{row:1,col:1,row_span:1,col_span:1,text:"Q2".into(),is_header:true},
+            RichCell{row:2,col:0,row_span:1,col_span:1,text:"10".into(),is_header:false},
+            RichCell{row:2,col:1,row_span:1,col_span:1,text:"20".into(),is_header:false},
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    let md = oxidize_pdf::pipeline::export::table_to_markdown_data(&data); // exact name per Step 3
+    assert_eq!(md, "| Region › Q1 | Region › Q2 |\n| --- | --- |\n| 10 | 20 |");
+}
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `cargo test --test issue_375_multi_level_header_test multi_level_header_flattens_with_separator`
+Expected: FAIL (function missing / current flat behavior).
+
+- [ ] **Step 3: Implement structure-aware export**
+
+Add a `pub(crate)` (or `pub`) `table_to_markdown_data(&TableElementData) -> String` and route `Element::Table` through it; keep `table_to_markdown(rows)` for the no-structure case:
+
+```rust
+pub fn table_to_markdown_data(data: &TableElementData) -> String {
+    match &data.structure {
+        Some(st) if st.header_rows > 1 && !data.rows.is_empty() => {
+            let ncols = data.rows[0].len();
+            let mut header = Vec::with_capacity(ncols);
+            for c in 0..ncols {
+                let mut parts: Vec<&str> = Vec::new();
+                for r in 0..st.header_rows.min(data.rows.len()) {
+                    let cell = data.rows[r].get(c).map(|s| s.as_str()).unwrap_or("");
+                    if parts.last() != Some(&cell) && !cell.is_empty() {
+                        parts.push(cell);
+                    }
+                }
+                header.push(parts.join(" › "));
+            }
+            let mut lines = vec![
+                format!("| {} |", header.join(" | ")),
+                format!("| {} |", vec!["---"; ncols].join(" | ")),
+            ];
+            for row in &data.rows[st.header_rows.min(data.rows.len())..] {
+                lines.push(format!("| {} |", row.join(" | ")));
+            }
+            lines.join("\n")
+        }
+        _ => table_to_markdown(&data.rows), // single/no header: unchanged
+    }
+}
+```
+
+Change the arm at line 54:
+```rust
+            Element::Table(t) => Some(table_to_markdown_data(t)),
+```
+
+- [ ] **Step 4: Run — PASS + existing export tests**
+
+Run: `cargo test --test issue_375_multi_level_header_test && cargo test --lib pipeline::export && cargo test --test '*export*' 2>/dev/null; cargo test --lib export`
+Expected: PASS; single-header tables unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/export.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): GFM export collapses multi-level headers, repeats merged spans"
+```
+
+---
+
+## Task 11: RAG metadata from the rich model
+
+**Files:**
+- Modify: `oxidize-pdf-core/src/pipeline/chunk_metadata.rs:262-277` (`table_dims`)
+
+**Interfaces:**
+- `table_dims` reports the rich `(num_rows, num_cols)` when `structure` is present (true geometry), else the flat `rows` dims.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/issue_375_multi_level_header_test.rs  (append) — or a chunk_metadata unit test
+#[test]
+fn table_dims_prefer_rich_structure() {
+    use oxidize_pdf::pipeline::chunk_metadata::ChunkMetadata; // if table_dims is private, test via ChunkMetadata
+    // Build a chunk whose only element is the rich merged table; assert table_cols == 2, table_rows == 3.
+    // (Use the same TableElementData as Task 10.)
+}
+```
+
+If `table_dims` is private (`fn table_dims`), assert through the public `ChunkMetadata` that exposes `table_rows`/`table_cols`. Confirm the constructor path:
+Run: `grep -n "pub fn.*ChunkMetadata\|table_dims\|pub struct ChunkMetadata" oxidize-pdf-core/src/pipeline/chunk_metadata.rs`
+
+- [ ] **Step 2: Run — FAIL** (counts come from flat rows, not structure)
+
+- [ ] **Step 3: Implement**
+
+```rust
+fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
+    elements
+        .iter()
+        .filter_map(|e| match e {
+            Element::Table(t) => Some(match &t.structure {
+                Some(st) => (st.num_rows, st.num_cols),
+                None => (t.rows.len(), t.rows.iter().map(|r| r.len()).max().unwrap_or(0)),
+            }),
+            _ => None,
+        })
+        .max_by_key(|(rows, _)| *rows)
+        .map(|(r, c)| (Some(r), Some(c)))
+        .unwrap_or((None, None))
+}
+```
+
+- [ ] **Step 4: Run — PASS + metadata regression**
+
+Run: `cargo test --lib pipeline::chunk_metadata && cargo test --test issue_375_multi_level_header_test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add oxidize-pdf-core/src/pipeline/chunk_metadata.rs oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+git commit -m "feat(#375): RAG table metadata counts rich structure geometry"
+```
+
+---
+
+## Task 12: Document the known limitation
+
+**Files:**
+- Modify: `docs/TABLE_DETECTION_GUIDE.md` (add a "Known limitations" section)
+- Modify: `oxidize-pdf-core/src/text/table_detection.rs` (module `//!` header — short note pointing to the guide)
+
+- [ ] **Step 1: Add the guide section**
+
+Append to `docs/TABLE_DETECTION_GUIDE.md`:
+
+```markdown
+## Known limitations (as of #375)
+
+Rich table structure — merged cells and multi-level headers — is only produced when a
+**hard signal** reveals it:
+
+- **Merged cells** are detected from the drawn grid: where an internal dividing line is
+  absent, the adjacent cells are merged. Tables without drawn borders ("borderless") are
+  returned as a flat grid with no merged-cell information.
+- **Multi-level headers** are represented as header rows containing merged cells (e.g. a
+  "Region" header spanning two columns above "Q1"/"Q2"). Header rows are identified from the
+  PDF's structure tags when the document is tagged, otherwise the top row is assumed to be
+  the header. A nested header *hierarchy* is not read from the PDF's internal structure tree.
+- **Borderless-table detection is intrinsically ambiguous** and best-effort; when in doubt
+  the content is preserved as prose rather than forced into a grid (no text is dropped).
+
+For GitHub-Flavored Markdown export, merged-cell values are repeated across every column
+they cover, and multi-level headers are flattened into a single header row joining the
+levels with " › ".
+```
+
+- [ ] **Step 2: Add the module note**
+
+Extend the `//!` header of `table_detection.rs` with one line:
+
+```rust
+//! Merged cells are detected from absent grid dividers; borderless tables and un-tagged
+//! multi-level headers stay flat. See `docs/TABLE_DETECTION_GUIDE.md` for the full limits.
+```
+
+- [ ] **Step 3: Build (rustdoc compiles) + commit**
+
+Run: `cargo build --lib`
+```bash
+git add docs/TABLE_DETECTION_GUIDE.md oxidize-pdf-core/src/text/table_detection.rs
+git commit -m "docs(#375): document borderless + un-tagged-header limitations"
+```
+
+---
+
+## Task 13: Integration sweep, MSRV, and quality-rust
+
+**Files:** none (verification only) — fixes land in the relevant prior task's files if issues surface.
+
+- [ ] **Step 1: Full library + integration suite**
+
+Run: `cargo test --lib && cargo test --test issue_375_text_conservation_test --test issue_375_merged_cells_test --test issue_375_merged_cells_detect_test --test issue_375_multi_level_header_test --test partition_table_detection_test --test ruling_table_partition_test --test table_integration_test --test advanced_tables_tests`
+Expected: all PASS.
+
+- [ ] **Step 2: Corpus text-conservation (real PDFs, no regression)**
+
+Run: `cargo test --test table_extraction_real_pdfs` and the corpus tests `t1`/`t2` per repo convention (see `.private`/CI). Confirm zero character-count regressions vs `develop` on a before/after sweep of a handful of table-bearing fixtures.
+
+- [ ] **Step 3: Lint, format, MSRV**
+
+Run:
+```bash
+cargo clippy --lib --all-features -- -D warnings
+cargo fmt --check
+cargo +1.88 build --lib --all-features --locked
+```
+Expected: all clean.
+
+- [ ] **Step 4: quality-rust pass (mandatory)**
+
+Dispatch the `quality-rust` agent over the #375 diff. Apply verified findings (correctness/security first). Re-run Steps 1 & 3 after any fix.
+
+- [ ] **Step 5: Final commit (if quality-rust produced fixes)**
+
+```bash
+git add -A
+git commit -m "chore(#375): quality-rust findings applied"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** data-loss (Tasks 1–4), additive rich model (Task 5), merged cells from grid (Tasks 6–7), header rows / multi-level (Tasks 8–9), Markdown degradation (Task 10), RAG metadata (Task 11), documentation (Task 12), verification + MSRV + quality-rust (Task 13). All spec sections covered.
+- **Uncertain anchors flagged for the implementer to confirm before coding:** (a) `ExtractedGraphics`/`VectorLine` test constructor (Task 7 Step 3); (b) structured `BoundingBox` containment method name (Task 3 Step 1); (c) the exact export entry-point name and `chunk_metadata` visibility (Tasks 10–11); (d) the header tag string(s) real tagged PDFs use (Task 8 — we match `TH`/`*HEADER*`, widen if corpus shows another). These are grounded to a `grep` step, not left as prose placeholders.
+- **Type consistency:** `RichCell`/`TableStructure` field names identical across Tasks 5, 9, 10, 11; `TableCell.row_span/col_span` and `DetectedTable.header_rows` identical across Tasks 6–9.

--- a/docs/superpowers/specs/2026-07-09-issue-375-table-extraction-quality-design.md
+++ b/docs/superpowers/specs/2026-07-09-issue-375-table-extraction-quality-design.md
@@ -1,0 +1,162 @@
+# Design — Issue #375: Table extraction quality + prose-as-empty-table data loss
+
+**Date:** 2026-07-09
+**Issue:** #375 (enhancement, RAG)
+**Branch:** `feature/issue-375-table-extraction-quality` (off `develop`)
+**SemVer:** MINOR (additive; no breaking change to the public table model)
+
+## Summary
+
+Issue #375 bundles three concerns, delivered as a single block:
+
+1. **Data-loss bug (priority):** pages of single-column prose can be misclassified as an
+   empty/sparse table, discarding the page text. Silent data loss in the RAG path.
+2. **Merged cells** (rowspan/colspan) are not preserved — spans collapse.
+3. **Multi-level (nested) headers** are flattened, losing column semantics.
+
+The fix is a correctness fix (concern 1) plus an additive enrichment of the table data
+model (concerns 2 & 3), populated only from hard structural signals. Borderless-table
+structure inference is explicitly out of scope and documented as a known limitation.
+
+## Background — current architecture
+
+Two independent table detectors feed one shared, flat table representation:
+
+- **Ruling-based detector:** reads the horizontal/vertical vector lines the PDF draws as
+  borders, derives a grid from the line crossings, and assigns text to cells.
+- **Spatial/borderless detector:** with no drawn borders, clusters text by X/Y position to
+  infer an implicit grid.
+
+Both produce the same shape: a flat grid of plain-text strings (rows, each a list of
+strings). There is **no representation** for merged cells or header rows today; those
+features are structurally unrepresentable, not merely unimplemented.
+
+Detected tables become a canonical pipeline element, flow into RAG chunks (with
+row/column-count metadata), and are exported to GitHub-Flavored Markdown (GFM).
+
+### Root cause of the data-loss bug
+
+When a region is accepted as a table, the partitioner marks **every text fragment whose
+position falls inside the table's bounding box as "claimed"** — independently of whether
+that fragment's text was actually placed into a cell. The prose classifier only processes
+*unclaimed* fragments. So text inside the bounding box but not inside any cell (gaps,
+border zones, coordinate-normalization misses) is claimed and never re-classified as prose
+→ its text is silently dropped. A prose page with as few as two horizontal and two vertical
+drawn lines (a frame, a box, header/footer rules) can trip the detector, claim the whole
+page, and emit a near-empty table.
+
+The earlier #345 work only exposed a config switch to turn table detection off — a
+workaround. The underlying claim-without-capture defect was never fixed.
+
+## Goals
+
+- No page loses text to an empty/sparse-table misclassification. Zero character-count
+  regression across the corpus.
+- Merged cells and multi-level headers are represented when a hard signal reveals them, and
+  round-trip to correct GFM.
+- Additive change only: existing consumers of the flat table view keep working unchanged.
+- No-ML, deterministic throughout.
+
+## Non-goals
+
+- Inferring merged cells or header hierarchy from borderless (whitespace-only) tables.
+  Documented as a known limitation.
+- Reading the PDF's deep structure tree to recover a nested-header hierarchy (parent/child
+  header grouping). That data does not reach the text/partition layer today — only a flat
+  per-fragment tag name does — and plumbing the full structure tree is a much larger change
+  reserved for a separate block. Multi-level headers are instead represented as header rows
+  containing merged cells (see Design §3).
+- Any breaking change to the public table model.
+
+## Design
+
+### 1. Data-loss safety net (concern 1, always on)
+
+- **Claim only what you capture.** A table may claim only the text it actually placed into a
+  cell. Text inside the bounding box but not in any cell stays unclaimed and flows to the
+  prose classifier as paragraphs. This removes the silent drop at its source.
+- **Reject degenerate tables.** A candidate table that captured almost no text decomposes
+  back to prose rather than being accepted.
+- **Text-conservation invariant.** After partitioning, the union of all element text must
+  cover the page's extracted text. This becomes a hard test (absent today) and the safety
+  net that catches any future leak.
+- Delivered automatically to everyone with detection enabled — a data-loss fix is not
+  hidden behind opt-in. The existing "disable detection" switch remains for compatibility
+  but is demoted from a data-safety necessity to a plain preference.
+
+### 2. Additive rich table model (concerns 2 & 3, representation)
+
+- The rich structure — cells with their row/column span, and which rows are headers — is
+  built internally as the source of truth.
+- The existing flat grid stays public and is **derived** from the rich structure, so the two
+  never desynchronize.
+- Consumers of the flat view are unaffected; consumers wanting structure use the new layer.
+- SemVer: MINOR (additive).
+
+### 3. Sources of rich structure (hard signals only)
+
+**Merged cells (the central, highest-risk task).** From the drawn grid. Today the grid
+detector keeps only the *positions* of gridlines (the Y of each horizontal rule, the X of
+each vertical rule) and then assumes a complete, perfect grid — it does **not** record which
+dividing segments are actually drawn. A merged cell is precisely a *missing* internal
+divider, which is invisible under that representation. So this task reworks grid construction
+to remember which dividers actually exist (the raw line segments are available upstream and
+are currently discarded during clustering) and, where an internal divider is absent, merges
+the adjacent cells into one spanning cell. This is the hardest part of the block; everything
+else is straightforward on top of it.
+
+**Header rows.** Identify which rows are header rows: from the per-fragment structure tag
+when the PDF is tagged (a fragment carrying a "header cell" tag), otherwise fall back to the
+existing convention that the top row is the header.
+
+**Multi-level headers = header rows + merged cells.** We do not read a nested-header
+hierarchy from anywhere; that grouping is not exposed at this layer (see Non-goals). A
+multi-level header is represented as header rows that contain merged cells — e.g. a "Region"
+header spanning two columns above "Q1"/"Q2". The merged-cell detection above is what makes it
+representable. Where there is neither a drawn header span nor a tag, we keep a single header
+row.
+
+**Borderless tables:** flat grid, best effort. No span/header inference.
+
+### 4. Outputs — Markdown degradation and RAG metadata
+
+GFM cannot express merged cells or multi-level headers. Deterministic degradation:
+
+- **Merged cell → repeat its value in every covered cell.** A query landing on any covered
+  column then sees the value instead of a gap (avoids the "disconnected numbers" failure).
+- **Multi-level header → flatten by joining levels** (e.g. `Region › Q1`) so each column
+  keeps its full semantic path.
+
+RAG metadata (row/column counts, has-table flag) is computed from the rich model, counting
+the real geometry of the spans.
+
+### 5. Documentation of the known limitation
+
+- Public table-detection guide (`docs/TABLE_DETECTION_GUIDE.md`): explanation with an
+  example — borderless tables get no rich structure and their detection is intrinsically
+  ambiguous; multi-level headers require a tagged PDF.
+- Library module-level docs (rustdoc header of the table-detection module): short note
+  pointing to the guide. Single source of truth in the guide; the module note just refers to
+  it.
+
+### 6. Testing
+
+- **Reproduce first (TDD red):** a real corpus fixture where a prose page is currently eaten
+  by an empty table; assert its text survives → then fix.
+- **Text-conservation invariant** over the corpus: zero character-count regression.
+- **Merged-cell fixture:** round-trips to correct GFM (spanned value repeated).
+- **Multi-level-header fixture (tagged PDF):** round-trips to correct flattened GFM header.
+- Every test verifies real content, not absence of crash.
+
+## Risks / known limitations
+
+- **Primary risk — merged-cell detection.** Requires reworking grid construction to retain
+  per-segment divider presence (§3). Higher effort and risk than the rest of the block; must
+  not regress existing full-grid table detection (guarded by the corpus/ruling tests).
+- Borderless-table structure and un-tagged multi-level headers remain flat — documented.
+- Changing the claim logic shifts some pages from (empty) table output to prose output. This
+  is the intended correction; corpus before/after sweep confirms text is preserved, not lost.
+
+## Rollout
+
+- MINOR release once merged to `develop` and validated. Quality-rust pass before PR.

--- a/oxidize-pdf-core/src/operations/source_highlighter.rs
+++ b/oxidize-pdf-core/src/operations/source_highlighter.rs
@@ -339,7 +339,11 @@ mod tests {
             .map(|f| f.text.as_str())
             .collect::<Vec<_>>()
             .join(" ");
-        ExtractedText { text, fragments }
+        ExtractedText {
+            text,
+            fragments,
+            truncated: false,
+        }
     }
 
     #[test]
@@ -347,6 +351,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -367,6 +372,7 @@ mod tests {
                 make_fragment("World", 160.0, 700.0, 55.0, 12.0),
                 make_fragment("Test", 225.0, 700.0, 40.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -383,10 +389,12 @@ mod tests {
         let page1 = ExtractedText {
             text: "Page one".to_string(),
             fragments: vec![make_fragment("Page one", 72.0, 700.0, 80.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "Page two".to_string(),
             fragments: vec![make_fragment("Page two", 72.0, 700.0, 80.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2]);
 
@@ -405,6 +413,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -417,6 +426,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -434,6 +444,7 @@ mod tests {
         let page = ExtractedText {
             text: "Hello".to_string(),
             fragments: vec![make_fragment("Hello", 100.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -477,6 +488,7 @@ mod tests {
         let page1 = ExtractedText {
             text: "AAA".to_string(),
             fragments: vec![make_fragment("AAA", 72.0, 700.0, 30.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "BBB CCC".to_string(),
@@ -484,6 +496,7 @@ mod tests {
                 make_fragment("BBB", 72.0, 700.0, 30.0, 12.0),
                 make_fragment("CCC", 110.0, 700.0, 30.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2]);
 
@@ -502,14 +515,17 @@ mod tests {
         let page1 = ExtractedText {
             text: "ABCDE".to_string(), // 5 chars
             fragments: vec![make_fragment("ABCDE", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let page2 = ExtractedText {
             text: "FGHIJ".to_string(), // 5 chars
             fragments: vec![make_fragment("FGHIJ", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let page3 = ExtractedText {
             text: "KLMNO".to_string(), // 5 chars
             fragments: vec![make_fragment("KLMNO", 72.0, 700.0, 50.0, 12.0)],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page1, page2, page3]);
 
@@ -532,6 +548,7 @@ mod tests {
                 make_fragment("", 130.0, 700.0, 10.0, 12.0), // empty fragment
                 make_fragment("World", 145.0, 700.0, 55.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 
@@ -551,6 +568,7 @@ mod tests {
                 make_fragment("CCC", 150.0, 700.0, 30.0, 12.0),
                 make_fragment("DDD", 190.0, 700.0, 30.0, 12.0),
             ],
+            truncated: false,
         };
         let index = TextPositionIndex::build(&[page]);
 

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -1409,9 +1409,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Extract and chunk with a custom [`TokenCounter`](crate::pipeline::TokenCounter).
@@ -1431,9 +1432,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         counter: std::sync::Arc<dyn crate::pipeline::TokenCounter>,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config).with_token_counter(counter);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Build RAG chunks stamped with source-document metadata.
@@ -1490,9 +1492,10 @@ impl<R: Read + Seek> PdfDocument<R> {
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         self.autofill_source(&mut source);
         let elements = self.partition()?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source)))
+        Ok(self.build_rag_chunks(&hybrid_chunks, Some(source), context_mode))
     }
 
     /// Fill `title`/`author`/`creation_date`/`total_pages` from the info
@@ -1605,7 +1608,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         // `mut` is needed only for the enricher pass below (gated `semantic`);
         // without that feature the binding is never mutated — silence the warning.
         #[allow(unused_mut)]
-        let mut chunks = self.build_rag_chunks(&hybrid, source);
+        let mut chunks = self.build_rag_chunks(&hybrid, source, pipeline.context_mode);
         #[cfg(feature = "semantic")]
         if !pipeline.enrichers.is_empty() {
             // Enrich each chunk's `extra` bag. The hybrid chunk (kept alongside)
@@ -1634,17 +1637,27 @@ impl<R: Read + Seek> PdfDocument<R> {
         &self,
         hybrid_chunks: &[crate::pipeline::HybridChunk],
         source: Option<crate::pipeline::DocumentSource>,
+        context_mode: crate::pipeline::ContextMode,
     ) -> Vec<crate::pipeline::RagChunk> {
         let mut chunks: Vec<crate::pipeline::RagChunk> = match &source {
             Some(s) => hybrid_chunks
                 .iter()
                 .enumerate()
-                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk_with_source(i, hc, s))
+                .map(|(i, hc)| {
+                    crate::pipeline::RagChunk::from_hybrid_chunk_with_source_and_mode(
+                        i,
+                        hc,
+                        s,
+                        context_mode,
+                    )
+                })
                 .collect(),
             None => hybrid_chunks
                 .iter()
                 .enumerate()
-                .map(|(i, hc)| crate::pipeline::RagChunk::from_hybrid_chunk(i, hc))
+                .map(|(i, hc)| {
+                    crate::pipeline::RagChunk::from_hybrid_chunk_with_mode(i, hc, context_mode)
+                })
                 .collect(),
         };
         crate::pipeline::chunk_metadata::link_chunks(&mut chunks);
@@ -1676,7 +1689,7 @@ impl<R: Read + Seek> PdfDocument<R> {
         let elements = self.partition_with_profile(profile)?;
         let chunker = crate::pipeline::HybridChunker::default();
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, crate::pipeline::ContextMode::Heading))
     }
 
     /// Combine a pre-configured extraction profile with a custom chunking config.
@@ -1701,9 +1714,10 @@ impl<R: Read + Seek> PdfDocument<R> {
         config: crate::pipeline::HybridChunkConfig,
     ) -> ParseResult<Vec<crate::pipeline::RagChunk>> {
         let elements = self.partition_with_profile(profile)?;
+        let context_mode = config.context_mode;
         let chunker = crate::pipeline::HybridChunker::new(config);
         let hybrid_chunks = chunker.chunk(&elements);
-        Ok(self.build_rag_chunks(&hybrid_chunks, None))
+        Ok(self.build_rag_chunks(&hybrid_chunks, None, context_mode))
     }
 
     /// Extract chunks as a JSON string ready for vector store ingestion.

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -265,14 +265,17 @@ fn table_dims(elements: &[Element]) -> (Option<usize>, Option<usize>) {
     elements
         .iter()
         .filter_map(|e| match e {
-            Element::Table(t) => Some(&t.rows),
+            Element::Table(t) => Some(match &t.structure {
+                Some(st) => (st.num_rows, st.num_cols),
+                None => (
+                    t.rows.len(),
+                    t.rows.iter().map(|r| r.len()).max().unwrap_or(0),
+                ),
+            }),
             _ => None,
         })
-        .max_by_key(|rows| rows.len())
-        .map(|rows| {
-            let cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-            (Some(rows.len()), Some(cols))
-        })
+        .max_by_key(|(rows, _)| *rows)
+        .map(|(r, c)| (Some(r), Some(c)))
         .unwrap_or((None, None))
 }
 
@@ -406,7 +409,7 @@ pub(crate) fn sentence_count(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pipeline::element::{Element, ElementData, ElementMetadata};
+    use crate::pipeline::element::{Element, ElementData, ElementMetadata, TableStructure};
 
     fn table_el() -> Element {
         Element::Table(crate::pipeline::element::TableElementData {
@@ -663,6 +666,24 @@ mod tests {
         let m = ChunkMetadata::from_elements(&els, "just prose", "just prose", 0, None);
         assert_eq!(m.table_rows, None);
         assert_eq!(m.table_cols, None);
+    }
+
+    #[test]
+    fn table_dims_prefers_rich_structure() {
+        // Flat `rows` says 1x1; rich `structure` says 3x4 (e.g. a merged-cell
+        // table where the flat fallback under-counts). table_dims must read
+        // the structure geometry, not the flat rows, when structure is present.
+        let el = Element::Table(crate::pipeline::element::TableElementData {
+            rows: vec![vec!["x".to_string()]],
+            structure: Some(TableStructure {
+                cells: vec![],
+                num_rows: 3,
+                num_cols: 4,
+                header_rows: 1,
+            }),
+            metadata: ElementMetadata::default(),
+        });
+        assert_eq!(table_dims(&[el]), (Some(3), Some(4)));
     }
 
     #[cfg(feature = "semantic")]

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -411,6 +411,7 @@ mod tests {
     fn table_el() -> Element {
         Element::Table(crate::pipeline::element::TableElementData {
             rows: vec![],
+            structure: None,
             metadata: crate::pipeline::element::ElementMetadata::default(),
         })
     }
@@ -631,6 +632,7 @@ mod tests {
                 .into_iter()
                 .map(|r| r.into_iter().map(String::from).collect())
                 .collect(),
+            structure: None,
             metadata: ElementMetadata::default(),
         })
     }

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -75,8 +75,16 @@ impl Aggregates {
 }
 
 /// Boolean flags describing the kinds of content present in a chunk.
+///
+/// Pipeline output: the chunker derives these from a chunk's element types;
+/// external consumers read them off [`ChunkMetadata::content_types`]. Like the
+/// enclosing [`ChunkMetadata`], this is `#[non_exhaustive]` so future content
+/// flags (e.g. `has_formula`, `has_footnote`) can be added without a breaking
+/// change. To build one outside the crate (e.g. in a test), start from
+/// [`ContentTypeFlags::default`] and set the fields you need.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct ContentTypeFlags {
     /// The chunk contains at least one table element.
     pub has_table: bool,

--- a/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
+++ b/oxidize-pdf-core/src/pipeline/chunk_metadata.rs
@@ -412,11 +412,10 @@ mod tests {
     use crate::pipeline::element::{Element, ElementData, ElementMetadata, TableStructure};
 
     fn table_el() -> Element {
-        Element::Table(crate::pipeline::element::TableElementData {
-            rows: vec![],
-            structure: None,
-            metadata: crate::pipeline::element::ElementMetadata::default(),
-        })
+        Element::Table(crate::pipeline::element::TableElementData::new(
+            vec![],
+            crate::pipeline::element::ElementMetadata::default(),
+        ))
     }
 
     #[test]
@@ -630,14 +629,12 @@ mod tests {
     }
 
     fn table_with(rows: Vec<Vec<&str>>) -> Element {
-        Element::Table(crate::pipeline::element::TableElementData {
-            rows: rows
-                .into_iter()
+        Element::Table(crate::pipeline::element::TableElementData::new(
+            rows.into_iter()
                 .map(|r| r.into_iter().map(String::from).collect())
                 .collect(),
-            structure: None,
-            metadata: ElementMetadata::default(),
-        })
+            ElementMetadata::default(),
+        ))
     }
 
     #[test]
@@ -673,6 +670,12 @@ mod tests {
         // Flat `rows` says 1x1; rich `structure` says 3x4 (e.g. a merged-cell
         // table where the flat fallback under-counts). table_dims must read
         // the structure geometry, not the flat rows, when structure is present.
+        // Deliberately construct rows/structure out of sync (1x1 flat rows vs
+        // 3x4 structure) to prove table_dims reads structure geometry, not the
+        // flat rows view. `from_structure` would derive rows FROM structure and
+        // erase this mismatch, so this stays a same-crate struct literal
+        // (unaffected by #[non_exhaustive], which only gates cross-crate
+        // construction).
         let el = Element::Table(crate::pipeline::element::TableElementData {
             rows: vec![vec!["x".to_string()]],
             structure: Some(TableStructure {

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -242,6 +242,7 @@ pub struct TableStructure {
 /// Data specific to table elements.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct TableElementData {
     /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
     /// present this is its expanded (span-repeated) view; otherwise it is the
@@ -253,6 +254,16 @@ pub struct TableElementData {
 }
 
 impl TableElementData {
+    /// Build a plain (non-rich) table from flat row-major cells. `structure` is
+    /// `None`; use `from_structure` when merged cells / header rows are known.
+    pub fn new(rows: Vec<Vec<String>>, metadata: ElementMetadata) -> Self {
+        Self {
+            rows,
+            structure: None,
+            metadata,
+        }
+    }
+
     /// Build from rich structure, deriving the flat `rows` view by expanding each
     /// spanning cell's text across every covered (row, col).
     pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {

--- a/oxidize-pdf-core/src/pipeline/element.rs
+++ b/oxidize-pdf-core/src/pipeline/element.rs
@@ -212,13 +212,64 @@ pub struct ElementData {
     pub metadata: ElementMetadata,
 }
 
+/// One cell of a table's rich structure. `row`/`col` are the cell's top-left
+/// position in the base grid; `row_span`/`col_span` are >= 1.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct RichCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub text: String,
+    pub is_header: bool,
+}
+
+/// Rich table structure: merged cells and header rows. Present only when a hard
+/// signal (drawn grid / structure tags) revealed it; borderless tables leave it
+/// `None` and use the flat `rows` view only.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
+pub struct TableStructure {
+    pub cells: Vec<RichCell>,
+    pub num_rows: usize,
+    pub num_cols: usize,
+    /// Number of leading rows that are headers (0 = none, 1 = single header row,
+    /// >1 = multi-level header expressed as header rows + merged cells).
+    pub header_rows: usize,
+}
+
 /// Data specific to table elements.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "semantic", derive(Serialize, Deserialize))]
 pub struct TableElementData {
-    /// Row-major cell data. Each inner Vec is one row.
+    /// Row-major flat cell data. Each inner Vec is one row. When `structure` is
+    /// present this is its expanded (span-repeated) view; otherwise it is the
+    /// primary representation.
     pub rows: Vec<Vec<String>>,
+    /// Rich structure (merged cells / header rows) when a hard signal revealed it.
+    pub structure: Option<TableStructure>,
     pub metadata: ElementMetadata,
+}
+
+impl TableElementData {
+    /// Build from rich structure, deriving the flat `rows` view by expanding each
+    /// spanning cell's text across every covered (row, col).
+    pub fn from_structure(structure: TableStructure, metadata: ElementMetadata) -> Self {
+        let mut rows = vec![vec![String::new(); structure.num_cols]; structure.num_rows];
+        for cell in &structure.cells {
+            for r in cell.row..(cell.row + cell.row_span).min(structure.num_rows) {
+                for c in cell.col..(cell.col + cell.col_span).min(structure.num_cols) {
+                    rows[r][c] = cell.text.clone();
+                }
+            }
+        }
+        Self {
+            rows,
+            structure: Some(structure),
+            metadata,
+        }
+    }
 }
 
 /// Data specific to image elements.

--- a/oxidize-pdf-core/src/pipeline/export.rs
+++ b/oxidize-pdf-core/src/pipeline/export.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::Element;
+use crate::pipeline::{Element, TableElementData};
 
 /// Configuration for element-aware markdown export.
 #[derive(Debug, Clone)]
@@ -51,7 +51,7 @@ impl ElementMarkdownExporter {
                 let alt = img.alt_text.as_deref().unwrap_or("");
                 Some(format!("![{}]()", alt))
             }
-            Element::Table(t) => Some(table_to_markdown(&t.rows)),
+            Element::Table(t) => Some(table_to_markdown_data(t)),
             Element::Header(_) | Element::Footer(_) => {
                 if self.config.include_headers_footers {
                     Some(element.display_text())
@@ -75,4 +75,174 @@ fn table_to_markdown(rows: &[Vec<String>]) -> String {
         lines.push(format!("| {} |", row.join(" | ")));
     }
     lines.join("\n")
+}
+
+/// Structure-aware table export: when `data.structure` reveals a multi-level
+/// header (`header_rows > 1`), collapse the first `header_rows` rows into a
+/// single GFM header row, joining each column's header texts top-to-bottom
+/// with " › " (skipping empties and consecutive duplicates so a vertically-
+/// or horizontally-merged header cell that is already repeated across the
+/// flat `rows` view doesn't render as "X › X"). Body rows start right after
+/// the header rows; merged body cells are already repeated in `rows`, so
+/// their rendering is unchanged.
+///
+/// When `structure` is absent or `header_rows <= 1`, delegates to
+/// [`table_to_markdown`] — behavior for single/no-header tables is unchanged.
+fn table_to_markdown_data(data: &TableElementData) -> String {
+    match &data.structure {
+        Some(st) if st.header_rows > 1 && !data.rows.is_empty() => {
+            let ncols = st.num_cols;
+            let header_rows = st.header_rows.min(data.rows.len());
+            let mut header = Vec::with_capacity(ncols);
+            for c in 0..ncols {
+                let mut parts: Vec<&str> = Vec::new();
+                for row in &data.rows[..header_rows] {
+                    let cell = row.get(c).map(|s| s.as_str()).unwrap_or("");
+                    if !cell.is_empty() && parts.last() != Some(&cell) {
+                        parts.push(cell);
+                    }
+                }
+                header.push(parts.join(" › "));
+            }
+            let mut lines = vec![
+                format!("| {} |", header.join(" | ")),
+                format!("| {} |", vec!["---"; ncols].join(" | ")),
+            ];
+            for row in &data.rows[header_rows..] {
+                lines.push(format!("| {} |", row.join(" | ")));
+            }
+            lines.join("\n")
+        }
+        _ => table_to_markdown(&data.rows),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::{ElementMetadata, RichCell, TableStructure};
+
+    #[test]
+    fn multi_level_header_flattens_with_separator() {
+        // "Region" spans both columns over row 0; row 1 sub-headers "Q1"/"Q2".
+        // Dedup must prevent "Region › Region" leaking through.
+        let structure = TableStructure {
+            num_rows: 3,
+            num_cols: 2,
+            header_rows: 2,
+            cells: vec![
+                RichCell {
+                    row: 0,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 2,
+                    text: "Region".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "Q1".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "Q2".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 2,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "10".into(),
+                    is_header: false,
+                },
+                RichCell {
+                    row: 2,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "20".into(),
+                    is_header: false,
+                },
+            ],
+        };
+        let data = TableElementData::from_structure(structure, ElementMetadata::default());
+        let md = table_to_markdown_data(&data);
+        assert_eq!(
+            md,
+            "| Region › Q1 | Region › Q2 |\n| --- | --- |\n| 10 | 20 |"
+        );
+    }
+
+    #[test]
+    fn no_structure_table_unchanged() {
+        let metadata = ElementMetadata::default();
+        let data = TableElementData {
+            rows: vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["1".to_string(), "2".to_string()],
+            ],
+            structure: None,
+            metadata,
+        };
+        let expected = table_to_markdown(&data.rows);
+        assert_eq!(table_to_markdown_data(&data), expected);
+        assert_eq!(expected, "| a | b |\n| --- | --- |\n| 1 | 2 |");
+    }
+
+    #[test]
+    fn single_header_row_structure_unchanged() {
+        // header_rows == 1: same behavior as the plain no-structure path.
+        let structure = TableStructure {
+            num_rows: 2,
+            num_cols: 2,
+            header_rows: 1,
+            cells: vec![
+                RichCell {
+                    row: 0,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "a".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 0,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "b".into(),
+                    is_header: true,
+                },
+                RichCell {
+                    row: 1,
+                    col: 0,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "1".into(),
+                    is_header: false,
+                },
+                RichCell {
+                    row: 1,
+                    col: 1,
+                    row_span: 1,
+                    col_span: 1,
+                    text: "2".into(),
+                    is_header: false,
+                },
+            ],
+        };
+        let data = TableElementData::from_structure(structure, ElementMetadata::default());
+        assert_eq!(
+            table_to_markdown_data(&data),
+            "| a | b |\n| --- | --- |\n| 1 | 2 |"
+        );
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/export.rs
+++ b/oxidize-pdf-core/src/pipeline/export.rs
@@ -184,14 +184,13 @@ mod tests {
     #[test]
     fn no_structure_table_unchanged() {
         let metadata = ElementMetadata::default();
-        let data = TableElementData {
-            rows: vec![
+        let data = TableElementData::new(
+            vec![
                 vec!["a".to_string(), "b".to_string()],
                 vec!["1".to_string(), "2".to_string()],
             ],
-            structure: None,
             metadata,
-        };
+        );
         let expected = table_to_markdown(&data.rows);
         assert_eq!(table_to_markdown_data(&data), expected);
         assert_eq!(expected, "| a | b |\n| --- | --- |\n| 1 | 2 |");

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -46,6 +46,7 @@ pub enum MergePolicy {
 ///     merge_adjacent: true,
 ///     propagate_headings: true,
 ///     merge_policy: MergePolicy::AnyInlineContent,
+///     ..Default::default()
 /// };
 /// assert_eq!(config.max_tokens, 256);
 /// ```
@@ -69,6 +70,11 @@ pub struct HybridChunkConfig {
     pub propagate_headings: bool,
     /// Merge policy for adjacent elements. Default: `MergePolicy::AnyInlineContent`.
     pub merge_policy: MergePolicy,
+    /// How each chunk's `full_text` is contextualized for RAG embedding
+    /// (issue #376). Default [`ContextMode::Heading`] — byte-identical to the
+    /// pre-#376 behavior. Set [`ContextMode::Contextual`] for deterministic,
+    /// no-ML document+section context prefixes.
+    pub context_mode: ContextMode,
 }
 
 impl Default for HybridChunkConfig {
@@ -79,8 +85,40 @@ impl Default for HybridChunkConfig {
             merge_adjacent: true,
             propagate_headings: true,
             merge_policy: MergePolicy::AnyInlineContent,
+            context_mode: ContextMode::Heading,
         }
     }
+}
+
+/// How each chunk's `full_text` (the text used for RAG embedding) is
+/// contextualized (issue #376). Contextualization is deterministic and no-ML —
+/// the no-ML analogue of Contextual Retrieval / Late Chunking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContextMode {
+    /// No context prefix — `full_text == text`.
+    None,
+    /// Prepend only the leaf heading context (the pre-#376 behavior, and the
+    /// default so existing callers see byte-identical output).
+    #[default]
+    Heading,
+    /// Prepend a deterministic document + section context snippet in the given
+    /// [`ContextFormat`], situating the chunk in its document (title/author or
+    /// filename, full heading breadcrumb, optional page span).
+    Contextual(ContextFormat),
+}
+
+/// Deterministic, no-ML context-prefix format for [`ContextMode::Contextual`].
+///
+/// `#[non_exhaustive]` so future formats (e.g. structured JSON/YAML) can be
+/// added without a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContextFormat {
+    /// Labeled lines, e.g. `Document: <title> — <author>` / `Section: <breadcrumb> (p. N–M)`.
+    Labeled,
+    /// A single natural-language sentence, e.g.
+    /// `This chunk is from "<title>" by <author>, section "<breadcrumb>" (p. N–M).`
+    Prose,
 }
 
 /// A hybrid chunk: a group of elements with heading context.

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -17,7 +17,7 @@ pub use chunk_metadata::detect_language;
 pub use chunk_metadata::{ChunkMetadata, ContentTypeFlags, DocumentSource, PageRegion};
 pub use element::{
     element_reading_order, Element, ElementBBox, ElementData, ElementMetadata, ImageElementData,
-    KeyValueElementData, TableElementData,
+    KeyValueElementData, RichCell, TableElementData, TableStructure,
 };
 pub use export::{ElementMarkdownExporter, ExportConfig};
 pub use graph::ElementGraph;

--- a/oxidize-pdf-core/src/pipeline/mod.rs
+++ b/oxidize-pdf-core/src/pipeline/mod.rs
@@ -21,7 +21,9 @@ pub use element::{
 };
 pub use export::{ElementMarkdownExporter, ExportConfig};
 pub use graph::ElementGraph;
-pub use hybrid_chunking::{HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy};
+pub use hybrid_chunking::{
+    ContextFormat, ContextMode, HybridChunk, HybridChunkConfig, HybridChunker, MergePolicy,
+};
 pub use partition::{PartitionConfig, Partitioner, ReadingOrderStrategy};
 pub use profile::{ExtractionProfile, ProfileConfig};
 pub use rag::RagChunk;

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -340,6 +340,7 @@ impl Partitioner {
                                 );
                                 elements.push(Element::Table(TableElementData {
                                     rows,
+                                    structure: None,
                                     metadata: ElementMetadata {
                                         page,
                                         bbox,
@@ -432,6 +433,7 @@ impl Partitioner {
 
                             elements.push(Element::Table(TableElementData {
                                 rows,
+                                structure: None,
                                 metadata: ElementMetadata {
                                     page,
                                     bbox,

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -324,6 +324,14 @@ impl Partitioner {
                                 if table.confidence < self.config.min_table_confidence {
                                     continue;
                                 }
+                                // #375: a table that captured too few cells is not a
+                                // table — skip it so its fragments become prose.
+                                let populated =
+                                    table.cells.iter().filter(|c| !c.text.is_empty()).count();
+                                if populated < table.rows.max(1) {
+                                    // fewer populated cells than rows => no real column structure
+                                    continue;
+                                }
                                 let rows = ruling_table_to_rows(table);
                                 let bbox = ElementBBox::new(
                                     table.bbox.x,
@@ -395,6 +403,18 @@ impl Partitioner {
                         for table in &result.tables {
                             // Apply minimum confidence filter.
                             if table.confidence < self.config.min_table_confidence {
+                                continue;
+                            }
+
+                            // #375: a table that captured too few cells is not a
+                            // table — skip it so its fragments become prose.
+                            let populated = table
+                                .rows
+                                .iter()
+                                .flat_map(|r| &r.cells)
+                                .filter(|c| !c.is_empty())
+                                .count();
+                            if populated < table.row_count().max(1) {
                                 continue;
                             }
 

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -1,7 +1,8 @@
 use crate::graphics::extraction::ExtractedGraphics;
 use crate::pipeline::reading_order::{ReadingOrder, SimpleReadingOrder, XYCutReadingOrder};
 use crate::pipeline::{
-    Element, ElementBBox, ElementData, ElementMetadata, KeyValueElementData, TableElementData,
+    Element, ElementBBox, ElementData, ElementMetadata, KeyValueElementData, RichCell,
+    TableElementData, TableStructure,
 };
 use crate::text::extraction::TextFragment;
 
@@ -331,23 +332,21 @@ impl Partitioner {
                                 if populated < 2 {
                                     continue;
                                 }
-                                let rows = ruling_table_to_rows(table);
                                 let bbox = ElementBBox::new(
                                     table.bbox.x,
                                     table.bbox.y,
                                     table.bbox.width,
                                     table.bbox.height,
                                 );
-                                elements.push(Element::Table(TableElementData {
-                                    rows,
-                                    structure: None,
-                                    metadata: ElementMetadata {
+                                elements.push(Element::Table(TableElementData::from_structure(
+                                    ruling_table_to_structure(table),
+                                    ElementMetadata {
                                         page,
                                         bbox,
                                         confidence: table.confidence,
                                         ..Default::default()
                                     },
-                                }));
+                                )));
                                 // #375: claim only fragments actually placed in a
                                 // cell. Fragments inside the table bbox but in no
                                 // cell (gaps, borders, normalization misses) stay
@@ -785,16 +784,31 @@ fn is_list_item(text: &str) -> bool {
     false
 }
 
-/// Flatten a ruling-detected table into row-major `Vec<Vec<String>>`, filling
-/// absent cells with empty strings.
-fn ruling_table_to_rows(table: &crate::text::table_detection::DetectedTable) -> Vec<Vec<String>> {
-    let mut grid = vec![vec![String::new(); table.columns]; table.rows];
-    for cell in &table.cells {
-        if cell.row < table.rows && cell.column < table.columns {
-            grid[cell.row][cell.column] = cell.text.clone();
-        }
+/// Convert a ruling-detected table (with merged cells + header rows) into a
+/// rich `TableStructure`. The flat `rows` view is derived by
+/// `TableElementData::from_structure`.
+fn ruling_table_to_structure(
+    table: &crate::text::table_detection::DetectedTable,
+) -> TableStructure {
+    let header_rows = table.header_rows;
+    let cells = table
+        .cells
+        .iter()
+        .map(|c| RichCell {
+            row: c.row,
+            col: c.column,
+            row_span: c.row_span.max(1),
+            col_span: c.col_span.max(1),
+            text: c.text.clone(),
+            is_header: c.row < header_rows,
+        })
+        .collect();
+    TableStructure {
+        cells,
+        num_rows: table.rows,
+        num_cols: table.columns,
+        header_rows,
     }
-    grid
 }
 
 /// Splits unclaimed fragments into Y-separated table candidate regions.

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -340,17 +340,20 @@ impl Partitioner {
                                         ..Default::default()
                                     },
                                 }));
-                                let (rx, ry) = (table.bbox.x, table.bbox.y);
-                                let (rr, rt) = (
-                                    table.bbox.x + table.bbox.width,
-                                    table.bbox.y + table.bbox.height,
-                                );
+                                // #375: claim only fragments actually placed in a
+                                // cell. Fragments inside the table bbox but in no
+                                // cell (gaps, borders, normalization misses) stay
+                                // unclaimed and fall through to prose classification.
                                 for (i, f) in fragments.iter().enumerate() {
-                                    if !claimed[i]
-                                        && f.x >= rx - 1.0
-                                        && f.x <= rr + 1.0
-                                        && f.y >= ry - 1.0
-                                        && f.y <= rt + 1.0
+                                    if claimed[i] {
+                                        continue;
+                                    }
+                                    let cx = f.x + f.width / 2.0;
+                                    let cy = f.y + f.height / 2.0;
+                                    if table
+                                        .cells
+                                        .iter()
+                                        .any(|cell| cell.bbox.contains_point(cx, cy))
                                     {
                                         claimed[i] = true;
                                     }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -430,16 +430,15 @@ impl Partitioner {
                                 table.bounding_box.height,
                             );
 
-                            elements.push(Element::Table(TableElementData {
+                            elements.push(Element::Table(TableElementData::new(
                                 rows,
-                                structure: None,
-                                metadata: ElementMetadata {
+                                ElementMetadata {
                                     page,
                                     bbox,
                                     confidence: table.confidence,
                                     ..Default::default()
                                 },
-                            }));
+                            )));
 
                             // #375: claim only fragments inside a populated cell.
                             for (i, f) in fragments.iter().enumerate() {

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -421,14 +421,19 @@ impl Partitioner {
                                 },
                             }));
 
-                            // Claim fragments that fall within this table's bounding box.
+                            // #375: claim only fragments inside a populated cell.
                             for (i, f) in fragments.iter().enumerate() {
-                                if !claimed[i]
-                                    && f.x >= table.bounding_box.x - 1.0
-                                    && f.x <= table.bounding_box.right() + 1.0
-                                    && f.y >= table.bounding_box.y - 1.0
-                                    && f.y <= table.bounding_box.top() + 1.0
-                                {
+                                if claimed[i] {
+                                    continue;
+                                }
+                                let cx = f.x + f.width / 2.0;
+                                let cy = f.y + f.height / 2.0;
+                                let in_cell = table
+                                    .rows
+                                    .iter()
+                                    .flat_map(|r| &r.cells)
+                                    .any(|c| !c.is_empty() && c.bounding_box.contains(cx, cy));
+                                if in_cell {
                                     claimed[i] = true;
                                 }
                             }

--- a/oxidize-pdf-core/src/pipeline/partition.rs
+++ b/oxidize-pdf-core/src/pipeline/partition.rs
@@ -324,12 +324,11 @@ impl Partitioner {
                                 if table.confidence < self.config.min_table_confidence {
                                     continue;
                                 }
-                                // #375: a table that captured too few cells is not a
-                                // table — skip it so its fragments become prose.
+                                // #375: a table with fewer than 2 populated cells is not
+                                // a real table — skip it so its fragments become prose.
                                 let populated =
                                     table.cells.iter().filter(|c| !c.text.is_empty()).count();
-                                if populated < table.rows.max(1) {
-                                    // fewer populated cells than rows => no real column structure
+                                if populated < 2 {
                                     continue;
                                 }
                                 let rows = ruling_table_to_rows(table);
@@ -406,15 +405,15 @@ impl Partitioner {
                                 continue;
                             }
 
-                            // #375: a table that captured too few cells is not a
-                            // table — skip it so its fragments become prose.
+                            // #375: a table with fewer than 2 populated cells is not
+                            // a real table — skip it so its fragments become prose.
                             let populated = table
                                 .rows
                                 .iter()
                                 .flat_map(|r| &r.cells)
                                 .filter(|c| !c.is_empty())
                                 .count();
-                            if populated < table.row_count().max(1) {
+                            if populated < 2 {
                                 continue;
                             }
 

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::pipeline::chunk_metadata::ChunkMetadata;
 use crate::pipeline::element::Element;
-use crate::pipeline::hybrid_chunking::HybridChunk;
+use crate::pipeline::hybrid_chunking::{ContextFormat, ContextMode, HybridChunk};
 use crate::pipeline::{DocumentSource, ElementBBox};
 
 #[cfg(feature = "semantic")]
@@ -54,7 +54,11 @@ pub struct RagChunk {
     pub chunk_index: usize,
     /// Chunk text content (elements joined by newlines).
     pub text: String,
-    /// Text with heading context prepended — use this for embedding generation.
+    /// Text for embedding generation, contextualized per the chunker's
+    /// [`ContextMode`](crate::pipeline::ContextMode): the bare `text`
+    /// (`None`), the leaf heading prepended (`Heading`, the default), or a
+    /// deterministic document + section prefix (`Contextual`). The display
+    /// `text` field is always context-free.
     pub full_text: String,
     /// Page numbers where this chunk's elements appear (deduplicated, sorted numerically).
     pub page_numbers: Vec<u32>,
@@ -76,30 +80,65 @@ pub struct RagChunk {
 }
 
 impl RagChunk {
-    /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its elements.
+    /// Build a `RagChunk` from a [`HybridChunk`], extracting all metadata from its
+    /// elements. Uses [`ContextMode::Heading`] for `full_text` (the pre-#376
+    /// behavior); use [`from_hybrid_chunk_with_mode`](Self::from_hybrid_chunk_with_mode)
+    /// to select a different [`ContextMode`].
     pub fn from_hybrid_chunk(chunk_index: usize, chunk: &HybridChunk) -> Self {
-        Self::from_hybrid_chunk_inner(chunk_index, chunk, None)
+        Self::from_hybrid_chunk_inner(chunk_index, chunk, None, ContextMode::Heading)
     }
 
     /// Like [`from_hybrid_chunk`](Self::from_hybrid_chunk) but stamping source
     /// metadata and using `source.doc_hash` for the chunk_id prefix when set.
+    /// Uses [`ContextMode::Heading`]; see
+    /// [`from_hybrid_chunk_with_source_and_mode`](Self::from_hybrid_chunk_with_source_and_mode).
     pub fn from_hybrid_chunk_with_source(
         chunk_index: usize,
         chunk: &HybridChunk,
         source: &DocumentSource,
     ) -> Self {
-        let mut c = Self::from_hybrid_chunk_inner(chunk_index, chunk, Some(source));
+        Self::from_hybrid_chunk_with_source_and_mode(
+            chunk_index,
+            chunk,
+            source,
+            ContextMode::Heading,
+        )
+    }
+
+    /// Build a `RagChunk` selecting how `full_text` is contextualized (issue #376).
+    /// No source is stamped, so `Contextual` prefixes carry section context only.
+    pub fn from_hybrid_chunk_with_mode(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        context_mode: ContextMode,
+    ) -> Self {
+        Self::from_hybrid_chunk_inner(chunk_index, chunk, None, context_mode)
+    }
+
+    /// Build a source-stamped `RagChunk` selecting how `full_text` is
+    /// contextualized (issue #376). `Contextual` prefixes draw the document
+    /// name/author from `source` and the section breadcrumb from the chunk's
+    /// elements.
+    pub fn from_hybrid_chunk_with_source_and_mode(
+        chunk_index: usize,
+        chunk: &HybridChunk,
+        source: &DocumentSource,
+        context_mode: ContextMode,
+    ) -> Self {
+        let mut c = Self::from_hybrid_chunk_inner(chunk_index, chunk, Some(source), context_mode);
         c.metadata.source = Some(source.clone());
         c
     }
 
     /// Shared constructor. `source` (when `Some`) supplies the `doc_hash` used
     /// as the chunk_id prefix, so the id is computed exactly once — callers that
-    /// also want the full source stamped do that themselves.
+    /// also want the full source stamped do that themselves. `context_mode`
+    /// selects how `full_text` is built (issue #376).
     fn from_hybrid_chunk_inner(
         chunk_index: usize,
         chunk: &HybridChunk,
         source: Option<&DocumentSource>,
+        context_mode: ContextMode,
     ) -> Self {
         let elements = chunk.elements();
         let page_numbers = collect_pages(elements);
@@ -107,7 +146,25 @@ impl RagChunk {
         let element_types: Vec<String> =
             elements.iter().map(|e| e.type_name().to_string()).collect();
         let text = chunk.text();
-        let full_text = chunk.full_text();
+        // `full_text` (the embedding text) is contextualized per `context_mode`.
+        // It is built before metadata because `ChunkMetadata::from_elements`
+        // hashes it for the content-derived `chunk_id`.
+        let full_text = match context_mode {
+            ContextMode::None => text.clone(),
+            ContextMode::Heading => chunk.full_text(),
+            ContextMode::Contextual(format) => {
+                let heading_path = elements
+                    .first()
+                    .map(|e| e.metadata().heading_path.clone())
+                    .unwrap_or_default();
+                let page_span = (!page_numbers.is_empty())
+                    .then(|| (page_numbers[0], page_numbers[page_numbers.len() - 1]));
+                match build_context_prefix(format, source, &heading_path, page_span) {
+                    Some(prefix) => format!("{prefix}\n\n{text}"),
+                    None => text.clone(),
+                }
+            }
+        };
         let doc_hash = source.and_then(|s| s.doc_hash.as_deref());
         let metadata =
             ChunkMetadata::from_elements(elements, &text, &full_text, chunk_index, doc_hash);
@@ -154,4 +211,200 @@ fn collect_pages(elements: &[Element]) -> Vec<u32> {
     }
     pages.sort_unstable();
     pages
+}
+
+/// Render a page span as `p. N` (single page) or `p. N–M` (range, en dash).
+fn render_page(span: (u32, u32)) -> String {
+    if span.0 == span.1 {
+        format!("p. {}", span.0)
+    } else {
+        format!("p. {}\u{2013}{}", span.0, span.1)
+    }
+}
+
+/// Build the deterministic, no-ML context prefix for a chunk (issue #376).
+///
+/// Pure function of its inputs (document source fields, heading breadcrumb, page
+/// span) → reproducible across runs. Returns `None` when there is neither a
+/// document name nor a section to anchor on (a page alone is not enough
+/// context); the caller then leaves `full_text == text`.
+///
+/// `author` is deliberately only rendered alongside a document name (title or
+/// filename) — an authored *section* reads oddly and adds no retrieval signal —
+/// so a source with only an `author` set and no title/filename contributes
+/// nothing to a section-only prefix.
+fn build_context_prefix(
+    format: ContextFormat,
+    source: Option<&DocumentSource>,
+    heading_path: &[String],
+    page_span: Option<(u32, u32)>,
+) -> Option<String> {
+    // `title` wins; `filename` is the fallback document name.
+    let doc_name = source.and_then(|s| s.title.clone().or_else(|| s.filename.clone()));
+    let author = source.and_then(|s| s.author.clone());
+    let section = (!heading_path.is_empty()).then(|| heading_path.join(" \u{203A} "));
+    let page = page_span.map(render_page);
+
+    // No document or section anchor → no prefix at all.
+    if doc_name.is_none() && section.is_none() {
+        return None;
+    }
+
+    let prefix = match format {
+        ContextFormat::Labeled => {
+            let mut lines: Vec<String> = Vec::new();
+            if let Some(name) = &doc_name {
+                lines.push(match &author {
+                    Some(a) => format!("Document: {name} — {a}"),
+                    None => format!("Document: {name}"),
+                });
+            }
+            if let Some(sec) = &section {
+                lines.push(format!("Section: {sec}"));
+            }
+            // The page span attaches to the last (most specific) context line.
+            if let (Some(pg), Some(last)) = (&page, lines.last_mut()) {
+                last.push_str(&format!(" ({pg})"));
+            }
+            lines.join("\n")
+        }
+        ContextFormat::Prose => {
+            let mut s = String::from("This chunk is from ");
+            if let Some(name) = &doc_name {
+                s.push_str(&format!("\"{name}\""));
+                if let Some(a) = &author {
+                    s.push_str(&format!(" by {a}"));
+                }
+                if let Some(sec) = &section {
+                    s.push_str(&format!(", section \"{sec}\""));
+                }
+            } else if let Some(sec) = &section {
+                s.push_str(&format!("section \"{sec}\""));
+            }
+            if let Some(pg) = &page {
+                s.push_str(&format!(" ({pg})"));
+            }
+            s.push('.');
+            s
+        }
+    };
+    Some(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::{ContextFormat, DocumentSource};
+
+    fn src(title: Option<&str>, author: Option<&str>, filename: Option<&str>) -> DocumentSource {
+        DocumentSource {
+            title: title.map(str::to_string),
+            author: author.map(str::to_string),
+            filename: filename.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn hp(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── issue #376: Labeled prefix ───────────────────────────────────────────
+
+    #[test]
+    fn labeled_full_fields() {
+        let s = src(Some("Annual Report"), Some("Acme Corp"), None);
+        let p = build_context_prefix(
+            ContextFormat::Labeled,
+            Some(&s),
+            &hp(&["1 Intro", "1.2 Scope"]),
+            Some((3, 4)),
+        );
+        assert_eq!(
+            p.as_deref(),
+            Some("Document: Annual Report — Acme Corp\nSection: 1 Intro › 1.2 Scope (p. 3–4)")
+        );
+    }
+
+    #[test]
+    fn labeled_title_only() {
+        let s = src(Some("Doc"), None, None);
+        let p = build_context_prefix(ContextFormat::Labeled, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("Document: Doc"));
+    }
+
+    #[test]
+    fn labeled_filename_fallback_when_no_title() {
+        let s = src(None, None, Some("report.pdf"));
+        let p = build_context_prefix(ContextFormat::Labeled, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("Document: report.pdf"));
+    }
+
+    #[test]
+    fn labeled_section_only_without_source() {
+        let p = build_context_prefix(ContextFormat::Labeled, None, &hp(&["A", "B"]), None);
+        assert_eq!(p.as_deref(), Some("Section: A › B"));
+    }
+
+    #[test]
+    fn labeled_single_page() {
+        let p = build_context_prefix(ContextFormat::Labeled, None, &hp(&["A"]), Some((7, 7)));
+        assert_eq!(p.as_deref(), Some("Section: A (p. 7)"));
+    }
+
+    #[test]
+    fn labeled_nothing_is_none() {
+        let s = src(None, None, None);
+        assert!(
+            build_context_prefix(ContextFormat::Labeled, Some(&s), &[], Some((3, 3))).is_none()
+        );
+        assert!(build_context_prefix(ContextFormat::Labeled, None, &[], None).is_none());
+    }
+
+    // ── issue #376: Prose prefix ─────────────────────────────────────────────
+
+    #[test]
+    fn prose_full_fields() {
+        let s = src(Some("Annual Report"), Some("Acme Corp"), None);
+        let p = build_context_prefix(
+            ContextFormat::Prose,
+            Some(&s),
+            &hp(&["1 Intro", "1.2 Scope"]),
+            Some((3, 4)),
+        );
+        assert_eq!(
+            p.as_deref(),
+            Some(
+                "This chunk is from \"Annual Report\" by Acme Corp, section \"1 Intro › 1.2 Scope\" (p. 3–4)."
+            )
+        );
+    }
+
+    #[test]
+    fn prose_title_only() {
+        let s = src(Some("Doc"), None, None);
+        let p = build_context_prefix(ContextFormat::Prose, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("This chunk is from \"Doc\"."));
+    }
+
+    #[test]
+    fn prose_section_only_without_source() {
+        let p = build_context_prefix(ContextFormat::Prose, None, &hp(&["A", "B"]), Some((5, 5)));
+        assert_eq!(
+            p.as_deref(),
+            Some("This chunk is from section \"A › B\" (p. 5).")
+        );
+    }
+
+    #[test]
+    fn prose_filename_fallback_and_no_section() {
+        let s = src(None, Some("Ann"), Some("f.pdf"));
+        let p = build_context_prefix(ContextFormat::Prose, Some(&s), &[], None);
+        assert_eq!(p.as_deref(), Some("This chunk is from \"f.pdf\" by Ann."));
+    }
+
+    #[test]
+    fn prose_nothing_is_none() {
+        assert!(build_context_prefix(ContextFormat::Prose, None, &[], Some((1, 2))).is_none());
+    }
 }

--- a/oxidize-pdf-core/src/pipeline/spi.rs
+++ b/oxidize-pdf-core/src/pipeline/spi.rs
@@ -135,7 +135,7 @@ pub trait MetadataEnricher: Send + Sync {
     fn enrich(&self, ctx: &EnrichContext, meta: &mut crate::pipeline::ChunkMetadata);
 }
 
-use crate::pipeline::hybrid_chunking::{HybridChunkConfig, HybridChunker};
+use crate::pipeline::hybrid_chunking::{ContextMode, HybridChunkConfig, HybridChunker};
 use crate::pipeline::{DocumentSource, PartitionConfig};
 
 /// Configures the analysis pipeline: which chunking strategy to run, the token
@@ -149,6 +149,12 @@ pub struct AnalysisPipeline {
     pub(crate) source: Option<DocumentSource>,
     pub(crate) classifier: Option<Box<dyn ElementClassifier>>,
     pub(crate) partition_config: PartitionConfig,
+    /// How each chunk's `full_text` is contextualized (issue #376). Carried on
+    /// the pipeline because the chunking `Box<dyn ChunkingStrategy>` produces
+    /// `ChunkGroup`s and cannot expose a `HybridChunkConfig` to read the mode
+    /// back from — so a custom strategy's `context_mode` would otherwise be
+    /// lost. Defaults to [`ContextMode::Heading`].
+    pub(crate) context_mode: ContextMode,
     #[cfg(feature = "semantic")]
     pub(crate) enrichers: Vec<Box<dyn MetadataEnricher>>,
 }
@@ -166,6 +172,7 @@ impl AnalysisPipeline {
         let config = HybridChunkConfig::default();
         Self {
             max_tokens: config.max_tokens,
+            context_mode: config.context_mode,
             chunking: Box::new(HybridChunker::new(config)),
             source: None,
             classifier: None,
@@ -173,6 +180,20 @@ impl AnalysisPipeline {
             #[cfg(feature = "semantic")]
             enrichers: Vec::new(),
         }
+    }
+
+    /// Set how each chunk's `full_text` is contextualized (issue #376).
+    ///
+    /// Needed on the pipeline because a custom chunking strategy (`Box<dyn
+    /// ChunkingStrategy>`) yields `ChunkGroup`s and carries no
+    /// `HybridChunkConfig`, so a `context_mode` set on a `HybridChunker` wired
+    /// via [`with_chunking`](Self::with_chunking) cannot be read back — set it
+    /// here instead. When the strategy *is* the built-in `HybridChunker`, this
+    /// takes precedence over any `context_mode` on its config.
+    #[must_use]
+    pub fn with_context_mode(mut self, context_mode: ContextMode) -> Self {
+        self.context_mode = context_mode;
+        self
     }
 
     /// Replace the chunking strategy.

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -76,6 +76,30 @@ pub struct ExtractionOptions {
     /// the layout path's reconstruction, not stream order); `.fragments` stays
     /// empty.
     pub reorder_columns: bool,
+    /// Stop accumulating decoded text for a page once this many bytes have been
+    /// collected, bounding the per-page peak memory of extraction. The limit is
+    /// enforced *during* accumulation, not by truncating the finished string, so
+    /// a single page with a huge or adversarially inflated content stream cannot
+    /// materialise an unbounded `String` before the caller sees it (issue #382).
+    ///
+    /// Semantics are *undershoot*: extraction stops before the fragment that
+    /// would push the accumulated bytes past the limit, so the returned
+    /// `text.len() <= max_extracted_bytes` and a multi-byte UTF-8 character is
+    /// never split. When the limit cuts extraction short,
+    /// [`ExtractedText::truncated`] is set to `true`.
+    ///
+    /// `None` (default) means no limit — output is byte-identical to before.
+    /// The `text.len() <= max_extracted_bytes` invariant holds on **every** path
+    /// (flat, `reorder_columns`, `preserve_layout`): the layout paths rebuild
+    /// `.text` from the already-bounded fragment set and are then clamped to the
+    /// limit at a UTF-8 char boundary as a final safety net.
+    ///
+    /// Because whole decoded runs are the unit of truncation, a page whose text
+    /// is a single run larger than the whole budget (e.g. one huge `Tj`, or an
+    /// `/ActualText` override) comes back with `text == ""` and
+    /// `truncated == true` rather than a partial run — the limit is never
+    /// satisfied by splitting a run mid-character.
+    pub max_extracted_bytes: Option<usize>,
 }
 
 impl Default for ExtractionOptions {
@@ -93,6 +117,7 @@ impl Default for ExtractionOptions {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         }
     }
 }
@@ -104,6 +129,11 @@ pub struct ExtractedText {
     pub text: String,
     /// Text fragments with position information (if preserve_layout is true)
     pub fragments: Vec<TextFragment>,
+    /// `true` when extraction stopped early because
+    /// [`ExtractionOptions::max_extracted_bytes`] was reached, so `text` is a
+    /// bounded prefix of the page's full text rather than the whole page
+    /// (issue #382). Always `false` when no limit is set.
+    pub truncated: bool,
 }
 
 /// Metadata about a space insertion decision during text extraction.
@@ -275,6 +305,10 @@ struct OpRunState {
     last_y: f64,
     extracted_text: String,
     fragments: Vec<TextFragment>,
+    /// Set once the per-page byte budget (`max_extracted_bytes`) has cut text
+    /// accumulation short. Propagates through Form XObject recursion and into
+    /// [`ExtractedText::truncated`] (issue #382).
+    truncated: bool,
 }
 
 impl Default for TextState {
@@ -707,6 +741,7 @@ impl TextExtractor {
             last_y,
             extracted_text,
             fragments,
+            truncated: false,
         };
 
         // Process each content stream
@@ -749,11 +784,18 @@ impl TextExtractor {
                 page_index,
                 0,
             )?;
+
+            // Per-page byte budget reached (issue #382): don't decode the
+            // remaining content streams — the text is already at the limit.
+            if run.truncated {
+                break;
+            }
         }
 
         let OpRunState {
             mut extracted_text,
             mut fragments,
+            mut truncated,
             ..
         } = run;
         {
@@ -805,11 +847,22 @@ impl TextExtractor {
                 extracted_text = self.reconstruct_text_from_fragments(&fragments);
                 fragments.clear();
             }
+
+            // Final safety net (issue #382): the layout/reorder reconstruction
+            // above rebuilds `.text` with its own separators, so guarantee the
+            // `text.len() <= max_extracted_bytes` invariant for every path here.
+            // No-op for the flat path (already bounded) and when no limit is set.
+            clamp_to_budget(
+                &mut extracted_text,
+                self.options.max_extracted_bytes,
+                &mut truncated,
+            );
         }
 
         Ok(ExtractedText {
             text: extracted_text,
             fragments,
+            truncated,
         })
     }
 
@@ -832,6 +885,7 @@ impl TextExtractor {
             mut last_y,
             mut extracted_text,
             mut fragments,
+            mut truncated,
         } = run;
 
         let page_properties: Option<&crate::parser::objects::PdfDictionary> =
@@ -842,6 +896,12 @@ impl TextExtractor {
 
         let _ops_span = tracing::info_span!("text_ops_loop").entered();
         for op in operations {
+            // Per-page byte budget reached (issue #382): stop processing further
+            // operators. Show-text arms also `break` mid-run, but a state-only
+            // op between two show ops would otherwise keep the loop alive.
+            if truncated {
+                break;
+            }
             match op {
                 ContentOperation::BeginText => {
                     in_text_object = true;
@@ -896,26 +956,42 @@ impl TextExtractor {
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
 
                         // Add spacing based on position change
-                        if !skip_text && !extracted_text.is_empty() {
-                            let dx = x - last_x;
-                            let dy = (y - last_y).abs();
-
-                            // A large backward jump in x is a line wrap: the pen
-                            // returns to the left margin on a new line. When the
-                            // line height is below `newline_threshold` the dy check
-                            // alone misses it, so treat a backward dx beyond one
-                            // line-height (2× the threshold, conservative) as a
-                            // newline regardless of dy (issue #390).
-                            let line_wrap = dx < -(self.options.newline_threshold * 2.0);
-                            if dy > self.options.newline_threshold || line_wrap {
-                                extracted_text.push('\n');
-                            } else if dx > self.options.space_threshold * state.font_size {
-                                extracted_text.push(' ');
-                            }
-                        }
-
                         if !skip_text {
-                            extracted_text.push_str(&decoded);
+                            let separator = if !extracted_text.is_empty() {
+                                let dx = x - last_x;
+                                let dy = (y - last_y).abs();
+
+                                // A large backward jump in x is a line wrap: the
+                                // pen returns to the left margin on a new line.
+                                // When the line height is below `newline_threshold`
+                                // the dy check alone misses it, so treat a backward
+                                // dx beyond one line-height (2× the threshold,
+                                // conservative) as a newline regardless of dy
+                                // (issue #390).
+                                let line_wrap = dx < -(self.options.newline_threshold * 2.0);
+                                if dy > self.options.newline_threshold || line_wrap {
+                                    Some('\n')
+                                } else if dx > self.options.space_threshold * state.font_size {
+                                    Some(' ')
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
+
+                            // Per-page byte budget (issue #382): stop before the
+                            // run that would overshoot; the outer loop guard ends
+                            // extraction on the next iteration.
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
+                            }
                         }
 
                         // Get font info for accurate width calculation.
@@ -985,16 +1061,26 @@ impl TextExtractor {
                                     // kern, so it is safe to break there.
                                     let line_wrap =
                                         (x - last_x) < -(self.options.newline_threshold * 2.0);
-                                    if !skip_text
-                                        && !extracted_text.is_empty()
-                                        && ((y - last_y).abs() > self.options.newline_threshold
-                                            || line_wrap)
-                                    {
-                                        extracted_text.push('\n');
-                                    }
-
                                     if !skip_text {
-                                        extracted_text.push_str(&decoded);
+                                        let separator = if !extracted_text.is_empty()
+                                            && ((y - last_y).abs() > self.options.newline_threshold
+                                                || line_wrap)
+                                        {
+                                            Some('\n')
+                                        } else {
+                                            None
+                                        };
+
+                                        // Per-page byte budget (issue #382).
+                                        if !append_bounded(
+                                            &mut extracted_text,
+                                            separator,
+                                            &decoded,
+                                            self.options.max_extracted_bytes,
+                                            &mut truncated,
+                                        ) {
+                                            break;
+                                        }
                                     }
 
                                     let text_width = {
@@ -1046,7 +1132,18 @@ impl TextExtractor {
                                         && !extracted_text.is_empty()
                                         && !extracted_text.ends_with(' ')
                                     {
-                                        extracted_text.push(' ');
+                                        // Per-page byte budget (issue #382): even
+                                        // the synthesised space counts, so the
+                                        // `text.len() <= limit` invariant holds.
+                                        if !append_bounded(
+                                            &mut extracted_text,
+                                            Some(' '),
+                                            "",
+                                            self.options.max_extracted_bytes,
+                                            &mut truncated,
+                                        ) {
+                                            break;
+                                        }
 
                                         // Skip the fragment-level emission while an
                                         // ActualText scope is pending: the synthesised
@@ -1106,10 +1203,21 @@ impl TextExtractor {
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
                         if !skip_text {
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
+                            let separator = if extracted_text.is_empty() {
+                                None
+                            } else {
+                                Some('\n')
+                            };
+                            // Per-page byte budget (issue #382).
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
                             }
-                            extracted_text.push_str(&decoded);
                         }
 
                         let text_width = {
@@ -1163,10 +1271,21 @@ impl TextExtractor {
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
                         if !skip_text {
-                            if !extracted_text.is_empty() {
-                                extracted_text.push('\n');
+                            let separator = if extracted_text.is_empty() {
+                                None
+                            } else {
+                                Some('\n')
+                            };
+                            // Per-page byte budget (issue #382).
+                            if !append_bounded(
+                                &mut extracted_text,
+                                separator,
+                                &decoded,
+                                self.options.max_extracted_bytes,
+                                &mut truncated,
+                            ) {
+                                break;
                             }
-                            extracted_text.push_str(&decoded);
                         }
 
                         let text_width = {
@@ -1341,6 +1460,25 @@ impl TextExtractor {
                                 let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
                                 let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
+                                    // Per-page byte budget (issue #382): the
+                                    // `/ActualText` override is this scope's
+                                    // canonical text and can be arbitrarily
+                                    // large. It bypasses the per-`Tj`
+                                    // `append_bounded` gate, so account it here
+                                    // against the same ledger (`extracted_text`,
+                                    // which these paths rebuild from `fragments`).
+                                    // If it would overshoot, drop the fragment and
+                                    // stop — a huge override must not escape the
+                                    // cap while reporting `truncated = false`.
+                                    if !append_bounded(
+                                        &mut extracted_text,
+                                        None,
+                                        &run.text,
+                                        self.options.max_extracted_bytes,
+                                        &mut truncated,
+                                    ) {
+                                        break;
+                                    }
                                     fragments.push(TextFragment {
                                         text: run.text,
                                         x: run.first_x,
@@ -1402,6 +1540,7 @@ impl TextExtractor {
                                 last_y,
                                 extracted_text,
                                 fragments,
+                                truncated,
                             };
                             let mut out = self.process_operations(
                                 xobj_ops,
@@ -1422,6 +1561,7 @@ impl TextExtractor {
                             last_y = out.last_y;
                             extracted_text = out.extracted_text;
                             fragments = out.fragments;
+                            truncated = out.truncated;
                         }
                     }
                 }
@@ -1438,6 +1578,7 @@ impl TextExtractor {
             last_y,
             extracted_text,
             fragments,
+            truncated,
         })
     }
 
@@ -2022,6 +2163,65 @@ fn skip_artifact_text(state: &TextState, include_artifacts: bool) -> bool {
     !include_artifacts && state.mc_stack.iter().any(|e| e.is_artifact)
 }
 
+/// Append an optional `separator` plus `decoded` to `acc`, honouring the
+/// per-page byte budget `limit` (issue #382).
+///
+/// Returns `true` when the run was appended. Returns `false` — appending
+/// nothing and setting `*truncated` — when the combined bytes would exceed
+/// `limit`. The separator is counted against the budget so the invariant
+/// `acc.len() <= limit` holds *exactly*, and because whole runs are the unit of
+/// truncation a multi-byte UTF-8 character is never split (undershoot
+/// semantics). A `None` limit always appends and never truncates, keeping the
+/// no-limit path byte-identical to before. Once `*truncated` is set the helper
+/// is a no-op, so a caller that keeps calling it after the budget is reached
+/// simply accumulates nothing further.
+fn append_bounded(
+    acc: &mut String,
+    separator: Option<char>,
+    decoded: &str,
+    limit: Option<usize>,
+    truncated: &mut bool,
+) -> bool {
+    if *truncated {
+        return false;
+    }
+    if let Some(max) = limit {
+        let add = separator.map_or(0, char::len_utf8) + decoded.len();
+        if acc.len() + add > max {
+            *truncated = true;
+            return false;
+        }
+    }
+    if let Some(sep) = separator {
+        acc.push(sep);
+    }
+    acc.push_str(decoded);
+    true
+}
+
+/// Defensive final clamp of a page's text to the byte budget (issue #382).
+///
+/// The `preserve_layout` / `reorder_columns` paths rebuild `.text` from the
+/// already-bounded fragment set via `reconstruct_text_from_fragments`, which
+/// reorders fragments and inserts its own separators — so the reconstructed
+/// length is not provably `<= limit` from the accumulation-time accounting
+/// alone. This clamps the result to `limit` at a UTF-8 char boundary (never
+/// splitting a character) and sets `*truncated` if it had to cut, making the
+/// `text.len() <= max_extracted_bytes` invariant hold for *every* path. A no-op
+/// when there is no limit or the text already fits.
+fn clamp_to_budget(text: &mut String, limit: Option<usize>, truncated: &mut bool) {
+    if let Some(max) = limit {
+        if text.len() > max {
+            let mut cut = max;
+            while cut > 0 && !text.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            text.truncate(cut);
+            *truncated = true;
+        }
+    }
+}
+
 fn emit_text_fragment(
     fragments: &mut Vec<TextFragment>,
     decoded: &str,
@@ -2559,6 +2759,99 @@ fn standard_14_space_width(base_font: &str) -> Option<f64> {
 mod tests {
     use super::*;
 
+    // ── issue #382: per-page byte-budget helper ──────────────────────────────
+
+    #[test]
+    fn test_append_bounded_no_limit_always_appends() {
+        let mut s = String::new();
+        let mut trunc = false;
+        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc));
+        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc));
+        assert_eq!(s, "hello world");
+        assert!(!trunc, "no limit never truncates");
+    }
+
+    #[test]
+    fn test_append_bounded_undershoot_counts_separator() {
+        // "abcd" (4) is at budget 5; a Some('\n') + "x" would need 2 more → over.
+        let mut s = String::from("abcd");
+        let mut trunc = false;
+        assert!(!append_bounded(
+            &mut s,
+            Some('\n'),
+            "x",
+            Some(5),
+            &mut trunc
+        ));
+        assert_eq!(s, "abcd", "nothing appended when it would overshoot");
+        assert!(trunc, "budget hit sets truncated");
+        // Exactly-fits case: "e" alone (1 byte, no separator) reaches 5.
+        let mut s2 = String::from("abcd");
+        let mut t2 = false;
+        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2));
+        assert_eq!(s2, "abcde");
+        assert!(!t2);
+        assert!(s2.len() <= 5, "invariant: len <= limit exactly");
+    }
+
+    #[test]
+    fn test_append_bounded_zero_limit_truncates_immediately() {
+        let mut s = String::new();
+        let mut trunc = false;
+        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc));
+        assert!(s.is_empty());
+        assert!(trunc);
+    }
+
+    #[test]
+    fn test_append_bounded_is_noop_once_truncated() {
+        let mut s = String::from("kept");
+        let mut trunc = true; // already truncated
+        assert!(!append_bounded(
+            &mut s,
+            None,
+            "more",
+            Some(1_000),
+            &mut trunc
+        ));
+        assert_eq!(s, "kept", "no further accumulation after truncation");
+    }
+
+    #[test]
+    fn test_clamp_to_budget_no_limit_or_fits_is_noop() {
+        let mut a = String::from("hello");
+        let mut t = false;
+        clamp_to_budget(&mut a, None, &mut t);
+        assert_eq!(a, "hello");
+        assert!(!t, "no limit never truncates");
+
+        let mut b = String::from("hi");
+        clamp_to_budget(&mut b, Some(10), &mut t);
+        assert_eq!(b, "hi", "already fits");
+        assert!(!t);
+    }
+
+    #[test]
+    fn test_clamp_to_budget_cuts_and_flags() {
+        let mut s = String::from("abcdefgh");
+        let mut t = false;
+        clamp_to_budget(&mut s, Some(3), &mut t);
+        assert_eq!(s, "abc");
+        assert!(t, "clamp that cut must set truncated");
+    }
+
+    #[test]
+    fn test_clamp_to_budget_never_splits_utf8() {
+        // "é" is 2 bytes (0xC3 0xA9). A 3-byte budget on "éé" (4 bytes) must cut
+        // back to the char boundary at 2, keeping one whole "é".
+        let mut s = String::from("éé");
+        let mut t = false;
+        clamp_to_budget(&mut s, Some(3), &mut t);
+        assert_eq!(s, "é", "must retreat to a char boundary, not split 'é'");
+        assert!(s.len() <= 3);
+        assert!(t);
+    }
+
     #[test]
     fn test_matrix_multiplication() {
         let identity = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -2606,6 +2899,7 @@ mod tests {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         };
         assert!(options.preserve_layout);
         assert_eq!(options.space_threshold, 0.5);
@@ -2734,6 +3028,7 @@ mod tests {
         let extracted = ExtractedText {
             text: "Hello World".to_string(),
             fragments: fragments,
+            truncated: false,
         };
 
         assert_eq!(extracted.text, "Hello World");
@@ -2807,6 +3102,7 @@ mod tests {
             reconstruct_paragraphs: false,
             include_artifacts: false,
             reorder_columns: false,
+            max_extracted_bytes: None,
         };
         let extractor = TextExtractor::with_options(options.clone());
         assert_eq!(extractor.options.preserve_layout, options.preserve_layout);

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1507,30 +1507,51 @@ impl TextExtractor {
 
     /// Sort text fragments by position and merge them appropriately
     fn sort_and_merge_fragments(&self, fragments: &mut [TextFragment]) {
-        // Sort fragments by Y position (top to bottom) then X position (left to right).
+        // Establish reading order (top-to-bottom, left-to-right) without ever
+        // collapsing two distinct visual lines into one.
         //
-        // We quantize Y into bands of `newline_threshold` width so that fragments
-        // on the "same line" get identical Y keys. This ensures the comparator is
-        // a strict total order (transitive), which Rust's sort algorithm requires.
-        // Without quantization, threshold-based "same line" detection breaks
-        // transitivity: A≈B and B≈C does NOT imply A≈C.
-        let threshold = self.options.newline_threshold;
-        fragments.sort_by(|a, b| {
-            // Quantize Y to nearest band (PDF Y increases upward, so negate first)
-            let band_a = if threshold > 0.0 {
-                (-a.y / threshold).round()
-            } else {
-                -a.y
-            };
-            let band_b = if threshold > 0.0 {
-                (-b.y / threshold).round()
-            } else {
-                -b.y
-            };
+        // A single `sort_by` with a threshold-based "same line" comparator is not
+        // transitive (A≈B, B≈C ⇏ A≈C), which Rust's sort requires. The previous
+        // implementation restored transitivity by quantizing Y into fixed bands of
+        // `newline_threshold` width — but fixed bands collide two lines that
+        // straddle a band boundary while sitting closer than the band width. With
+        // 8pt leading under the 10pt default, y=684 → band −68 and y=676 → band
+        // −68 land in the same band; the secondary X sort then interleaved the two
+        // lines glyph-by-glyph, shredding any token that straddled the corruption
+        // (issue #408).
+        //
+        // Instead, sort in two transitive phases over an index permutation. First
+        // by exact Y (top-to-bottom — a real total order). Then group consecutive
+        // fragments into visual lines with a jitter tolerance anchored to the
+        // line's head, matching `merge_into_lines` (`height * 0.2`, which tracks
+        // font size, not the paragraph-break `newline_threshold`), and order each
+        // line left-to-right by X. Ties broken by original index keep it stable.
+        let n = fragments.len();
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|&i, &j| fragments[j].y.total_cmp(&fragments[i].y).then(i.cmp(&j)));
 
-            // Compare by Y band (top to bottom), then by X within same band
-            band_a.total_cmp(&band_b).then_with(|| a.x.total_cmp(&b.x))
-        });
+        let mut line_start = 0usize;
+        while line_start < n {
+            let head_y = fragments[order[line_start]].y;
+            let head_h = fragments[order[line_start]].height;
+            let mut line_end = line_start + 1;
+            while line_end < n {
+                let frag = &fragments[order[line_end]];
+                let tol = head_h.min(frag.height) * 0.2;
+                if (head_y - frag.y).abs() >= tol {
+                    break;
+                }
+                line_end += 1;
+            }
+            order[line_start..line_end].sort_by(|&i, &j| fragments[i].x.total_cmp(&fragments[j].x));
+            line_start = line_end;
+        }
+
+        // Apply the permutation in place (one clone per fragment, then move back).
+        let reordered: Vec<TextFragment> = order.iter().map(|&i| fragments[i].clone()).collect();
+        for (slot, frag) in fragments.iter_mut().zip(reordered) {
+            *slot = frag;
+        }
 
         // Detect columns if requested. `reorder_columns` forces column detection
         // only on the flat path (`!preserve_layout`); in layout mode `detect_columns`

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1538,7 +1538,10 @@ impl TextExtractor {
             while line_end < n {
                 let frag = &fragments[order[line_end]];
                 let tol = head_h.min(frag.height) * 0.2;
-                if (head_y - frag.y).abs() >= tol {
+                // Negated `< tol` (not `>= tol`) so a non-finite Y from a
+                // degenerate text matrix forces a line break instead of a
+                // NaN comparison silently swallowing every remaining fragment.
+                if !((head_y - frag.y).abs() < tol) {
                     break;
                 }
                 line_end += 1;
@@ -3959,5 +3962,34 @@ mod tests {
         let props = MarkedContentProps::ResourceRef("PropsName".to_string());
         let (mcid, _) = super::resolve_props(&props, Some(&properties));
         assert_eq!(mcid, None);
+    }
+
+    #[test]
+    fn sort_and_merge_fragments_nan_y_does_not_swallow_other_lines() {
+        // A fragment with a non-finite Y (reachable from a degenerate text
+        // matrix in a malformed PDF) must not chain every remaining fragment
+        // into one pseudo-line. The tolerance filter compares with `< tol`; a
+        // `>= tol` phrasing would let a NaN anchor never terminate the line,
+        // collapsing the whole page into a single X-sorted "line".
+        let extractor = TextExtractor::with_options(ExtractionOptions::default());
+
+        // Four well-separated lines whose X order is the reverse of their Y
+        // (reading) order: if the NaN anchor swallows the rest, they get
+        // re-sorted purely by X into D,C,B,A instead of the reading order.
+        let mut fragments = vec![
+            tf("A", 400.0, f64::NAN, 10.0, 12.0),
+            tf("B", 300.0, 500.0, 10.0, 12.0),
+            tf("C", 200.0, 300.0, 10.0, 12.0),
+            tf("D", 100.0, 100.0, 10.0, 12.0),
+        ];
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["A", "B", "C", "D"],
+            "NaN-Y fragment must stay its own line; the finite lines keep \
+             top-to-bottom reading order instead of collapsing to X order"
+        );
     }
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -122,8 +122,15 @@ impl Default for ExtractionOptions {
     }
 }
 
-/// Extracted text with position information
+/// Extracted text with position information.
+///
+/// Pipeline output: returned by the `extract_text*` entry points on
+/// [`Page`](crate::page::Page) / [`PdfDocument`](crate::parser::PdfDocument).
+/// `#[non_exhaustive]` so future fields (e.g. per-run diagnostics) can be added
+/// without a breaking change — construct one outside the crate via
+/// [`ExtractedText::new`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ExtractedText {
     /// The extracted text content
     pub text: String,
@@ -134,6 +141,20 @@ pub struct ExtractedText {
     /// bounded prefix of the page's full text rather than the whole page
     /// (issue #382). Always `false` when no limit is set.
     pub truncated: bool,
+}
+
+impl ExtractedText {
+    /// Build an `ExtractedText` from its text and fragments, with `truncated`
+    /// set to `false`. Provided because `ExtractedText` is `#[non_exhaustive]`,
+    /// so external callers cannot use a struct literal. Set [`truncated`](Self::truncated)
+    /// afterwards if you are synthesizing a bounded result.
+    pub fn new(text: String, fragments: Vec<TextFragment>) -> Self {
+        Self {
+            text,
+            fragments,
+            truncated: false,
+        }
+    }
 }
 
 /// Metadata about a space insertion decision during text extraction.

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -346,9 +346,59 @@ impl TableDetector {
         let num_rows = grid.rows.len().saturating_sub(1);
         let num_cols = grid.columns.len().saturating_sub(1);
 
-        let table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        let mut table = DetectedTable::new(bbox, cells_with_text, num_rows, num_cols);
+        table.header_rows = Self::count_header_rows(&table, text_fragments);
 
         Ok(Some(table))
+    }
+
+    /// Counts the leading contiguous header rows of a detected table
+    /// (issue #375, Task 8).
+    ///
+    /// A row is a header row when at least one text fragment landing inside
+    /// one of its cells carries a header structure tag (`"TH"`, or any tag
+    /// containing `"HEADER"`, case-insensitively — e.g. PDF/UA `"TH"` cells
+    /// or a custom `"TableHeader"` role). Only *leading* tagged rows count:
+    /// counting stops at the first row without a header-tagged fragment, so
+    /// a tagged row that is not contiguous with the top does not count.
+    ///
+    /// When no rows carry a header tag, a bordered table with at least two
+    /// rows falls back to treating the top row as the header (the common
+    /// convention for ruled tables without structure information).
+    fn count_header_rows(table: &DetectedTable, fragments: &[TextFragment]) -> usize {
+        fn is_header_tag(tag: &str) -> bool {
+            let t = tag.to_ascii_uppercase();
+            t == "TH" || t.contains("HEADER")
+        }
+
+        let mut tagged_leading = 0usize;
+        for r in 0..table.rows {
+            let row_cells: Vec<&TableCell> = table
+                .cells
+                .iter()
+                .filter(|c| c.row <= r && r < c.row + c.row_span)
+                .collect();
+            let has_header = fragments.iter().any(|f| {
+                f.struct_tag.as_deref().map(is_header_tag).unwrap_or(false)
+                    && row_cells.iter().any(|c| {
+                        c.bbox
+                            .contains_point(f.x + f.width / 2.0, f.y + f.height / 2.0)
+                    })
+            });
+            if has_header {
+                tagged_leading = r + 1;
+            } else {
+                break;
+            }
+        }
+
+        if tagged_leading > 0 {
+            tagged_leading
+        } else if table.rows >= 2 {
+            1
+        } else {
+            0
+        }
     }
 
     /// Detects a grid pattern from horizontal and vertical lines.

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -96,6 +96,7 @@ impl Default for TableDetectionConfig {
 
 /// A detected table with cells, rows, and columns.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct DetectedTable {
     /// Bounding box of the entire table
     pub bbox: BoundingBox,
@@ -165,6 +166,7 @@ impl DetectedTable {
 
 /// A single cell in a detected table.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct TableCell {
     /// Row index (0-based)
     pub row: usize,

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -45,6 +45,7 @@
 
 use crate::graphics::extraction::{ExtractedGraphics, LineOrientation, VectorLine};
 use crate::text::extraction::TextFragment;
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 /// Errors that can occur during table detection.
@@ -326,6 +327,10 @@ impl TableDetector {
         // Calculate cell boundaries
         let cells = self.create_cells_from_grid(&grid);
 
+        // Merge base cells across absent interior dividers before text assignment
+        // so text lands in the merged (spanning) cells (issue #375).
+        let cells = self.merge_cells_across_absent_dividers(&grid, cells);
+
         // Assign text to cells
         let cells_with_text = self.assign_text_to_cells(cells, text_fragments);
 
@@ -361,7 +366,23 @@ impl TableDetector {
         // Reverse rows so row 0 is at the top (highest Y) for intuitive indexing
         rows.reverse();
 
-        Ok(GridPattern { rows, columns })
+        // Retain the raw divider segments (normalized) so absent interior
+        // dividers can be detected for merged-cell reconstruction (issue #375).
+        let h_segments: Vec<(f64, f64, f64)> = h_lines
+            .iter()
+            .map(|line| (line.y1, line.x1.min(line.x2), line.x1.max(line.x2)))
+            .collect();
+        let v_segments: Vec<(f64, f64, f64)> = v_lines
+            .iter()
+            .map(|line| (line.x1, line.y1.min(line.y2), line.y1.max(line.y2)))
+            .collect();
+
+        Ok(GridPattern {
+            rows,
+            columns,
+            h_segments,
+            v_segments,
+        })
     }
 
     /// Clusters lines by their primary position (Y for horizontal, X for vertical).
@@ -453,6 +474,116 @@ impl TableDetector {
         cells
     }
 
+    /// Returns true if a vertical divider is drawn at `x` covering the Y-range
+    /// `[y0, y1]` (within `alignment_tolerance`) — i.e. some retained vertical
+    /// segment sits at that column and spans the given row band (issue #375).
+    fn divider_present_vertical(&self, grid: &GridPattern, x: f64, y0: f64, y1: f64) -> bool {
+        let tol = self.config.alignment_tolerance;
+        let (lo, hi) = (y0.min(y1), y0.max(y1));
+        grid.v_segments
+            .iter()
+            .any(|&(sx, s0, s1)| (sx - x).abs() <= tol && s0 <= lo + tol && s1 >= hi - tol)
+    }
+
+    /// Returns true if a horizontal divider is drawn at `y` covering the
+    /// X-range `[x0, x1]` (within `alignment_tolerance`) (issue #375).
+    fn divider_present_horizontal(&self, grid: &GridPattern, y: f64, x0: f64, x1: f64) -> bool {
+        let tol = self.config.alignment_tolerance;
+        let (lo, hi) = (x0.min(x1), x0.max(x1));
+        grid.h_segments
+            .iter()
+            .any(|&(sy, s0, s1)| (sy - y).abs() <= tol && s0 <= lo + tol && s1 >= hi - tol)
+    }
+
+    /// Merges base cells across *absent* interior dividers into spanning cells.
+    ///
+    /// Two adjacent base cells belong to the same merged region when the divider
+    /// on their shared edge is not drawn. Union-find groups connected base cells;
+    /// each region becomes one [`TableCell`] positioned at its top-left base
+    /// index with `row_span`/`col_span` equal to its extent (issue #375).
+    ///
+    /// A fully-ruled table (every divider present) yields all-`1` spans, i.e.
+    /// output identical to the base grid.
+    fn merge_cells_across_absent_dividers(
+        &self,
+        grid: &GridPattern,
+        cells: Vec<TableCell>,
+    ) -> Vec<TableCell> {
+        let num_rows = grid.rows.len().saturating_sub(1);
+        let num_cols = grid.columns.len().saturating_sub(1);
+        if num_rows == 0 || num_cols == 0 {
+            return cells;
+        }
+
+        // Union-find over base cells (flat index = r * num_cols + c).
+        fn find(parent: &mut [usize], i: usize) -> usize {
+            if parent[i] != i {
+                let root = find(parent, parent[i]);
+                parent[i] = root;
+            }
+            parent[i]
+        }
+
+        let mut parent: Vec<usize> = (0..num_rows * num_cols).collect();
+        for r in 0..num_rows {
+            for c in 0..num_cols {
+                // Merge right across an absent vertical divider at columns[c+1].
+                if c + 1 < num_cols {
+                    let x = grid.columns[c + 1];
+                    if !self.divider_present_vertical(grid, x, grid.rows[r], grid.rows[r + 1]) {
+                        let a = find(&mut parent, r * num_cols + c);
+                        let b = find(&mut parent, r * num_cols + c + 1);
+                        parent[a] = b;
+                    }
+                }
+                // Merge down across an absent horizontal divider at rows[r+1].
+                if r + 1 < num_rows {
+                    let y = grid.rows[r + 1];
+                    if !self.divider_present_horizontal(
+                        grid,
+                        y,
+                        grid.columns[c],
+                        grid.columns[c + 1],
+                    ) {
+                        let a = find(&mut parent, r * num_cols + c);
+                        let b = find(&mut parent, (r + 1) * num_cols + c);
+                        parent[a] = b;
+                    }
+                }
+            }
+        }
+
+        // Group base cells by root. BTreeMap keeps the output deterministic.
+        let mut groups: BTreeMap<usize, Vec<&TableCell>> = BTreeMap::new();
+        for cell in &cells {
+            let root = find(&mut parent, cell.row * num_cols + cell.column);
+            groups.entry(root).or_default().push(cell);
+        }
+
+        let mut merged = Vec::with_capacity(groups.len());
+        for group in groups.into_values() {
+            let min_r = group.iter().map(|c| c.row).min().unwrap_or(0);
+            let min_c = group.iter().map(|c| c.column).min().unwrap_or(0);
+            let max_r = group.iter().map(|c| c.row).max().unwrap_or(0);
+            let max_c = group.iter().map(|c| c.column).max().unwrap_or(0);
+
+            // Merged bbox spans the grid extents of the region (deterministic).
+            let x = grid.columns[min_c];
+            let y = grid.rows[min_r].min(grid.rows[max_r + 1]);
+            let w = (grid.columns[max_c + 1] - grid.columns[min_c]).abs();
+            let h = (grid.rows[max_r + 1] - grid.rows[min_r]).abs();
+
+            let mut cell = TableCell::new(min_r, min_c, BoundingBox::new(x, y, w, h));
+            cell.has_borders = true;
+            cell.row_span = max_r - min_r + 1;
+            cell.col_span = max_c - min_c + 1;
+            merged.push(cell);
+        }
+
+        merged.sort_by_key(|c| (c.row, c.column));
+        merged
+    }
+
     /// Assigns text fragments to cells based on spatial containment.
     ///
     /// **Coordinate Space Normalization**:
@@ -525,6 +656,13 @@ struct GridPattern {
     rows: Vec<f64>,
     /// Column X coordinates (sorted)
     columns: Vec<f64>,
+    /// Raw horizontal divider segments as `(y, x_start, x_end)` with
+    /// `x_start <= x_end`. Retained so absent interior dividers (merged cells)
+    /// can be detected instead of assuming a fully dense grid (issue #375).
+    h_segments: Vec<(f64, f64, f64)>,
+    /// Raw vertical divider segments as `(x, y_start, y_end)` with
+    /// `y_start <= y_end` (issue #375).
+    v_segments: Vec<(f64, f64, f64)>,
 }
 
 impl Default for TableDetector {

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -103,6 +103,8 @@ pub struct DetectedTable {
     pub columns: usize,
     /// Confidence score (0.0 to 1.0)
     pub confidence: f64,
+    /// Leading header rows (0 until header detection runs; Task 8).
+    pub header_rows: usize,
 }
 
 impl DetectedTable {
@@ -115,6 +117,7 @@ impl DetectedTable {
             rows,
             columns,
             confidence,
+            header_rows: 0,
         }
     }
 
@@ -169,6 +172,10 @@ pub struct TableCell {
     pub text: String,
     /// Whether this cell has borders
     pub has_borders: bool,
+    /// Number of base rows this cell spans (>= 1).
+    pub row_span: usize,
+    /// Number of base columns this cell spans (>= 1).
+    pub col_span: usize,
 }
 
 impl TableCell {
@@ -180,6 +187,8 @@ impl TableCell {
             bbox,
             text: String::new(),
             has_borders: false,
+            row_span: 1,
+            col_span: 1,
         }
     }
 

--- a/oxidize-pdf-core/src/text/table_detection.rs
+++ b/oxidize-pdf-core/src/text/table_detection.rs
@@ -42,6 +42,9 @@
 //! }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//!
+//! Merged cells are detected from absent grid dividers; borderless tables and un-tagged
+//! multi-level headers stay flat. See `docs/TABLE_DETECTION_GUIDE.md` for the full limits.
 
 use crate::graphics::extraction::{ExtractedGraphics, LineOrientation, VectorLine};
 use crate::text::extraction::TextFragment;

--- a/oxidize-pdf-core/tests/analysis_spi_test.rs
+++ b/oxidize-pdf-core/tests/analysis_spi_test.rs
@@ -45,6 +45,7 @@ fn hybrid_chunker_is_the_default_strategy() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     // Inherent API: Vec<HybridChunk>.
@@ -172,6 +173,7 @@ fn decorator_wraps_default_and_refines() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let base_count = ChunkingStrategy::chunk(&inner, &elements).len();
     assert_eq!(base_count, 4, "default emits one group per element here");
@@ -548,5 +550,41 @@ fn pipeline_owns_oversized_flag_regardless_of_strategy() {
     assert!(
         none_over.iter().all(|c| !c.is_oversized),
         "generous budget → no chunk is oversized"
+    );
+}
+
+/// Issue #376 (QR critical): `context_mode` set on the pipeline must reach
+/// `full_text` through the SPI path, not be silently dropped to `Heading`.
+#[test]
+fn pipeline_context_mode_threads_through_spi_path() {
+    use oxidize_pdf::pipeline::{ContextFormat, ContextMode, DocumentSource};
+    let bytes = build_two_section_doc();
+
+    // Default pipeline (Heading): no contextual `Document:`/`Section:` prefix.
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let heading = parsed
+        .rag_chunks_with_pipeline(&AnalysisPipeline::new())
+        .expect("rag_chunks_with_pipeline");
+    assert!(
+        !heading.iter().any(|c| c.full_text.contains("Document:")),
+        "default pipeline must not add a contextual prefix"
+    );
+
+    // Contextual mode set on the pipeline must reach every chunk's full_text.
+    let mut source = DocumentSource::with_file(Some("two.pdf".into()), Some("h".into()));
+    source.title = Some("Two Section Doc".into());
+    let parsed = PdfDocument::new(PdfReader::new(Cursor::new(&bytes)).unwrap());
+    let pipeline = AnalysisPipeline::new()
+        .with_source(source)
+        .with_context_mode(ContextMode::Contextual(ContextFormat::Labeled));
+    let ctx = parsed
+        .rag_chunks_with_pipeline(&pipeline)
+        .expect("rag_chunks_with_pipeline");
+    assert!(!ctx.is_empty(), "fixture must produce chunks");
+    assert!(
+        ctx.iter()
+            .all(|c| c.full_text.starts_with("Document: Two Section Doc")),
+        "context_mode must thread through the SPI path: {:?}",
+        ctx.iter().map(|c| c.full_text.clone()).collect::<Vec<_>>()
     );
 }

--- a/oxidize-pdf-core/tests/common/rag_helpers.rs
+++ b/oxidize-pdf-core/tests/common/rag_helpers.rs
@@ -28,6 +28,7 @@ pub fn make_rag_chunk(
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&[Element::Paragraph(ElementData {
         text: text.to_string(),

--- a/oxidize-pdf-core/tests/element_types_test.rs
+++ b/oxidize-pdf-core/tests/element_types_test.rs
@@ -35,18 +35,17 @@ fn test_element_paragraph_creation() {
 fn test_element_table_creation() {
     use oxidize_pdf::pipeline::TableElementData;
 
-    let table = Element::Table(TableElementData {
-        rows: vec![
+    let table = Element::Table(TableElementData::new(
+        vec![
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
             vec!["1".to_string(), "2".to_string(), "3".to_string()],
             vec!["X".to_string(), "Y".to_string(), "Z".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 1,
             ..Default::default()
         },
-    });
+    ));
 
     assert!(matches!(table, Element::Table(_)));
     assert_eq!(table.row_count(), Some(3));
@@ -66,11 +65,7 @@ fn test_element_variants_exhaustive() {
     let elements = vec![
         Element::Title(data()),
         Element::Paragraph(data()),
-        Element::Table(TableElementData {
-            rows: vec![],
-            structure: None,
-            metadata: ElementMetadata::default(),
-        }),
+        Element::Table(TableElementData::new(vec![], ElementMetadata::default())),
         Element::Header(data()),
         Element::Footer(data()),
         Element::ListItem(data()),
@@ -207,14 +202,13 @@ fn test_element_sort_by_reading_order() {
 fn test_element_display_text_table() {
     use oxidize_pdf::pipeline::TableElementData;
 
-    let table = Element::Table(TableElementData {
-        rows: vec![
+    let table = Element::Table(TableElementData::new(
+        vec![
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata::default(),
-    });
+        ElementMetadata::default(),
+    ));
 
     let display = table.display_text();
     assert!(display.contains("Name"));

--- a/oxidize-pdf-core/tests/element_types_test.rs
+++ b/oxidize-pdf-core/tests/element_types_test.rs
@@ -41,6 +41,7 @@ fn test_element_table_creation() {
             vec!["1".to_string(), "2".to_string(), "3".to_string()],
             vec!["X".to_string(), "Y".to_string(), "Z".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata {
             page: 1,
             ..Default::default()
@@ -67,6 +68,7 @@ fn test_element_variants_exhaustive() {
         Element::Paragraph(data()),
         Element::Table(TableElementData {
             rows: vec![],
+            structure: None,
             metadata: ElementMetadata::default(),
         }),
         Element::Header(data()),
@@ -210,6 +212,7 @@ fn test_element_display_text_table() {
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata::default(),
     });
 

--- a/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunker_disjoint_test.rs
@@ -168,6 +168,7 @@ fn synthetic_overflow_flushes_emit_disjoint_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -206,6 +207,7 @@ fn synthetic_merge_disabled_with_overlap_still_disjoint() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -57,6 +57,7 @@ fn test_heading_context_propagated_to_chunks() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -79,6 +80,7 @@ fn test_no_heading_before_first_title() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -103,6 +105,7 @@ fn test_heading_context_changes_on_new_title() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -133,6 +136,7 @@ fn test_merge_adjacent_paragraphs_within_budget() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -157,6 +161,7 @@ fn test_no_merge_different_element_types() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -185,6 +190,7 @@ fn test_merge_disabled_one_chunk_per_element() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     assert_eq!(chunker.chunk(&elements).len(), 3);
 }
@@ -215,6 +221,7 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -249,6 +256,7 @@ fn test_overlap_chunks_preserve_heading_context() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -332,6 +340,7 @@ fn test_list_items_merge_with_list_items_not_paragraphs() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -198,15 +198,14 @@ fn test_oversized_table_gets_own_oversized_chunk() {
 
     let elements = vec![
         para_with_heading("Before table.", 0, 750.0, None),
-        Element::Table(TableElementData {
-            rows: big_rows,
-            structure: None,
-            metadata: ElementMetadata {
+        Element::Table(TableElementData::new(
+            big_rows,
+            ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),
                 ..Default::default()
             },
-        }),
+        )),
         para_with_heading("After table.", 0, 100.0, None),
     ];
 

--- a/oxidize-pdf-core/tests/hybrid_chunking_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_test.rs
@@ -200,6 +200,7 @@ fn test_oversized_table_gets_own_oversized_chunk() {
         para_with_heading("Before table.", 0, 750.0, None),
         Element::Table(TableElementData {
             rows: big_rows,
+            structure: None,
             metadata: ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -38,19 +38,18 @@ fn title_elem(text: &str, page: u32, y: f64) -> Element {
 }
 
 fn make_small_table() -> Element {
-    Element::Table(TableElementData {
-        rows: vec![
+    Element::Table(TableElementData::new(
+        vec![
             vec!["Header A".to_string(), "Header B".to_string()],
             vec!["Row 1A".to_string(), "Row 1B".to_string()],
             vec!["Row 2A".to_string(), "Row 2B".to_string()],
         ],
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 400.0, 400.0, 100.0),
             ..Default::default()
         },
-    })
+    ))
 }
 
 fn frag(text: &str, x: f64, y: f64, font_size: f64) -> TextFragment {
@@ -227,15 +226,14 @@ fn test_table_oversized_remains_atomic_not_split() {
     let big_rows: Vec<Vec<String>> = (0..100)
         .map(|i| vec![format!("key_{}", i), format!("value_{}", i)])
         .collect();
-    let elements = vec![Element::Table(TableElementData {
-        rows: big_rows,
-        structure: None,
-        metadata: ElementMetadata {
+    let elements = vec![Element::Table(TableElementData::new(
+        big_rows,
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),
             ..Default::default()
         },
-    })];
+    ))];
     let chunker = HybridChunker::new(HybridChunkConfig {
         max_tokens: 20,
         overlap_tokens: 0,

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -44,6 +44,7 @@ fn make_small_table() -> Element {
             vec!["Row 1A".to_string(), "Row 1B".to_string()],
             vec!["Row 2A".to_string(), "Row 2B".to_string()],
         ],
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 400.0, 400.0, 100.0),
@@ -228,6 +229,7 @@ fn test_table_oversized_remains_atomic_not_split() {
         .collect();
     let elements = vec![Element::Table(TableElementData {
         rows: big_rows,
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 300.0, 400.0, 400.0),

--- a/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
+++ b/oxidize-pdf-core/tests/hybrid_chunking_v2_test.rs
@@ -88,6 +88,7 @@ fn test_merge_paragraph_and_list_item_under_same_heading() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -113,6 +114,7 @@ fn test_same_type_only_policy_preserves_legacy_behavior() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     assert_eq!(
@@ -134,6 +136,7 @@ fn test_title_never_merges_with_adjacent_paragraph() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // Title must be its own chunk — it is structural, not inline.
@@ -163,6 +166,7 @@ fn test_table_never_merges_with_adjacent_paragraph() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // Table must be isolated in its own chunk.
@@ -193,6 +197,7 @@ fn test_oversized_paragraph_splits_at_sentence_boundary() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -240,6 +245,7 @@ fn test_table_oversized_remains_atomic_not_split() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -266,6 +272,7 @@ fn test_single_very_long_sentence_stays_in_one_chunk() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
     // No sentence boundaries → entire text is one "sentence" → one chunk.
@@ -286,6 +293,7 @@ fn test_sentence_split_preserves_parent_heading_metadata() {
         merge_adjacent: false,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let chunks = chunker.chunk(&elements);
 
@@ -379,6 +387,7 @@ fn test_hybrid_chunker_v2_end_to_end_with_partition() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     let graph = ElementGraph::build(&elements);

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -106,3 +106,71 @@ fn merged_header_cell_detected_with_col_span_2() {
         "bottom-right single cell"
     );
 }
+
+/// Same fragment as `frag`, but tagged as a table-header structure element.
+fn th(t: &str, x: f64, y: f64) -> TextFragment {
+    let mut f = frag(t, x, y);
+    f.struct_tag = Some("TH".to_string());
+    f
+}
+
+/// Issue #375 Task 8: a fully-ruled 2x2 table whose top row is tagged `TH`
+/// must report `header_rows == 1`; the untagged bottom row must not count.
+#[test]
+fn header_row_detected_from_th_tag() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),
+        vline(200.0, 100.0, 200.0),
+        vline(300.0, 100.0, 200.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        th("H1", 130.0, 170.0),
+        th("H2", 230.0, 170.0),
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(table.header_rows, 1, "top row tagged TH must be the header");
+}
+
+/// Issue #375 Task 8: with no structure tags at all, a >=2-row bordered
+/// table still defaults `header_rows` to 1 (top row fallback).
+#[test]
+fn header_row_defaults_to_top_row_without_tags() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0),
+        vline(200.0, 100.0, 200.0),
+        vline(300.0, 100.0, 200.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("H1", 130.0, 170.0),
+        frag("H2", 230.0, 170.0),
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(
+        table.header_rows, 1,
+        "no tags present: must default to top-row fallback"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -215,3 +215,142 @@ fn header_rows_two_when_top_two_of_three_rows_tagged() {
         "top two tagged rows must both count as header rows"
     );
 }
+
+/// Issue #375 Task 7 (final-review I2/T7d): vertical merge coverage.
+///
+/// Grid: X gridlines 100/200/300 (2 cols); Y gridlines 100/150/200 (2 row
+/// bands, row 0 = top). The middle horizontal divider at y=150 is drawn only
+/// over the RIGHT column (x 200..300); it is absent over the LEFT column
+/// (x 100..200). `divider_present_horizontal` therefore reports the divider
+/// missing on the left, so the two left-column base cells merge vertically
+/// into one `row_span == 2` cell, while the right column — where the divider
+/// is present — keeps two separate `row_span == 1` cells.
+#[test]
+fn merged_cell_detected_with_row_span_2() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0), // bottom border
+        hline(200.0, 300.0, 150.0), // middle divider, RIGHT column only
+        hline(100.0, 300.0, 200.0), // top border
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(200.0, 100.0, 200.0), // middle vertical (full height, both rows)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Left", 130.0, 150.0),
+        frag("TopRight", 230.0, 170.0),
+        frag("BottomRight", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x2.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 2, "base grid columns");
+
+    let left = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(left.row_span, 2, "left column should span 2 rows");
+    assert_eq!(left.col_span, 1, "left merged cell spans a single column");
+
+    // The vertical merge must not leave a separate cell at (1,0).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 1 && c.column == 0),
+        "interior position of a vertically merged cell must be omitted"
+    );
+
+    // The right column keeps two single (unmerged) cells.
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 0 && c.column == 1 && c.row_span == 1 && c.col_span == 1),
+        "top-right single cell"
+    );
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 1 && c.row_span == 1 && c.col_span == 1),
+        "bottom-right single cell"
+    );
+}
+
+/// Issue #375 Task 7 (final-review I2/T7d): transitive multi-cell merge
+/// coverage.
+///
+/// Grid: X gridlines 100/200/300/400 (3 cols); Y gridlines 100/150/200 (2 row
+/// bands). In the TOP row band (y 150..200) BOTH interior verticals (x=200
+/// and x=300) are absent — each is drawn only over the BOTTOM band
+/// (y 100..150) — so all three top-row base cells merge transitively
+/// (0-1 absent, 1-2 absent -> union-find connects all three) into one
+/// `col_span == 3` cell. The bottom row keeps both interior verticals, so it
+/// stays as three separate `col_span == 1` cells.
+#[test]
+fn transitive_merge_across_three_columns_detected() {
+    let h = vec![
+        hline(100.0, 400.0, 100.0), // bottom border
+        hline(100.0, 400.0, 150.0), // middle divider, full width
+        hline(100.0, 400.0, 200.0), // top border
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(400.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // interior divider 1, BOTTOM band only
+        vline(300.0, 100.0, 150.0), // interior divider 2, BOTTOM band only
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Top", 250.0, 170.0),
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+        frag("C", 330.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x3.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 3, "base grid columns");
+
+    let top = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(
+        top.col_span, 3,
+        "top row should transitively merge 3 columns"
+    );
+    assert_eq!(top.row_span, 1, "top merged cell spans a single row");
+
+    // The transitive merge must not leave separate cells at (0,1) or (0,2).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 1),
+        "interior position (0,1) of the merged cell must be omitted"
+    );
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 2),
+        "interior position (0,2) of the merged cell must be omitted"
+    );
+
+    // The bottom row keeps three single (unmerged) cells.
+    for col in 0..3 {
+        assert!(
+            table
+                .cells
+                .iter()
+                .any(|c| { c.row == 1 && c.column == col && c.row_span == 1 && c.col_span == 1 }),
+            "bottom row cell at column {col} should remain unmerged"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -174,3 +174,44 @@ fn header_row_defaults_to_top_row_without_tags() {
         "no tags present: must default to top-row fallback"
     );
 }
+
+/// Issue #375 Task 8: a fully-ruled 3x2 table with the TOP TWO rows tagged
+/// `TH` must report `header_rows == 2`. This is discriminating from the
+/// untagged `rows >= 2 -> 1` fallback: a broken tag-matching path can only
+/// ever produce 1 here, never 2.
+#[test]
+fn header_rows_two_when_top_two_of_three_rows_tagged() {
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 140.0),
+        hline(100.0, 300.0, 180.0),
+        hline(100.0, 300.0, 220.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 220.0),
+        vline(200.0, 100.0, 220.0),
+        vline(300.0, 100.0, 220.0),
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        // Top row (row 0), tagged.
+        th("H1", 130.0, 200.0),
+        th("H2", 230.0, 200.0),
+        // Middle row (row 1), tagged.
+        th("H3", 130.0, 160.0),
+        th("H4", 230.0, 160.0),
+        // Bottom row (row 2), plain.
+        frag("a", 130.0, 120.0),
+        frag("b", 230.0, 120.0),
+    ];
+
+    let tables = TableDetector::default()
+        .detect(&graphics, &frags)
+        .expect("detect");
+    let table = tables.first().expect("one table");
+    assert_eq!(table.rows, 3, "base grid rows");
+    assert_eq!(
+        table.header_rows, 2,
+        "top two tagged rows must both count as header rows"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -1,0 +1,108 @@
+//! Issue #375 Task 7: detect merged cells from a drawn grid by retaining which
+//! divider line-segments are actually present.
+//!
+//! Fixture: a bordered 2-column table whose TOP row omits the middle vertical
+//! divider (a single spanning header cell) while the BOTTOM row keeps it (two
+//! cells). Detection must yield a top-left cell with `col_span == 2` and two
+//! `col_span == 1` cells in the bottom row.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::text::extraction::TextFragment;
+use oxidize_pdf::text::table_detection::TableDetector;
+
+/// Horizontal line at height `y` from `x1` to `x2`.
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+
+/// Vertical line at `x` from `y1` to `y2`.
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: t.into(),
+        x,
+        y,
+        width: 30.0,
+        height: 10.0,
+        font_size: 10.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
+    let mut g = ExtractedGraphics::new();
+    for line in h.into_iter().chain(v.into_iter()) {
+        g.add_line(line);
+    }
+    g
+}
+
+#[test]
+fn merged_header_cell_detected_with_col_span_2() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // MIDDLE divider only in row 1
+    ];
+    let graphics = build_graphics(h, v);
+    let frags = vec![
+        frag("Header", 150.0, 170.0),
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+    ];
+
+    let det = TableDetector::default();
+    let tables = det.detect(&graphics, &frags).expect("detect");
+    let table = tables.first().expect("one table");
+
+    // Base grid dimensions stay 2x2.
+    assert_eq!(table.rows, 2, "base grid rows");
+    assert_eq!(table.columns, 2, "base grid columns");
+
+    let top_left = table
+        .cells
+        .iter()
+        .find(|c| c.row == 0 && c.column == 0)
+        .expect("cell 0,0");
+    assert_eq!(top_left.col_span, 2, "merged header should span 2 columns");
+    assert_eq!(top_left.row_span, 1, "merged header spans a single row");
+
+    // The merged header must NOT leave a separate cell at (0,1).
+    assert!(
+        !table.cells.iter().any(|c| c.row == 0 && c.column == 1),
+        "interior position of a merged cell must be omitted"
+    );
+
+    // The non-merged bottom row keeps two single cells.
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 0 && c.col_span == 1 && c.row_span == 1),
+        "bottom-left single cell"
+    );
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|c| c.row == 1 && c.column == 1 && c.col_span == 1 && c.row_span == 1),
+        "bottom-right single cell"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_test.rs
@@ -1,0 +1,48 @@
+// tests/issue_375_merged_cells_test.rs  (create; more tests added in Task 7/9)
+use oxidize_pdf::pipeline::{ElementMetadata, RichCell, TableElementData, TableStructure};
+
+#[test]
+fn from_structure_expands_spans_into_flat_rows() {
+    // 2x2 grid; top row is a single cell spanning both columns (a merged header).
+    let structure = TableStructure {
+        num_rows: 2,
+        num_cols: 2,
+        header_rows: 1,
+        cells: vec![
+            RichCell {
+                row: 0,
+                col: 0,
+                row_span: 1,
+                col_span: 2,
+                text: "Region".into(),
+                is_header: true,
+            },
+            RichCell {
+                row: 1,
+                col: 0,
+                row_span: 1,
+                col_span: 1,
+                text: "Q1".into(),
+                is_header: false,
+            },
+            RichCell {
+                row: 1,
+                col: 1,
+                row_span: 1,
+                col_span: 1,
+                text: "Q2".into(),
+                is_header: false,
+            },
+        ],
+    };
+    let data = TableElementData::from_structure(structure, ElementMetadata::default());
+    // Flat view repeats the spanned header value across both covered columns.
+    assert_eq!(
+        data.rows,
+        vec![
+            vec!["Region".to_string(), "Region".to_string()],
+            vec!["Q1".to_string(), "Q2".to_string()],
+        ]
+    );
+    assert_eq!(data.structure.as_ref().unwrap().header_rows, 1);
+}

--- a/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
@@ -1,0 +1,99 @@
+//! Issue #375 Task 9: the ruling-detector partition path must emit the RICH
+//! `TableStructure` (merged cells + header rows), with the flat `rows` view
+//! derived from it via `TableElementData::from_structure`. The spatial path
+//! keeps `structure: None` (unchanged, not exercised here).
+//!
+//! Fixture: same merged-header grid as the Task 7 detect test (a 2-col table
+//! whose top row omits the middle vertical divider, producing one spanning
+//! header cell with `col_span == 2`), run through the full partition path.
+
+use oxidize_pdf::graphics::extraction::{ExtractedGraphics, VectorLine};
+use oxidize_pdf::pipeline::{Element, PartitionConfig, Partitioner};
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn hline(x1: f64, x2: f64, y: f64) -> VectorLine {
+    VectorLine::new(x1, y, x2, y, 1.0, true, None)
+}
+
+fn vline(x: f64, y1: f64, y2: f64) -> VectorLine {
+    VectorLine::new(x, y1, x, y2, 1.0, true, None)
+}
+
+fn frag(t: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: t.into(),
+        x,
+        y,
+        width: 30.0,
+        height: 10.0,
+        font_size: 10.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
+    let mut g = ExtractedGraphics::new();
+    for line in h.into_iter().chain(v.into_iter()) {
+        g.add_line(line);
+    }
+    g
+}
+
+#[test]
+fn ruling_partition_emits_rich_structure_with_merged_header() {
+    // Grid X at 100,200,300 ; Y at 100 (bottom),150 (mid),200 (top).
+    // Row 0 (top band, y 150..200) has NO middle vertical => one spanning cell.
+    // Row 1 (y 100..150) HAS the middle vertical => two cells.
+    let h = vec![
+        hline(100.0, 300.0, 100.0),
+        hline(100.0, 300.0, 150.0),
+        hline(100.0, 300.0, 200.0),
+    ];
+    let v = vec![
+        vline(100.0, 100.0, 200.0), // left border (full height)
+        vline(300.0, 100.0, 200.0), // right border (full height)
+        vline(200.0, 100.0, 150.0), // MIDDLE divider only in row 1
+    ];
+    let graphics = build_graphics(h, v);
+
+    let mut header_frag = frag("Header", 150.0, 170.0);
+    header_frag.struct_tag = Some("TH".to_string());
+    let frags = vec![
+        header_frag,
+        frag("A", 130.0, 120.0),
+        frag("B", 230.0, 120.0),
+    ];
+
+    let elements = Partitioner::new(PartitionConfig::default()).partition_fragments_with_graphics(
+        &frags,
+        Some(&graphics),
+        0,
+        842.0,
+    );
+
+    let table = elements
+        .iter()
+        .find_map(|e| match e {
+            Element::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("a table element");
+
+    let st = table.structure.as_ref().expect("rich structure present");
+    assert!(
+        st.cells
+            .iter()
+            .any(|c| c.row == 0 && c.col == 0 && c.col_span == 2 && c.is_header),
+        "expected a spanning header cell at row 0, col 0 with col_span == 2"
+    );
+    assert_eq!(st.header_rows, 1, "single header row expected");
+
+    // Flat view still complete (spanned value repeated across both columns).
+    assert_eq!(table.rows[0].len(), 2);
+}

--- a/oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_text_conservation_test.rs
@@ -1,0 +1,165 @@
+// tests/issue_375_text_conservation_test.rs
+//
+// #375 data-loss guard: after partitioning, the union of all element text must
+// cover the page's extracted text. A prose page misdetected as an (empty) table
+// currently drops its text -> this fails RED until the claim fix lands.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::PartitionConfig;
+use oxidize_pdf::text::TextExtractor;
+
+const FIXTURE: &str = "tests/fixtures/issue_272_boe_sumario_2025_01_15.pdf";
+
+/// Non-whitespace tokens of `s`, lowercased, for order-independent containment.
+fn tokens(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|t| t.to_lowercase()).collect()
+}
+
+#[test]
+fn partition_conserves_page_text_default_config() {
+    let doc = PdfDocument::new(PdfReader::open(FIXTURE).expect("open fixture"));
+
+    // Expected: raw extracted text of every page.
+    let mut extractor = TextExtractor::new();
+    let page_count = doc.page_count().expect("page_count");
+    let mut expected = String::new();
+    for p in 0..page_count {
+        let page_text = extractor
+            .extract_from_page(&doc, p)
+            .expect("extract page")
+            .text;
+        expected.push('\n');
+        expected.push_str(&page_text);
+    }
+
+    // Actual: union of all element display text.
+    let elements = doc
+        .partition_with(PartitionConfig::default())
+        .expect("partition");
+    let actual: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let actual_tokens: std::collections::HashSet<String> = tokens(&actual).into_iter().collect();
+
+    // Every expected token must survive partitioning (allow a small slack for
+    // tokenization artifacts at cell boundaries).
+    let missing: Vec<String> = tokens(&expected)
+        .into_iter()
+        .filter(|t| !actual_tokens.contains(t))
+        .collect();
+
+    let miss_ratio = missing.len() as f64 / tokens(&expected).len().max(1) as f64;
+    assert!(
+        miss_ratio < 0.01,
+        "partition dropped {:.1}% of page tokens ({} missing), e.g. {:?}",
+        miss_ratio * 100.0,
+        missing.len(),
+        &missing.iter().take(15).collect::<Vec<_>>()
+    );
+}
+
+use oxidize_pdf::pipeline::Partitioner;
+use oxidize_pdf::text::extraction::TextFragment;
+
+fn frag(text: &str, x: f64, y: f64) -> TextFragment {
+    TextFragment {
+        text: text.to_string(),
+        x,
+        y,
+        width: text.len() as f64 * 6.0,
+        height: 12.0,
+        font_size: 12.0,
+        font_name: None,
+        is_bold: false,
+        is_italic: false,
+        color: None,
+        space_decisions: Vec::new(),
+        mcid: None,
+        struct_tag: None,
+    }
+}
+
+#[test]
+fn spatial_table_does_not_drop_interior_prose() {
+    // A justified prose block: 3 X-columns x 4 Y-rows, but one stray token sits
+    // in a gap between columns (inside the table bbox, outside every cell).
+    //
+    // NOTE: with the current spatial-cluster detector, an isolated in-gap point
+    // like this becomes its own singleton column (any point far enough from its
+    // neighbors starts a new cluster) and so is captured, not dropped. This test
+    // currently passes; it is kept as a durable guard for that shape of
+    // regression. The actual data-loss reproduction is
+    // `spatial_table_drops_column_jitter_outliers` below.
+    let mut frags = Vec::new();
+    for (r, y) in [780.0, 760.0, 740.0, 720.0].iter().enumerate() {
+        for (c, x) in [72.0, 200.0, 330.0].iter().enumerate() {
+            frags.push(frag(&format!("w{r}{c}"), *x, *y));
+        }
+    }
+    frags.push(frag("ORPHAN", 150.0, 730.0)); // in-bbox, between columns
+
+    let elements =
+        Partitioner::new(PartitionConfig::default()).partition_fragments(&frags, 0, 842.0);
+    let all: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all.contains("ORPHAN"),
+        "interior prose token was dropped: {all}"
+    );
+}
+
+/// #375 root-cause reproduction: a column whose X positions drift within the
+/// spatial detector's clustering tolerance (5.0pt) still forms a single column
+/// cluster, but `find_cell_for_fragment` only accepts a fragment into a cell
+/// when it is within `2 * column_alignment_tolerance` (10.0pt) of the
+/// *cluster mean* — not the raw point. A cluster built from a chain of small
+/// (<=5pt) steps can have a mean far enough from its own extreme members that
+/// those members fail the cell-assignment check and are placed in no cell.
+///
+/// The bounding box used to *claim* fragments is computed from the column's
+/// full raw extent (`min`/`max`, padded to a 50pt minimum width), which is
+/// wide enough to still cover those extreme members. So they get claimed by
+/// the table (removed from consideration for prose) but never appear in any
+/// cell's text: the fragment's text is silently dropped, matching the #375
+/// root cause ("claim without capture") described for the ruling-detector
+/// case in the design doc, reproduced here via the spatial detector.
+#[test]
+fn spatial_table_drops_column_jitter_outliers() {
+    let mut frags = Vec::new();
+    // A tight, well-behaved column (x == 250.0 for every row).
+    let ys = [700.0, 680.0, 660.0, 640.0, 620.0, 600.0, 580.0, 560.0];
+    // A second column whose x drifts by 4.5pt per row (each step <= the 5.0pt
+    // column_alignment_tolerance, so cluster_columns still merges all 8 points
+    // into one cluster), spanning 31.5pt total -- enough for the two extreme
+    // rows on each end to fall outside `2 * tolerance` (10.0pt) of the
+    // resulting cluster mean.
+    let drift_xs = [100.0, 104.5, 109.0, 113.5, 118.0, 122.5, 127.0, 131.5];
+    for (i, (&y, &x)) in ys.iter().zip(drift_xs.iter()).enumerate() {
+        frags.push(frag(&format!("A{i}"), 250.0, y));
+        frags.push(frag(&format!("B{i}"), x, y));
+    }
+
+    let elements =
+        Partitioner::new(PartitionConfig::default()).partition_fragments(&frags, 0, 842.0);
+    let all: String = elements
+        .iter()
+        .map(|e| e.display_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let missing: Vec<String> = (0..8)
+        .map(|i| format!("B{i}"))
+        .filter(|tok| !all.contains(tok.as_str()))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "column-jitter outliers were claimed by the table but dropped from every cell: {missing:?}\nfull output: {all}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_376_contextual_chunks.rs
+++ b/oxidize-pdf-core/tests/issue_376_contextual_chunks.rs
@@ -1,0 +1,182 @@
+//! Feature tests for issue #376 — first-class deterministic contextual RAG
+//! chunks (no-ML Contextual Retrieval).
+//!
+//! `ContextMode` on `HybridChunkConfig` selects how each chunk's `full_text`
+//! (the embedding text) is contextualized: `None` (== text), `Heading` (the
+//! pre-#376 leaf-heading behavior, default), or `Contextual(ContextFormat)`
+//! which prepends a deterministic document + section snippet. The display
+//! `text` field always stays context-free.
+
+use oxidize_pdf::pipeline::{
+    ContextFormat, ContextMode, DocumentSource, Element, ElementData, ElementMetadata, HybridChunk,
+    HybridChunkConfig, HybridChunker, RagChunk,
+};
+
+/// A paragraph on page 3 under the breadcrumb `1 Intro › 1.2 Scope`.
+fn para(text: &str) -> Element {
+    let mut e = Element::Paragraph(ElementData {
+        text: text.to_string(),
+        metadata: ElementMetadata::default(),
+    });
+    e.metadata_mut().page = 3;
+    e.set_parent_heading(Some("1.2 Scope".to_string()));
+    e.set_heading_path(vec!["1 Intro".to_string(), "1.2 Scope".to_string()]);
+    e
+}
+
+fn one_chunk() -> Vec<HybridChunk> {
+    let chunker = HybridChunker::new(HybridChunkConfig::default());
+    chunker.chunk(&[para("Alpha beta gamma."), para("Delta epsilon.")])
+}
+
+fn source() -> DocumentSource {
+    let mut s = DocumentSource::with_file(Some("annual.pdf".to_string()), Some("h123".to_string()));
+    s.title = Some("Annual Report".to_string());
+    s.author = Some("Acme".to_string());
+    s
+}
+
+#[test]
+fn mode_none_full_text_equals_text() {
+    let hcs = one_chunk();
+    let c =
+        RagChunk::from_hybrid_chunk_with_source_and_mode(0, &hcs[0], &source(), ContextMode::None);
+    assert_eq!(c.full_text, c.text, "None mode: full_text is the bare text");
+}
+
+#[test]
+fn mode_heading_matches_legacy_behavior() {
+    let hcs = one_chunk();
+    let legacy = RagChunk::from_hybrid_chunk_with_source(0, &hcs[0], &source());
+    let heading = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Heading,
+    );
+    assert_eq!(
+        heading.full_text, legacy.full_text,
+        "Heading mode must be byte-identical to the pre-#376 constructor"
+    );
+}
+
+#[test]
+fn mode_contextual_labeled_prefix_and_clean_text() {
+    let hcs = one_chunk();
+    let c = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert!(
+        c.full_text
+            .starts_with("Document: Annual Report — Acme\nSection: 1 Intro › 1.2 Scope (p. 3)\n\n"),
+        "labeled prefix missing/wrong: {:?}",
+        c.full_text
+    );
+    assert!(
+        c.full_text.ends_with(&c.text),
+        "full_text must end with the bare chunk text"
+    );
+    assert!(
+        !c.text.contains("Document:") && !c.text.contains("Section:"),
+        "display text must stay context-free: {:?}",
+        c.text
+    );
+}
+
+#[test]
+fn mode_contextual_prose_prefix() {
+    let hcs = one_chunk();
+    let c = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Prose),
+    );
+    assert!(
+        c.full_text.starts_with(
+            "This chunk is from \"Annual Report\" by Acme, section \"1 Intro › 1.2 Scope\" (p. 3).\n\n"
+        ),
+        "prose prefix missing/wrong: {:?}",
+        c.full_text
+    );
+    assert!(c.full_text.ends_with(&c.text));
+}
+
+#[test]
+fn contextual_is_deterministic() {
+    let hcs = one_chunk();
+    let mk = || {
+        RagChunk::from_hybrid_chunk_with_source_and_mode(
+            0,
+            &hcs[0],
+            &source(),
+            ContextMode::Contextual(ContextFormat::Labeled),
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert_eq!(a.full_text, b.full_text, "prefix is a pure function");
+    assert_eq!(
+        a.metadata.chunk_id, b.metadata.chunk_id,
+        "chunk_id reproducible"
+    );
+}
+
+#[test]
+fn contextual_without_source_is_section_only() {
+    let hcs = one_chunk();
+    // No `DocumentSource`: the prefix carries the section breadcrumb only.
+    let labeled = RagChunk::from_hybrid_chunk_with_mode(
+        0,
+        &hcs[0],
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert!(
+        labeled
+            .full_text
+            .starts_with("Section: 1 Intro › 1.2 Scope (p. 3)\n\n"),
+        "no-source labeled prefix should be section-only: {:?}",
+        labeled.full_text
+    );
+    assert!(
+        !labeled.full_text.contains("Document:"),
+        "no source → no Document line"
+    );
+
+    let prose = RagChunk::from_hybrid_chunk_with_mode(
+        0,
+        &hcs[0],
+        ContextMode::Contextual(ContextFormat::Prose),
+    );
+    assert!(
+        prose
+            .full_text
+            .starts_with("This chunk is from section \"1 Intro › 1.2 Scope\" (p. 3).\n\n"),
+        "no-source prose prefix should be section-only: {:?}",
+        prose.full_text
+    );
+}
+
+#[test]
+fn chunk_id_is_mode_independent_when_doc_hash_set() {
+    let hcs = one_chunk();
+    let heading = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Heading,
+    );
+    let contextual = RagChunk::from_hybrid_chunk_with_source_and_mode(
+        0,
+        &hcs[0],
+        &source(),
+        ContextMode::Contextual(ContextFormat::Labeled),
+    );
+    assert_eq!(
+        heading.metadata.chunk_id, contextual.metadata.chunk_id,
+        "with doc_hash set, chunk_id is derived from the hash, not full_text"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
+++ b/oxidize-pdf-core/tests/issue_377_token_counter_test.rs
@@ -105,6 +105,7 @@ fn rag_chunks_with_counter_word_proxy_parity() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
 
     let base = doc.rag_chunks_with(config.clone()).unwrap();

--- a/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
+++ b/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
@@ -1,0 +1,412 @@
+//! Regression / feature tests for issue #382 — `extract_from_page` had no
+//! per-page text-length limit, so a single page with a huge content stream
+//! materialised the whole decoded string in RAM before the caller saw it.
+//!
+//! `ExtractionOptions::max_extracted_bytes` caps the bytes of decoded text
+//! accumulated for one page. The cap is enforced *during* accumulation (not by
+//! truncating the finished string), so it bounds peak RAM. When the cap cuts
+//! extraction short, `ExtractedText::truncated` is `true`.
+//!
+//! Semantics are *undershoot*: extraction stops before the fragment that would
+//! push the accumulated bytes over the limit, so `text.len() <= limit` and a
+//! multi-byte UTF-8 character is never split.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractedText, ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid single-page PDF whose content stream is `content`.
+/// `/F1` maps to Helvetica (Type1) so decoding is trivial (1 byte → 1 char).
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+/// A page with `lines` separate `Tj` show operators, each drawing `chunk`
+/// (ASCII, so one byte of content stream = one byte of decoded text). Each
+/// operator is its own text fragment, so the undershoot boundary is exercised
+/// at fragment granularity.
+fn build_repeated_text(chunk: &str, lines: usize) -> String {
+    let mut c = String::new();
+    let mut y = 760.0_f64;
+    for _ in 0..lines {
+        c.push_str(&format!(
+            "BT\n/F1 12 Tf\n1 0 0 1 72 {y:.2} Tm\n({chunk}) Tj\nET\n"
+        ));
+        y -= 14.0;
+        if y < 20.0 {
+            y = 760.0;
+        }
+    }
+    c
+}
+
+// ── Cycle 1: cap bounds the flat (default) path and sets the flag ────────────
+
+#[test]
+fn test_bounds_flat_text_and_sets_flag() {
+    // 40 fragments × 50 chars ≈ 2 KB of decoded text (plus newlines the
+    // extractor inserts between fragments on separate lines).
+    let content = build_repeated_text(&"A".repeat(50), 40);
+
+    // No limit: full text, not truncated.
+    let full = extract(&content, ExtractionOptions::default());
+    assert!(
+        full.text.len() >= 40 * 50,
+        "unbounded extraction should contain all {} chars, got {}",
+        40 * 50,
+        full.text.len()
+    );
+    assert!(
+        !full.truncated,
+        "unbounded extraction must not be truncated"
+    );
+
+    // With a 500-byte cap: bounded and flagged.
+    let opts = ExtractionOptions {
+        max_extracted_bytes: Some(500),
+        ..Default::default()
+    };
+    let capped = extract(&content, opts);
+    assert!(
+        capped.text.len() <= 500,
+        "capped text must be <= 500 bytes, got {}",
+        capped.text.len()
+    );
+    assert!(
+        capped.truncated,
+        "capped extraction must set truncated = true"
+    );
+    // Content check (not just length): the kept text is a genuine prefix of the
+    // full extraction — extraction stopped early, it did not reorder or mangle.
+    assert!(
+        full.text.starts_with(&capped.text),
+        "capped text must be a prefix of the full text"
+    );
+    assert!(!capped.text.is_empty(), "a 500-byte cap keeps some text");
+}
+
+// ── Cycle 2: the cap flows through the reorder / preserve-layout paths ────────
+
+#[test]
+fn test_bounds_reorder_and_preserve_layout() {
+    let content = build_repeated_text(&"B".repeat(40), 40);
+
+    for (label, mut opts) in [
+        ("reorder_columns", ExtractionOptions::default()),
+        ("preserve_layout", ExtractionOptions::default()),
+    ] {
+        match label {
+            "reorder_columns" => opts.reorder_columns = true,
+            _ => opts.preserve_layout = true,
+        }
+
+        let full = extract(&content, opts.clone());
+        assert!(!full.truncated, "{label}: unbounded must not be truncated");
+
+        opts.max_extracted_bytes = Some(400);
+        let capped = extract(&content, opts);
+
+        // The flag is authoritative for every path.
+        assert!(
+            capped.truncated,
+            "{label}: capped extraction must set truncated"
+        );
+        // These paths rebuild `.text` from the already-bounded fragment set and
+        // insert their own separators, but the final `clamp_to_budget` safety
+        // net guarantees the hard invariant on every path, not just the flat one.
+        assert!(
+            capped.text.len() <= 400,
+            "{label}: capped text ({}) must respect the 400-byte cap",
+            capped.text.len()
+        );
+        assert!(
+            capped.text.len() < full.text.len(),
+            "{label}: capped text ({}) must be shorter than full ({})",
+            capped.text.len(),
+            full.text.len()
+        );
+        assert!(
+            !capped.text.is_empty(),
+            "{label}: a 400-byte cap keeps text"
+        );
+    }
+}
+
+// ── Cycle 3: the cap never splits a multi-byte UTF-8 character ────────────────
+
+/// `build_pdf`, but the content stream is raw bytes so we can embed WinAnsi
+/// high bytes (e.g. `0xE9` → `é`) that decode to multi-byte UTF-8.
+fn build_pdf_bytes(content: &[u8]) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+              /Encoding /WinAnsiEncoding >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(format!("5 0 obj\n<< /Length {clen} >>\nstream\n").as_bytes());
+    buf.extend_from_slice(content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_bytes(content: &[u8], opts: ExtractionOptions) -> ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf_bytes(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+#[test]
+fn test_never_splits_utf8() {
+    // Each `Tj` draws 10 × `0xE9` (WinAnsi 'é', 2 UTF-8 bytes each → 20 bytes of
+    // decoded text per fragment). A 45-byte cap lands *inside* the third
+    // fragment; undershoot must drop that whole fragment, never half a 'é'.
+    let mut content = Vec::<u8>::new();
+    let mut y = 760.0_f64;
+    for _ in 0..20 {
+        content.extend_from_slice(format!("BT\n/F1 12 Tf\n1 0 0 1 72 {y:.2} Tm\n(").as_bytes());
+        content.extend(std::iter::repeat_n(0xE9u8, 10));
+        content.extend_from_slice(b") Tj\nET\n");
+        y -= 14.0;
+    }
+
+    // Sanity: unbounded decode really produced multi-byte 'é'.
+    let full = extract_bytes(&content, ExtractionOptions::default());
+    assert!(
+        full.text.contains('é'),
+        "fixture must decode WinAnsi 0xE9 to 'é', got {:?}",
+        full.text.chars().take(8).collect::<String>()
+    );
+    assert!(!full.truncated);
+
+    let opts = ExtractionOptions {
+        max_extracted_bytes: Some(45),
+        ..Default::default()
+    };
+    let capped = extract_bytes(&content, opts);
+
+    // No panic, valid UTF-8 (String guarantees it), and bounded.
+    assert!(
+        capped.truncated,
+        "45-byte cap on 20-byte fragments must truncate"
+    );
+    assert!(
+        capped.text.len() <= 45,
+        "flat path holds text.len() <= limit"
+    );
+    // Undershoot at fragment granularity: the kept text is a whole number of
+    // fragments, so every 'é' is complete — assert no lone continuation byte.
+    assert!(
+        std::str::from_utf8(capped.text.as_bytes()).is_ok(),
+        "text must be valid UTF-8"
+    );
+    assert!(
+        full.text.starts_with(&capped.text),
+        "capped text is a clean prefix, no split char"
+    );
+}
+
+// ── Cycle 4: zero budget and empty page ──────────────────────────────────────
+
+#[test]
+fn test_zero_budget_and_empty_page() {
+    // Some(0): a page with text yields empty output, flagged truncated.
+    let content = build_repeated_text(&"C".repeat(20), 5);
+    let zero = extract(
+        &content,
+        ExtractionOptions {
+            max_extracted_bytes: Some(0),
+            ..Default::default()
+        },
+    );
+    assert!(
+        zero.text.is_empty(),
+        "Some(0) keeps no text, got {:?}",
+        zero.text
+    );
+    assert!(zero.truncated, "Some(0) on a non-empty page is truncated");
+
+    // Empty page (no show-text ops): never truncated, whatever the limit.
+    let empty_page = "BT\n/F1 12 Tf\n1 0 0 1 72 700 Tm\nET\n";
+    let empty = extract(
+        empty_page,
+        ExtractionOptions {
+            max_extracted_bytes: Some(100),
+            ..Default::default()
+        },
+    );
+    assert!(empty.text.is_empty(), "no show-text → no text");
+    assert!(!empty.truncated, "a page with no text is never truncated");
+}
+
+// ── Cycle 5: composes with a document-level output budget (the issue's loop) ──
+
+#[test]
+fn test_composes_with_document_budget() {
+    // The issue's motivating loop: a per-page cap bounds each page's peak, while
+    // the caller keeps its own document-level output budget. Here we drive one
+    // page repeatedly (a stand-in for a multi-page document) and confirm every
+    // page is individually bounded and correctly flagged.
+    let content = build_repeated_text(&"D".repeat(60), 30);
+    let per_page_cap = 300usize;
+
+    let mut doc_budget = 1000usize;
+    let mut out = String::new();
+    let mut any_page_truncated = false;
+
+    for _ in 0..5 {
+        let page = extract(
+            &content,
+            ExtractionOptions {
+                max_extracted_bytes: Some(per_page_cap),
+                ..Default::default()
+            },
+        );
+        // Per-page peak is bounded regardless of the document budget.
+        assert!(
+            page.text.len() <= per_page_cap,
+            "each page must respect the per-page cap"
+        );
+        assert!(page.truncated, "each dense page hits the per-page cap");
+        any_page_truncated |= page.truncated;
+
+        // Caller's document-level truncation still composes on top.
+        let take = page.text.len().min(doc_budget);
+        out.push_str(&page.text[..take]);
+        doc_budget -= take;
+        if doc_budget == 0 {
+            break;
+        }
+    }
+
+    assert!(any_page_truncated);
+    assert!(out.len() <= 1000, "document output budget is respected");
+    assert!(!out.is_empty());
+}
+
+// ── Cycle 6: /ActualText override cannot bypass the budget (QR critical #1) ────
+
+#[test]
+fn test_actualtext_scope_respects_budget() {
+    // A single marked-content scope declaring an inline `/ActualText` string of
+    // 4000 bytes, populated by one tiny `Tj`. On the layout / reorder paths the
+    // scope's fragment text is the *declared* string, and `.text` is rebuilt
+    // from fragments — so without budgeting this leaks the whole 4000 bytes with
+    // `truncated == false`. This is the adversarial single-operator case #382
+    // exists to defend against.
+    let big = "Z".repeat(4000);
+    let content = format!(
+        "BT\n/F1 12 Tf\n1 0 0 1 72 700 Tm\n\
+         /Span << /ActualText ({big}) >> BDC\n(x) Tj\nEMC\nET\n"
+    );
+
+    for (label, base) in [
+        ("preserve_layout", {
+            let mut o = ExtractionOptions::default();
+            o.preserve_layout = true;
+            o
+        }),
+        ("reorder_columns", {
+            let mut o = ExtractionOptions::default();
+            o.reorder_columns = true;
+            o
+        }),
+    ] {
+        // Unbounded: the ActualText override does surface (sanity that the
+        // fixture exercises the ActualText path at all).
+        let full = extract(&content, base.clone());
+        assert!(
+            full.text.len() >= 4000,
+            "{label}: fixture must exercise ActualText (got {} bytes)",
+            full.text.len()
+        );
+        assert!(!full.truncated, "{label}: unbounded not truncated");
+
+        // Bounded: the override must NOT escape the cap, and the flag must tell
+        // the truth.
+        let mut opts = base;
+        opts.max_extracted_bytes = Some(50);
+        let capped = extract(&content, opts);
+        assert!(
+            capped.text.len() <= 50,
+            "{label}: ActualText must not bypass the 50-byte cap, got {}",
+            capped.text.len()
+        );
+        assert!(
+            capped.truncated,
+            "{label}: a bypassed budget must still report truncated"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_408_dense_prose_reorder_test.rs
+++ b/oxidize-pdf-core/tests/issue_408_dense_prose_reorder_test.rs
@@ -1,0 +1,148 @@
+//! Regression tests for issue #408 — `reorder_columns` corrupted dense
+//! multi-line prose even with no table on the page.
+//!
+//! Root cause: `sort_and_merge_fragments` quantized Y into bands via
+//! `round(-y / newline_threshold)`. Two adjacent lines whose leading is below
+//! `newline_threshold` (e.g. 8pt leading, 10pt threshold) could straddle a band
+//! boundary and land in the *same* band (y=684 → −68.4 → band −68; y=676 →
+//! −67.6 → band −68). The secondary X sort then interleaved the two lines
+//! glyph-by-glyph, shredding any token that straddled the corruption.
+//!
+//! The corruption surfaced only on paths that rebuild text from the band-sorted
+//! fragments (`reorder_columns`, `preserve_layout`); the flat default keeps
+//! draw-order text and never rebuilds, which is why it stayed intact.
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract(content: &str, opts: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+}
+
+fn escape(ch: char) -> String {
+    match ch {
+        '(' => "\\(".to_string(),
+        ')' => "\\)".to_string(),
+        '\\' => "\\\\".to_string(),
+        _ => ch.to_string(),
+    }
+}
+
+/// Four dense prose lines, one glyph per fragment (matches CID-font granularity),
+/// with 8pt leading — below the 10pt default `newline_threshold`, common in
+/// legal/financial boilerplate. No table, no columnar gap anywhere.
+fn build_dense_prose() -> String {
+    const LINES: [&str; 4] = [
+        "This document references placeholder identifier AB-11223344-99",
+        "in the following paragraph for demonstration purposes only, and",
+        "continues with more filler text so the block spans several lines",
+        "before mentioning a second placeholder id CD-55667788-00 here,",
+    ];
+    let mut c = String::new();
+    let mut y = 700.0_f64;
+    for line in LINES {
+        let mut x = 72.0_f64;
+        for ch in line.chars() {
+            c.push_str(&format!(
+                "BT\n/F1 10 Tf\n1 0 0 1 {x:.2} {y:.2} Tm\n({}) Tj\nET\n",
+                escape(ch)
+            ));
+            x += 6.0;
+        }
+        y -= 8.0;
+    }
+    c
+}
+
+#[test]
+fn dense_prose_reorder_columns_keeps_lines_intact() {
+    let opts = ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    };
+    let text = extract(&build_dense_prose(), opts).text;
+
+    // The token that straddled the band collision must survive.
+    assert!(
+        text.contains("CD-55667788-00"),
+        "token spanning the Y-band boundary must not be shredded: {text:?}"
+    );
+
+    // Each source line must stay contiguous (not interleaved with its neighbour).
+    for line in [
+        "This document references placeholder identifier AB-11223344-99",
+        "in the following paragraph for demonstration purposes only, and",
+        "continues with more filler text so the block spans several lines",
+        "before mentioning a second placeholder id CD-55667788-00 here,",
+    ] {
+        assert!(
+            text.contains(line),
+            "line must appear intact, not glyph-interleaved with its neighbour: \
+             missing {line:?} in {text:?}"
+        );
+    }
+}
+
+#[test]
+fn dense_prose_preserve_layout_keeps_lines_intact() {
+    // Same band-collision path is reachable via preserve_layout, which also
+    // rebuilds text from the band-sorted fragments.
+    let opts = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let text = extract(&build_dense_prose(), opts).text;
+    assert!(
+        text.contains("CD-55667788-00"),
+        "preserve_layout must not shred the token either: {text:?}"
+    );
+    assert!(
+        text.contains("continues with more filler text so the block spans several lines"),
+        "line 3 must stay contiguous under preserve_layout: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/partition_confidence_test.rs
+++ b/oxidize-pdf-core/tests/partition_confidence_test.rs
@@ -210,13 +210,12 @@ fn test_kv_confidence_minimum_is_0_5() {
 // Cycle 2.5
 #[test]
 fn test_table_element_confidence_is_not_overridden() {
-    let table = Element::Table(TableElementData {
-        rows: vec![vec!["A".to_string(), "B".to_string()]],
-        structure: None,
-        metadata: ElementMetadata {
+    let table = Element::Table(TableElementData::new(
+        vec![vec!["A".to_string(), "B".to_string()]],
+        ElementMetadata {
             confidence: 0.7,
             ..Default::default()
         },
-    });
+    ));
     assert!((table.metadata().confidence - 0.7).abs() < f64::EPSILON);
 }

--- a/oxidize-pdf-core/tests/partition_confidence_test.rs
+++ b/oxidize-pdf-core/tests/partition_confidence_test.rs
@@ -212,6 +212,7 @@ fn test_kv_confidence_minimum_is_0_5() {
 fn test_table_element_confidence_is_not_overridden() {
     let table = Element::Table(TableElementData {
         rows: vec![vec!["A".to_string(), "B".to_string()]],
+        structure: None,
         metadata: ElementMetadata {
             confidence: 0.7,
             ..Default::default()

--- a/oxidize-pdf-core/tests/pipeline_export_test.rs
+++ b/oxidize-pdf-core/tests/pipeline_export_test.rs
@@ -62,6 +62,7 @@ fn test_export_table_pipe_format() {
             vec!["Alice".to_string(), "30".to_string()],
             vec!["Bob".to_string(), "25".to_string()],
         ],
+        structure: None,
         metadata: meta(),
     })];
     let output = exporter.export(&elements);

--- a/oxidize-pdf-core/tests/pipeline_export_test.rs
+++ b/oxidize-pdf-core/tests/pipeline_export_test.rs
@@ -56,15 +56,14 @@ fn test_export_paragraph_produces_plain_text() {
 #[test]
 fn test_export_table_pipe_format() {
     let exporter = ElementMarkdownExporter::default();
-    let elements = vec![Element::Table(TableElementData {
-        rows: vec![
+    let elements = vec![Element::Table(TableElementData::new(
+        vec![
             vec!["Name".to_string(), "Age".to_string()],
             vec!["Alice".to_string(), "30".to_string()],
             vec!["Bob".to_string(), "25".to_string()],
         ],
-        structure: None,
-        metadata: meta(),
-    })];
+        meta(),
+    ))];
     let output = exporter.export(&elements);
     assert!(output.contains("| Name | Age |"));
     assert!(output.contains("| --- | --- |"));

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -56,6 +56,7 @@ fn build_chunks() -> Vec<RagChunk> {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     parsed
         .rag_chunks_with(config)
@@ -464,6 +465,7 @@ fn rag_chunks_with_source_and_config_applies_both() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     let tight_source = DocumentSource::with_file(None, Some("h".to_string()));
     let tight_chunks = parsed

--- a/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_metadata_test.rs
@@ -490,3 +490,43 @@ fn rag_chunks_with_source_and_config_applies_both() {
     // doc_hash drives the chunk_id prefix here too.
     assert!(tight_chunks[0].metadata.chunk_id.starts_with("h:"));
 }
+
+/// `ContentTypeFlags` is pipeline output: readable off `ChunkMetadata`, and
+/// `#[non_exhaustive]` so future content flags cannot break external consumers.
+///
+/// This verifies the blindaje contract from an external crate (the integration
+/// test crate is compiled separately, so `#[non_exhaustive]` is in force here):
+///   1. the flags are readable and reflect the real document — `build_chunks`
+///      produces a table/list/code-free doc, so every chunk reports all three
+///      absent;
+///   2. the only cross-crate construction path is `default()` + field mutation.
+///      A struct literal `ContentTypeFlags { has_table: .., .. }` here would
+///      fail to compile (E0639) — that is precisely what the attribute buys.
+#[test]
+fn content_type_flags_are_output_and_non_exhaustive() {
+    use oxidize_pdf::pipeline::ContentTypeFlags;
+
+    let chunks = build_chunks();
+    assert!(!chunks.is_empty(), "expected chunks to read flags from");
+
+    // (1) Real content: the fixture has no tables, lists, or code blocks, so no
+    // chunk may claim them. Read through the non_exhaustive type from outside.
+    for (i, c) in chunks.iter().enumerate() {
+        let f = c.metadata.content_types;
+        assert!(!f.has_table, "chunk[{i}] wrongly flagged has_table");
+        assert!(!f.has_list, "chunk[{i}] wrongly flagged has_list");
+        assert!(!f.has_code, "chunk[{i}] wrongly flagged has_code");
+    }
+
+    // (2) Supported cross-crate construction: start from Default, set fields.
+    // The struct literal form is rejected by #[non_exhaustive].
+    let mut flags = ContentTypeFlags::default();
+    assert_eq!(flags, ContentTypeFlags::default());
+    flags.has_table = true;
+    assert!(flags.has_table);
+    assert_ne!(
+        flags,
+        ContentTypeFlags::default(),
+        "mutating a field must diverge from the default value"
+    );
+}

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -398,6 +398,7 @@ fn test_element_type_names_for_all_variants() {
             "table",
             Element::Table(TableElementData {
                 rows: vec![vec!["a".into()]],
+                structure: None,
                 metadata: md.clone(),
             }),
         ),

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -69,6 +69,7 @@ fn test_rag_chunk_from_hybrid_chunk() {
         merge_adjacent: true,
         propagate_headings: true,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     assert_eq!(hybrid_chunks.len(), 1);
@@ -103,6 +104,7 @@ fn test_rag_chunk_collects_pages_from_multi_page_elements() {
         merge_adjacent: true,
         merge_policy: MergePolicy::AnyInlineContent,
         propagate_headings: false,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
@@ -181,6 +183,7 @@ fn test_rag_chunks_indices_are_sequential() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag_chunks: Vec<RagChunk> = hybrid_chunks
@@ -216,6 +219,7 @@ fn test_rag_chunks_with_custom_config_produces_more_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
     let large_config = HybridChunkConfig {
         max_tokens: 512,
@@ -223,6 +227,7 @@ fn test_rag_chunks_with_custom_config_produces_more_chunks() {
         merge_adjacent: true,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     };
 
     let small_chunks: Vec<RagChunk> = HybridChunker::new(small_config)
@@ -275,6 +280,7 @@ fn test_rag_chunks_json_serializes_vec_as_array() {
         merge_adjacent: false,
         propagate_headings: false,
         merge_policy: MergePolicy::AnyInlineContent,
+        context_mode: Default::default(),
     });
 
     let rag_chunks: Vec<RagChunk> = chunker
@@ -305,6 +311,7 @@ fn test_rag_chunk_page_numbers_are_sorted() {
         merge_adjacent: true,
         merge_policy: MergePolicy::AnyInlineContent,
         propagate_headings: false,
+        context_mode: Default::default(),
     });
     let hybrid_chunks = chunker.chunk(&elements);
     let rag = RagChunk::from_hybrid_chunk(0, &hybrid_chunks[0]);
@@ -329,6 +336,7 @@ fn test_element_type_names_for_all_variants() {
             merge_adjacent: false,
             propagate_headings: false,
             merge_policy: MergePolicy::AnyInlineContent,
+            context_mode: Default::default(),
         });
         let chunks = chunker.chunk(&[element]);
         RagChunk::from_hybrid_chunk(0, &chunks[0])

--- a/oxidize-pdf-core/tests/rag_chunk_test.rs
+++ b/oxidize-pdf-core/tests/rag_chunk_test.rs
@@ -396,11 +396,7 @@ fn test_element_type_names_for_all_variants() {
         ),
         (
             "table",
-            Element::Table(TableElementData {
-                rows: vec![vec!["a".into()]],
-                structure: None,
-                metadata: md.clone(),
-            }),
+            Element::Table(TableElementData::new(vec![vec!["a".into()]], md.clone())),
         ),
     ];
 

--- a/oxidize-pdf-core/tests/semantic_chunking_test.rs
+++ b/oxidize-pdf-core/tests/semantic_chunking_test.rs
@@ -69,6 +69,7 @@ fn test_semantic_chunk_table_stays_whole() {
                 vec!["1".into(), "2".into()],
                 vec!["3".into(), "4".into()],
             ],
+            structure: None,
             metadata: ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 600.0, 400.0, 100.0),
@@ -95,6 +96,7 @@ fn test_semantic_chunk_large_table_allowed_to_overflow() {
         rows: (0..50)
             .map(|i| vec![format!("cell_{}_0", i), format!("cell_{}_1", i)])
             .collect(),
+        structure: None,
         metadata: ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 100.0, 400.0, 500.0),

--- a/oxidize-pdf-core/tests/semantic_chunking_test.rs
+++ b/oxidize-pdf-core/tests/semantic_chunking_test.rs
@@ -63,19 +63,18 @@ fn test_semantic_chunk_title_not_split() {
 fn test_semantic_chunk_table_stays_whole() {
     let elements = vec![
         para("Before table.", 0, 750.0),
-        Element::Table(TableElementData {
-            rows: vec![
+        Element::Table(TableElementData::new(
+            vec![
                 vec!["A".into(), "B".into()],
                 vec!["1".into(), "2".into()],
                 vec!["3".into(), "4".into()],
             ],
-            structure: None,
-            metadata: ElementMetadata {
+            ElementMetadata {
                 page: 0,
                 bbox: ElementBBox::new(50.0, 600.0, 400.0, 100.0),
                 ..Default::default()
             },
-        }),
+        )),
         para("After table.", 0, 450.0),
     ];
 
@@ -92,17 +91,16 @@ fn test_semantic_chunk_table_stays_whole() {
 
 #[test]
 fn test_semantic_chunk_large_table_allowed_to_overflow() {
-    let big_table = Element::Table(TableElementData {
-        rows: (0..50)
+    let big_table = Element::Table(TableElementData::new(
+        (0..50)
             .map(|i| vec![format!("cell_{}_0", i), format!("cell_{}_1", i)])
             .collect(),
-        structure: None,
-        metadata: ElementMetadata {
+        ElementMetadata {
             page: 0,
             bbox: ElementBBox::new(50.0, 100.0, 400.0, 500.0),
             ..Default::default()
         },
-    });
+    ));
 
     let chunks =
         SemanticChunker::new(SemanticChunkConfig::new(20).with_overlap(0)).chunk(&[big_table]);


### PR DESCRIPTION
## Release 4.0.0 (MAJOR)

Bundle 4.0.0 — aggregates the RAG-quality cycle plus public-API hardening.

### Included
- **#375** rich table extraction (merged cells / header rows; text-conservation fix)
- **#376** deterministic contextual RAG chunks (no-ML `ContextMode::Contextual`)
- **#382** bounded per-page extraction memory (`max_extracted_bytes` / `truncated`)
- **#408** dense-prose reorder fix (`reorder_columns`/`preserve_layout` shredding)
- **`#[non_exhaustive]` hardening** of the public output surface: `TableElementData`, `ContentTypeFlags`, `ExtractedText`

### Breaking
Several public output/config types gained fields and/or became `#[non_exhaustive]`. Migration notes in `CHANGELOG.md` (BREAKING CHANGES).

### Verification
- Pre-commit green on both release commits (6629 lib tests).
- Regression gate: corpus **t0–t3 over 5853 PDFs — 0 panics**, parse rates 97.7–100% per tier (all above threshold).

Tag `v4.0.0` on main after merge triggers `release.yml` → crates.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)