### PR TITLE
fix(extraction): require column-gap alignment before merging lines into a block (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `reorder_columns` no longer merges unrelated normal-leading lines that each
+  contain a wide gap at a different X into a false column block, which shredded
+  tokens (e.g. CNPJ identifiers in label/value forms). Column blocks now require
+  the wide gaps to align horizontally across rows (#422).
 - **`reorder_columns` no longer shreds dense prose** (#417, follow-up to #408).
   `detect_and_sort_columns` grouped lines with a fixed `newline_threshold` band
   keyed to the previous fragment, merging tight-leading prose into one

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1792,6 +1792,24 @@ impl TextExtractor {
             })
         };
 
+        // Two column boundaries within this many points are the same corridor.
+        // Shared by the alignment gate (#422) and the boundary-dedup step below (#403).
+        const COLUMN_ALIGN_TOL: f64 = 10.0;
+
+        // Wide-gap boundary X positions of a line: the midpoint of each internal gap
+        // wider than `column_threshold`. Non-empty iff `line_is_columnar(line)`.
+        let line_boundaries = |line: &[usize]| -> Vec<f64> {
+            let mut bs = Vec::new();
+            for w in line.windows(2) {
+                let (a, b) = (&fragments[w[0]], &fragments[w[1]]);
+                let gap = b.x - (a.x + a.width);
+                if gap > self.options.column_threshold {
+                    bs.push(a.x + a.width + gap / 2.0);
+                }
+            }
+            bs
+        };
+
         // Segment lines into blocks: consecutive columnar lines share one segment
         // id (a multi-line column block); every other line is its own segment.
         // Segment ids are monotonic top-to-bottom, so a later stable sort keyed on
@@ -1799,26 +1817,34 @@ impl TextExtractor {
         let n = fragments.len();
         let mut segment_of = vec![0usize; n];
         let mut column_of = vec![0usize; n];
+
         let mut has_columnar_block = false;
         let mut seg_id = 0usize;
         let mut prev_columnar = false;
         let mut prev_y = f64::INFINITY;
         let mut prev_h = 0.0_f64;
+        let mut prev_boundaries: Vec<f64> = Vec::new();
 
         for (li, line) in lines.iter().enumerate() {
-            let columnar = line_is_columnar(line);
+            let boundaries = line_boundaries(line);
+            let columnar = !boundaries.is_empty();
             let head = &fragments[line[0]];
             // Two consecutive columnar lines share a multi-line column block only
             // when they are spaced like real table rows — at least a line height
             // apart. Tight-leading wrapped prose whose lines each happen to hold a
-            // wide (>`column_threshold`) gap forms a common whitespace corridor and
-            // is geometrically indistinguishable from a 2-column layout; merging it
-            // into a block and reordering column-major shredded the prose (#417).
-            // Below the row-height threshold each such line self-segments instead,
-            // and a single columnar line's column-major order equals its reading
-            // order, so the text is left intact.
+            // wide gap forms a common whitespace corridor and is geometrically
+            // indistinguishable from a 2-column layout; merging it and reordering
+            // column-major shredded the prose (#417).
             let row_spaced = (prev_y - head.y).abs() >= head.height.max(prev_h);
-            if li > 0 && !(columnar && prev_columnar && row_spaced) {
+            // ...and only when their wide gaps ALIGN horizontally. A real column
+            // is a whitespace corridor shared across rows; several unrelated wide
+            // gaps at different X (e.g. a label/value form with varying label
+            // lengths) are not a table. Without this, pooled boundaries from
+            // unaligned gaps shredded any token straddling one (#422).
+            let aligned = prev_boundaries
+                .iter()
+                .any(|&p| boundaries.iter().any(|&c| (p - c).abs() < COLUMN_ALIGN_TOL));
+            if li > 0 && !(columnar && prev_columnar && row_spaced && aligned) {
                 seg_id += 1;
             }
             for &i in line {
@@ -1827,6 +1853,7 @@ impl TextExtractor {
             prev_columnar = columnar;
             prev_y = head.y;
             prev_h = head.height;
+            prev_boundaries = boundaries;
         }
 
         // For each columnar block (a segment whose lines are columnar), derive
@@ -1853,7 +1880,10 @@ impl TextExtractor {
                     let gap = b.x - (a.x + a.width);
                     if gap > self.options.column_threshold {
                         let boundary = a.x + a.width + gap / 2.0;
-                        if !boundaries.iter().any(|&x| (x - boundary).abs() < 10.0) {
+                        if !boundaries
+                            .iter()
+                            .any(|&x| (x - boundary).abs() < COLUMN_ALIGN_TOL)
+                        {
                             boundaries.push(boundary);
                         }
                     }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -81,6 +81,12 @@ pub struct ExtractionOptions {
     /// geometrically indistinguishable from tight-leading prose that merely
     /// contains a wide gap, so they are intentionally left in reading order
     /// rather than risk shredding prose (issue #417); text is never corrupted.
+    ///
+    /// Column blocks require gaps that align horizontally across rows: a set of
+    /// unrelated wide gaps at different X (e.g. a label/value form with varying
+    /// label lengths) is left in reading order, never reflowed (#422). A genuine
+    /// table whose column corridor drifts more than ~10pt between rows may also
+    /// be left un-reordered; text is never corrupted.
     pub reorder_columns: bool,
     /// Stop accumulating decoded text for a page once this many bytes have been
     /// collected, bounding the per-page peak memory of extraction. The limit is

--- a/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
+++ b/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
@@ -1,0 +1,140 @@
+//! Issue #422 — `detect_and_sort_columns` merged consecutive *columnar* lines
+//! into one block whenever each line independently had a wide gap and the lines
+//! were row-spaced (the #417 guard). It never checked that the wide gaps ALIGN
+//! horizontally. A label/value form with varying label lengths has a wide gap on
+//! every line, but at a different X per line — not a table, just unrelated gaps.
+//! Merging them pooled boundaries from unaligned gaps and shredded any token
+//! straddling one. Fix: require a shared boundary X (within the dedup tolerance)
+//! before merging. No smoke tests: assert the token stays intact AND the lines
+//! keep reading order.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Write;
+
+fn escape(ch: char) -> String {
+    match ch {
+        '(' => "\\(".to_string(),
+        ')' => "\\)".to_string(),
+        '\\' => "\\\\".to_string(),
+        _ => ch.to_string(),
+    }
+}
+
+/// One glyph per `Tj`. A `|` inserts a 65pt jump (above the 50pt
+/// `column_threshold`) with no glyph — a wide gap whose X depends on how many
+/// glyphs preceded it, so varying label lengths put the gap at varying X.
+fn emit_line(content: &mut Vec<u8>, text: &str, start_x: f64, y: f64, advance: f64) {
+    let mut x = start_x;
+    for ch in text.chars() {
+        if ch == '|' {
+            x += 65.0;
+            continue;
+        }
+        let escaped = escape(ch);
+        content.extend_from_slice(
+            format!("BT\n/F1 10 Tf\n{x:.2} {y:.2} Td\n({escaped}) Tj\nET\n").as_bytes(),
+        );
+        x += advance;
+    }
+}
+
+fn wrap_pdf(content: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = Vec::new();
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    let mut obj4 = Vec::new();
+    write!(obj4, "4 0 obj\n<< /Length {} >>\nstream\n", content.len()).unwrap();
+    obj4.extend_from_slice(content);
+    obj4.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(&obj4);
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    );
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n");
+    writeln!(pdf, "0 {}", offsets.len() + 1).unwrap();
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        writeln!(pdf, "{:010} 00000 n ", off).unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+        offsets.len() + 1,
+        xref_offset
+    )
+    .unwrap();
+    pdf
+}
+
+/// Five form lines, normal leading (14pt > line height), each `label|value`.
+/// Labels differ in length, so the wide gap lands at a different X per line —
+/// no shared column corridor. The ID line carries a CNPJ-shaped token.
+fn build_form_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    let fields = [
+        ("Name", "SomeoneExample"),
+        ("AddressLineOneHere", "SomeStreet123"),
+        ("ID", "12.345.678/0001-99"),
+        ("Department", "Sales"),
+        ("Notes", "noneprovidedtoday"),
+    ];
+    let mut y = 700.0;
+    for (label, value) in fields {
+        emit_line(&mut content, &format!("{label}|{value}"), 72.0, y, 6.0);
+        y -= 14.0;
+    }
+    wrap_pdf(&content)
+}
+
+fn extract_form(reorder: bool) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_form_pdf()),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(ExtractionOptions {
+        reorder_columns: reorder,
+        ..Default::default()
+    })
+    .extract_from_page(&doc, 0)
+    .expect("extraction should succeed")
+    .text
+}
+
+const TOKEN: &str = "12.345.678/0001-99";
+
+#[test]
+fn reorder_columns_keeps_token_intact_on_misaligned_form() {
+    let text = extract_form(true);
+    assert!(
+        text.contains(TOKEN),
+        "misaligned form gaps must not be treated as a column block; token \
+         `{TOKEN}` was shredded. Got: {text:?}"
+    );
+}
+
+#[test]
+fn reorder_columns_preserves_reading_order_on_misaligned_form() {
+    // Unaligned lines stay singletons → left in reading order top-to-bottom.
+    let text = extract_form(true);
+    let name = text.find("Name").expect("Name present");
+    let addr = text.find("AddressLineOneHere").expect("Address present");
+    let id = text.find("ID").expect("ID present");
+    let dept = text.find("Department").expect("Department present");
+    let notes = text.find("Notes").expect("Notes present");
+    assert!(
+        name < addr && addr < id && id < dept && dept < notes,
+        "unaligned form lines must keep reading order. Got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
+++ b/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
@@ -216,9 +216,11 @@ fn extract_two_row(offset: f64) -> String {
 
 #[test]
 fn aligned_within_tolerance_merges_column_major() {
-    // Boundary drift ~4pt (< 10) → same corridor → merge → column-major:
-    // both left cells (Aa, Cc) before both right cells (Bb, Dd).
-    let text = extract_two_row(2.0);
+    // Boundary drift ~8pt: still inside the 10pt `COLUMN_ALIGN_TOL` → same
+    // corridor → merge → column-major (both left cells Aa, Cc before both right
+    // cells Bb, Dd). Chosen close to the tolerance edge so this also pins the
+    // constant: a regression shrinking `COLUMN_ALIGN_TOL` below ~8pt breaks it.
+    let text = extract_two_row(8.0);
     let cc = text.find("Cc").expect("Cc present");
     let bb = text.find("Bb").expect("Bb present");
     assert!(

--- a/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
+++ b/oxidize-pdf-core/tests/issue_422_column_boundary_alignment_test.rs
@@ -138,3 +138,106 @@ fn reorder_columns_preserves_reading_order_on_misaligned_form() {
         "unaligned form lines must keep reading order. Got: {text:?}"
     );
 }
+
+/// Real two-column layout: both cells' wide gap sits at the SAME X across rows.
+/// The alignment gate must still merge these and reflow column-major.
+fn build_aligned_table_pdf(row_pitch: f64, right_x: f64) -> Vec<u8> {
+    let mut content = Vec::new();
+    let rows = [("Alpha", "Beta"), ("Gamma", "Delta"), ("Epsilon", "Zeta")];
+    let mut y = 700.0;
+    for (left, right) in rows {
+        emit_line(&mut content, left, 72.0, y, 6.0);
+        emit_line(&mut content, right, right_x, y, 6.0);
+        y -= row_pitch;
+    }
+    wrap_pdf(&content)
+}
+
+fn extract_table(row_pitch: f64, right_x: f64) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_aligned_table_pdf(row_pitch, right_x)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    })
+    .extract_from_page(&doc, 0)
+    .expect("extraction should succeed")
+    .text
+}
+
+#[test]
+fn aligned_two_columns_still_reflow_column_major() {
+    // Right cells all start at x=300 → gaps align → block merges → column-major.
+    let text = extract_table(14.0, 300.0);
+    let left_last = text.find("Epsilon").expect("left column present");
+    let right_first = text.find("Beta").expect("right column present");
+    assert!(
+        left_last < right_first,
+        "aligned real columns must still reflow column-major (all left before any \
+         right). The #422 alignment gate must not suppress genuine tables. Got: {text:?}"
+    );
+}
+
+/// Threshold: build a 2-row table whose second row's right cell is offset so the
+/// gap boundary drifts by ~`offset` points from the first row. Within tolerance
+/// (<10) → merges → column-major; outside (>10) → not a block → reading order.
+fn build_two_row_offset_pdf(offset: f64) -> Vec<u8> {
+    let mut content = Vec::new();
+    // Row 1: left "Aa" at 72, right "Bb" at 300.
+    emit_line(&mut content, "Aa", 72.0, 700.0, 6.0);
+    emit_line(&mut content, "Bb", 300.0, 700.0, 6.0);
+    // Row 2: left "Cc" at 72, right "Dd" at 300+offset (left width equal, so the
+    // gap midpoint shifts by offset/2 relative to row 1... use 2*offset so the
+    // boundary shift equals `offset`).
+    emit_line(&mut content, "Cc", 72.0, 686.0, 6.0);
+    emit_line(&mut content, "Dd", 300.0 + 2.0 * offset, 686.0, 6.0);
+    wrap_pdf(&content)
+}
+
+fn extract_two_row(offset: f64) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_two_row_offset_pdf(offset)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::with_options(ExtractionOptions {
+        reorder_columns: true,
+        ..Default::default()
+    })
+    .extract_from_page(&doc, 0)
+    .expect("extraction should succeed")
+    .text
+}
+
+#[test]
+fn aligned_within_tolerance_merges_column_major() {
+    // Boundary drift ~4pt (< 10) → same corridor → merge → column-major:
+    // both left cells (Aa, Cc) before both right cells (Bb, Dd).
+    let text = extract_two_row(2.0);
+    let cc = text.find("Cc").expect("Cc present");
+    let bb = text.find("Bb").expect("Bb present");
+    assert!(
+        cc < bb,
+        "rows within alignment tolerance must merge and reflow column-major \
+         (left column Aa,Cc before right column Bb,Dd). Got: {text:?}"
+    );
+}
+
+#[test]
+fn misaligned_beyond_tolerance_stays_reading_order() {
+    // Boundary drift ~40pt (> 10) → not a shared corridor → not a block →
+    // reading order: row 1 (Aa, Bb) before row 2 (Cc, Dd).
+    let text = extract_two_row(20.0);
+    let bb = text.find("Bb").expect("Bb present");
+    let cc = text.find("Cc").expect("Cc present");
+    assert!(
+        bb < cc,
+        "rows whose gaps drift beyond tolerance must stay in reading order \
+         (row 1 Bb before row 2 Cc), never merged into a false block. Got: {text:?}"
+    );
+}


### PR DESCRIPTION
Addresses #422.

Fourth independent failure mode in `detect_and_sort_columns` (opt-in `reorder_columns`), after #403/#408/#417.

## Problem

The line-grouping merged consecutive "columnar" lines into one reorder block whenever each line independently had a wide gap and the lines were row-spaced (`row_spaced`, the #417 guard) — but it never checked the wide gaps **align at the same X**. A label/value form with varying label lengths has a wide gap on every line, each at a different X. Those lines merged into a false block; boundaries pooled from unaligned gaps then shredded any token straddling one:

```
ID 12.345.678/0001-99        ->  12. / 345.678/000 / 1-99   (scattered)
```

`row_spaced` only validates vertical spacing, so normal-leading forms (not the tight-leading case #417 fixed) still merged.

## Fix

Add horizontal alignment as a precondition for merging two consecutive columnar lines into a block: a wide-gap boundary of one must align with a wide-gap boundary of the other within the existing boundary-dedup tolerance (`COLUMN_ALIGN_TOL = 10.0`, now named and reused). Unaligned lines stay singletons — a single columnar line's column-major order equals its reading order, so the text is left intact. Genuine tables (aligned gaps row after row) still merge and reflow column-major.

Confined to the segmentation phase of `detect_and_sort_columns`; boundary collection, column assignment, and the stable permutation are unchanged. Default flat extraction (opt-out) is byte-identical.

**Accepted trade-off** (same posture as #417, documented in the `reorder_columns` rustdoc): a real table whose column corridor drifts >~10pt between rows may be left un-reordered or split into sub-blocks; text is never corrupted.

## Tests

`tests/issue_422_column_boundary_alignment_test.rs` (5): misaligned-form token intact + reading order; aligned real 2-column table still reflows column-major; within-tolerance merges (pinned near the 10pt edge at ~8pt); beyond-tolerance stays reading order. Ablation-confirmed the misaligned/repro tests fail with the gate disabled (genuine regression guards, not tautologies).

## Verification

- `cargo-semver-checks`: 196 checks, 0 breaking → **SemVer PATCH** (no public API change).
- No regression: #403 / #408 / #417 / #389, two-column writer roundtrip, `partition_table_detection`, `table_extraction_real_pdfs`, lib `text::` 799, full lib 6662.
- clippy `--all-features -D warnings`, fmt, MSRV 1.88 build — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
