### PR TITLE
fix: reorder_columns shreds dense prose on tight leading (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **`reorder_columns` no longer shreds dense prose** (#417, follow-up to #408).
+  `detect_and_sort_columns` grouped lines with a fixed `newline_threshold` band
+  keyed to the previous fragment, merging tight-leading prose into one
+  pseudo-line, and then treated consecutive lines that each held an incidental
+  wide gap as a multi-column table, reordering them column-major and splitting
+  tokens. Line grouping is now head-anchored (matching #408), and a multi-line
+  column block only forms when its rows are at least one line height apart;
+  tighter blocks are left in reading order. Real tables / multi-column layouts
+  are unaffected. Only the opt-in `reorder_columns` / `detect_columns` path was
+  affected.
+
 ## [4.0.1] - 2026-07-12
 
 ### Fixed

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -75,6 +75,12 @@ pub struct ExtractionOptions {
     /// When on, `.text` is produced by the fragment pipeline (its shape matches
     /// the layout path's reconstruction, not stream order); `.fragments` stays
     /// empty.
+    ///
+    /// Column reflow only triggers for column blocks whose rows are spaced at
+    /// least one line height apart. Layouts pitched tighter than that are
+    /// geometrically indistinguishable from tight-leading prose that merely
+    /// contains a wide gap, so they are intentionally left in reading order
+    /// rather than risk shredding prose (issue #417); text is never corrupted.
     pub reorder_columns: bool,
     /// Stop accumulating decoded text for a page once this many bytes have been
     /// collected, bounding the per-page peak memory of extraction. The limit is
@@ -1744,19 +1750,34 @@ impl TextExtractor {
         // internal gap wider than `column_threshold` — and leave full-width
         // "flow" lines in their natural reading order.
 
-        // Group fragment indices into lines by Y band. Indices (not `&mut`) so we
-        // can later reorder the slice by a computed permutation.
+        // Group fragment indices into lines. Indices (not `&mut`) so we can later
+        // reorder the slice by a computed permutation.
+        //
+        // The tolerance is anchored to the *line head* with a font-relative jitter
+        // (`min(head, frag).height * 0.2`), matching `sort_and_merge_fragments` /
+        // `merge_into_lines` (issue #408). A fixed `newline_threshold` band keyed
+        // to the *previous* fragment accumulated drift on tight (sub-threshold)
+        // leading and merged nearly a whole page into one pseudo-line, which the
+        // block reorder below then reshuffled by X, shredding tokens (issue #417).
         let mut lines: Vec<Vec<usize>> = Vec::new();
         let mut current_line: Vec<usize> = Vec::new();
-        let mut last_y = f64::INFINITY;
+        let mut head_y = f64::INFINITY;
+        let mut head_h = 0.0_f64;
         for (i, fragment) in fragments.iter().enumerate() {
-            if (last_y - fragment.y).abs() > self.options.newline_threshold
-                && !current_line.is_empty()
-            {
-                lines.push(std::mem::take(&mut current_line));
+            if !current_line.is_empty() {
+                let tol = head_h.min(fragment.height) * 0.2;
+                // Negated `< tol` (not `>= tol`) so a non-finite Y from a
+                // degenerate text matrix forces a line break rather than swallowing
+                // the whole page into one line.
+                if !((head_y - fragment.y).abs() < tol) {
+                    lines.push(std::mem::take(&mut current_line));
+                }
+            }
+            if current_line.is_empty() {
+                head_y = fragment.y;
+                head_h = fragment.height;
             }
             current_line.push(i);
-            last_y = fragment.y;
         }
         if !current_line.is_empty() {
             lines.push(current_line);
@@ -1781,16 +1802,31 @@ impl TextExtractor {
         let mut has_columnar_block = false;
         let mut seg_id = 0usize;
         let mut prev_columnar = false;
+        let mut prev_y = f64::INFINITY;
+        let mut prev_h = 0.0_f64;
 
         for (li, line) in lines.iter().enumerate() {
             let columnar = line_is_columnar(line);
-            if li > 0 && !(columnar && prev_columnar) {
+            let head = &fragments[line[0]];
+            // Two consecutive columnar lines share a multi-line column block only
+            // when they are spaced like real table rows — at least a line height
+            // apart. Tight-leading wrapped prose whose lines each happen to hold a
+            // wide (>`column_threshold`) gap forms a common whitespace corridor and
+            // is geometrically indistinguishable from a 2-column layout; merging it
+            // into a block and reordering column-major shredded the prose (#417).
+            // Below the row-height threshold each such line self-segments instead,
+            // and a single columnar line's column-major order equals its reading
+            // order, so the text is left intact.
+            let row_spaced = (prev_y - head.y).abs() >= head.height.max(prev_h);
+            if li > 0 && !(columnar && prev_columnar && row_spaced) {
                 seg_id += 1;
             }
             for &i in line {
                 segment_of[i] = seg_id;
             }
             prev_columnar = columnar;
+            prev_y = head.y;
+            prev_h = head.height;
         }
 
         // For each columnar block (a segment whose lines are columnar), derive

--- a/oxidize-pdf-core/tests/issue_417_column_line_grouping_test.rs
+++ b/oxidize-pdf-core/tests/issue_417_column_line_grouping_test.rs
@@ -1,0 +1,242 @@
+//! Issue #417 — `detect_and_sort_columns` performs its own line-grouping pass
+//! (run when `reorder_columns=true`) and still used the pre-#408 logic:
+//! `(last_y - fragment.y).abs() > newline_threshold`, i.e. distance to the
+//! *previous* fragment against a fixed 10pt band. On dense prose with tight
+//! (sub-`newline_threshold`) leading, that accumulates drift and merges nearly
+//! the whole page into one pseudo-line; an incidental gap wider than
+//! `column_threshold` then flags it "columnar" and the merged line is reshuffled
+//! by X, shredding tokens.
+//!
+//! The fix anchors line grouping to the line head with a font-relative tolerance
+//! (`min(head, frag).height * 0.2`), matching the #408 fix in
+//! `sort_and_merge_fragments`. No smoke tests: we assert real identifiers stay
+//! contiguous in the reordered output.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Write;
+
+fn escape(ch: char) -> String {
+    match ch {
+        '(' => "\\(".to_string(),
+        ')' => "\\)".to_string(),
+        '\\' => "\\\\".to_string(),
+        _ => ch.to_string(),
+    }
+}
+
+/// Emit one glyph per `Tj` (CID-font granularity). A `|` inserts a 65pt jump
+/// (above the default `column_threshold` of 50) instead of a glyph — an
+/// incidental wide gap (quoted aside, wide parenthetical, kerning artifact),
+/// not a real table column.
+fn emit_line(content: &mut Vec<u8>, text: &str, start_x: f64, y: f64, advance: f64) {
+    let mut x = start_x;
+    for ch in text.chars() {
+        if ch == '|' {
+            x += 65.0;
+            continue;
+        }
+        let escaped = escape(ch);
+        content.extend_from_slice(
+            format!("BT\n/F1 10 Tf\n{x:.2} {y:.2} Td\n({escaped}) Tj\nET\n").as_bytes(),
+        );
+        x += advance;
+    }
+}
+
+/// Dense prose at 8pt leading (below the 10pt `newline_threshold`) plus a small
+/// unrelated table, so a columnar block exists for the reorder pass to act on.
+fn build_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    let lines = [
+        "Line one contains|identifier AA-11112222-33 in the middle of it.",
+        "Line two continues|with unrelated filler text for demonstration.",
+        "Line three has|another identifier BB-44445555-66 embedded here.",
+        "Line four is|more filler content padding out the paragraph body.",
+        "Line five contains|a final identifier CC-77778888-99 to check.",
+        "Line six closes out|the paragraph with some trailing filler text.",
+    ];
+    let mut y = 700.0;
+    for line in &lines {
+        emit_line(&mut content, line, 72.0, y, 6.0);
+        y -= 8.0;
+    }
+    emit_line(&mut content, "Col1", 72.0, 500.0, 6.0);
+    emit_line(&mut content, "Col2", 250.0, 500.0, 6.0);
+    emit_line(&mut content, "Col3", 420.0, 500.0, 6.0);
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = Vec::new();
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    let mut obj4 = Vec::new();
+    write!(obj4, "4 0 obj\n<< /Length {} >>\nstream\n", content.len()).unwrap();
+    obj4.extend_from_slice(&content);
+    obj4.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(&obj4);
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    );
+
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n");
+    writeln!(pdf, "0 {}", offsets.len() + 1).unwrap();
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        writeln!(pdf, "{:010} 00000 n ", off).unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+        offsets.len() + 1,
+        xref_offset
+    )
+    .unwrap();
+    pdf
+}
+
+fn extract(opts: ExtractionOptions) -> String {
+    let doc =
+        PdfReader::new_with_options(std::io::Cursor::new(build_pdf()), ParseOptions::lenient())
+            .expect("PDF should parse")
+            .into_document();
+    TextExtractor::with_options(opts)
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+const IDS: [&str; 3] = ["AA-11112222-33", "BB-44445555-66", "CC-77778888-99"];
+
+#[test]
+fn reorder_columns_keeps_identifiers_intact_on_tight_leading() {
+    let text = extract(ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    });
+    for id in IDS {
+        assert!(
+            text.contains(id),
+            "reorder_columns shredded `{id}` — tight-leading prose was merged into \
+             one pseudo-line and reshuffled by X. Got: {text:?}"
+        );
+    }
+}
+
+#[test]
+fn flat_extraction_keeps_identifiers_intact() {
+    // Baseline / contrast: the default flat path was never affected.
+    let text = extract(ExtractionOptions::default());
+    for id in IDS {
+        assert!(
+            text.contains(id),
+            "flat extraction must keep `{id}` intact. Got: {text:?}"
+        );
+    }
+}
+
+/// Builds a genuine two-column layout with the given row pitch. Each row holds a
+/// left cell and a right cell separated by a wide (column-sized) gap.
+fn build_two_column_pdf(row_pitch: f64) -> Vec<u8> {
+    let mut content = Vec::new();
+    let rows = [("Alpha", "Beta"), ("Gamma", "Delta"), ("Epsilon", "Zeta")];
+    let mut y = 700.0;
+    for (left, right) in rows {
+        emit_line(&mut content, left, 72.0, y, 6.0);
+        emit_line(&mut content, right, 300.0, y, 6.0);
+        y -= row_pitch;
+    }
+
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = Vec::new();
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    let mut obj4 = Vec::new();
+    write!(obj4, "4 0 obj\n<< /Length {} >>\nstream\n", content.len()).unwrap();
+    obj4.extend_from_slice(&content);
+    obj4.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(&obj4);
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    );
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n");
+    writeln!(pdf, "0 {}", offsets.len() + 1).unwrap();
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        writeln!(pdf, "{:010} 00000 n ", off).unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+        offsets.len() + 1,
+        xref_offset
+    )
+    .unwrap();
+    pdf
+}
+
+fn extract_two_column(row_pitch: f64) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_two_column_pdf(row_pitch)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    })
+    .extract_from_page(&doc, 0)
+    .expect("extraction should succeed")
+    .text
+}
+
+/// Normal-pitch (rows ≥ one line height apart, 10pt font / 14pt pitch) real
+/// columns still reflow **column-major**: the whole left column, then the whole
+/// right column.
+#[test]
+fn normal_pitch_two_columns_reflow_column_major() {
+    let text = extract_two_column(14.0);
+    let left_last = text.find("Epsilon").expect("left column present");
+    let right_first = text.find("Beta").expect("right column present");
+    assert!(
+        left_last < right_first,
+        "normal-pitch columns must reflow column-major (all left cells before any \
+         right cell). Got: {text:?}"
+    );
+}
+
+/// Documented, accepted limitation (issue #417): a real two-column layout whose
+/// rows are pitched **tighter than one line height** (here 8pt pitch under a
+/// 10pt font) is geometrically indistinguishable from tight-leading prose with
+/// an incidental gap. To avoid shredding prose, `reorder_columns` deliberately
+/// declines to reflow such blocks and leaves them in reading (row-major) order.
+/// This pins that trade-off so it stays intentional; text is never corrupted,
+/// only left un-reordered.
+#[test]
+fn tight_pitch_two_columns_stay_in_reading_order_accepted_limitation() {
+    let text = extract_two_column(8.0);
+    let beta = text.find("Beta").expect("Beta present");
+    let gamma = text.find("Gamma").expect("Gamma present");
+    assert!(
+        beta < gamma,
+        "tight-pitch columns are intentionally left row-major (Beta, the row-1 \
+         right cell, before Gamma, the row-2 left cell). Got: {text:?}"
+    );
+}


### PR DESCRIPTION
Follow-up to #408. `reorder_columns=true` (opt-in) corrupted dense prose. Two independent defects in `detect_and_sort_columns`, both fixed:

1. **Line grouping** used the pre-#408 logic — `(last_y - fragment.y).abs() > newline_threshold`, a fixed 10pt band against the *previous* fragment. On tight (8pt) leading this drifted and merged nearly a whole page into one pseudo-line. Fixed to the head-anchored `min(head, frag).height * 0.2` tolerance already used by `sort_and_merge_fragments` (#408).

2. **Block formation** (the real root cause): even with correct grouping, N prose lines that each hold an incidental wide gap form a common whitespace corridor — geometrically indistinguishable from a 2-column table — and were reordered column-major, splitting tokens. A multi-line column block now only forms when its rows are spaced **at least one line height apart**. Tight-leading columnar lines self-segment; a single columnar line's column-major order equals its reading order, so text stays intact.

### Accepted trade-off (documented + pinned)

A genuine 2-column layout pitched *tighter than one line height* is now left in reading (row-major) order rather than reflowed column-major — **text is never corrupted, only un-reordered**. This is the mirror of the bug being fixed; the geometry is ambiguous and biasing away from shredding prose is the safer default for an opt-in feature. Pinned by `normal_pitch_two_columns_reflow_column_major` (real columns still reflow) and `tight_pitch_two_columns_stay_in_reading_order_accepted_limitation`.

### Tests (TDD RED→GREEN)

`tests/issue_417_column_line_grouping_test.rs` (4): tight-leading prose repro from the issue, flat baseline, normal-pitch columns reflow column-major, tight-pitch limitation pinned.

### Verification

lib 6631/0 · fmt · clippy `--lib --all-features -D warnings` · MSRV 1.88 · no regression in issue_408 / issue_403 / issue_389 / extraction_two_column_writer_roundtrip / partition_table_detection / table_extraction_real_pdfs. Quality review (quality-rust) found no correctness bugs; its one Important finding (the tight-pitch trade-off) is now documented and pinned by tests. Kripteia 100/100.

Addresses #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)