### PR TITLE
test(invariants): proactive RAG contract invariants

### DIFF
--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -14,6 +14,8 @@
 //! grouping path with its own section logic and is NOT covered here (it needs an
 //! `ElementGraph`). Example guards live in `hybrid_chunking_graph_test.rs`.
 
+#[cfg(feature = "tiktoken")]
+use oxidize_pdf::pipeline::TiktokenCounter;
 use oxidize_pdf::pipeline::{
     ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
     HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, RagChunk, TableElementData,
@@ -21,6 +23,8 @@ use oxidize_pdf::pipeline::{
 };
 use proptest::prelude::*;
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "tiktoken")]
+use std::sync::{Arc, OnceLock};
 
 /// A generated element, before it is given its position-derived marker.
 #[derive(Debug, Clone)]
@@ -264,6 +268,54 @@ proptest! {
             let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
             let actual: BTreeSet<u32> = rag.page_numbers.iter().copied().collect();
             prop_assert_eq!(actual, expected, "chunk {} page set", i);
+        }
+    }
+}
+
+/// cl100k_base ships multi-MB rank tables; load once for the whole suite rather
+/// than per generated case.
+#[cfg(feature = "tiktoken")]
+fn tiktoken() -> Arc<TiktokenCounter> {
+    static C: OnceLock<Arc<TiktokenCounter>> = OnceLock::new();
+    C.get_or_init(|| Arc::new(TiktokenCounter::cl100k_base()))
+        .clone()
+}
+
+// Fewer cases than the other blocks: every case runs real BPE over the whole
+// chunk set, which is orders of magnitude slower than the word proxy.
+#[cfg(feature = "tiktoken")]
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I3-BPE — BUDGET UNDER THE INJECTED COUNTER: no chunk the chunker did not
+    /// itself flag oversized may exceed `max_tokens` when measured with the very
+    /// counter that governed the split.
+    ///
+    /// The split decision sums per-element counts while the stamp counts the
+    /// joined text (`hybrid_chunking.rs:296,308` vs `:271-277`). That identity
+    /// holds for whitespace counting and not for BPE.
+    #[test]
+    fn no_chunk_exceeds_its_budget_under_bpe(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let counter = tiktoken();
+        let max_tokens = config.max_tokens;
+        let chunks = HybridChunker::new(config)
+            .with_token_counter(counter.clone())
+            .chunk(&elements);
+        for (i, c) in chunks.iter().enumerate() {
+            if c.is_oversized() {
+                continue;
+            }
+            let measured = counter.count(&c.text());
+            prop_assert!(
+                measured <= max_tokens,
+                "chunk {}: {} BPE tokens over a {}-token budget",
+                i,
+                measured,
+                max_tokens
+            );
         }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -1,0 +1,180 @@
+//! Chunking-layer invariants, stated from the RAG contract (`the chunk set is a
+//! faithful partition of the input text, and every chunk is fit to be
+//! vectorized`), not from a reported bug. `HybridChunker::chunk` is a pure
+//! function of (elements, config), so the generator is cheap and the input space
+//! is large: element types × lengths × headings × five config dimensions × two
+//! token counters.
+//!
+//! Layer rule (see spec §4): an invariant lives at the cheapest layer where it
+//! is NOT tautological. `chunk_index` and `heading_path` are supplied by the
+//! caller at this layer, so asserting them here would test the test. They live
+//! in `prop_rag_e2e_invariants.rs`.
+//!
+//! Known gap, accepted: `HybridChunker::chunk_with_graph` is a second public
+//! grouping path with its own section logic and is NOT covered here (it needs an
+//! `ElementGraph`). Example guards live in `hybrid_chunking_graph_test.rs`.
+
+use oxidize_pdf::pipeline::{
+    ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
+    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, TableElementData,
+};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+/// A generated element, before it is given its position-derived marker.
+#[derive(Debug, Clone)]
+struct ElemSpec {
+    /// 0=Paragraph 1=ListItem 2=KeyValue (inline, mergeable);
+    /// 3=Title 4=Table 5=CodeBlock (structural, always start a new chunk).
+    kind: u8,
+    words: usize,
+    page: u32,
+    has_heading: bool,
+}
+
+fn elem_spec() -> impl Strategy<Value = ElemSpec> {
+    (0u8..6u8, 1usize..=60usize, 0u32..=3u32, any::<bool>()).prop_map(
+        |(kind, words, page, has_heading)| ElemSpec {
+            kind,
+            words,
+            page,
+            has_heading,
+        },
+    )
+}
+
+/// Build the element for `s` at input position `idx`.
+///
+/// The text opens with the unique marker `E{idx}_`. Markers are prefix-free
+/// thanks to the trailing `_` and a body that never contains `_`, so
+/// `text.contains("E1_")` cannot be satisfied by `E11_`.
+///
+/// Every fifth word ends in `.` so the text carries real sentence boundaries —
+/// without them `split_by_sentences` returns the whole text as one fragment and
+/// the oversized-split path (`hybrid_chunking.rs:337-356`) is never exercised.
+fn make_element(s: &ElemSpec, idx: usize) -> Element {
+    let body = (0..s.words)
+        .map(|w| {
+            if w % 5 == 4 {
+                format!("w{w}.")
+            } else {
+                format!("w{w}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let text = format!("E{idx}_ {body}");
+    let metadata = ElementMetadata {
+        page: s.page,
+        parent_heading: s.has_heading.then(|| format!("H{idx}")),
+        ..Default::default()
+    };
+    match s.kind {
+        0 => Element::Paragraph(ElementData { text, metadata }),
+        1 => Element::ListItem(ElementData { text, metadata }),
+        2 => Element::KeyValue(KeyValueElementData {
+            key: text,
+            value: String::from("v"),
+            metadata,
+        }),
+        3 => Element::Title(ElementData { text, metadata }),
+        4 => Element::Table(TableElementData::new(vec![vec![text]], metadata)),
+        _ => Element::CodeBlock(ElementData { text, metadata }),
+    }
+}
+
+fn element_seq() -> impl Strategy<Value = Vec<Element>> {
+    prop::collection::vec(elem_spec(), 1..=12).prop_map(|specs| {
+        specs
+            .iter()
+            .enumerate()
+            .map(|(i, s)| make_element(s, i))
+            .collect()
+    })
+}
+
+/// `max_tokens` in 4..=64 against elements of 1..=60 words: the budget is
+/// routinely smaller than a single element, so the flush, the type-boundary and
+/// the oversized-split paths all fire.
+fn chunk_config() -> impl Strategy<Value = HybridChunkConfig> {
+    (
+        4usize..=64usize,
+        any::<bool>(),
+        any::<bool>(),
+        prop_oneof![
+            Just(MergePolicy::SameTypeOnly),
+            Just(MergePolicy::AnyInlineContent)
+        ],
+        prop_oneof![
+            Just(ContextMode::None),
+            Just(ContextMode::Heading),
+            Just(ContextMode::Contextual(ContextFormat::Labeled)),
+            Just(ContextMode::Contextual(ContextFormat::Prose)),
+        ],
+    )
+        .prop_map(
+            |(max_tokens, merge_adjacent, propagate_headings, merge_policy, context_mode)| {
+                HybridChunkConfig {
+                    max_tokens,
+                    overlap_tokens: 0,
+                    merge_adjacent,
+                    propagate_headings,
+                    merge_policy,
+                    context_mode,
+                }
+            },
+        )
+}
+
+fn chunk(elements: &[Element], config: HybridChunkConfig) -> Vec<HybridChunk> {
+    HybridChunker::new(config).chunk(elements)
+}
+
+/// Word -> occurrence count. Whitespace-split, so it is robust to the chunker's
+/// legitimate reflow of separators but still catches a dropped or duplicated word.
+fn word_multiset(s: &str) -> BTreeMap<&str, usize> {
+    let mut m = BTreeMap::new();
+    for w in s.split_whitespace() {
+        *m.entry(w).or_insert(0) += 1;
+    }
+    m
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I2a — IDENTITY: each input element's marker lands in exactly one chunk.
+    /// When an oversized element is split, its marker rides the first fragment,
+    /// so the count stays 1 either way.
+    #[test]
+    fn every_element_marker_lands_in_exactly_one_chunk(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let chunks = chunk(&elements, config);
+        for idx in 0..elements.len() {
+            let marker = format!("E{idx}_");
+            let hits = chunks.iter().filter(|c| c.text().contains(&marker)).count();
+            prop_assert_eq!(hits, 1, "marker {} landed in {} chunks", marker, hits);
+        }
+    }
+
+    /// I2b — CONSERVATION: the chunk set carries every input word exactly as
+    /// often as the input did. Identity alone (I2a) is satisfiable by dropping
+    /// everything but the first word of each element; conservation alone does
+    /// not localize. Both are required.
+    #[test]
+    fn chunk_text_conserves_every_input_word(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let input = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let chunks = chunk(&elements, config);
+        let output = chunks.iter().map(|c| c.text()).collect::<Vec<_>>().join("\n");
+        prop_assert_eq!(word_multiset(&output), word_multiset(&input));
+    }
+}

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -16,7 +16,8 @@
 
 use oxidize_pdf::pipeline::{
     ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
-    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, TableElementData,
+    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, RagChunk, TableElementData,
+    TokenCounter, WordProxyCounter,
 };
 use proptest::prelude::*;
 use std::collections::BTreeMap;
@@ -176,5 +177,44 @@ proptest! {
         let chunks = chunk(&elements, config);
         let output = chunks.iter().map(|c| c.text()).collect::<Vec<_>>().join("\n");
         prop_assert_eq!(word_multiset(&output), word_multiset(&input));
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I3 — HONEST BUDGET: the number stamped as a chunk's cost counts exactly
+    /// the text the library designates as embeddable.
+    ///
+    /// `RagChunk::full_text` is that designated text (`rag.rs:23`:
+    /// "use this for embedding generation") and `token_estimate` is documented
+    /// as its token count. If they disagree, a consumer sizing against a real
+    /// embedding model's hard limit is silently over budget: the provider
+    /// truncates the tail, the tail never reaches the vector, and that content
+    /// becomes unretrievable while still sitting in the store.
+    ///
+    /// PINNED: fails today — see issue #434. The property states the contract;
+    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
+    /// this becomes a permanent guard. Precedent: #430.
+    #[test]
+    #[ignore = "issue #434: token_estimate does not measure full_text"]
+    fn stamped_count_measures_the_text_designated_for_embedding(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let mode = config.context_mode;
+        let chunks = chunk(&elements, config);
+        for (i, c) in chunks.iter().enumerate() {
+            let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
+            let measured = WordProxyCounter.count(&rag.full_text);
+            prop_assert_eq!(
+                rag.token_estimate,
+                measured,
+                "chunk {}: stamped {} tokens, full_text measures {}",
+                i,
+                rag.token_estimate,
+                measured
+            );
+        }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -255,6 +255,12 @@ proptest! {
     /// I4b — PAGE TRACEABILITY: a chunk's `page_numbers` is exactly the union of
     /// its elements' pages. It is a filter field in the vector store: if it
     /// lies, a page-scoped query returns incomplete results and never errors.
+    ///
+    /// Scope: this guards the union/dedup/sort of pages the chunk carries, not
+    /// whether each element's page was assigned correctly — the chunker does not
+    /// assign pages, partition does. A mis-assigned page is I1's territory (E2E),
+    /// not observable here where both sides read `metadata().page` from the same
+    /// elements.
     #[test]
     fn chunk_pages_are_the_union_of_its_elements_pages(
         elements in element_seq(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -294,7 +294,12 @@ proptest! {
     /// The split decision sums per-element counts while the stamp counts the
     /// joined text (`hybrid_chunking.rs:296,308` vs `:271-277`). That identity
     /// holds for whitespace counting and not for BPE.
+    ///
+    /// PINNED: fails today — see issue #435. The property states the contract;
+    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
+    /// this becomes a permanent guard. Precedent: #430.
     #[test]
+    #[ignore = "issue #435: split decision sums per-element counts; BPE is not additive across the join"]
     fn no_chunk_exceeds_its_budget_under_bpe(
         elements in element_seq(),
         config in chunk_config(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -6,9 +6,12 @@
 //! token counters.
 //!
 //! Layer rule (see spec §4): an invariant lives at the cheapest layer where it
-//! is NOT tautological. `chunk_index` and `heading_path` are supplied by the
-//! caller at this layer, so asserting them here would test the test. They live
-//! in `prop_rag_e2e_invariants.rs`.
+//! is NOT tautological. `heading_path` is supplied by the caller at this layer,
+//! so asserting it here would test the test; it is guarded end-to-end by the
+//! breadcrumb property in `prop_rag_e2e_invariants.rs`. `chunk_index` is not
+//! separately guarded: production assigns it by `enumerate()`, so a
+//! contiguity assertion at any layer is structurally trivial (there is no input
+//! that makes it non-sequential) — not worth a property.
 //!
 //! Known gap, accepted: `HybridChunker::chunk_with_graph` is a second public
 //! grouping path with its own section logic and is NOT covered here (it needs an
@@ -256,11 +259,13 @@ proptest! {
     /// its elements' pages. It is a filter field in the vector store: if it
     /// lies, a page-scoped query returns incomplete results and never errors.
     ///
-    /// Scope: this guards the union/dedup/sort of pages the chunk carries, not
-    /// whether each element's page was assigned correctly — the chunker does not
-    /// assign pages, partition does. A mis-assigned page is I1's territory (E2E),
-    /// not observable here where both sides read `metadata().page` from the same
-    /// elements.
+    /// Scope: because both sides are compared as `BTreeSet`s, this guards
+    /// membership — no page dropped, none foreign — but not the dedup/ordering
+    /// of the production `Vec` (the set re-sorts and re-dedups both sides). Nor
+    /// does it guard whether each element's page was assigned correctly: the
+    /// chunker does not assign pages, partition does, so a mis-assigned page is
+    /// I1's territory (E2E), not observable here where both sides read
+    /// `metadata().page` from the same elements.
     #[test]
     fn chunk_pages_are_the_union_of_its_elements_pages(
         elements in element_seq(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -20,7 +20,7 @@ use oxidize_pdf::pipeline::{
     TokenCounter, WordProxyCounter,
 };
 use proptest::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A generated element, before it is given its position-derived marker.
 #[derive(Debug, Clone)]
@@ -215,6 +215,55 @@ proptest! {
                 rag.token_estimate,
                 measured
             );
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I4a — ORDER: chunks come out in input-element order. Consumers rebuild
+    /// context from neighbouring chunks, so a reordering silently changes what
+    /// an LLM is handed as "the surrounding text".
+    ///
+    /// Fragments of a split element carry no marker (only the first fragment
+    /// does), so they are skipped here; they are contiguous with their marked
+    /// head by construction.
+    #[test]
+    fn chunks_come_out_in_input_element_order(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let n = elements.len();
+        let chunks = chunk(&elements, config);
+        let firsts: Vec<usize> = chunks
+            .iter()
+            .filter_map(|c| {
+                let t = c.text();
+                (0..n).find(|i| t.contains(&format!("E{i}_")))
+            })
+            .collect();
+        let mut sorted = firsts.clone();
+        sorted.sort_unstable();
+        prop_assert_eq!(&firsts, &sorted, "chunk order does not follow input order");
+    }
+
+    /// I4b — PAGE TRACEABILITY: a chunk's `page_numbers` is exactly the union of
+    /// its elements' pages. It is a filter field in the vector store: if it
+    /// lies, a page-scoped query returns incomplete results and never errors.
+    #[test]
+    fn chunk_pages_are_the_union_of_its_elements_pages(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let mode = config.context_mode;
+        let chunks = chunk(&elements, config);
+        for (i, c) in chunks.iter().enumerate() {
+            let expected: BTreeSet<u32> =
+                c.elements().iter().map(|e| e.metadata().page).collect();
+            let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
+            let actual: BTreeSet<u32> = rag.page_numbers.iter().copied().collect();
+            prop_assert_eq!(actual, expected, "chunk {} page set", i);
         }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -46,6 +46,60 @@ fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
     doc.to_bytes().expect("serialize")
 }
 
+/// Build a single-page document of `paras_per_section.len()` sections. Each
+/// section is a 20pt bold title `T{s}_HEADING` followed by its 10pt paragraphs
+/// `S{n}_ ...`, where `n` is a document-global paragraph counter.
+///
+/// Returns the bytes plus `para_section[n] = s`, the true section of paragraph
+/// `n` — the ground truth the property checks the breadcrumb against.
+///
+/// Geometry: at most 3 sections × 3 paragraphs = 3 × (60 + 3×20) = 360pt from
+/// y=760, so the content never runs off an A4 page.
+///
+/// The 60pt title→body gap (vs. 20pt between body lines) is deliberate, not
+/// cosmetic: `merge_into_paragraphs` (src/text/extraction.rs) folds adjacent
+/// lines into one fragment using a threshold of `1.5 * median(line_height)`
+/// with no check on font-size/weight change between them. In a section with
+/// only 1-2 body paragraphs, title lines are a large enough fraction of the
+/// page that the median skews toward the *title's* line height, inflating the
+/// threshold enough to bridge a 40pt title→body gap and merge the title into
+/// its body (and, for the shortest documents, into the *next* section's title
+/// too) — producing a self-referential `heading_path` (the whole merged blob,
+/// not a heading string) that this property then correctly flags as a
+/// violation. 60pt clears that inflated threshold across the whole generated
+/// input space (verified: 1-3 sections × 1-3 paragraphs). This is a real,
+/// reproducible defect in the paragraph-merge heuristic — tracked in the task
+/// report, not papered over here.
+fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut y = 760.0;
+    let mut para_section = Vec::new();
+    let mut n = 0usize;
+
+    for (s, &count) in paras_per_section.iter().enumerate() {
+        page.text()
+            .set_font(Font::HelveticaBold, 20.0)
+            .at(72.0, y)
+            .write(&format!("T{s}_HEADING"))
+            .expect("write title");
+        y -= 60.0;
+        for _ in 0..count {
+            page.text()
+                .set_font(Font::Helvetica, 10.0)
+                .at(72.0, y)
+                .write(&format!("S{n}_ body text of this paragraph"))
+                .expect("write paragraph");
+            para_section.push(s);
+            n += 1;
+            y -= 20.0;
+        }
+    }
+
+    doc.add_page(page);
+    (doc.to_bytes().expect("serialize"), para_section)
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(64))]
 
@@ -79,6 +133,57 @@ proptest! {
             for m in markers {
                 let hits = chunks.iter().filter(|c| c.text.contains(m.as_str())).count();
                 prop_assert_eq!(hits, 1, "run {} landed in {} chunks", m, hits);
+            }
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I5 — BREADCRUMB FIDELITY: a chunk's `heading_path` never names a heading
+    /// that appears after the chunk's own content. `heading_path` is a filter
+    /// field in the vector store; a breadcrumb naming the wrong section returns
+    /// wrong passages for a section-scoped query and never errors.
+    ///
+    /// Honest precondition: the property only asserts on chunks that actually
+    /// carry a breadcrumb. If the classifier did not promote our 20pt bold runs
+    /// to `Title`, the case proves nothing about breadcrumbs and is discarded —
+    /// discarded here, in the open, not hidden behind a weaker assertion.
+    #[test]
+    fn breadcrumb_never_names_a_later_heading(
+        paras_per_section in prop::collection::vec(1usize..=3usize, 1..=3),
+    ) {
+        let (bytes, para_section) = build_titled_doc(&paras_per_section);
+        let doc = open(bytes);
+        let chunks = doc.rag_chunks().expect("rag_chunks");
+
+        prop_assume!(chunks.iter().any(|c| !c.metadata.heading_path.is_empty()));
+
+        for c in &chunks {
+            if c.metadata.heading_path.is_empty() {
+                continue;
+            }
+            // Lowest section index among the paragraphs this chunk carries.
+            let own_section = (0..para_section.len())
+                .filter(|n| c.text.contains(&format!("S{n}_")))
+                .map(|n| para_section[n])
+                .min();
+            let Some(own_section) = own_section else {
+                continue; // title-only chunk: no paragraph to anchor against
+            };
+            for h in &c.metadata.heading_path {
+                for s in 0..paras_per_section.len() {
+                    if h.contains(&format!("T{s}_")) {
+                        prop_assert!(
+                            s <= own_section,
+                            "chunk in section {} carries breadcrumb {:?} from later section {}",
+                            own_section,
+                            h,
+                            s
+                        );
+                    }
+                }
             }
         }
     }

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -53,23 +53,17 @@ fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
 /// Returns the bytes plus `para_section[n] = s`, the true section of paragraph
 /// `n` — the ground truth the property checks the breadcrumb against.
 ///
-/// Geometry: at most 3 sections × 3 paragraphs = 3 × (60 + 3×20) = 360pt from
+/// Geometry: at most 3 sections × 3 paragraphs = 3 × (40 + 3×20) = 300pt from
 /// y=760, so the content never runs off an A4 page.
 ///
-/// The 60pt title→body gap (vs. 20pt between body lines) is deliberate, not
-/// cosmetic: `merge_into_paragraphs` (src/text/extraction.rs) folds adjacent
-/// lines into one fragment using a threshold of `1.5 * median(line_height)`
-/// with no check on font-size/weight change between them. In a section with
-/// only 1-2 body paragraphs, title lines are a large enough fraction of the
-/// page that the median skews toward the *title's* line height, inflating the
-/// threshold enough to bridge a 40pt title→body gap and merge the title into
-/// its body (and, for the shortest documents, into the *next* section's title
-/// too) — producing a self-referential `heading_path` (the whole merged blob,
-/// not a heading string) that this property then correctly flags as a
-/// violation. 60pt clears that inflated threshold across the whole generated
-/// input space (verified: 1-3 sections × 1-3 paragraphs). This is a real,
-/// reproducible defect in the paragraph-merge heuristic — tracked in the task
-/// report, not papered over here.
+/// The 40pt title→body gap (vs. 20pt between body lines) is the plan's
+/// original, realistic geometry: more space-before-heading than intra-
+/// paragraph line spacing, as in a real document. At this gap,
+/// `merge_into_paragraphs` (src/text/extraction.rs) folds the title into its
+/// body — see issue #436 — because its merge threshold
+/// (`1.5 * median(line_height)`) has no check on font-size/weight change
+/// between lines. Left at 40pt deliberately so the property keeps exercising
+/// (and failing against) that real bug instead of walking around it.
 fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
     let mut doc = Document::new();
     let mut page = Page::a4();
@@ -83,7 +77,7 @@ fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
             .at(72.0, y)
             .write(&format!("T{s}_HEADING"))
             .expect("write title");
-        y -= 60.0;
+        y -= 40.0;
         for _ in 0..count {
             page.text()
                 .set_font(Font::Helvetica, 10.0)
@@ -150,7 +144,19 @@ proptest! {
     /// carry a breadcrumb. If the classifier did not promote our 20pt bold runs
     /// to `Title`, the case proves nothing about breadcrumbs and is discarded —
     /// discarded here, in the open, not hidden behind a weaker assertion.
+    ///
+    /// The plan's `.first()`/`.last()` ablation is structurally unreachable
+    /// through `rag_chunks()`: `HybridChunker::chunk()` treats `Title` as a
+    /// hard chunk boundary, so no chunk spans two sections. This property's
+    /// falsifiability is instead demonstrated by the real bug #436 it catches.
+    ///
+    /// PINNED: fails today — see issue #436 (text extraction merges a heading
+    /// into the following body when they are close, corrupting heading_path).
+    /// The property states the contract; extraction does not honor it yet.
+    /// Remove `#[ignore]` when #436 ships and this becomes a permanent guard.
+    /// Precedent: #430, #434, #435.
     #[test]
+    #[ignore = "issue #436: font-blind paragraph merge swallows headings into body"]
     fn breadcrumb_never_names_a_later_heading(
         paras_per_section in prop::collection::vec(1usize..=3usize, 1..=3),
     ) {

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -1,0 +1,85 @@
+//! End-to-end RAG invariants: from PDF bytes through `rag_chunks_with`.
+//!
+//! These state the two contract properties that are tautological one layer down
+//! (see spec §4). A property over `HybridChunker::chunk` takes the `Element`s it
+//! is handed as ground truth, so it cannot see that partition dropped a
+//! paragraph — for it, that paragraph never existed. Only this layer can.
+//!
+//! The generator is deliberately narrow (documents this crate's writer can
+//! build) and the properties assert over injected markers rather than the whole
+//! extracted string: the pipeline reflows separators legitimately.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::HybridChunkConfig;
+use oxidize_pdf::{Document, Font, Page};
+use proptest::prelude::*;
+use std::io::Cursor;
+
+/// Printable, non-space ASCII with no `_`: survives a WinAnsi `write()`, extracts
+/// as one contiguous run, and keeps the `_`-terminated markers prefix-free.
+fn marker() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9]{4,24}"
+}
+
+fn open(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("re-parse written PDF");
+    PdfDocument::new(reader)
+}
+
+/// One page per inner Vec; each marker on its own baseline, 60pt apart so each
+/// extracts as its own run and classifies as its own element.
+fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
+    let mut doc = Document::new();
+    for markers in pages {
+        let mut page = Page::a4();
+        let mut y = 760.0;
+        for m in markers {
+            page.text()
+                .set_font(Font::Helvetica, 12.0)
+                .at(72.0, y)
+                .write(m)
+                .expect("write marker");
+            y -= 60.0;
+        }
+        doc.add_page(page);
+    }
+    doc.to_bytes().expect("serialize")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I1 — CONSERVATION: every text run written to the document lands in the
+    /// `text` of exactly one chunk. Not "at least one": duplication at the
+    /// partition layer is invisible to the chunking-layer property, which would
+    /// see two distinct elements, place each in its own chunk, and pass clean.
+    ///
+    /// The `P{p}M{j}_` prefix makes every marker unique and prefix-free, so a
+    /// `contains` hit is exact.
+    #[test]
+    fn every_written_run_lands_in_exactly_one_chunk(
+        raw in prop::collection::vec(prop::collection::vec(marker(), 1..=3), 1..=3),
+    ) {
+        let pages: Vec<Vec<String>> = raw
+            .iter()
+            .enumerate()
+            .map(|(p, ms)| {
+                ms.iter()
+                    .enumerate()
+                    .map(|(j, m)| format!("P{p}M{j}_{m}"))
+                    .collect()
+            })
+            .collect();
+
+        let doc = open(build_marker_doc(&pages));
+        let config = HybridChunkConfig { max_tokens: 512, ..Default::default() };
+        let chunks = doc.rag_chunks_with(config).expect("rag_chunks_with");
+
+        for markers in &pages {
+            for m in markers {
+                let hits = chunks.iter().filter(|c| c.text.contains(m.as_str())).count();
+                prop_assert_eq!(hits, 1, "run {} landed in {} chunks", m, hits);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Test-only. No production code touched. SemVer: PATCH.

Contract-derived property invariants for the RAG subsystem — the flagship
feature — written from the documented contract ("the chunk set is a faithful
partition of the document's text, and every chunk is fit to be vectorized and
filtered"), not from any reported bug.

## ⚠️ On the three issues below: they are OPEN and UNRESOLVED

This PR does **not** fix #434, #435 or #436. Every one of those bugs is still
live in production exactly as before. What this PR adds is the **detectors**:
properties that fail against today's code, landed `#[ignore]`d and pinned to
each issue, so that the day someone fixes the bug the property turns green on its
own and becomes a permanent regression guard. Each fix is separate work — #434
and #435 will likely be closed by one change; #436 is a distinct
text-extraction bug. This PR closes nothing.

## Properties

`tests/prop_rag_chunking_invariants.rs` (chunking layer: `Element[] + config -> chunks`, pure)
- **Partition** — each element's marker lands in exactly one chunk, and the
  chunk set conserves the input word multiset. Identity alone is satisfiable by
  dropping text; conservation alone does not localize. Both assert. ✅ green
- **Honest budget** — the stamped count measures the text designated for
  embedding (`full_text`). 📌 pinned, detects #434
- **Budget under BPE** — no non-oversized chunk exceeds `max_tokens` measured
  with the injected counter (feature `tiktoken`). 📌 pinned, detects #435
- **Order + pages** — chunks follow input order; `page_numbers` is the honest
  union of the chunk's elements' pages. ✅ green

`tests/prop_rag_e2e_invariants.rs` (end-to-end: PDF bytes -> `rag_chunks`)
- **Conservation** — every written run lands in exactly one chunk (not "at
  least one": the strong form catches partition-level duplication a
  chunking-layer property is blind to). ✅ green
- **Breadcrumb fidelity** — a chunk's `heading_path` never names a later
  heading. 📌 pinned, detects #436

Two layers on purpose: a chunking-layer property takes the `Element`s it is
handed as ground truth, so it cannot see partition dropping or duplicating text.
The E2E property says *that* something was lost; the chunking one says *where*.

## The three detected bugs

- **#434** — `token_estimate` is computed over the elements' text only, never
  the heading or #376 context prefix, while `full_text` (the documented
  embedding text) includes them. Default settings, any document with headings →
  the reported count is short → a consumer sizing against its embedding model's
  hard limit silently overshoots, the provider truncates, the tail never reaches
  the vector. Minimal case: stamped 2 vs measured 3.
- **#435** — the merge decision sums per-element counts while the emitted chunk
  counts the joined text; additive for whitespace, not for BPE. Scoped to
  callers who inject a BPE counter (opt-in `tiktoken`). Minimal case: a merged,
  not-oversized chunk measuring 44 tokens against a 43-token budget.
- **#436** — text extraction's `merge_into_paragraphs` merges lines on vertical
  gap alone, font/weight/tag-blind, so a heading pressed against its body is
  swallowed and the section breadcrumb is corrupted. Caught against stock code
  with no ablation, at a realistic 40pt heading gap.

All three found pre-report by these invariants. Pins follow the #430 precedent.

## Verification

New files green (chunking 4+1 / 4+2 with tiktoken; e2e 1+1); each pinned
property confirmed failing under `-- --ignored` for its stated reason. No
regression across the RAG/chunking/extraction/roundtrip suites. fmt + clippy
`-D warnings` clean (default and `tiktoken`). MSRV 1.88 `--tests --all-features
--locked` builds. quality-rust: READY, reproduced all three pins independently.

Accepted coverage gap: `HybridChunker::chunk_with_graph` (needs an
`ElementGraph`) is not covered here; example guards remain in
`hybrid_chunking_graph_test.rs`. Documented in the test file.

Detects #434, #435, #436 — none closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)