### PR TITLE
feat(graphics): Type 4 mesh + exact conic shadings (#407)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,38 @@ jobs:
       # binary at runtime via subprocess, so the C library is not needed to compile.
       - name: Build library on MSRV (all features, locked)
         run: cargo build --lib --all-features --locked
+
+  semver:
+    name: SemVer (no undeclared breaking changes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Gate that catches breaking public-API changes that would be published
+      # without the corresponding major bump. The baseline is the crate's latest
+      # release on crates.io; the action fails the job when the source introduces
+      # a major-requiring change (removed/renamed public item, new enum variant on
+      # a non-`#[non_exhaustive]` enum, changed signature, etc.) that the manifest
+      # version does not accommodate. Additive (minor) and patch changes pass.
+      #
+      # Rationale: a breaking change slipped into a MINOR once (#375) because there
+      # was no such gate. With ~17K crates.io downloads and an anonymous
+      # third-party consumer base, breaking changes must be batched into a planned
+      # MAJOR bundle, never leak into a minor. rustdoc-JSON generation only
+      # compiles the crate; the tesseract C library is not needed (OCR shells out
+      # at runtime), same as the MSRV job.
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-semver-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check semver (oxidize-pdf)
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: oxidize-pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Added
+
+- **Type 4 (free-form Gouraud triangle mesh) shading** (#407). New public
+  `FreeFormGouraudShading` + `GouraudVertex` (re-exported from `graphics`)
+  emit a Type 4 mesh as a PDF stream per ISO 32000-1 §8.7.4.5.5 — the shading
+  dictionary plus byte-aligned packed vertex data (configurable
+  `BitsPerCoordinate`/`BitsPerComponent`/`BitsPerFlag` and `Decode`). Register
+  on a page with `Page::add_mesh_shading`.
+- **Exact conic (angular) gradient** (#407). New public `ConicShading` emits a
+  Type 1 function-based shading whose `/Function` is a real Type 4 PostScript
+  calculator (angle around a center → colour ramp), so conic gradients are
+  resolution-independent rather than a mesh approximation. Register with
+  `Page::add_conic_shading`. This unblocks lossless `conic-gradient` rendering
+  downstream. The pre-existing hollow `FunctionBasedShading` placeholder is
+  unchanged.
+
+  Both are additive: `ShadingDefinition` and existing types are untouched, so
+  this is a minor release. Folding the new shadings into `ShadingDefinition`
+  and removing the `FunctionBasedShading` placeholder are deferred to the next
+  major.
+
 ### Fixed
 
 - **`reorder_columns` no longer shreds dense prose** (#417, follow-up to #408).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.0.1"
+version = "4.1.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/examples/mesh_and_conic_shading.rs
+++ b/oxidize-pdf-core/examples/mesh_and_conic_shading.rs
@@ -1,0 +1,84 @@
+//! Type 4 free-form Gouraud mesh and exact conic (angular) gradient shadings
+//! (issue #407).
+//!
+//! Both are additive APIs: `Page::add_mesh_shading` registers a Type 4 mesh
+//! (emitted as a stream), `Page::add_conic_shading` registers a Type 1
+//! function-based shading whose colour is an exact function of the angle around
+//! a center (a real Type 4 PostScript calculator, not a mesh approximation).
+//! Each is painted with the `sh` operator inside a clipped rectangle.
+
+use oxidize_pdf::graphics::{
+    Color, ColorStop, ConicShading, FreeFormGouraudShading, GouraudVertex, Point,
+};
+use oxidize_pdf::{Document, Page};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+
+    // A single RGB triangle: three vertices, red / green / blue corners.
+    let mesh = FreeFormGouraudShading::new(
+        "MeshTri",
+        "DeviceRGB",
+        // Decode: x,y in [0,200], each colour component in [0,1].
+        vec![0.0, 200.0, 0.0, 200.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        vec![
+            GouraudVertex {
+                flag: 0,
+                x: 40.0,
+                y: 40.0,
+                color: Color::Rgb(1.0, 0.0, 0.0),
+            },
+            GouraudVertex {
+                flag: 1,
+                x: 160.0,
+                y: 40.0,
+                color: Color::Rgb(0.0, 1.0, 0.0),
+            },
+            GouraudVertex {
+                flag: 1,
+                x: 100.0,
+                y: 160.0,
+                color: Color::Rgb(0.0, 0.0, 1.0),
+            },
+        ],
+    );
+    page.add_mesh_shading("MeshTri", mesh)?;
+
+    // An exact conic sweep: red → green → blue → red around (300, 500).
+    let conic = ConicShading::new(
+        "ConicSweep",
+        Point::new(300.0, 500.0),
+        [220.0, 380.0, 420.0, 580.0],
+        vec![
+            ColorStop::new(0.0, Color::Rgb(1.0, 0.0, 0.0)),
+            ColorStop::new(0.33, Color::Rgb(0.0, 1.0, 0.0)),
+            ColorStop::new(0.66, Color::Rgb(0.0, 0.0, 1.0)),
+            ColorStop::new(1.0, Color::Rgb(1.0, 0.0, 0.0)),
+        ],
+    );
+    page.add_conic_shading("ConicSweep", conic)?;
+
+    // Paint the mesh into its triangle region.
+    page.graphics()
+        .save_state()
+        .rectangle(40.0, 40.0, 120.0, 120.0)
+        .clip()
+        .end_path()
+        .paint_shading("MeshTri")
+        .restore_state();
+
+    // Paint the conic into its square region.
+    page.graphics()
+        .save_state()
+        .rectangle(220.0, 420.0, 160.0, 160.0)
+        .clip()
+        .end_path()
+        .paint_shading("ConicSweep")
+        .restore_state();
+
+    doc.add_page(page);
+    doc.save("examples/results/mesh_and_conic_shading.pdf")?;
+    println!("Wrote examples/results/mesh_and_conic_shading.pdf");
+    Ok(())
+}

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -48,6 +48,9 @@ pub use shadings::{
     GouraudVertex, Point, RadialShading, ShadingDefinition, ShadingManager, ShadingPattern,
     ShadingType,
 };
+// Internal wrapper for the additive mesh/conic shadings registered on a Page;
+// consumed by the writer, not part of the public API.
+pub(crate) use shadings::AdvancedShading;
 pub use soft_mask::{SoftMask, SoftMaskState, SoftMaskType};
 pub use state::{
     BlendMode, ExtGState, ExtGStateFont, ExtGStateManager, Halftone, LineDashPattern,

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -44,8 +44,9 @@ pub use separation_color::{
     AlternateColorSpace, SeparationColor, SeparationColorSpace, SpotColors, TintTransform,
 };
 pub use shadings::{
-    AxialShading, ColorStop, FreeFormGouraudShading, FunctionBasedShading, GouraudVertex, Point,
-    RadialShading, ShadingDefinition, ShadingManager, ShadingPattern, ShadingType,
+    AxialShading, ColorStop, ConicShading, FreeFormGouraudShading, FunctionBasedShading,
+    GouraudVertex, Point, RadialShading, ShadingDefinition, ShadingManager, ShadingPattern,
+    ShadingType,
 };
 pub use soft_mask::{SoftMask, SoftMaskState, SoftMaskType};
 pub use state::{

--- a/oxidize-pdf-core/src/graphics/mod.rs
+++ b/oxidize-pdf-core/src/graphics/mod.rs
@@ -44,8 +44,8 @@ pub use separation_color::{
     AlternateColorSpace, SeparationColor, SeparationColorSpace, SpotColors, TintTransform,
 };
 pub use shadings::{
-    AxialShading, ColorStop, FunctionBasedShading, Point, RadialShading, ShadingDefinition,
-    ShadingManager, ShadingPattern, ShadingType,
+    AxialShading, ColorStop, FreeFormGouraudShading, FunctionBasedShading, GouraudVertex, Point,
+    RadialShading, ShadingDefinition, ShadingManager, ShadingPattern, ShadingType,
 };
 pub use soft_mask::{SoftMask, SoftMaskState, SoftMaskType};
 pub use state::{

--- a/oxidize-pdf-core/src/graphics/shadings.rs
+++ b/oxidize-pdf-core/src/graphics/shadings.rs
@@ -679,6 +679,31 @@ impl ConicShading {
     }
 }
 
+/// Internal wrapper for the additive shading types (Type 4 mesh, Type 1 conic)
+/// registered via [`Page::add_mesh_shading`](crate::Page::add_mesh_shading) and
+/// [`Page::add_conic_shading`](crate::Page::add_conic_shading). Kept in a
+/// separate page collection from [`ShadingDefinition`] so the public gradient
+/// enum stays unchanged (folding these in is a 5.0.0 breaking-bundle item).
+#[derive(Debug, Clone)]
+pub(crate) enum AdvancedShading {
+    /// Type 4 free-form Gouraud mesh (emitted as a stream).
+    Mesh(FreeFormGouraudShading),
+    /// Type 1 conic gradient (emitted as a dictionary with a `/Function`
+    /// stream the writer hoists).
+    Conic(ConicShading),
+}
+
+impl AdvancedShading {
+    /// Emit the shading as a PDF object: a stream for the mesh, a dictionary
+    /// for the conic.
+    pub(crate) fn to_pdf_object(&self) -> Result<Object> {
+        match self {
+            AdvancedShading::Mesh(m) => m.to_pdf_object(),
+            AdvancedShading::Conic(c) => Ok(Object::Dictionary(c.to_pdf_dictionary()?)),
+        }
+    }
+}
+
 /// Coordinate point for shading definitions
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point {

--- a/oxidize-pdf-core/src/graphics/shadings.rs
+++ b/oxidize-pdf-core/src/graphics/shadings.rs
@@ -206,6 +206,280 @@ fn assemble_gradient_dict(
     Ok(dict)
 }
 
+/// MSB-first bit packer for Type 4 mesh vertex streams (ISO 32000-1
+/// §8.7.4.5.5). Coordinate/component/flag values are written most-significant-
+/// bit first; each vertex is padded to a byte boundary via [`align_to_byte`].
+struct BitWriter {
+    buffer: Vec<u8>,
+    current_byte: u8,
+    bits_filled: u8,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            current_byte: 0,
+            bits_filled: 0,
+        }
+    }
+
+    /// Append the low `bits` bits of `value`, most-significant-bit first.
+    fn write_bits(&mut self, value: u64, bits: u8) {
+        for i in (0..bits).rev() {
+            let bit = ((value >> i) & 1) as u8;
+            self.current_byte = (self.current_byte << 1) | bit;
+            self.bits_filled += 1;
+            if self.bits_filled == 8 {
+                self.buffer.push(self.current_byte);
+                self.current_byte = 0;
+                self.bits_filled = 0;
+            }
+        }
+    }
+
+    /// Zero-pad any partial byte up to the next byte boundary.
+    fn align_to_byte(&mut self) {
+        if self.bits_filled > 0 {
+            self.current_byte <<= 8 - self.bits_filled;
+            self.buffer.push(self.current_byte);
+            self.current_byte = 0;
+            self.bits_filled = 0;
+        }
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.buffer
+    }
+}
+
+/// Map a real `value` in `[min, max]` to an unsigned integer of `bits` width
+/// for a Type 4 mesh vertex stream (ISO 32000-1 §8.7.4.5.5, `/Decode`). The
+/// value is clamped to the range, normalised to `[0, 1]`, then scaled to
+/// `2^bits - 1` with round-half-away-from-zero (Rust `f64::round`).
+fn encode_value(value: f64, min: f64, max: f64, bits: u8) -> u64 {
+    let span = max - min;
+    let frac = if span == 0.0 {
+        0.0
+    } else {
+        ((value.clamp(min, max) - min) / span).clamp(0.0, 1.0)
+    };
+    let max_int = (1u64 << bits) - 1;
+    (frac * max_int as f64).round() as u64
+}
+
+/// A single vertex of a Type 4 free-form Gouraud-shaded triangle mesh
+/// (ISO 32000-1 §8.7.4.5.5). `flag` is the edge flag (0 starts a new
+/// triangle; 1 and 2 share an edge with the previous triangle).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GouraudVertex {
+    /// Edge flag (0, 1, or 2).
+    pub flag: u8,
+    /// X coordinate in shading space.
+    pub x: f64,
+    /// Y coordinate in shading space.
+    pub y: f64,
+    /// Vertex colour.
+    pub color: Color,
+}
+
+/// Pack one mesh vertex into its byte-aligned binary form (ISO 32000-1
+/// §8.7.4.5.5): edge flag, then x, y, then colour components, each written at
+/// its declared bit width via [`BitWriter`] with coordinates/components mapped
+/// through `decode`. Each vertex's data is an integral number of bytes.
+fn pack_vertex(
+    vertex: &GouraudVertex,
+    bits_per_flag: u8,
+    bits_per_coordinate: u8,
+    bits_per_component: u8,
+    decode: &[f64],
+    color_space: &str,
+) -> Vec<u8> {
+    let mut w = BitWriter::new();
+    w.write_bits(vertex.flag as u64, bits_per_flag);
+    w.write_bits(
+        encode_value(vertex.x, decode[0], decode[1], bits_per_coordinate),
+        bits_per_coordinate,
+    );
+    w.write_bits(
+        encode_value(vertex.y, decode[2], decode[3], bits_per_coordinate),
+        bits_per_coordinate,
+    );
+    for (i, comp) in color_components(&vertex.color, color_space)
+        .into_iter()
+        .enumerate()
+    {
+        let lo = decode[4 + 2 * i];
+        let hi = decode[4 + 2 * i + 1];
+        w.write_bits(
+            encode_value(comp, lo, hi, bits_per_component),
+            bits_per_component,
+        );
+    }
+    w.align_to_byte();
+    w.into_bytes()
+}
+
+/// Number of colour components for a device colour space name (used to size
+/// the `/Decode` array and validate mesh vertex colours).
+fn n_components(color_space: &str) -> usize {
+    match color_space {
+        "DeviceGray" => 1,
+        "DeviceCMYK" => 4,
+        // DeviceRGB and any unexpected name default to 3-component RGB.
+        _ => 3,
+    }
+}
+
+/// Free-form Gouraud-shaded triangle mesh (Type 4 shading, ISO 32000-1
+/// §8.7.4.5.5). Emitted as a PDF stream: the shading dictionary plus a binary
+/// body of packed vertex data. Construct with [`FreeFormGouraudShading::new`]
+/// (defaulting to 16-bit coordinates and 8-bit components/flags) and adjust the
+/// bit widths with [`with_bits`](FreeFormGouraudShading::with_bits).
+///
+/// Marked `#[non_exhaustive]`: future additive fields (e.g. an optional
+/// `/Function` over the vertices) must not break external construction, so
+/// build via `new`/`with_bits` rather than a struct literal across crates.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FreeFormGouraudShading {
+    /// Shading name for referencing.
+    pub name: String,
+    /// Device colour space name (`DeviceGray`/`DeviceRGB`/`DeviceCMYK`).
+    pub color_space: String,
+    /// Bits per coordinate (∈ {1,2,4,8,12,16,24,32}).
+    pub bits_per_coordinate: u8,
+    /// Bits per colour component (∈ {1,2,4,8,12,16}).
+    pub bits_per_component: u8,
+    /// Bits per edge flag (∈ {2,4,8}).
+    pub bits_per_flag: u8,
+    /// Decode array `[xmin xmax ymin ymax c1min c1max …]` (§8.7.4.5.5).
+    pub decode: Vec<f64>,
+    /// Mesh vertices in emission order.
+    pub vertices: Vec<GouraudVertex>,
+}
+
+impl FreeFormGouraudShading {
+    /// Create a mesh shading with default bit widths (16-bit coordinates,
+    /// 8-bit components, 8-bit flags). `decode` must have
+    /// `4 + 2 * n_components(color_space)` entries.
+    pub fn new(
+        name: impl Into<String>,
+        color_space: impl Into<String>,
+        decode: Vec<f64>,
+        vertices: Vec<GouraudVertex>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            color_space: color_space.into(),
+            bits_per_coordinate: 16,
+            bits_per_component: 8,
+            bits_per_flag: 8,
+            decode,
+            vertices,
+        }
+    }
+
+    /// Override the packed bit widths.
+    pub fn with_bits(
+        mut self,
+        bits_per_coordinate: u8,
+        bits_per_component: u8,
+        bits_per_flag: u8,
+    ) -> Self {
+        self.bits_per_coordinate = bits_per_coordinate;
+        self.bits_per_component = bits_per_component;
+        self.bits_per_flag = bits_per_flag;
+        self
+    }
+
+    /// Validate the mesh against the Type 4 constraints (ISO 32000-1
+    /// §8.7.4.5.5): permitted bit widths, `/Decode` length matching the colour
+    /// space, at least one vertex, and a leading edge flag of 0.
+    pub fn validate(&self) -> Result<()> {
+        if !matches!(self.bits_per_coordinate, 1 | 2 | 4 | 8 | 12 | 16 | 24 | 32) {
+            return Err(PdfError::InvalidStructure(format!(
+                "BitsPerCoordinate must be 1,2,4,8,12,16,24 or 32, got {}",
+                self.bits_per_coordinate
+            )));
+        }
+        if !matches!(self.bits_per_component, 1 | 2 | 4 | 8 | 12 | 16) {
+            return Err(PdfError::InvalidStructure(format!(
+                "BitsPerComponent must be 1,2,4,8,12 or 16, got {}",
+                self.bits_per_component
+            )));
+        }
+        if !matches!(self.bits_per_flag, 2 | 4 | 8) {
+            return Err(PdfError::InvalidStructure(format!(
+                "BitsPerFlag must be 2, 4 or 8, got {}",
+                self.bits_per_flag
+            )));
+        }
+        let expected = 4 + 2 * n_components(&self.color_space);
+        if self.decode.len() != expected {
+            return Err(PdfError::InvalidStructure(format!(
+                "Decode must have {} entries for {}, got {}",
+                expected,
+                self.color_space,
+                self.decode.len()
+            )));
+        }
+        if self.vertices.is_empty() {
+            return Err(PdfError::InvalidStructure(
+                "Mesh shading must have at least one vertex".to_string(),
+            ));
+        }
+        if self.vertices[0].flag != 0 {
+            return Err(PdfError::InvalidStructure(
+                "First mesh vertex must have edge flag 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Build the Type 4 shading as a PDF stream object: the shading dictionary
+    /// plus the byte-aligned packed vertex data. A mesh cannot be inlined as a
+    /// plain dictionary, so this is the emission entry point (the writer hoists
+    /// it to an indirect object).
+    pub fn to_pdf_object(&self) -> Result<Object> {
+        self.validate()?;
+
+        let mut dict = Dictionary::new();
+        dict.set(
+            "ShadingType",
+            Object::Integer(ShadingType::FreeFormGouraud as i64),
+        );
+        dict.set("ColorSpace", Object::Name(self.color_space.clone()));
+        dict.set(
+            "BitsPerCoordinate",
+            Object::Integer(self.bits_per_coordinate as i64),
+        );
+        dict.set(
+            "BitsPerComponent",
+            Object::Integer(self.bits_per_component as i64),
+        );
+        dict.set("BitsPerFlag", Object::Integer(self.bits_per_flag as i64));
+        dict.set(
+            "Decode",
+            Object::Array(self.decode.iter().map(|&d| Object::Real(d)).collect()),
+        );
+
+        let mut data = Vec::new();
+        for v in &self.vertices {
+            data.extend(pack_vertex(
+                v,
+                self.bits_per_flag,
+                self.bits_per_coordinate,
+                self.bits_per_component,
+                &self.decode,
+                &self.color_space,
+            ));
+        }
+
+        Ok(Object::Stream(dict, data))
+    }
+}
+
 /// Coordinate point for shading definitions
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point {
@@ -819,6 +1093,210 @@ impl ShadingManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Issue #407 Track A: BitWriter (MSB-first packing for mesh vertex data) ──
+
+    #[test]
+    fn test_bitwriter_single_value_byte_aligned() {
+        // 4 bits 0b1011 then pad to a byte → 0b1011_0000.
+        let mut w = BitWriter::new();
+        w.write_bits(0b1011, 4);
+        w.align_to_byte();
+        assert_eq!(w.into_bytes(), vec![0xB0]);
+    }
+
+    #[test]
+    fn test_bitwriter_value_spans_two_bytes() {
+        // 9-bit value 0x1FF crosses the byte boundary: 1111_1111 | 1___ then pad.
+        let mut w = BitWriter::new();
+        w.write_bits(0b1_1111_1111, 9);
+        w.align_to_byte();
+        assert_eq!(w.into_bytes(), vec![0xFF, 0x80]);
+    }
+
+    #[test]
+    fn test_bitwriter_accumulates_across_writes() {
+        // 0b10 then 0b110 → 0b10110, padded to 0b1011_0000.
+        let mut w = BitWriter::new();
+        w.write_bits(0b10, 2);
+        w.write_bits(0b110, 3);
+        w.align_to_byte();
+        assert_eq!(w.into_bytes(), vec![0xB0]);
+    }
+
+    #[test]
+    fn test_encode_value_maps_real_to_packed_integer() {
+        // 50 in [0,100] over 8 bits → 0.5 * 255 = 127.5 → round half away → 128.
+        assert_eq!(encode_value(50.0, 0.0, 100.0, 8), 128);
+    }
+
+    #[test]
+    fn test_encode_value_clamps_out_of_range() {
+        assert_eq!(encode_value(150.0, 0.0, 100.0, 8), 255);
+        assert_eq!(encode_value(-10.0, 0.0, 100.0, 8), 0);
+        assert_eq!(encode_value(100.0, 0.0, 100.0, 8), 255);
+    }
+
+    #[test]
+    fn test_encode_value_16_bit_precision() {
+        // 0.5 in [0,1] over 16 bits → 0.5 * 65535 = 32767.5 → round half away → 32768.
+        assert_eq!(encode_value(0.5, 0.0, 1.0, 16), 32768);
+    }
+
+    #[test]
+    fn test_gouraud_vertex_pack_byte_aligned() {
+        // flag(8) + x,y(16 each) + 3 rgb components(8 each) = 64 bits = 8 bytes.
+        let v = GouraudVertex {
+            flag: 0,
+            x: 10.0,
+            y: 20.0,
+            color: Color::Rgb(1.0, 0.0, 0.0),
+        };
+        let decode = [0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let bytes = pack_vertex(&v, 8, 16, 8, &decode, "DeviceRGB");
+        // x=10→0.1*65535=6554=0x199A, y=20→0x3333, r=255,g=0,b=0.
+        assert_eq!(bytes, vec![0x00, 0x19, 0x9A, 0x33, 0x33, 0xFF, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn test_gouraud_vertex_pack_with_padding() {
+        // flag(2) + x,y(8 each) + 1 gray component(8) = 26 bits → 4 bytes (6 pad).
+        let v = GouraudVertex {
+            flag: 1,
+            x: 50.0,
+            y: 25.0,
+            color: Color::Gray(0.5),
+        };
+        let decode = [0.0, 100.0, 0.0, 100.0, 0.0, 1.0];
+        let bytes = pack_vertex(&v, 2, 8, 8, &decode, "DeviceGray");
+        // flag=01, x=128=0x80, y=64=0x40, gray=128=0x80 → 01 10000000 01000000 10000000.
+        assert_eq!(bytes, vec![0x60, 0x10, 0x20, 0x00]);
+    }
+
+    /// Three valid RGB vertices for the mesh-level tests (flags 0,1,1).
+    fn sample_rgb_mesh() -> FreeFormGouraudShading {
+        FreeFormGouraudShading::new(
+            "M".to_string(),
+            "DeviceRGB".to_string(),
+            vec![0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            vec![
+                GouraudVertex {
+                    flag: 0,
+                    x: 10.0,
+                    y: 20.0,
+                    color: Color::Rgb(1.0, 0.0, 0.0),
+                },
+                GouraudVertex {
+                    flag: 1,
+                    x: 50.0,
+                    y: 50.0,
+                    color: Color::Rgb(0.0, 1.0, 0.0),
+                },
+                GouraudVertex {
+                    flag: 1,
+                    x: 90.0,
+                    y: 10.0,
+                    color: Color::Rgb(0.0, 0.0, 1.0),
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn test_freeform_gouraud_creation_defaults() {
+        let mesh = sample_rgb_mesh();
+        assert!(mesh.validate().is_ok());
+        assert_eq!(mesh.name, "M");
+        assert_eq!(mesh.color_space, "DeviceRGB");
+        // new() defaults: 16-bit coords, 8-bit components, 8-bit flags.
+        assert_eq!(mesh.bits_per_coordinate, 16);
+        assert_eq!(mesh.bits_per_component, 8);
+        assert_eq!(mesh.bits_per_flag, 8);
+        assert_eq!(mesh.vertices.len(), 3);
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_invalid_bits() {
+        let mut m = sample_rgb_mesh();
+        m.bits_per_coordinate = 5; // not in {1,2,4,8,12,16,24,32}
+        assert!(m.validate().is_err());
+
+        let mut m = sample_rgb_mesh();
+        m.bits_per_component = 3; // not in {1,2,4,8,12,16}
+        assert!(m.validate().is_err());
+
+        let mut m = sample_rgb_mesh();
+        m.bits_per_flag = 3; // not in {2,4,8}
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_decode_length_mismatch() {
+        let mut m = sample_rgb_mesh();
+        // DeviceRGB needs 4 + 2*3 = 10 entries; give 8.
+        m.decode = vec![0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0];
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_empty_vertices() {
+        let mut m = sample_rgb_mesh();
+        m.vertices.clear();
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_nonzero_first_flag() {
+        let mut m = sample_rgb_mesh();
+        m.vertices[0].flag = 1;
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_to_pdf_object_dict_keys() {
+        let obj = sample_rgb_mesh().to_pdf_object().unwrap();
+        let dict = match &obj {
+            Object::Stream(d, _) => d,
+            other => panic!("mesh must emit a Stream, got {other:?}"),
+        };
+        assert_eq!(dict.get("ShadingType"), Some(&Object::Integer(4)));
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceRGB".to_string()))
+        );
+        assert_eq!(dict.get("BitsPerCoordinate"), Some(&Object::Integer(16)));
+        assert_eq!(dict.get("BitsPerComponent"), Some(&Object::Integer(8)));
+        assert_eq!(dict.get("BitsPerFlag"), Some(&Object::Integer(8)));
+        assert_eq!(
+            dict.get("Decode"),
+            Some(&Object::Array(
+                vec![0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_freeform_gouraud_stream_body_exact_bytes() {
+        let obj = sample_rgb_mesh().to_pdf_object().unwrap();
+        let data = match &obj {
+            Object::Stream(_, d) => d,
+            other => panic!("mesh must emit a Stream, got {other:?}"),
+        };
+        assert_eq!(
+            *data,
+            vec![
+                // v0: flag0, x10, y20, red
+                0x00, 0x19, 0x9A, 0x33, 0x33, 0xFF, 0x00, 0x00, //
+                // v1: flag1, x50, y50, green
+                0x01, 0x80, 0x00, 0x80, 0x00, 0x00, 0xFF, 0x00, //
+                // v2: flag1, x90, y10, blue
+                0x01, 0xE6, 0x66, 0x19, 0x9A, 0x00, 0x00, 0xFF,
+            ]
+        );
+    }
 
     #[test]
     fn test_color_stop_creation() {

--- a/oxidize-pdf-core/src/graphics/shadings.rs
+++ b/oxidize-pdf-core/src/graphics/shadings.rs
@@ -87,6 +87,9 @@ fn color_components(color: &Color, space: &str) -> Vec<f64> {
             vec![c, m, y, k]
         }
         // DeviceRGB (and any unexpected name) → exact RGB conversion.
+        // Invariant: `Color::to_rgb` (color.rs) always returns `Color::Rgb`. If
+        // a future `Color` variant changes that, update this arm — the compiler
+        // will not flag it here.
         _ => match color.to_rgb() {
             Color::Rgb(r, g, b) => vec![r, g, b],
             _ => unreachable!("to_rgb always yields Color::Rgb"),
@@ -424,6 +427,17 @@ impl FreeFormGouraudShading {
                 self.decode.len()
             )));
         }
+        // Each Decode pair must be non-decreasing: `encode_value` maps within
+        // `[lo, hi]` (a reversed range would panic `f64::clamp`) and this
+        // encoder does not express an inverted decode.
+        for pair in self.decode.chunks_exact(2) {
+            if pair[0] > pair[1] {
+                return Err(PdfError::InvalidStructure(format!(
+                    "Decode ranges must be non-decreasing, got [{}, {}]",
+                    pair[0], pair[1]
+                )));
+            }
+        }
         if self.vertices.is_empty() {
             return Err(PdfError::InvalidStructure(
                 "Mesh shading must have at least one vertex".to_string(),
@@ -433,6 +447,25 @@ impl FreeFormGouraudShading {
             return Err(PdfError::InvalidStructure(
                 "First mesh vertex must have edge flag 0".to_string(),
             ));
+        }
+        // Per-vertex checks: edge flags are 0/1/2 (bit packer would silently
+        // truncate anything larger), and a `DeviceGray` mesh requires
+        // `Color::Gray` vertices (other variants would hit the unreachable! in
+        // `color_components`). RGB/CMYK spaces convert any `Color` losslessly.
+        let gray_space = self.color_space == "DeviceGray";
+        for (i, v) in self.vertices.iter().enumerate() {
+            if v.flag > 2 {
+                return Err(PdfError::InvalidStructure(format!(
+                    "Vertex {i} edge flag must be 0, 1 or 2, got {}",
+                    v.flag
+                )));
+            }
+            if gray_space && !matches!(v.color, Color::Gray(_)) {
+                return Err(PdfError::InvalidStructure(format!(
+                    "Vertex {i} color must be Color::Gray to match DeviceGray, got {:?}",
+                    v.color
+                )));
+            }
         }
         Ok(())
     }
@@ -633,11 +666,27 @@ impl ConicShading {
                 "Invalid domain: min values must be less than max values".to_string(),
             ));
         }
+        // Strictly ascending: equal adjacent positions would emit a `0 div`
+        // (division by a zero-width segment) into the PostScript ramp.
         for window in self.color_stops.windows(2) {
-            if window[0].position > window[1].position {
+            if window[0].position >= window[1].position {
                 return Err(PdfError::InvalidStructure(
-                    "Color stops must be in ascending order".to_string(),
+                    "Color stops must be in strictly ascending order".to_string(),
                 ));
+            }
+        }
+        // The conic sweeps the full turn: with 2+ stops the ramp maps the
+        // normalised angle t∈[0,1) across the stops, so the first must sit at
+        // 0.0 and the last at 1.0 (interior positions are honoured). Otherwise
+        // a 2-stop ramp would silently ignore its positions and a general ramp
+        // would extrapolate past the ends.
+        if self.color_stops.len() >= 2 {
+            let first = self.color_stops[0].position;
+            let last = self.color_stops[self.color_stops.len() - 1].position;
+            if first != 0.0 || last != 1.0 {
+                return Err(PdfError::InvalidStructure(format!(
+                    "Conic color stops must span [0.0, 1.0]; first={first}, last={last}"
+                )));
             }
         }
         Ok(())
@@ -1676,6 +1725,119 @@ mod tests {
             vec![],
         );
         assert!(empty.validate().is_err());
+    }
+
+    // ── #407 QR hardening: validate() must reject inputs that would otherwise
+    //    panic (clamp/unreachable) or emit malformed output ──
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_color_space_mismatch() {
+        // DeviceGray declared but vertices carry RGB colours → would hit the
+        // unreachable! in color_components; validate must reject first.
+        let mut m = sample_rgb_mesh();
+        m.color_space = "DeviceGray".to_string();
+        m.decode = vec![0.0, 100.0, 0.0, 100.0, 0.0, 1.0]; // valid DeviceGray length
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_inverted_decode() {
+        // Inverted x range [100,0] would panic f64::clamp in encode_value.
+        let mut m = sample_rgb_mesh();
+        m.decode[0] = 100.0;
+        m.decode[1] = 0.0;
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_validate_rejects_out_of_range_flag() {
+        // Edge flags are 0/1/2 (ISO 32000-1 §8.7.4.5.5); 3 would be silently
+        // truncated by the bit packer.
+        let mut m = sample_rgb_mesh();
+        m.vertices[1].flag = 3;
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn test_freeform_gouraud_cmyk_mesh_validates_and_packs() {
+        // Coverage: a CMYK mesh (4 components → 12 decode entries) round-trips
+        // through validate + pack.
+        let mesh = FreeFormGouraudShading::new(
+            "Cmyk".to_string(),
+            "DeviceCMYK".to_string(),
+            vec![
+                0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+            ],
+            vec![GouraudVertex {
+                flag: 0,
+                x: 0.0,
+                y: 0.0,
+                color: Color::Cmyk(1.0, 0.0, 0.0, 0.0),
+            }],
+        )
+        .with_bits(8, 8, 8);
+        assert!(mesh.validate().is_ok());
+        let bytes = pack_vertex(&mesh.vertices[0], 8, 8, 8, &mesh.decode, "DeviceCMYK");
+        // flag0, x0, y0, then cyan=255, m=0, y=0, k=0.
+        assert_eq!(bytes, vec![0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn test_conic_shading_validate_requires_full_range_endpoints() {
+        // Stops at 0.25/0.75 (not 0/1) would silently produce the same program
+        // as 0/1 — reject so the caller isn't misled.
+        let conic = ConicShading::new(
+            "C".to_string(),
+            Point::new(0.0, 0.0),
+            [0.0, 1.0, 0.0, 1.0],
+            vec![
+                ColorStop::new(0.25, Color::red()),
+                ColorStop::new(0.75, Color::blue()),
+            ],
+        );
+        assert!(conic.validate().is_err());
+    }
+
+    #[test]
+    fn test_conic_shading_validate_rejects_equal_positions() {
+        // Equal adjacent positions would emit `0 div` into the PostScript ramp.
+        let conic = ConicShading::new(
+            "C".to_string(),
+            Point::new(0.0, 0.0),
+            [0.0, 1.0, 0.0, 1.0],
+            vec![
+                ColorStop::new(0.0, Color::red()),
+                ColorStop::new(0.5, Color::green()),
+                ColorStop::new(0.5, Color::blue()),
+                ColorStop::new(1.0, Color::red()),
+            ],
+        );
+        assert!(conic.validate().is_err());
+    }
+
+    #[test]
+    fn test_conic_shading_three_stops_no_zero_div_and_one_ifelse() {
+        // A valid 3-stop conic (endpoints 0/1, strictly ascending) produces a
+        // well-formed nested ramp: no `0 div`, exactly one ifelse.
+        let conic = ConicShading::new(
+            "C".to_string(),
+            Point::new(50.0, 50.0),
+            [0.0, 100.0, 0.0, 100.0],
+            vec![
+                ColorStop::new(0.0, Color::red()),
+                ColorStop::new(0.5, Color::green()),
+                ColorStop::new(1.0, Color::blue()),
+            ],
+        );
+        let dict = conic.to_pdf_dictionary().unwrap();
+        let code = match dict.get("Function") {
+            Some(Object::Stream(_, c)) => String::from_utf8(c.clone()).unwrap(),
+            other => panic!("Function must be a stream, got {other:?}"),
+        };
+        // A zero-width segment would emit the token ` 0 div`; the angle
+        // prologue's `360 div` must not be mistaken for it.
+        assert!(!code.contains(" 0 div"), "no zero-width segment:\n{code}");
+        assert_eq!(code.matches("ifelse").count(), 1);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/graphics/shadings.rs
+++ b/oxidize-pdf-core/src/graphics/shadings.rs
@@ -480,6 +480,205 @@ impl FreeFormGouraudShading {
     }
 }
 
+/// Assemble a Type 4 (PostScript calculator) function object (ISO 32000-1
+/// §7.10.5): a stream whose body is the calculator program `code` verbatim,
+/// with the given `/Domain` and `/Range`. Mirrors the shape used elsewhere in
+/// the crate (`devicen_color`), returned as `(dict, bytes)` for the writer to
+/// hoist to an indirect object.
+fn postscript_type4_function(code: &str, domain: &[f64], range: &[f64]) -> (Dictionary, Vec<u8>) {
+    let mut dict = Dictionary::new();
+    dict.set("FunctionType", Object::Integer(4));
+    dict.set(
+        "Domain",
+        Object::Array(domain.iter().map(|&d| Object::Real(d)).collect()),
+    );
+    dict.set(
+        "Range",
+        Object::Array(range.iter().map(|&r| Object::Real(r)).collect()),
+    );
+    (dict, code.as_bytes().to_vec())
+}
+
+/// PostScript that maps a local parameter `t ∈ [0,1]` on the stack to the `n`
+/// colour components of a two-stop linear interpolation `start → end`. Ends
+/// with the components in order (component 0 deepest).
+fn ramp2_ps(start: &Color, end: &Color, space: &str) -> String {
+    let s = color_components(start, space);
+    let e = color_components(end, space);
+    let n = s.len();
+    let mut parts = Vec::with_capacity(n);
+    for j in 0..n {
+        let block = format!("{} mul {} add", e[j] - s[j], s[j]);
+        if j + 1 < n {
+            // Keep a fresh copy of t for the next component and tuck the result
+            // beneath it, preserving output order.
+            parts.push(format!("dup {block} exch"));
+        } else {
+            parts.push(block);
+        }
+    }
+    parts.join(" ")
+}
+
+/// PostScript that remaps a global `t` on the stack to a segment-local
+/// parameter `(t - lo) / (hi - lo)`.
+fn remap_local_ps(lo: f64, hi: f64) -> String {
+    format!("{} sub {} div", lo, hi - lo)
+}
+
+/// PostScript mapping a global `t ∈ [0,1]` on the stack to colour components
+/// across `stops` (≥ 1). One stop → constant colour (discards `t`); two →
+/// [`ramp2_ps`]; more → nested `ifelse` split at the interior stop positions,
+/// each segment remapped to `[0,1]` then interpolated.
+fn build_color_ramp_ps(stops: &[ColorStop], space: &str) -> String {
+    match stops {
+        [] => String::new(),
+        [only] => {
+            let mut s = String::from("pop");
+            for c in color_components(&only.color, space) {
+                s.push_str(&format!(" {c}"));
+            }
+            s
+        }
+        [a, b] => ramp2_ps(&a.color, &b.color, space),
+        _ => build_ramp_nested_ps(stops, space),
+    }
+}
+
+/// Recursive nested-`ifelse` ramp for 3+ stops. Each level splits at the next
+/// interior stop position; the deepest level (two stops) is a remapped
+/// [`ramp2_ps`].
+fn build_ramp_nested_ps(stops: &[ColorStop], space: &str) -> String {
+    debug_assert!(stops.len() >= 2);
+    let lo = stops[0].position;
+    let hi = stops[1].position;
+    let seg0 = format!(
+        "{} {}",
+        remap_local_ps(lo, hi),
+        ramp2_ps(&stops[0].color, &stops[1].color, space)
+    );
+    if stops.len() == 2 {
+        return seg0;
+    }
+    let split = stops[1].position;
+    let rest = build_ramp_nested_ps(&stops[1..], space);
+    format!("dup {split} lt {{ {seg0} }} {{ {rest} }} ifelse")
+}
+
+/// PostScript prologue for a conic (angular) gradient: given `x y` on the
+/// stack, computes the angle of the vector from `center` and normalises it to
+/// `t = angle / 360 ∈ [0,1)`. `atan` (ISO 32000-1 Table 42) takes `num den`
+/// and returns `atan2(num, den)` in degrees `[0,360)`; with `dy dx` on the
+/// stack it yields the angle of `(dx, dy)`.
+fn build_conic_angle_prologue(center: Point) -> String {
+    // stack: x y → (y - cy)=dy, exch, (x - cx)=dx → dy dx → atan → /360.
+    format!("{} sub exch {} sub atan 360 div", center.y, center.x)
+}
+
+/// Conic (angular / "sweep") gradient, emitted as an exact Type 1
+/// function-based shading (ISO 32000-1 §8.7.4.5.2) whose `/Function` is a real
+/// Type 4 PostScript calculator: the colour is a resolution-independent
+/// function of the angle around `center`, not a piecewise mesh approximation.
+///
+/// Marked `#[non_exhaustive]`: build via [`ConicShading::new`] /
+/// [`with_matrix`](ConicShading::with_matrix) so future additive fields stay
+/// non-breaking.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ConicShading {
+    /// Shading name for referencing.
+    pub name: String,
+    /// Centre of the angular sweep, in the shading's domain coordinates.
+    pub center: Point,
+    /// Domain `[xmin xmax ymin ymax]` the function is evaluated over.
+    pub domain: [f64; 4],
+    /// Optional matrix mapping domain space to the shading target space.
+    pub matrix: Option<[f64; 6]>,
+    /// Colour stops swept from angle 0 (t=0) to a full turn (t=1).
+    pub color_stops: Vec<ColorStop>,
+}
+
+impl ConicShading {
+    /// Create a conic gradient centred at `center` over `domain`.
+    pub fn new(
+        name: impl Into<String>,
+        center: Point,
+        domain: [f64; 4],
+        color_stops: Vec<ColorStop>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            center,
+            domain,
+            matrix: None,
+            color_stops,
+        }
+    }
+
+    /// Set the shading-to-target transformation matrix.
+    pub fn with_matrix(mut self, matrix: [f64; 6]) -> Self {
+        self.matrix = Some(matrix);
+        self
+    }
+
+    /// Validate stops (non-empty, ascending) and domain (min < max).
+    pub fn validate(&self) -> Result<()> {
+        if self.color_stops.is_empty() {
+            return Err(PdfError::InvalidStructure(
+                "Conic shading must have at least one color stop".to_string(),
+            ));
+        }
+        if self.domain[0] >= self.domain[1] || self.domain[2] >= self.domain[3] {
+            return Err(PdfError::InvalidStructure(
+                "Invalid domain: min values must be less than max values".to_string(),
+            ));
+        }
+        for window in self.color_stops.windows(2) {
+            if window[0].position > window[1].position {
+                return Err(PdfError::InvalidStructure(
+                    "Color stops must be in ascending order".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the Type 1 function-based shading dictionary with a real Type 4
+    /// PostScript `/Function` (angle prologue + colour ramp) and the required
+    /// `/ColorSpace`. The `/Function` is inlined as a stream; the writer hoists
+    /// it to an indirect object (a stream cannot be a dictionary value).
+    pub fn to_pdf_dictionary(&self) -> Result<Dictionary> {
+        self.validate()?;
+        let space = resolve_color_space(&self.color_stops);
+        let code = format!(
+            "{{ {} {} }}",
+            build_conic_angle_prologue(self.center),
+            build_color_ramp_ps(&self.color_stops, space)
+        );
+        let range: Vec<f64> = (0..n_components(space)).flat_map(|_| [0.0, 1.0]).collect();
+        let (fdict, fbytes) = postscript_type4_function(&code, &self.domain, &range);
+
+        let mut dict = Dictionary::new();
+        dict.set(
+            "ShadingType",
+            Object::Integer(ShadingType::FunctionBased as i64),
+        );
+        dict.set("ColorSpace", Object::Name(space.to_string()));
+        dict.set(
+            "Domain",
+            Object::Array(self.domain.iter().map(|&d| Object::Real(d)).collect()),
+        );
+        dict.set("Function", Object::Stream(fdict, fbytes));
+        if let Some(matrix) = self.matrix {
+            dict.set(
+                "Matrix",
+                Object::Array(matrix.iter().map(|&v| Object::Real(v)).collect()),
+            );
+        }
+        Ok(dict)
+    }
+}
+
 /// Coordinate point for shading definitions
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point {
@@ -1296,6 +1495,162 @@ mod tests {
                 0x01, 0xE6, 0x66, 0x19, 0x9A, 0x00, 0x00, 0xFF,
             ]
         );
+    }
+
+    // ── Issue #407 Track B: Type 1 conic (PostScript Type 4 function) ──
+
+    #[test]
+    fn test_postscript_type4_function_shape() {
+        // Wraps arbitrary calculator code with FunctionType 4 + Domain/Range;
+        // the code bytes are stored verbatim (no transformation).
+        let (dict, code) = postscript_type4_function(
+            "{ 1 }",
+            &[0.0, 1.0, 0.0, 1.0],
+            &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        );
+        assert_eq!(dict.get("FunctionType"), Some(&Object::Integer(4)));
+        assert_eq!(
+            dict.get("Domain"),
+            Some(&Object::Array(
+                vec![0.0, 1.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+        assert_eq!(
+            dict.get("Range"),
+            Some(&Object::Array(
+                vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+        assert_eq!(code, b"{ 1 }");
+    }
+
+    #[test]
+    fn test_color_ramp_ps_two_stops_no_branching() {
+        // 2 stops → straight per-component linear interpolation of a local t on
+        // the stack, no ifelse. red→blue over DeviceRGB: deltas (-1, 0, 1).
+        let stops = vec![
+            ColorStop::new(0.0, Color::Rgb(1.0, 0.0, 0.0)),
+            ColorStop::new(1.0, Color::Rgb(0.0, 0.0, 1.0)),
+        ];
+        let ps = build_color_ramp_ps(&stops, "DeviceRGB");
+        assert_eq!(ps, "dup -1 mul 1 add exch dup 0 mul 0 add exch 1 mul 0 add");
+        assert!(!ps.contains("ifelse"));
+    }
+
+    #[test]
+    fn test_color_ramp_ps_three_stops_has_bound_check() {
+        // 3 stops → one ifelse splitting at the interior stop (0.5), two
+        // interpolation segments (3 muls each over DeviceRGB → 6 total).
+        let stops = vec![
+            ColorStop::new(0.0, Color::red()),
+            ColorStop::new(0.5, Color::green()),
+            ColorStop::new(1.0, Color::blue()),
+        ];
+        let ps = build_color_ramp_ps(&stops, "DeviceRGB");
+        assert_eq!(ps.matches("ifelse").count(), 1, "one split for three stops");
+        assert!(ps.contains("0.5"), "interior bound present");
+        assert_eq!(ps.matches("mul").count(), 6, "two RGB segments");
+    }
+
+    #[test]
+    fn test_conic_angle_prologue_exact_ps() {
+        // stack in: x y. dy=y-cy, dx=x-cx, angle=atan2(dy,dx), t=angle/360.
+        let ps = build_conic_angle_prologue(Point::new(50.0, 50.0));
+        assert_eq!(ps, "50 sub exch 50 sub atan 360 div");
+    }
+
+    #[test]
+    fn test_conic_shading_emits_type1_with_ps_function_and_colorspace() {
+        let stops = vec![
+            ColorStop::new(0.0, Color::red()),
+            ColorStop::new(1.0, Color::blue()),
+        ];
+        let conic = ConicShading::new(
+            "C".to_string(),
+            Point::new(50.0, 50.0),
+            [0.0, 100.0, 0.0, 100.0],
+            stops.clone(),
+        );
+        let dict = conic.to_pdf_dictionary().unwrap();
+
+        // Function-based (Type 1) shading with the required ColorSpace + Domain.
+        assert_eq!(dict.get("ShadingType"), Some(&Object::Integer(1)));
+        assert_eq!(
+            dict.get("ColorSpace"),
+            Some(&Object::Name("DeviceRGB".to_string()))
+        );
+        assert_eq!(
+            dict.get("Domain"),
+            Some(&Object::Array(
+                vec![0.0, 100.0, 0.0, 100.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+
+        // /Function is a real Type 4 PostScript stream, not a placeholder.
+        let (fdict, fcode) = match dict.get("Function") {
+            Some(Object::Stream(d, c)) => (d, c),
+            other => panic!("Function must be a Type 4 stream, got {other:?}"),
+        };
+        assert_eq!(fdict.get("FunctionType"), Some(&Object::Integer(4)));
+        // Function domain == shading domain (2 inputs x, y).
+        assert_eq!(
+            fdict.get("Domain"),
+            Some(&Object::Array(
+                vec![0.0, 100.0, 0.0, 100.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+        // Range == n_components pairs of [0, 1] (3 for RGB).
+        assert_eq!(
+            fdict.get("Range"),
+            Some(&Object::Array(
+                vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(Object::Real)
+                    .collect()
+            ))
+        );
+        // Program == "{ <angle prologue> <colour ramp> }".
+        let expected = format!(
+            "{{ {} {} }}",
+            build_conic_angle_prologue(Point::new(50.0, 50.0)),
+            build_color_ramp_ps(&stops, "DeviceRGB")
+        );
+        assert_eq!(fcode, &expected.into_bytes());
+    }
+
+    #[test]
+    fn test_conic_shading_validate_rejects_bad_domain_and_empty_stops() {
+        let stops = vec![
+            ColorStop::new(0.0, Color::red()),
+            ColorStop::new(1.0, Color::blue()),
+        ];
+        let bad_domain = ConicShading::new(
+            "C".to_string(),
+            Point::new(0.0, 0.0),
+            [1.0, 0.0, 0.0, 1.0], // xmin > xmax
+            stops,
+        );
+        assert!(bad_domain.validate().is_err());
+
+        let empty = ConicShading::new(
+            "C".to_string(),
+            Point::new(0.0, 0.0),
+            [0.0, 1.0, 0.0, 1.0],
+            vec![],
+        );
+        assert!(empty.validate().is_err());
     }
 
     #[test]

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -126,6 +126,10 @@ pub struct Page {
     /// Registered shadings, emitted as indirect dictionary objects
     /// referenced from `/Resources/Shading` per ISO 32000-1 §8.7.4.
     shadings: HashMap<String, crate::graphics::ShadingDefinition>,
+    /// Registered mesh (Type 4) and conic (Type 1) shadings, emitted into the
+    /// same `/Resources/Shading` dict as `shadings` but kept in a separate map
+    /// so the public `ShadingDefinition` enum stays unchanged (#407).
+    advanced_shadings: HashMap<String, crate::graphics::AdvancedShading>,
     header: Option<HeaderFooter>,
     footer: Option<HeaderFooter>,
     annotations: Vec<Annotation>,
@@ -177,6 +181,7 @@ impl Page {
             color_spaces: HashMap::new(),
             patterns: HashMap::new(),
             shadings: HashMap::new(),
+            advanced_shadings: HashMap::new(),
             header: None,
             footer: None,
             annotations: Vec::new(),
@@ -1300,6 +1305,53 @@ impl Page {
     /// Returns all shadings registered on this page.
     pub fn shadings(&self) -> &HashMap<String, crate::graphics::ShadingDefinition> {
         &self.shadings
+    }
+
+    /// Register a Type 4 free-form Gouraud mesh shading (#407), referenced
+    /// from `/Resources/Shading/<name>` and painted with `/<name> sh`. The
+    /// mesh is emitted as a stream object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid PDF
+    /// resource name (ISO 32000-1 §7.3.5) or the mesh fails validation.
+    pub fn add_mesh_shading(
+        &mut self,
+        name: impl Into<String>,
+        shading: crate::graphics::FreeFormGouraudShading,
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        shading.validate()?;
+        self.advanced_shadings
+            .insert(name, crate::graphics::AdvancedShading::Mesh(shading));
+        Ok(())
+    }
+
+    /// Register an exact conic (angular) gradient as a Type 1 function-based
+    /// shading (#407), referenced from `/Resources/Shading/<name>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] if `name` is not a valid PDF
+    /// resource name (ISO 32000-1 §7.3.5) or the shading fails validation.
+    pub fn add_conic_shading(
+        &mut self,
+        name: impl Into<String>,
+        shading: crate::graphics::ConicShading,
+    ) -> Result<()> {
+        let name = name.into();
+        validate_pdf_resource_name(&name)?;
+        shading.validate()?;
+        self.advanced_shadings
+            .insert(name, crate::graphics::AdvancedShading::Conic(shading));
+        Ok(())
+    }
+
+    /// Returns the mesh/conic shadings registered on this page (crate-internal;
+    /// consumed by the writer).
+    pub(crate) fn advanced_shadings(&self) -> &HashMap<String, crate::graphics::AdvancedShading> {
+        &self.advanced_shadings
     }
 
     /// Append raw PDF operators to the content stream and record which

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -2937,28 +2937,30 @@ impl<W: Write> PdfWriter<W> {
             resources.set("Pattern", Object::Dictionary(pat_dict));
         }
 
-        if !page.shadings().is_empty() {
+        if !page.shadings().is_empty() || !page.advanced_shadings().is_empty() {
             let mut sh_dict = Dictionary::new();
+
+            // Gradient shadings (Axial/Radial/FunctionBased) → dictionaries.
             let mut entries: Vec<(&String, &crate::graphics::ShadingDefinition)> =
                 page.shadings().iter().collect();
             entries.sort_by_key(|(name, _)| name.as_str());
             for (name, shading) in entries {
-                let mut shading_dict = shading.to_pdf_dictionary()?;
-                // Hoist the inline /Function to an indirect object (issue #297 B).
-                // ISO 32000-1 §8.7.4.5.2: functions are normally indirect. Only
-                // a dictionary value is hoisted; FunctionBased shadings carry an
-                // external function id (an Integer) which is left untouched.
-                if let Some(Object::Dictionary(_)) = shading_dict.get("Function") {
-                    if let Some(func_obj) = shading_dict.remove("Function") {
-                        let func_id = self.allocate_object_id();
-                        self.write_object(func_id, func_obj)?;
-                        shading_dict.set("Function", Object::Reference(func_id));
-                    }
-                }
-                let shading_id = self.allocate_object_id();
-                self.write_object(shading_id, Object::Dictionary(shading_dict))?;
+                let obj = Object::Dictionary(shading.to_pdf_dictionary()?);
+                let shading_id = self.write_shading_object(obj)?;
                 sh_dict.set(name, Object::Reference(shading_id));
             }
+
+            // Additive mesh (Type 4, stream) / conic (Type 1, dict) shadings
+            // (#407), emitted into the same /Shading resource.
+            let mut adv: Vec<(&String, &crate::graphics::AdvancedShading)> =
+                page.advanced_shadings().iter().collect();
+            adv.sort_by_key(|(name, _)| name.as_str());
+            for (name, shading) in adv {
+                let obj = shading.to_pdf_object()?;
+                let shading_id = self.write_shading_object(obj)?;
+                sh_dict.set(name, Object::Reference(shading_id));
+            }
+
             resources.set("Shading", Object::Dictionary(sh_dict));
         }
 
@@ -3471,6 +3473,44 @@ impl<W: Write> PdfWriter<W> {
         let id = ObjectId::new(self.next_object_id, 0);
         self.next_object_id += 1;
         id
+    }
+
+    /// Write a shading as an indirect object and return its id. For a
+    /// dictionary shading, an inline `/Function` (dictionary OR stream) is
+    /// first hoisted to its own indirect object: ISO 32000-1 §8.7.4.5.2 makes
+    /// functions normally indirect, and a stream in particular CANNOT be an
+    /// inline dictionary value (the conic Type 4 PostScript function would
+    /// otherwise be invalid PDF). A `FunctionBased` shading whose `/Function`
+    /// is an `Integer` placeholder is left untouched. Stream shadings (the
+    /// Type 4 mesh) are written directly.
+    fn write_shading_object(&mut self, obj: Object) -> Result<ObjectId> {
+        match obj {
+            Object::Dictionary(mut dict) => {
+                if matches!(
+                    dict.get("Function"),
+                    Some(Object::Dictionary(_)) | Some(Object::Stream(_, _))
+                ) {
+                    if let Some(func_obj) = dict.remove("Function") {
+                        let func_id = self.allocate_object_id();
+                        self.write_object(func_id, func_obj)?;
+                        dict.set("Function", Object::Reference(func_id));
+                    }
+                }
+                let shading_id = self.allocate_object_id();
+                self.write_object(shading_id, Object::Dictionary(dict))?;
+                Ok(shading_id)
+            }
+            stream @ Object::Stream(_, _) => {
+                let shading_id = self.allocate_object_id();
+                self.write_object(shading_id, stream)?;
+                Ok(shading_id)
+            }
+            other => {
+                let shading_id = self.allocate_object_id();
+                self.write_object(shading_id, other)?;
+                Ok(shading_id)
+            }
+        }
     }
 
     /// Get catalog_id, returning error if not initialized

--- a/oxidize-pdf-core/tests/page_shadings_test.rs
+++ b/oxidize-pdf-core/tests/page_shadings_test.rs
@@ -16,8 +16,8 @@
 //!     from `/Resources/Shading/<Name>`.
 
 use oxidize_pdf::graphics::{
-    AxialShading, Color, ColorStop, FunctionBasedShading, Point as ShadingPoint, RadialShading,
-    ShadingDefinition,
+    AxialShading, Color, ColorStop, ConicShading, FreeFormGouraudShading, FunctionBasedShading,
+    GouraudVertex, Point as ShadingPoint, RadialShading, ShadingDefinition,
 };
 use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::{ParseOptions, PdfReader};
@@ -398,5 +398,203 @@ fn paint_shading_emits_sh_operator_in_content_stream() {
     assert!(
         content.contains("/Sh1 sh"),
         "content stream must paint the shading with `/Sh1 sh`:\n{content}"
+    );
+}
+
+// ── Issue #407 Phase 3: mesh (Type 4) + conic (Type 1) writer integration ──
+
+/// The exact 3-vertex RGB mesh used across the integration tests (matches the
+/// unit-level packing fixture: 24 bytes, 8 per vertex).
+fn make_mesh() -> FreeFormGouraudShading {
+    FreeFormGouraudShading::new(
+        "Mesh1".to_string(),
+        "DeviceRGB".to_string(),
+        vec![0.0, 100.0, 0.0, 100.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        vec![
+            GouraudVertex {
+                flag: 0,
+                x: 10.0,
+                y: 20.0,
+                color: Color::Rgb(1.0, 0.0, 0.0),
+            },
+            GouraudVertex {
+                flag: 1,
+                x: 50.0,
+                y: 50.0,
+                color: Color::Rgb(0.0, 1.0, 0.0),
+            },
+            GouraudVertex {
+                flag: 1,
+                x: 90.0,
+                y: 10.0,
+                color: Color::Rgb(0.0, 0.0, 1.0),
+            },
+        ],
+    )
+}
+
+fn make_conic() -> ConicShading {
+    ConicShading::new(
+        "Conic1".to_string(),
+        ShadingPoint::new(50.0, 50.0),
+        [0.0, 100.0, 0.0, 100.0],
+        vec![
+            ColorStop::new(0.0, Color::red()),
+            ColorStop::new(1.0, Color::blue()),
+        ],
+    )
+}
+
+const MESH_PACKED_BYTES: [u8; 24] = [
+    0x00, 0x19, 0x9A, 0x33, 0x33, 0xFF, 0x00, 0x00, // v0: flag0, x10, y20, red
+    0x01, 0x80, 0x00, 0x80, 0x00, 0x00, 0xFF, 0x00, // v1: flag1, x50, y50, green
+    0x01, 0xE6, 0x66, 0x19, 0x9A, 0x00, 0x00, 0xFF, // v2: flag1, x90, y10, blue
+];
+
+/// C1: a mesh and a conic registered on the same page both surface under
+/// `/Resources/Shading`. The mesh resolves to an indirect STREAM with
+/// `/ShadingType 4`; the conic resolves to an indirect DICTIONARY with
+/// `/ShadingType 1` whose `/Function` was hoisted to an indirect Type 4
+/// PostScript stream.
+#[test]
+fn page_mesh_and_conic_appear_in_shading_resource() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_mesh_shading("Mesh1", make_mesh()).expect("mesh");
+    page.add_conic_shading("Conic1", make_conic())
+        .expect("conic");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+
+    // Mesh → indirect stream, ShadingType 4.
+    let (mn, mg) = sh
+        .get("Mesh1")
+        .and_then(|o| o.as_reference())
+        .expect("/Mesh1 must be an indirect reference");
+    let mesh_obj = reader.get_object(mn, mg).expect("resolve Mesh1").clone();
+    let mesh_stream = mesh_obj
+        .as_stream()
+        .expect("Type 4 mesh must resolve to a stream object");
+    assert_eq!(
+        mesh_stream
+            .dict
+            .get("ShadingType")
+            .and_then(|o| o.as_integer()),
+        Some(4),
+        "mesh /ShadingType must be 4"
+    );
+
+    // Conic → indirect dict, ShadingType 1, /Function hoisted to a stream.
+    let (cn, cg) = sh
+        .get("Conic1")
+        .and_then(|o| o.as_reference())
+        .expect("/Conic1 must be an indirect reference");
+    let conic_obj = reader.get_object(cn, cg).expect("resolve Conic1").clone();
+    let conic_dict = conic_obj.as_dict().expect("conic must resolve to a dict");
+    assert_eq!(
+        conic_dict.get("ShadingType").and_then(|o| o.as_integer()),
+        Some(1),
+        "conic /ShadingType must be 1 (function-based)"
+    );
+    let (fnn, fng) = conic_dict
+        .get("Function")
+        .and_then(|o| o.as_reference())
+        .expect("conic /Function must be an indirect reference, not inline");
+    let func_obj = reader
+        .get_object(fnn, fng)
+        .expect("resolve conic /Function")
+        .clone();
+    let func_stream = func_obj
+        .as_stream()
+        .expect("conic /Function must be a Type 4 PostScript stream");
+    assert_eq!(
+        func_stream
+            .dict
+            .get("FunctionType")
+            .and_then(|o| o.as_integer()),
+        Some(4),
+        "conic /Function must be a Type 4 calculator"
+    );
+}
+
+/// C3: the packed mesh vertex bytes survive the full write → parse pipeline
+/// byte-for-byte (no compression or serialisation corruption).
+#[test]
+fn page_mesh_stream_bytes_survive_roundtrip() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_mesh_shading("Mesh1", make_mesh()).expect("mesh");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+    let (mn, mg) = sh
+        .get("Mesh1")
+        .and_then(|o| o.as_reference())
+        .expect("/Mesh1 reference");
+    let mesh_obj = reader.get_object(mn, mg).expect("resolve Mesh1").clone();
+    let stream = mesh_obj.as_stream().expect("mesh stream");
+    let data = stream
+        .decode(&ParseOptions::default())
+        .expect("decode mesh stream");
+    assert_eq!(
+        data,
+        MESH_PACKED_BYTES.to_vec(),
+        "packed mesh vertex bytes must round-trip through the writer unchanged"
+    );
+}
+
+/// C2 regression: the conic PostScript program survives the pipeline with its
+/// angular `atan` operator and both stop colours, decoded from the hoisted
+/// Type 4 function stream (content verification, not a smoke test).
+#[test]
+fn conic_function_stream_contains_atan_and_stop_colors() {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_conic_shading("Conic1", make_conic())
+        .expect("conic");
+    doc.add_page(page);
+
+    let bytes = doc.to_bytes().expect("serialize");
+    let mut reader = PdfReader::new(Cursor::new(&bytes)).expect("parse");
+    let sh = resolve_page0_shading_dict(&mut reader);
+    let (cn, cg) = sh
+        .get("Conic1")
+        .and_then(|o| o.as_reference())
+        .expect("/Conic1 reference");
+    let conic_dict = reader
+        .get_object(cn, cg)
+        .expect("resolve Conic1")
+        .clone()
+        .as_dict()
+        .expect("conic dict")
+        .clone();
+    let (fnn, fng) = conic_dict
+        .get("Function")
+        .and_then(|o| o.as_reference())
+        .expect("conic /Function reference");
+    let func_stream = reader
+        .get_object(fnn, fng)
+        .expect("resolve /Function")
+        .clone();
+    let func_stream = func_stream.as_stream().expect("Type 4 function stream");
+    let code = func_stream
+        .decode(&ParseOptions::default())
+        .expect("decode function stream");
+    let code = String::from_utf8(code).expect("PostScript is ASCII");
+
+    assert!(
+        code.contains("atan"),
+        "conic function must be angular:\n{code}"
+    );
+    // red→blue over DeviceRGB: the ramp encodes deltas (-1, 0, 1) with starts
+    // (1, 0, 0); the "-1 mul 1 add" for the red channel is the tell.
+    assert!(
+        code.contains("-1 mul 1 add"),
+        "conic ramp must carry the red→blue interpolation:\n{code}"
     );
 }


### PR DESCRIPTION
Addresses #407.

## Summary

Adds two shading types requested in #407, both **additive and non-breaking** (verified by `cargo-semver-checks`: 4.0.1 → 4.1.0, 0 breaking changes). Ships as a **minor (4.1.0)**, not a major — breaking changes stay batched for a future 5.0.0 bundle.

- **Type 4 (free-form Gouraud triangle mesh)** — `FreeFormGouraudShading` + `GouraudVertex`, registered via `Page::add_mesh_shading`, emitted as a PDF stream (ISO 32000-1 §8.7.4.5.5): shading dict + byte-aligned packed vertex data (configurable `BitsPerCoordinate`/`BitsPerComponent`/`BitsPerFlag` + `Decode`).
- **Exact conic (angular) gradient** — `ConicShading`, registered via `Page::add_conic_shading`, emitted as a Type 1 function-based shading whose `/Function` is a real Type 4 PostScript calculator (angle around a center → colour ramp). Resolution-independent, **not** a mesh approximation — this is the lossless vectorial path the "conic-gradient" gap needs.

The pre-existing hollow `FunctionBasedShading` placeholder and the public `ShadingDefinition` enum are **untouched**; folding the new shadings into the enum and removing the placeholder are queued for the next major.

## Notable

- **CI gate added**: `cargo-semver-checks` job — a breaking change slipped into a minor once (#375) with no gate. With ~17K crates.io downloads and an anonymous third-party consumer base, this mechanically blocks any undeclared breaking change from reaching a minor.
- **Writer bug fixed**: the `/Function` indirect-hoist only fired for a `Dictionary` value, so a stream `/Function` (the conic PostScript) would have stayed inline inside a dictionary — invalid PDF. `write_shading_object` now hoists `Dictionary` OR `Stream` functions and writes stream shadings directly.

## Testing

- 15 TDD cycles for the mesh (exact-byte assertions), full PostScript generation for the conic (exact-string/structure), integration tests (write → parse): mesh surfaces as a ShadingType-4 stream, conic as a ShadingType-1 dict with the `/Function` hoisted to a Type 4 stream, packed mesh bytes survive round-trip byte-for-byte, conic function stream decodes to PostScript carrying `atan`.
- Quality review (quality-rust) applied: 4 real bugs + 3 minor fixed with reproducing tests first — two reachable panics in mesh validation (color/space mismatch, inverted Decode) and two silent conic-ramp correctness bugs (2-stop positions ignored, equal positions → `0 div`), all turned into fail-safe `PdfError::InvalidStructure`.
- `cargo test -p oxidize-pdf --lib graphics::shadings` 62/0, `--test page_shadings_test` 10/0, full crate suite green, `clippy --all -D warnings` clean, `cargo-semver-checks` clean.
- New example `mesh_and_conic_shading` produces a valid PDF (ShadingType 4/1 + FunctionType 4 + `atan`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
