### PR TITLE
Back-merge: release 4.0.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-10
+
 ### BREAKING CHANGES
 
 - `TableElementData` (`oxidize_pdf::pipeline`), and `DetectedTable` / `TableCell`
@@ -17,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TableElementData` via `TableElementData::new(rows, metadata)` (flat) or
   `TableElementData::from_structure(structure, metadata)` (rich); build `TableCell` via
   `TableCell::new(..)` and `DetectedTable` via `DetectedTable::new(..)`. (#375)
+- **Contextual chunking API (#376).** `HybridChunkConfig` gained a `context_mode` field
+  (`ContextMode`), so full struct-literal construction now requires it — use
+  `HybridChunkConfig { max_tokens, ..Default::default() }`. The default (`ContextMode::Heading`)
+  is byte-identical to previous output. New enum `ContextFormat` is `#[non_exhaustive]`.
+- **Bounded extraction fields (#382).** `ExtractionOptions` gained `max_extracted_bytes:
+  Option<usize>` and `ExtractedText` gained `truncated: bool`, so full struct-literal
+  construction of `ExtractionOptions` now requires the new field — use
+  `ExtractionOptions { ..Default::default() }`.
+- **Output-type hardening.** `ExtractedText` (`oxidize_pdf::text`) and `ContentTypeFlags`
+  (`oxidize_pdf::pipeline`) are now `#[non_exhaustive]`, so future fields can be added without a
+  breaking change. External code can no longer construct them with a struct literal: build
+  `ExtractedText` via `ExtractedText::new(text, fragments)`, and `ContentTypeFlags` via
+  `ContentTypeFlags::default()` + field assignment.
 
 ### Added
 
@@ -27,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapses multi-level headers (joined with `›`) and repeats merged-cell values; RAG chunk
   metadata (`table_rows`/`table_cols`) counts the rich geometry. Borderless tables and
   un-tagged multi-level headers remain flat — see `docs/TABLE_DETECTION_GUIDE.md`.
+- **Contextual Retrieval (no-ML) for RAG chunks (#376).** Opt-in `ContextMode::Contextual`
+  prepends a deterministic document + section snippet (title/author or filename, heading
+  breadcrumb, optional page span) to each chunk's `full_text` (the embedding text) while the
+  display `text` stays context-free. Two formats — `ContextFormat::Labeled` and `Prose`. The
+  prefix is a pure function of the source, breadcrumb and page span, so `chunk_id` stays
+  deterministic. Threaded through every `rag_chunks_with*` entry and the `unstable-spi`
+  pipeline (`AnalysisPipeline::with_context_mode`).
+- **Per-page extraction memory bound (#382).** `ExtractionOptions::max_extracted_bytes` caps
+  decoded-text accumulation *during* a page run (across the show-text arms, TJ spacing, Form
+  XObject recursion, and `/ActualText` overrides), so an adversarially inflated content stream
+  cannot materialise an unbounded `String`. Undershoot semantics: extraction stops before the
+  run that would overshoot (never splits a UTF-8 char); `ExtractedText::truncated` reports it.
+  `None` (default) is byte-identical to before.
 
 ### Fixed
 
@@ -35,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the table bounding box but not in any cell falls back to prose instead of being discarded.
   Near-empty tables (< 2 populated cells) decompose to prose. Guarded by a text-conservation
   invariant test.
+- **Dense prose no longer shredded under column reorder (#408).** `reorder_columns` /
+  `preserve_layout` fragmented dense paragraphs character-by-character because
+  `sort_and_merge_fragments` ran twice; the double pass is removed. A `NaN` Y anchor now
+  breaks the line instead of swallowing the rest of the page.
 
 ## [3.1.1] - 2026-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.2"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most PDF libraries give you a wall of text. oxidize-pdf gives you **structured, 
 
 ```toml
 [dependencies]
-oxidize-pdf = "3.1"
+oxidize-pdf = "4.0"
 ```
 
 ### RAG Pipeline -- One Liner

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -122,8 +122,15 @@ impl Default for ExtractionOptions {
     }
 }
 
-/// Extracted text with position information
+/// Extracted text with position information.
+///
+/// Pipeline output: returned by the `extract_text*` entry points on
+/// [`Page`](crate::page::Page) / [`PdfDocument`](crate::parser::PdfDocument).
+/// `#[non_exhaustive]` so future fields (e.g. per-run diagnostics) can be added
+/// without a breaking change — construct one outside the crate via
+/// [`ExtractedText::new`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ExtractedText {
     /// The extracted text content
     pub text: String,
@@ -134,6 +141,20 @@ pub struct ExtractedText {
     /// bounded prefix of the page's full text rather than the whole page
     /// (issue #382). Always `false` when no limit is set.
     pub truncated: bool,
+}
+
+impl ExtractedText {
+    /// Build an `ExtractedText` from its text and fragments, with `truncated`
+    /// set to `false`. Provided because `ExtractedText` is `#[non_exhaustive]`,
+    /// so external callers cannot use a struct literal. Set [`truncated`](Self::truncated)
+    /// afterwards if you are synthesizing a bounded result.
+    pub fn new(text: String, fragments: Vec<TextFragment>) -> Self {
+        Self {
+            text,
+            fragments,
+            truncated: false,
+        }
+    }
 }
 
 /// Metadata about a space insertion decision during text extraction.


### PR DESCRIPTION
Brings the 4.0.0 version bump, CHANGELOG stamp, README, and the ExtractedText #[non_exhaustive] hardening into develop after the main release (tag v4.0.0). Standard gitflow back-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)