### PR TITLE
Release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Indirect `/Kids` and `/Count` page trees now parse** (#415). A `/Pages` node
+  that stores `/Kids` or `/Count` as an indirect reference (`N G R`) instead of
+  inline — spec-legal per ISO 32000-1 §7.3.10, emitted by iText — made
+  `page_count()` return 0 and `extract_text()` return empty text with no error.
+  One level of indirection is now resolved consistently across the page-tree
+  flat index, `PdfReader::page_count()`, and PDF/A page-walk validation.
+- **LZW `EarlyChange` code-width boundary** (#415). The decoder widened the code
+  one entry too late (`2^width` instead of `2^width - 1` under the default
+  `EarlyChange=1`), desyncing streams that grew past 511/1023/2047 dictionary
+  entries and failing with `invalid code`. Corrected per ISO 32000-1 §7.4.4.2.
+
+### Changed
+
+- Dropped the unused `serialize` (serde) feature from the `quick-xml` dependency;
+  XMP metadata parsing only uses the streaming pull-parser (#416).
+
 ## [4.0.0] - 2026-07-10
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.0.1] - 2026-07-12
+
 ### Fixed
 
 - **Indirect `/Kids` and `/Count` page trees now parse** (#415). A `/Pages` node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EarlyChange=1`), desyncing streams that grew past 511/1023/2047 dictionary
   entries and failing with `invalid code`. Corrected per ISO 32000-1 §7.4.4.2.
 
-### Changed
+### Security
 
-- Dropped the unused `serialize` (serde) feature from the `quick-xml` dependency;
-  XMP metadata parsing only uses the streaming pull-parser (#416).
+- Bumped `quick-xml` 0.39 → 0.41 to clear **RUSTSEC-2026-0194** and
+  **RUSTSEC-2026-0195** — DoS advisories (quadratic duplicate-attribute check;
+  unbounded namespace-declaration allocation) reachable through untrusted XMP
+  metadata. Also dropped its unused `serialize` (serde) feature; XMP parsing
+  uses only the streaming pull-parser (#416).
 
 ## [4.0.0] - 2026-07-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "unicode-normalization",
  "ureq",
  "webpki-roots 1.0.7",
+ "weezl",
  "whatlang",
  "winapi",
  "x509-cert",
@@ -1863,7 +1864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,8 +70,10 @@ regex = "1.11"
 base64 = "0.21"
 uuid = { version = "1.0", features = ["v4"] }
 # XMP metadata parsing uses only the streaming pull-parser (Reader/Event); the
-# `serialize` (serde) feature was enabled but never used. See issue #416.
-quick-xml = { version = "0.39" }
+# `serialize` (serde) feature was enabled but never used. Pinned >= 0.41 to
+# clear RUSTSEC-2026-0194/0195 (DoS in NsReader / duplicate-attribute check).
+# See issue #416.
+quick-xml = { version = "0.41" }
 reqwest = { version = "0.11", features = ["json"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ regex = "1.11"
 # Pro dependencies
 base64 = "0.21"
 uuid = { version = "1.0", features = ["v4"] }
-quick-xml = { version = "0.39", features = ["serialize"] }
+# XMP metadata parsing uses only the streaming pull-parser (Reader/Event); the
+# `serialize` (serde) feature was enabled but never used. See issue #416.
+quick-xml = { version = "0.39" }
 reqwest = { version = "0.11", features = ["json"] }
 
 [profile.release]

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -111,6 +111,11 @@ rusty-tesseract = { version = "1.1.10", optional = true }
 # leptonica-plumbing = { version = "1.0", optional = true }
 
 [dev-dependencies]
+# Trusted TIFF/PDF (early-change) LZW codec, used only to encode boundary-
+# crossing fixtures for the LZW decoder regression tests. Also pulled in
+# transitively under --all-features (image/tiff/gif); pinned to the resolved
+# version.
+weezl = "0.1.12"
 criterion = { version = "0.8", features = ["html_reports"] }
 flate2 = { workspace = true }
 proptest = { workspace = true }

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -1171,6 +1171,59 @@ mod tests {
     }
 
     #[test]
+    fn test_lzw_decode_crosses_9_to_10_bit_boundary_early_change() {
+        // Regression for issue #415 Bug 2: under EarlyChange=1 (the PDF
+        // default) the decoder must widen the code from 9 to 10 bits when the
+        // dictionary reaches 2^9 - 1 = 511 entries. A well-distributed payload
+        // grows the dictionary well past that boundary; weezl (TIFF/PDF
+        // early-change LZW) is the trusted encoder, so a byte-identical
+        // round-trip proves the boundary is handled. The previous `2^width`
+        // threshold widened one entry too late and desynced the bitstream,
+        // surfacing as `LZW decode error: invalid code <N>`.
+        let payload: Vec<u8> = (0..2000u32)
+            .map(|i| (i.wrapping_mul(2_654_435_761) >> 24) as u8)
+            .collect();
+        let encoded = weezl::encode::Encoder::with_tiff_size_switch(weezl::BitOrder::Msb, 8)
+            .encode(&payload)
+            .expect("weezl LZW encode");
+
+        let mut params = PdfDictionary::new();
+        params.insert("EarlyChange".to_string(), PdfObject::Integer(1));
+
+        let decoded =
+            decode_lzw(&encoded, Some(&params)).expect("decode LZW across 9->10 bit boundary");
+        assert_eq!(
+            decoded, payload,
+            "round-trip must be byte-identical across the 9->10 bit code-width boundary"
+        );
+    }
+
+    #[test]
+    fn test_lzw_decode_crosses_boundary_no_early_change() {
+        // Companion to the EarlyChange=1 case: with EarlyChange=0 the writer
+        // widens the code at 2^width entries (the original/GIF timing). weezl's
+        // non-TIFF encoder produces exactly this stream. The previous
+        // `2^width + 1` threshold was one entry too late here too (issue #415
+        // Bug 2 notes both branches were off by one).
+        let payload: Vec<u8> = (0..2000u32)
+            .map(|i| (i.wrapping_mul(2_654_435_761) >> 24) as u8)
+            .collect();
+        let encoded = weezl::encode::Encoder::new(weezl::BitOrder::Msb, 8)
+            .encode(&payload)
+            .expect("weezl LZW encode (no early change)");
+
+        let mut params = PdfDictionary::new();
+        params.insert("EarlyChange".to_string(), PdfObject::Integer(0));
+
+        let decoded = decode_lzw(&encoded, Some(&params))
+            .expect("decode LZW (EarlyChange=0) across the code-width boundary");
+        assert_eq!(
+            decoded, payload,
+            "round-trip must be byte-identical with EarlyChange=0 across the boundary"
+        );
+    }
+
+    #[test]
     fn test_lzw_decode_early_change_false() {
         let mut params = PdfDictionary::new();
         params.insert("EarlyChange".to_string(), PdfObject::Integer(0));
@@ -1913,10 +1966,15 @@ fn decode_lzw(data: &[u8], params: Option<&PdfDictionary>) -> ParseResult<Vec<u8
 
                 // Increase code size if necessary
                 let dict_size = dictionary.len();
+                // ISO 32000-1 §7.4.4.2: with EarlyChange=1 (the default) the
+                // writer widens the code once the table holds 2^width - 1
+                // entries; without early change, at 2^width. Using 2^width /
+                // 2^width + 1 here widened one entry too late and desynced the
+                // bitstream past 511/1023/2047 entries (issue #415 Bug 2).
                 let threshold = if early_change {
-                    1 << code_size
+                    (1 << code_size) - 1
                 } else {
-                    (1 << code_size) + 1
+                    1 << code_size
                 };
 
                 if dict_size >= threshold as usize && code_size < MAX_BITS {

--- a/oxidize-pdf-core/src/parser/page_tree.rs
+++ b/oxidize-pdf-core/src/parser/page_tree.rs
@@ -132,6 +132,21 @@ pub struct PageTree {
     page_refs: Vec<(u32, u16)>,
 }
 
+/// Resolve a `/Kids` value into its list of page/pages object references.
+///
+/// The value may be a direct array (`/Kids [ ... ]`) or an indirect reference
+/// to an array (`/Kids N G R`), which ISO 32000-1 §7.3.10 permits for any
+/// object and iText 5.5.9 emits in practice. One level of indirection is
+/// resolved; anything else yields an empty list.
+fn resolve_kids<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    kids_obj: Option<&PdfObject>,
+) -> Vec<(u32, u16)> {
+    super::reader::resolve_to_array(reader, kids_obj)
+        .map(|a| a.0.iter().filter_map(|k| k.as_reference()).collect())
+        .unwrap_or_default()
+}
+
 impl PageTree {
     /// Create a new page tree navigator
     pub fn new(page_count: u32) -> Self {
@@ -206,14 +221,13 @@ impl PageTree {
         // Work stack: each entry is an object reference to process
         let mut stack: Vec<(u32, u16)> = Vec::new();
 
-        // Seed from root Kids array
-        if let Some(kids) = pages_dict.get("Kids").and_then(|k| k.as_array()) {
-            // Push in reverse so first kid is processed first (LIFO stack)
-            for kid_obj in kids.0.iter().rev() {
-                if let Some(kid_ref) = kid_obj.as_reference() {
-                    stack.push(kid_ref);
-                }
-            }
+        // Seed from root Kids array.
+        // Push in reverse so first kid is processed first (LIFO stack).
+        for kid_ref in resolve_kids(reader, pages_dict.get("Kids"))
+            .into_iter()
+            .rev()
+        {
+            stack.push(kid_ref);
         }
 
         while let Some(obj_ref) = stack.pop() {
@@ -232,8 +246,10 @@ impl PageTree {
                 continue;
             }
 
-            // Resolve the object
-            let obj = match reader.get_object(obj_ref.0, obj_ref.1) {
+            // Resolve the object. Own it (clone) so the reader borrow ends
+            // here — the `Pages` arm below resolves indirect `/Kids` via the
+            // reader while this node is still in scope.
+            let obj = match reader.get_object(obj_ref.0, obj_ref.1).cloned() {
                 Ok(o) => o,
                 Err(e) => {
                     tracing::warn!(
@@ -274,13 +290,10 @@ impl PageTree {
                     page_refs.push(obj_ref);
                 }
                 Some("Pages") => {
-                    if let Some(kids) = dict.get("Kids").and_then(|k| k.as_array()) {
-                        // Push in reverse for correct order
-                        for kid_obj in kids.0.iter().rev() {
-                            if let Some(kid_ref) = kid_obj.as_reference() {
-                                stack.push(kid_ref);
-                            }
-                        }
+                    // Push in reverse for correct order. `/Kids` may be an
+                    // indirect reference to the array (ISO 32000-1 §7.3.10).
+                    for kid_ref in resolve_kids(reader, dict.get("Kids")).into_iter().rev() {
+                        stack.push(kid_ref);
                     }
                 }
                 _ => {

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -18,6 +18,27 @@ use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
+/// Resolve a dictionary value that is expected to be an array into an owned
+/// [`PdfArray`], transparently following a single level of indirection.
+///
+/// ISO 32000-1 §7.3.10 permits any object — including `/Kids` — to be written
+/// as an indirect reference (`N G R`) instead of inline; iText 5.5.9 emits page
+/// trees this way. Returns `None` if the value is absent, is neither an array
+/// nor a reference to one, or cannot be resolved. Only one level is followed,
+/// which covers every real-world page tree observed (a reference-to-a-reference
+/// `/Kids` chain is not produced by any known writer).
+pub(crate) fn resolve_to_array<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    value: Option<&PdfObject>,
+) -> Option<PdfArray> {
+    match value {
+        Some(PdfObject::Reference(num, gen)) => {
+            reader.get_object(*num, *gen).ok()?.as_array().cloned()
+        }
+        other => other.and_then(|o| o.as_array()).cloned(),
+    }
+}
+
 /// Bounded window for manual dictionary extraction (Issue #339). Object headers
 /// are located by the chunked scanner and only this many bytes are read at the
 /// object offset, instead of buffering the whole file. Large enough for any
@@ -1115,26 +1136,48 @@ impl<R: Read + Seek> PdfReader<R> {
         // Try standard method first
         match self.pages() {
             Ok(pages) => {
-                // Try to get Count first
-                if let Some(count_obj) = pages.get("Count") {
-                    if let Some(count) = count_obj.as_integer() {
-                        let count = count as u32;
-                        if count <= MAX_PAGE_COUNT {
-                            return Ok(count);
-                        }
-                        tracing::warn!(
-                            "PDF /Count {} exceeds limit {}, falling back to Kids array length",
-                            count,
-                            MAX_PAGE_COUNT
-                        );
-                        // Fall through to Kids counting
+                // Read /Count and /Kids up front. Each may be inline or an
+                // indirect reference (ISO 32000-1 §7.3.10); extract Copy values
+                // now so the `pages` borrow ends before we resolve references.
+                let count_inline = pages.get("Count").and_then(|o| o.as_integer());
+                let count_ref = pages.get("Count").and_then(|o| o.as_reference());
+                let kids_len_inline = pages
+                    .get("Kids")
+                    .and_then(|o| o.as_array())
+                    .map(|a| a.0.len());
+                let kids_ref = pages.get("Kids").and_then(|o| o.as_reference());
+
+                // Resolve /Count to an integer, whether inline or indirect.
+                let count = count_inline.or_else(|| {
+                    count_ref
+                        .and_then(|(n, g)| self.get_object(n, g).ok().and_then(|o| o.as_integer()))
+                });
+                if let Some(count) = count {
+                    let count = count as u32;
+                    if count <= MAX_PAGE_COUNT {
+                        return Ok(count);
                     }
+                    tracing::warn!(
+                        "PDF /Count {} exceeds limit {}, falling back to Kids array length",
+                        count,
+                        MAX_PAGE_COUNT
+                    );
+                    // Fall through to Kids counting
                 }
 
-                // If Count is missing, invalid, or exceeds limit, try to count manually
-                if let Some(kids_obj) = pages.get("Kids") {
-                    if let Some(kids_array) = kids_obj.as_array() {
-                        return Ok(kids_array.0.len() as u32);
+                // If Count is missing, invalid, or exceeds limit, count the
+                // Kids array — inline or resolved from an indirect reference.
+                if let Some(len) = kids_len_inline {
+                    return Ok(len as u32);
+                }
+                if let Some((n, g)) = kids_ref {
+                    if let Some(len) = self
+                        .get_object(n, g)
+                        .ok()
+                        .and_then(|o| o.as_array())
+                        .map(|a| a.0.len())
+                    {
+                        return Ok(len as u32);
                     }
                 }
 

--- a/oxidize-pdf-core/src/pdfa/validator.rs
+++ b/oxidize-pdf-core/src/pdfa/validator.rs
@@ -504,10 +504,10 @@ impl PdfAValidator {
             .map_err(|e| PdfAError::ParseError(e.to_string()))?
             .clone();
 
-        // Get Kids array
-        let kids = pages_dict
-            .get("Kids")
-            .and_then(|k| k.as_array())
+        // Get Kids array, resolving a single level of indirection: ISO 32000-1
+        // §7.3.10 permits `/Kids N G R` (iText 5.5.9 emits this), and a bare
+        // `as_array()` would silently reject it (issue #415).
+        let kids = crate::parser::reader::resolve_to_array(reader, pages_dict.get("Kids"))
             .ok_or_else(|| PdfAError::ParseError("Pages missing Kids array".to_string()))?;
 
         // Get page reference

--- a/oxidize-pdf-core/tests/issue_415_indirect_kids_test.rs
+++ b/oxidize-pdf-core/tests/issue_415_indirect_kids_test.rs
@@ -1,0 +1,153 @@
+//! Issue #415 Bug 1: indirect `/Kids` (and `/Count`) references break the page
+//! tree, so `page_count()` returns 0 and `extract_text()` yields empty text —
+//! with no error — for spec-legal PDFs (ISO 32000-1 §7.3.10: any object may be
+//! an indirect reference). Observed on iText-produced documents.
+//!
+//! The `/Pages` node stores `/Count N G R` and `/Kids N G R` instead of an
+//! inline integer / array; the array itself lives in a separate object.
+//! No smoke tests: we assert the real page count and the real page text.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pdfa::{PdfALevel, PdfAValidator};
+use std::io::Cursor;
+
+/// Builds a one-page PDF whose `/Pages` node references `/Count` and `/Kids`
+/// **indirectly** (objects 6 and 7), mirroring iText 5.5.9 output.
+fn build_pdf_with_indirect_kids(content_stream: &[u8]) -> Vec<u8> {
+    let stream_len = content_stream.len();
+    let bodies: Vec<Vec<u8>> = vec![
+        // 1: Catalog
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        // 2: Pages — Count and Kids are indirect references, not inline
+        b"<< /Type /Pages /Count 6 0 R /Kids 7 0 R >>".to_vec(),
+        // 3: Page
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        // 4: Content stream
+        {
+            let mut s = format!("<< /Length {stream_len} >>\nstream\n").into_bytes();
+            s.extend_from_slice(content_stream);
+            s.extend_from_slice(b"\nendstream");
+            s
+        },
+        // 5: Font
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+        // 6: the /Count value, as a standalone indirect integer object
+        b"1".to_vec(),
+        // 7: the /Kids array, as a standalone indirect array object
+        b"[ 3 0 R ]".to_vec(),
+    ];
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (i, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len() as u64);
+        pdf.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = pdf.len() as u64;
+    let n = bodies.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {n}\n").as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn indirect_kids_yields_correct_page_count() {
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello Indirect Kids) Tj ET";
+    let pdf = build_pdf_with_indirect_kids(content);
+
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let document = PdfDocument::new(reader);
+
+    assert_eq!(
+        document.page_count().expect("page_count"),
+        1,
+        "indirect /Kids and /Count must resolve to one page, not zero"
+    );
+}
+
+#[test]
+fn indirect_kids_extracts_document_text() {
+    // Faithful reproduction of the reporter's symptom: the whole-document
+    // `extract_text()` iterates `0..page_count()`. An empty page-tree flat
+    // index makes it silently return an empty Vec.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello Indirect Kids) Tj ET";
+    let pdf = build_pdf_with_indirect_kids(content);
+
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let document = PdfDocument::new(reader);
+
+    let pages = document.extract_text().expect("extract_text");
+    assert_eq!(pages.len(), 1, "extract_text must yield one page, not zero");
+    assert!(
+        pages[0].text.contains("Hello Indirect Kids"),
+        "page text lost — the page tree was not traversed. Got: {:?}",
+        pages[0].text
+    );
+}
+
+#[test]
+fn indirect_kids_resolves_in_get_page() {
+    // `PdfDocument::get_page` must reach the page via the (now correct) flat
+    // index for an indirect-/Kids document — not silently fall through.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello Indirect Kids) Tj ET";
+    let pdf = build_pdf_with_indirect_kids(content);
+
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    let document = PdfDocument::new(reader);
+
+    let page = document
+        .get_page(0)
+        .expect("get_page(0) must resolve indirect /Kids");
+    assert!(
+        page.dict.get("Contents").is_some(),
+        "resolved page must carry its content stream"
+    );
+}
+
+#[test]
+fn indirect_kids_does_not_break_pdfa_page_iteration() {
+    // The PDF/A validator reads `/Kids` independently of the page-tree flat
+    // index (pdfa::validator::get_page_dict). With an indirect `/Kids` it used
+    // to hard-error "Pages missing Kids array", aborting validation. After the
+    // fix, validation completes and returns a result (with whatever
+    // conformance errors), never a parse failure over the page tree.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello Indirect Kids) Tj ET";
+    let pdf = build_pdf_with_indirect_kids(content);
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+
+    let result = PdfAValidator::new(PdfALevel::A1b).validate(&mut reader);
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            panic!("indirect /Kids must resolve in the PDF/A page walk, got parse error: {e}")
+        }
+    }
+}
+
+#[test]
+fn indirect_count_resolves_in_reader_page_count() {
+    // `PdfReader::page_count()` (public, lower-level API) reads `/Count` via
+    // `as_integer()` and falls back to `/Kids` via `as_array()`; both return
+    // None for an indirect reference. Issue #415 cites reader.rs directly.
+    let content = b"BT /F1 12 Tf 72 700 Td (Hello Indirect Kids) Tj ET";
+    let pdf = build_pdf_with_indirect_kids(content);
+
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse PDF");
+    assert_eq!(
+        reader.page_count().expect("page_count"),
+        1,
+        "indirect /Count must resolve in PdfReader::page_count"
+    );
+}


### PR DESCRIPTION
PATCH release. No public API changes (SemVer PATCH).

## Fixed (#415)

- **Indirect `/Kids` / `/Count` page trees** — a `/Pages` node storing `/Kids` or `/Count` as an indirect reference (`N G R`, spec-legal per ISO 32000-1 §7.3.10, emitted by iText) made `page_count()` return 0 and `extract_text()` return empty text with no error. Resolved consistently across the page-tree flat index, `PdfReader::page_count()`, and PDF/A page-walk validation via a shared one-level resolver.
- **LZW `EarlyChange` boundary** — decoder widened the code one entry too late (`2^width` vs `2^width - 1`), desyncing LZW streams past 511/1023/2047 dictionary entries. Corrected per ISO 32000-1 §7.4.4.2.

## Security (#416)

- Bumped `quick-xml` 0.39 → 0.41, clearing **RUSTSEC-2026-0194** and **RUSTSEC-2026-0195** (DoS via untrusted XMP metadata). Dropped its unused `serialize` (serde) feature.

## Verification

lib 6631/0 · fmt · clippy `--lib --all-features -D warnings` · MSRV 1.88 · `cargo audit` clears the quick-xml advisories. #418 CI green on ubuntu/macOS/Windows + T0/T1 before merge to develop.

Includes #415, #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)