### PR TITLE
Fix UTF-8 boundary panic in catalog recovery

### DIFF
--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -1221,8 +1221,12 @@ impl XRefTable {
                         let before_obj_str = String::from_utf8_lossy(before_obj);
                         let trimmed = before_obj_str.trim_end();
 
-                        if let Some(digit_start) = trimmed.rfind(|c: char| !c.is_ascii_digit()) {
-                            let num_str = trimmed[digit_start + 1..].trim();
+                        if let Some((digit_start, ch)) = trimmed
+                            .char_indices()
+                            .rev()
+                            .find(|(_, c)| !c.is_ascii_digit())
+                        {
+                            let num_str = trimmed[digit_start + ch.len_utf8()..].trim();
                             if !num_str.is_empty() {
                                 if let Ok(obj_num) = num_str.parse::<u32>() {
                                     tracing::debug!(

--- a/oxidize-pdf-core/tests/issue_427_char_boundary_test.rs
+++ b/oxidize-pdf-core/tests/issue_427_char_boundary_test.rs
@@ -1,0 +1,26 @@
+//! Regression test for issue #427.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use std::io::Cursor;
+
+#[test]
+fn malformed_catalog_scan_does_not_panic_on_invalid_utf8() {
+    let bytes: &[u8] = &[
+        37, 80, 68, 70, 45, 49, 53, 255, 255, 32, 48, 32, 111, 98, 106, 10, 60, 60, 47, 84, 121,
+        112, 101, 47, 67, 97, 116, 97, 108, 111, 103, 37, 110, 116, 10, 49, 32, 48, 32, 111, 98,
+        106, 116,
+    ];
+
+    let result = std::panic::catch_unwind(|| {
+        PdfReader::new_with_options(Cursor::new(bytes), ParseOptions::lenient())
+    });
+
+    assert!(
+        result.is_ok(),
+        "malformed input must return a parse result instead of panicking"
+    );
+    assert!(
+        result.unwrap().is_err(),
+        "the malformed PDF should be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

Prevent malformed PDFs from panicking during the extreme last-resort catalog scan. The scan now advances past the full non-digit character before slicing, so lossy UTF-8 replacement characters cannot produce an invalid byte boundary.

Fixes #427

## Changes

- use `char_indices` and `len_utf8` when locating the catalog object number
- add a regression test using the minimized malformed input from the issue

## Testing

- [x] `cargo test -p oxidize-pdf --test issue_427_char_boundary_test`
- [x] `cargo test -p oxidize-pdf`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] New behavior is covered by a regression test that asserts the malformed PDF returns an error without panicking

## Checklist

- [x] Branch follows gitflow and targets `develop`
- [x] No public API changes
- [ ] CHANGELOG.md updated (not needed for this narrow parser bug fix)