### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [4.2.0] - 2026-07-21
+
+### Fixed
+
+- **A lone space decoded from `/ToUnicode` was discarded as garbage** (#438).
+  Both `/ToUnicode` paths tested a decode for usability by trimming it first, so
+  a code mapping to exactly `U+0020` trimmed to empty and was rejected — the
+  extractor then fell back to the raw code and emitted the byte as a literal
+  ASCII character, corrupting word boundaries in subsetted-font documents. The
+  simple-font and CID paths had diverging copies of that predicate; they now
+  share one, and a decode is unusable only when it produced no characters at all
+  or nothing but non-whitespace control codes. Whitespace is real text. The
+  shared predicate also tightened the CID path, which previously accepted C1
+  control codes (U+0080–U+009F) as genuine text.
+- **Chunk budgets were decided on a sum of per-element token counts** (#435).
+  The decision summed what each element cost separately while the emitted chunk
+  measured the elements joined — equal only for a counter that is additive
+  across the separator, which BPE is not. So a chunk could be approved on a cost
+  that was never measured, and exceed `max_tokens` in the tokenizer that
+  governed the split. Every budget decision now measures the text it is about to
+  emit: the merge check, the sentence splitter, and the oversize flag on split
+  fragments. A fragment that still exceeds the budget is flagged rather than
+  passed off as within it.
+- **Paragraphs ran together across a font change in extraction** (#436). A
+  change of font size or weight now ends the paragraph, so a heading set in the
+  same block as its body no longer merges into one run of text.
+
+### Added
+
+- **`TokenCounter::is_additive_over_whitespace_join`**, a defaulted trait method
+  (`false`, the safe answer) by which a counter declares that
+  `count(a) + count(b)` equals the cost of joining `a` and `b` with any single
+  whitespace character. The chunker uses it to accumulate a budget in O(1)
+  instead of re-tokenizing the whole buffer per candidate; `WordProxyCounter`,
+  the default, declares `true`, and the BPE counter correctly does not. Existing
+  implementors are unaffected — the default keeps the measured, always-correct
+  path.
+- **Property-based invariant suites for the RAG pipeline and font mapping**,
+  continuing the bug-class guards begun in 4.1.1. Chunking: the chunk set is a
+  faithful partition of the input (every element in exactly one chunk, every
+  word conserved, input order preserved, pages the union of their elements'),
+  the stamped token count measures the content the budget governs, no chunk
+  exceeds its budget under either counter, and an oversized fragment is
+  irreducible rather than over-packed. End-to-end: text conservation from
+  written PDF to chunk, and a breadcrumb that never names a later heading.
+  Fonts: the mapping invariant across every mechanism a document has for saying
+  what a code means (WinAnsi, subset `/ToUnicode`, Identity-H, CID table) plus a
+  coverage report that agrees with what survives extraction. Token counters: a
+  counter's additivity claim is verified against it, over every separator the
+  claim covers. #435, #436 and #438 were all reproduced from the contract by
+  these suites.
+
+### Changed
+
+- **`is_oversized` is now set on sentence-split fragments that exceed the
+  budget.** Previously such a fragment always reported `false`, regardless of
+  its real cost. Consumers filtering on this field will see more `true`s; that
+  is the honest answer, and the reason #435 was invisible.
+
 ## [4.1.1] - 2026-07-16
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.1.1"
+version = "4.2.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -263,6 +263,10 @@ impl HybridChunker {
 
     /// Build a chunk, stamping its token count once over the whole chunk text
     /// with the active counter.
+    ///
+    /// The separator here and in [`join_texts`] must stay the same: the budget
+    /// decision measures the text this function will later emit, and a different
+    /// separator would make the two measurements disagree again (#435).
     fn make_chunk(
         &self,
         elements: Vec<Element>,
@@ -289,35 +293,68 @@ impl HybridChunker {
             return Vec::new();
         }
 
+        let additive = self.counter.is_additive_over_newline();
+
         let mut chunks = Vec::new();
         let mut buffer: Vec<Element> = Vec::new();
+        // Only maintained for non-additive counters, which are the only ones
+        // that need the joined string in order to measure it. Keeping it for an
+        // additive counter would copy the whole buffer per element for nothing.
+        let mut buffer_text = String::new();
         let mut buffer_tokens = 0usize;
         let mut buffer_heading: Option<String> = None;
 
         for element in elements {
-            let elem_tokens = self.counter.count(&element.display_text());
+            let elem_text = element.display_text();
+            let elem_tokens = self.counter.count(&elem_text);
             let elem_heading = if self.config.propagate_headings {
                 element.metadata().parent_heading.clone()
             } else {
                 None
             };
 
+            // Cost of the chunk this element would produce if it joined the
+            // buffer, measured over the JOINED text — the text that would
+            // actually be emitted. Summing per-element counts instead is only
+            // valid for a counter that is additive across the join separator;
+            // BPE is not, so a sum can approve a chunk whose real cost was never
+            // measured (#435).
+            //
+            // A counter that declares itself additive over the join separator
+            // makes the accumulated sum exactly equal to the joined count, so
+            // there is no reason to re-tokenize the buffer: the two agree by the
+            // counter's own contract, checked against it in
+            // `prop_token_counter_invariants.rs`. Everything else pays a
+            // re-count of the buffered text per candidate element, which is what
+            // correctness costs when `count(a) + count(b) != count(a\nb)`.
+            let joined_tokens = if buffer.is_empty() {
+                elem_tokens
+            } else if additive {
+                buffer_tokens + elem_tokens
+            } else {
+                self.counter
+                    .count(&append_element_text(&buffer_text, &elem_text, false))
+            };
+
             // Check if this element can merge with the buffer
             let can_merge = self.config.merge_adjacent
                 && !buffer.is_empty()
                 && can_merge_elements(buffer.last().unwrap(), element, &self.config.merge_policy)
-                && buffer_tokens + elem_tokens <= self.config.max_tokens;
+                && joined_tokens <= self.config.max_tokens;
 
             if can_merge {
+                if !additive {
+                    buffer_text = append_element_text(&buffer_text, &elem_text, false);
+                }
                 buffer.push(element.clone());
-                buffer_tokens += elem_tokens;
+                buffer_tokens = joined_tokens;
                 continue;
             }
 
             // Can't merge — check if buffer needs flushing
             if !buffer.is_empty() {
                 // Flush if: adding would overflow, or types differ, or merge disabled
-                if buffer_tokens + elem_tokens > self.config.max_tokens
+                if joined_tokens > self.config.max_tokens
                     || !can_merge_elements(
                         buffer.last().unwrap(),
                         element,
@@ -328,6 +365,7 @@ impl HybridChunker {
                     self.flush_buffer(
                         &mut chunks,
                         &mut buffer,
+                        &mut buffer_text,
                         &mut buffer_tokens,
                         &mut buffer_heading,
                     );
@@ -341,11 +379,19 @@ impl HybridChunker {
                     let fragments =
                         split_by_sentences(&text, self.counter.as_ref(), self.config.max_tokens);
                     for fragment in fragments {
-                        let fragment_element = make_text_fragment_element(element, fragment.trim());
+                        let fragment = fragment.trim();
+                        // A single sentence longer than the budget cannot be
+                        // split any further without cutting mid-sentence, so it
+                        // is emitted whole — but it is flagged, not passed off
+                        // as within budget. Claiming `oversized: false` for a
+                        // fragment that exceeds `max_tokens` is the same lie the
+                        // budget invariant exists to catch (#435).
+                        let over = self.counter.count(fragment) > self.config.max_tokens;
+                        let fragment_element = make_text_fragment_element(element, fragment);
                         chunks.push(self.make_chunk(
                             vec![fragment_element],
                             elem_heading.clone(),
-                            false,
+                            over,
                         ));
                     }
                 } else {
@@ -355,12 +401,18 @@ impl HybridChunker {
                 continue;
             }
 
-            // Start or append to buffer
-            if buffer.is_empty() {
-                buffer_heading = elem_heading;
+            // Start a new buffer. Reaching here always means the buffer is
+            // empty: appending to a non-empty buffer only happens on the
+            // `can_merge` path above (which `continue`s), and every other way
+            // through with a non-empty buffer flushes it first — the flush
+            // condition is the exact negation of the merge condition.
+            debug_assert!(buffer.is_empty(), "buffer must be flushed before restart");
+            buffer_heading = elem_heading;
+            if !additive {
+                buffer_text = elem_text;
             }
+            buffer_tokens = elem_tokens;
             buffer.push(element.clone());
-            buffer_tokens += elem_tokens;
         }
 
         // Flush remaining
@@ -442,6 +494,7 @@ impl HybridChunker {
         &self,
         chunks: &mut Vec<HybridChunk>,
         buffer: &mut Vec<Element>,
+        buffer_text: &mut String,
         buffer_tokens: &mut usize,
         buffer_heading: &mut Option<String>,
     ) {
@@ -455,10 +508,33 @@ impl HybridChunker {
         // suite in tests/hybrid_chunker_disjoint_test.rs.
         let flushed = std::mem::take(buffer);
         let heading = buffer_heading.take();
+        buffer_text.clear();
         *buffer_tokens = 0;
 
         chunks.push(self.make_chunk(flushed, heading, false));
     }
+}
+
+/// Append one element's text to the buffered chunk text, exactly as
+/// [`HybridChunker::make_chunk`] will join the elements: `"\n"` between every
+/// pair of ELEMENTS.
+///
+/// `buffer_is_empty` is about elements, not about text, and the distinction is
+/// load-bearing. An element whose `display_text()` is empty is legal (the field
+/// is a plain `pub String`), so "the buffer holds nothing" and "the buffered
+/// text is the empty string" are different questions. Keying the separator on
+/// the second makes the budget decision measure zero while the emitted chunk
+/// keeps growing one separator at a time — those separators are real tokens
+/// under BPE, which is #435 all over again.
+///
+/// Single definition on purpose: the budget decision and the emitted chunk have
+/// to measure the same string, which they can only do by building it the same
+/// way.
+fn append_element_text(buffered: &str, next: &str, buffer_is_empty: bool) -> String {
+    if buffer_is_empty {
+        return next.to_string();
+    }
+    format!("{buffered}\n{next}")
 }
 
 /// Whether two adjacent elements can be merged according to the given policy.
@@ -497,29 +573,29 @@ fn split_by_sentences(text: &str, counter: &dyn TokenCounter, max_tokens: usize)
 
     let mut fragments: Vec<String> = Vec::new();
     let mut current = String::new();
-    let mut current_tokens = 0usize;
 
     for sentence in sentences {
         let sentence = sentence.trim();
         if sentence.is_empty() {
             continue;
         }
-        let sentence_tokens = counter.count(sentence);
 
         if current.is_empty() {
             // Starting a new fragment
             current.push_str(sentence);
-            current_tokens = sentence_tokens;
-        } else if current_tokens + 1 + sentence_tokens <= max_tokens {
-            // Adding a space separator between sentences
-            current.push(' ');
-            current.push_str(sentence);
-            current_tokens += 1 + sentence_tokens;
+            continue;
+        }
+
+        // Measure the joined candidate rather than summing the parts plus one
+        // for the separator: that arithmetic assumes an additive counter, which
+        // BPE is not (#435).
+        let candidate = format!("{current} {sentence}");
+        if counter.count(&candidate) <= max_tokens {
+            current = candidate;
         } else {
             // Current sentence doesn't fit: flush and start new fragment
-            fragments.push(current.clone());
+            fragments.push(std::mem::take(&mut current));
             current = sentence.to_string();
-            current_tokens = sentence_tokens;
         }
     }
 

--- a/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
+++ b/oxidize-pdf-core/src/pipeline/hybrid_chunking.rs
@@ -293,7 +293,7 @@ impl HybridChunker {
             return Vec::new();
         }
 
-        let additive = self.counter.is_additive_over_newline();
+        let additive = self.counter.is_additive_over_whitespace_join();
 
         let mut chunks = Vec::new();
         let mut buffer: Vec<Element> = Vec::new();
@@ -327,13 +327,17 @@ impl HybridChunker {
             // `prop_token_counter_invariants.rs`. Everything else pays a
             // re-count of the buffered text per candidate element, which is what
             // correctness costs when `count(a) + count(b) != count(a\nb)`.
-            let joined_tokens = if buffer.is_empty() {
-                elem_tokens
-            } else if additive {
-                buffer_tokens + elem_tokens
-            } else {
-                self.counter
-                    .count(&append_element_text(&buffer_text, &elem_text, false))
+            // Built once and reused if the merge goes ahead: it is the exact
+            // text `buffer_text` would become, and re-deriving it on the merge
+            // path would pay for a second string build and a second full
+            // re-tokenization per merged element.
+            let joined_text = (!buffer.is_empty() && !additive)
+                .then(|| append_element_text(&buffer_text, &elem_text, false));
+
+            let joined_tokens = match &joined_text {
+                Some(joined) => self.counter.count(joined),
+                None if buffer.is_empty() => elem_tokens,
+                None => buffer_tokens + elem_tokens,
             };
 
             // Check if this element can merge with the buffer
@@ -343,8 +347,8 @@ impl HybridChunker {
                 && joined_tokens <= self.config.max_tokens;
 
             if can_merge {
-                if !additive {
-                    buffer_text = append_element_text(&buffer_text, &elem_text, false);
+                if let Some(joined) = joined_text {
+                    buffer_text = joined;
                 }
                 buffer.push(element.clone());
                 buffer_tokens = joined_tokens;
@@ -571,8 +575,19 @@ fn split_by_sentences(text: &str, counter: &dyn TokenCounter, max_tokens: usize)
     // Split into sentences preserving the delimiter as part of the sentence.
     let sentences = split_into_sentences(text);
 
+    // Sentences are joined with `' '`, a single whitespace character, so a
+    // counter that declares itself additive over a whitespace join promises the
+    // sum equals the measured cost of the join — the same promise the element
+    // loop in `chunk` rests on, and checked against every counter in
+    // `prop_token_counter_invariants.rs`. Without it, every candidate costs a
+    // re-tokenization of the whole accumulated fragment.
+    let additive = counter.is_additive_over_whitespace_join();
+
     let mut fragments: Vec<String> = Vec::new();
     let mut current = String::new();
+    // Only meaningful while `current` is non-empty, and only maintained for an
+    // additive counter — the other path measures the candidate directly.
+    let mut current_tokens = 0usize;
 
     for sentence in sentences {
         let sentence = sentence.trim();
@@ -583,19 +598,36 @@ fn split_by_sentences(text: &str, counter: &dyn TokenCounter, max_tokens: usize)
         if current.is_empty() {
             // Starting a new fragment
             current.push_str(sentence);
+            current_tokens = if additive { counter.count(sentence) } else { 0 };
             continue;
         }
 
         // Measure the joined candidate rather than summing the parts plus one
         // for the separator: that arithmetic assumes an additive counter, which
-        // BPE is not (#435).
-        let candidate = format!("{current} {sentence}");
-        if counter.count(&candidate) <= max_tokens {
-            current = candidate;
+        // BPE is not (#435). For a counter that does declare additivity, the sum
+        // IS the measurement, by its own contract.
+        let sentence_tokens = counter.count(sentence);
+        let (fits, candidate) = if additive {
+            (current_tokens + sentence_tokens <= max_tokens, None)
+        } else {
+            let candidate = format!("{current} {sentence}");
+            (counter.count(&candidate) <= max_tokens, Some(candidate))
+        };
+
+        if fits {
+            match candidate {
+                Some(candidate) => current = candidate,
+                None => {
+                    current.push(' ');
+                    current.push_str(sentence);
+                    current_tokens += sentence_tokens;
+                }
+            }
         } else {
             // Current sentence doesn't fit: flush and start new fragment
             fragments.push(std::mem::take(&mut current));
             current = sentence.to_string();
+            current_tokens = sentence_tokens;
         }
     }
 

--- a/oxidize-pdf-core/src/pipeline/rag.rs
+++ b/oxidize-pdf-core/src/pipeline/rag.rs
@@ -19,14 +19,21 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Field guide
 ///
-/// - `text`: raw chunk text for display or keyword search
-/// - `full_text`: heading context + text — **use this for embedding generation**
-/// - `token_estimate`: token count under the chunker's active `TokenCounter`
-///   (word-count proxy by default; a real tokenizer such as cl100k_base when a
-///   counter is injected via `rag_chunks_with_counter`). `RagChunk` does not
-///   store the counter; query the counter you injected via its `name()` for
-///   provenance.
-/// - `is_oversized`: true when a single element exceeds `max_tokens`
+/// - `text`: the chunk's content — **this is what you embed**, and what
+///   `max_tokens` and `token_estimate` both measure.
+/// - `full_text`: heading context + text, for display and for assembling a
+///   prompt at query time. **Do not embed this.** The vector represents the
+///   content, never the metadata around it: a heading repeated across every
+///   chunk of a section dilutes the signal and spends the embedding model's
+///   input budget on text that is already available, structured, as metadata to
+///   filter on.
+/// - `token_estimate`: token count of `text` under the chunker's active
+///   `TokenCounter` (word-count proxy by default; a real tokenizer such as
+///   cl100k_base when a counter is injected via `rag_chunks_with_counter`).
+///   `RagChunk` does not store the counter; query the counter you injected via
+///   its `name()` for provenance.
+/// - `is_oversized`: true when the chunk's content exceeds `max_tokens` and the
+///   chunker could not split it further without cutting mid-sentence
 ///
 /// # Example
 ///

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -7,6 +7,27 @@ pub trait TokenCounter: Send + Sync {
     fn count(&self, text: &str) -> usize;
     /// Stable provenance identifier, e.g. `"word-proxy"` or `"cl100k_base"`.
     fn name(&self) -> &'static str;
+
+    /// Whether this counter is additive across a newline join, i.e. whether
+    /// `count(a) + count(b) == count(&format!("{a}\n{b}"))` for every `a`, `b`.
+    ///
+    /// Chunking has to know the cost of the text it is about to emit, which is
+    /// the elements joined with `"\n"`. A counter that is additive lets that be
+    /// computed by accumulation; one that is not forces the chunker to re-count
+    /// the joined text on every candidate element, which is correct but costs a
+    /// re-tokenization of the whole buffer each time.
+    ///
+    /// Defaults to `false`, the safe answer: an over-claim here silently
+    /// restores the budget bug of #435, where a sum approved a chunk whose real
+    /// cost was never measured. Whitespace counting is additive because the
+    /// separator cannot fuse two words into one; subword (BPE) counting is not,
+    /// because the join boundary re-tokenizes.
+    ///
+    /// Override only with a proof or a test. `prop_token_counter_invariants.rs`
+    /// checks every counter in this crate against its own answer.
+    fn is_additive_over_newline(&self) -> bool {
+        false
+    }
 }
 
 /// Zero-dependency default: whitespace-separated word count. Reproduces the
@@ -20,6 +41,11 @@ impl TokenCounter for WordProxyCounter {
     }
     fn name(&self) -> &'static str {
         "word-proxy"
+    }
+    /// Additive: `"\n"` is whitespace, so joining cannot merge the last word of
+    /// `a` with the first of `b`, nor create a word that was in neither.
+    fn is_additive_over_newline(&self) -> bool {
+        true
     }
 }
 

--- a/oxidize-pdf-core/src/pipeline/token_counter.rs
+++ b/oxidize-pdf-core/src/pipeline/token_counter.rs
@@ -8,24 +8,34 @@ pub trait TokenCounter: Send + Sync {
     /// Stable provenance identifier, e.g. `"word-proxy"` or `"cl100k_base"`.
     fn name(&self) -> &'static str;
 
-    /// Whether this counter is additive across a newline join, i.e. whether
-    /// `count(a) + count(b) == count(&format!("{a}\n{b}"))` for every `a`, `b`.
+    /// Whether this counter is additive across a whitespace join, i.e. whether
+    /// `count(a) + count(b) == count(&format!("{a}{sep}{b}"))` for every `a`,
+    /// `b` and every single whitespace character `sep`.
     ///
-    /// Chunking has to know the cost of the text it is about to emit, which is
-    /// the elements joined with `"\n"`. A counter that is additive lets that be
-    /// computed by accumulation; one that is not forces the chunker to re-count
-    /// the joined text on every candidate element, which is correct but costs a
-    /// re-tokenization of the whole buffer each time.
+    /// Chunking has to know the cost of the text it is about to emit, and it
+    /// builds that text by joining pieces with one whitespace character: `"\n"`
+    /// between elements, `" "` between sentences inside an oversized element. A
+    /// counter that is additive lets that cost be computed by accumulation; one
+    /// that is not forces a re-count of the joined text on every candidate,
+    /// which is correct but costs a re-tokenization of everything buffered so
+    /// far, each time.
+    ///
+    /// The promise deliberately covers ANY whitespace separator rather than one
+    /// named character: a counter answering for `"\n"` alone would leave the
+    /// sentence-join path with no contract to stand on, and using the newline
+    /// answer there anyway would be precisely the unmeasured assumption that
+    /// #435 was.
     ///
     /// Defaults to `false`, the safe answer: an over-claim here silently
-    /// restores the budget bug of #435, where a sum approved a chunk whose real
-    /// cost was never measured. Whitespace counting is additive because the
+    /// restores that budget bug, where a sum approved a chunk whose real cost
+    /// was never measured. Whitespace counting is additive because the
     /// separator cannot fuse two words into one; subword (BPE) counting is not,
     /// because the join boundary re-tokenizes.
     ///
     /// Override only with a proof or a test. `prop_token_counter_invariants.rs`
-    /// checks every counter in this crate against its own answer.
-    fn is_additive_over_newline(&self) -> bool {
+    /// checks every counter in this crate against its own answer, over every
+    /// separator the promise covers.
+    fn is_additive_over_whitespace_join(&self) -> bool {
         false
     }
 }
@@ -42,9 +52,11 @@ impl TokenCounter for WordProxyCounter {
     fn name(&self) -> &'static str {
         "word-proxy"
     }
-    /// Additive: `"\n"` is whitespace, so joining cannot merge the last word of
-    /// `a` with the first of `b`, nor create a word that was in neither.
-    fn is_additive_over_newline(&self) -> bool {
+    /// Additive: the count is `split_whitespace().count()`, so a separator that
+    /// is itself whitespace cannot merge the last word of `a` with the first of
+    /// `b`, nor create a word that was in neither — whichever whitespace
+    /// character it is.
+    fn is_additive_over_whitespace_join(&self) -> bool {
         true
     }
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -405,6 +405,37 @@ pub fn parse_font_style(font_name: &str) -> (bool, bool) {
     (is_bold, is_italic)
 }
 
+/// Relative font-size difference below which two lines still count as the same
+/// typographic style. Absorbs the sub-point jitter a scaled text matrix
+/// produces (11.96 vs 12.0) without absorbing a real size step: the smallest
+/// step in common use is 12 → 13pt (8%).
+const PARAGRAPH_STYLE_SIZE_TOLERANCE: f64 = 0.05;
+
+/// Whether two consecutive lines share the typographic style that makes them
+/// one paragraph.
+///
+/// A paragraph is a run of lines set in the same face; a change of size or
+/// weight marks a new block. Vertical gap alone cannot tell a heading from its
+/// body — a title set 40pt above 10pt body text falls inside the same 1.5×
+/// median-line-height window as ordinary line spacing (issue #436).
+///
+/// The cost of the two errors is asymmetric, which is why this splits on a
+/// signal as weak as a weight change. An over-split leaves two adjacent
+/// fragments that downstream chunking can still group. An under-split is
+/// irreversible: the merged fragment inherits the heading's size and weight,
+/// so `partition` classifies the whole block as a `Title` and its text becomes
+/// the `heading_path` breadcrumb of everything that follows.
+fn same_paragraph_style(a: &TextFragment, b: &TextFragment) -> bool {
+    if a.is_bold != b.is_bold {
+        return false;
+    }
+    let scale = a.font_size.abs().max(b.font_size.abs());
+    if scale <= 0.0 {
+        return true; // no usable size on either line: gap decides
+    }
+    (a.font_size - b.font_size).abs() / scale <= PARAGRAPH_STYLE_SIZE_TOLERANCE
+}
+
 /// Text extractor for PDF pages with CMap support
 pub struct TextExtractor {
     options: ExtractionOptions,
@@ -643,11 +674,13 @@ impl TextExtractor {
         }
     }
 
-    /// Group consecutive lines into paragraphs based on vertical gap.
+    /// Group consecutive lines into paragraphs based on vertical gap and
+    /// typographic style.
     ///
     /// Two consecutive lines are part of the same paragraph when the vertical
-    /// gap between them is less than 1.5× the median line height in the
-    /// input. Hyphenated line breaks (previous line ends with `-` and
+    /// gap between them is less than 1.5× the median line height in the input
+    /// **and** they share the same style — see [`same_paragraph_style`].
+    /// Hyphenated line breaks (previous line ends with `-` and
     /// `merge_hyphenated` is set) join without a separator and drop the
     /// hyphen; otherwise lines join with `'\n'`.
     fn merge_into_paragraphs(&self, lines: &[TextFragment]) -> Vec<TextFragment> {
@@ -669,7 +702,11 @@ impl TextExtractor {
             let line_top = line.y + line.height;
             let gap = prev_bottom - line_top;
 
-            if gap < 0.0 || gap > max_paragraph_gap || current.mcid != line.mcid {
+            if gap < 0.0
+                || gap > max_paragraph_gap
+                || current.mcid != line.mcid
+                || !same_paragraph_style(&current, line)
+            {
                 paragraphs.push(current);
                 current = line.clone();
                 continue;
@@ -4282,6 +4319,75 @@ mod tests {
         assert_eq!(paragraphs.len(), 2);
         assert_eq!(paragraphs[0].text, "P1L1.\nP1L2.");
         assert_eq!(paragraphs[1].text, "P2L1.");
+    }
+
+    /// A heading is a different block from the body that follows it, even when
+    /// the vertical gap is small enough to look like line spacing. Merging them
+    /// destroys the two signals `partition` uses to classify a `Title`
+    /// (font-size ratio and bold-short), so the heading text is never
+    /// recoverable downstream (issue #436).
+    #[test]
+    fn merge_into_paragraphs_splits_on_font_size_change() {
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        // 20pt title at y=760, 10pt body line 40pt below: gap = 30pt, which is
+        // exactly the 1.5 * median(20, 10) = 30pt vertical threshold, so only
+        // the style change can separate them.
+        let lines = vec![
+            tf("Section Heading", 72.0, 760.0, 120.0, 20.0),
+            tf("Body text of this section.", 72.0, 720.0, 150.0, 10.0),
+        ];
+        let paragraphs = extractor.merge_into_paragraphs(&lines);
+        assert_eq!(
+            paragraphs.len(),
+            2,
+            "font-size change must end the paragraph"
+        );
+        assert_eq!(paragraphs[0].text, "Section Heading");
+        assert_eq!(paragraphs[0].font_size, 20.0);
+        assert_eq!(paragraphs[1].text, "Body text of this section.");
+    }
+
+    /// Same size, different weight: the classic run-in bold heading. `partition`
+    /// classifies it through `bold_short_title`, which needs the heading to
+    /// survive extraction as its own fragment (issue #436).
+    #[test]
+    fn merge_into_paragraphs_splits_on_weight_change() {
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        let mut heading = tf("Overview", 72.0, 400.0, 60.0, 12.0);
+        heading.is_bold = true;
+        let lines = vec![heading, tf("Body line.", 72.0, 386.0, 60.0, 12.0)];
+        let paragraphs = extractor.merge_into_paragraphs(&lines);
+        assert_eq!(paragraphs.len(), 2, "weight change must end the paragraph");
+        assert_eq!(paragraphs[0].text, "Overview");
+        assert!(paragraphs[0].is_bold);
+        assert_eq!(paragraphs[1].text, "Body line.");
+    }
+
+    /// Sub-point rounding (11.96pt vs 12pt from a scaled text matrix) is not a
+    /// style change: the paragraph must stay whole.
+    #[test]
+    fn merge_into_paragraphs_tolerates_subpoint_font_size_jitter() {
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            reconstruct_paragraphs: true,
+            ..Default::default()
+        });
+        let lines = vec![
+            tf("Line one.", 50.0, 400.0, 60.0, 12.0),
+            tf("Line two.", 50.0, 386.0, 60.0, 11.96),
+        ];
+        let paragraphs = extractor.merge_into_paragraphs(&lines);
+        assert_eq!(
+            paragraphs.len(),
+            1,
+            "0.3% size jitter is not a style change"
+        );
+        assert_eq!(paragraphs[0].text, "Line one.\nLine two.");
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2240,10 +2240,11 @@ impl TextExtractor {
                 if let Ok(decoded) =
                     crate::text::extraction_cmap::decode_text_with_font(text, font_info)
                 {
-                    // Only accept if we got meaningful text (not all null bytes or garbage)
-                    if !decoded.trim().is_empty()
-                        && !decoded.chars().all(|c| c == '\0' || c.is_ascii_control())
-                    {
+                    // Only accept if we got meaningful text (not all null bytes
+                    // or garbage). Whitespace counts as meaningful: a decode
+                    // that is exactly a space is a space, not a failed decode
+                    // (#438). See `decode_is_usable`.
+                    if crate::text::extraction_cmap::decode_is_usable(&decoded) {
                         // Apply sanitization to remove control characters (Issue #116)
                         let sanitized = sanitize_extracted_text(&decoded);
                         tracing::debug!(

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -550,6 +550,33 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
     }
 }
 
+/// The whitespace `sanitize_extracted_text` keeps downstream. `decode_is_usable`
+/// uses the same set on purpose: accepting a decode that the next stage then
+/// deletes would turn "usable" into an empty string — worse than the guessed
+/// fallback it was accepted over.
+fn is_preservable_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r')
+}
+
+/// Whether a decode produced usable text, or nothing the caller can act on.
+///
+/// A decode is unusable only when it yielded no characters at all, or nothing
+/// but control codes that carry no text (NUL included) — the signature of
+/// reading bytes through the wrong table. Whitespace is real text: a subsetted
+/// font's first glyph is routinely the space, mapped by `/ToUnicode` to U+0020,
+/// and content streams routinely show it in a text-showing operator of its own.
+///
+/// Treating such a decode as a failure sends the caller to a *guessed* encoding,
+/// and in a subset font with no `/Encoding` the codes mean nothing outside their
+/// CMap — so the guess renders the code as its own literal ASCII, replacing every
+/// space with `!` or `"` and shredding word boundaries document-wide (#438).
+pub(crate) fn decode_is_usable(decoded: &str) -> bool {
+    !decoded.is_empty()
+        && !decoded
+            .chars()
+            .all(|c| c.is_control() && !is_preservable_whitespace(c))
+}
+
 /// Decode text using font information — free function (no allocations).
 ///
 /// Tries ToUnicode CMap first, then CID→Unicode tables for CJK fonts,
@@ -598,9 +625,9 @@ pub fn decode_text_with_font(text_bytes: &[u8], font_info: &FontInfo) -> ParseRe
                     crate::text::cid_to_unicode::CidCollection::from_ordering(ordering)
                 {
                     let result = decode_with_cid_table(text_bytes, &collection);
-                    if !result.is_empty()
-                        && !result.chars().all(|c| c == '\0' || c.is_ascii_control())
-                    {
+                    // Same predicate as the ToUnicode path — one definition so
+                    // the two acceptance rules cannot drift apart (#438).
+                    if decode_is_usable(&result) {
                         return Ok(result);
                     }
                 }

--- a/oxidize-pdf-core/tests/prop_font_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_font_invariants.rs
@@ -10,6 +10,18 @@
 //!   2. NO SILENT GLYPH SUBSTITUTION. A character in the font's supported set,
 //!      drawn through a WinAnsi standard-14 font, extracts back as itself — never
 //!      as '?' or a dropped/garbled glyph (#272, #287, #392).
+//!   3. A DEFINED MAPPING IS HONOURED, AND AN UNDEFINED ONE IS DECLARED. Two
+//!      halves of one contract, over every way a document can define what a code
+//!      means (`/Encoding`, `/ToUnicode`, `/Identity-H` + CID):
+//!      (a) no character that has a mapping is silently extracted as something
+//!      else — not '?', not `.notdef`, not the literal ASCII of its code, not
+//!      dropped; and (b) when the font genuinely cannot render a character, the
+//!      coverage report (`Document::font_missing_glyphs`) lists it. Reporting
+//!      `[]` while the glyph does not survive the round-trip is the aggravating
+//!      half of #392: the check that should warn gives a green light.
+//!
+//!      Guards #272 (CFF/ToUnicode garbage), #287 (.notdef), #392 ('?' plus false
+//!      all-clear) and the CMap paths those left unguarded.
 //!
 //! Written from the contract up front so the whole "font mangles characters"
 //! class is guarded, not just the reported instances.
@@ -124,7 +136,7 @@ fn winansi_pdf(text: &str) -> Vec<u8> {
     let xref_pos = pdf.len();
     write!(pdf, "xref\n0 6\n0000000000 65535 f \n").unwrap();
     for off in &offsets {
-        write!(pdf, "{off:010} 00000 n \n").unwrap();
+        writeln!(pdf, "{off:010} 00000 n ").unwrap();
     }
     write!(
         pdf,
@@ -158,5 +170,430 @@ proptest! {
             &got, &text,
             "WinAnsi Latin-1 must extract unchanged; got {:?} for {:?}", got, text
         );
+    }
+}
+
+// ---------- Invariant 3a: a defined mapping is honoured, on every path ----------
+//
+// A PDF can define what a character code means in more than one way, and the
+// extraction has to honour whichever the document used. The generator's axis is
+// therefore the *mapping mechanism*, with the drawn string ranging over the
+// mapped character set:
+//
+//   * `/Encoding /WinAnsiEncoding` — the code is a WinAnsi byte;
+//   * `/ToUnicode` on a subsetted simple font with NO `/Encoding` — the codes are
+//     font-internal, so the CMap is the only thing that can decode them;
+//   * `/Identity-H` + a CID descendant with `/ToUnicode` — two-byte codes.
+//
+// The last two are the paths where guessing is not merely inaccurate but
+// meaningless: the code values carry no information outside their CMap.
+
+/// Characters the generated documents map codes to. Latin, accented, Cyrillic
+/// (outside any single-byte encoding) and the space — the space matters because
+/// a subset font's first glyph is routinely U+0020 and content streams show it
+/// in a text-showing operator of its own.
+const MAPPED_ALPHABET: &[char] = &['A', 'B', 'C', 'z', 'á', 'ñ', 'ü', 'Э', 'ч', 'ф', '€', ' '];
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Mapping {
+    /// Simple font, `/ToUnicode` only, no `/Encoding` (Word-style subset).
+    ToUnicodeSubset,
+    /// Type0 `/Identity-H` with a CID descendant and a two-byte `/ToUnicode`.
+    IdentityH,
+    /// Type0 `/Identity-H` with NO `/ToUnicode` anywhere: the meaning of a code
+    /// comes from the descendant's `/CIDSystemInfo /Ordering` and the built-in
+    /// CID→Unicode table for that collection. A separate decoder with its own
+    /// acceptance rule, so a property that never reaches it does not guard it.
+    CidTable,
+}
+
+/// The CID collection `Mapping::CidTable` documents in `/CIDSystemInfo`.
+const CID_ORDERING: &str = "Japan1";
+
+/// CIDs to draw in the CID-table property: taken from the collection itself
+/// rather than hardcoded, because the table has gaps (CID 300 is unmapped in
+/// Adobe-Japan1) and a hand-picked list silently rots.
+///
+/// The low CIDs come first, so the sample always includes CID 1 = U+00A0, a
+/// no-break space. That is deliberate: it is a whitespace-only decode reached
+/// through this decoder — the same shape as the #438 trigger on the other path.
+/// (No CID in this range maps to U+0020; verified against the table.)
+fn cid_sample() -> Vec<u16> {
+    let collection = oxidize_pdf::text::cid_to_unicode::CidCollection::from_ordering(CID_ORDERING)
+        .expect("known CID collection");
+    (1u16..400)
+        .filter(|cid| collection.cid_to_unicode(*cid).is_some())
+        .take(24)
+        .collect()
+}
+
+/// Serialize `bodies` (object 1..=n) into a PDF with a correct xref table.
+fn assemble_pdf(bodies: Vec<Vec<u8>>) -> Vec<u8> {
+    let mut pdf = Vec::from(&b"%PDF-1.5\n"[..]);
+    let mut offsets = Vec::new();
+    for (i, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len());
+        writeln!(pdf, "{} 0 obj", i + 1).unwrap();
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = pdf.len();
+    writeln!(pdf, "xref\n0 {}", bodies.len() + 1).unwrap();
+    writeln!(pdf, "0000000000 65535 f ").unwrap();
+    for off in &offsets {
+        writeln!(pdf, "{off:010} 00000 n ").unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n",
+        bodies.len() + 1
+    )
+    .unwrap();
+    pdf
+}
+
+/// A stream object body with the right `/Length`.
+fn stream_body(data: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    write!(body, "<< /Length {} >>\nstream\n", data.len()).unwrap();
+    body.extend_from_slice(data);
+    body.extend_from_slice(b"\nendstream");
+    body
+}
+
+/// `/ToUnicode` CMap mapping each `(code, char)` pair. Codes are `code_bytes`
+/// wide (1 for a simple font, 2 for Identity-H).
+fn to_unicode_stream(pairs: &[(u32, char)], code_bytes: usize) -> Vec<u8> {
+    let hex_code = |c: u32| match code_bytes {
+        1 => format!("<{c:02x}>"),
+        _ => format!("<{c:04x}>"),
+    };
+    let mut cmap = String::from(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n1 begincodespacerange\n",
+    );
+    cmap.push_str(match code_bytes {
+        1 => "<00> <ff>\n",
+        _ => "<0000> <ffff>\n",
+    });
+    cmap.push_str("endcodespacerange\n");
+    cmap.push_str(&format!("{} beginbfchar\n", pairs.len()));
+    for (code, ch) in pairs {
+        // BMP only — every character in MAPPED_ALPHABET is.
+        cmap.push_str(&format!("{} <{:04x}>\n", hex_code(*code), *ch as u32));
+    }
+    cmap.push_str("endbfchar\nendcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n");
+    cmap.into_bytes()
+}
+
+/// Codes are assigned from 0x21 so that the LOW BYTE of every code lands in
+/// printable ASCII. That is what makes a fallback observable: if the extraction
+/// discards the declared mapping and re-reads the bytes through a guessed
+/// encoding, the code surfaces as its own literal ASCII instead of vanishing
+/// into a control character that sanitization would silently drop — which would
+/// make the property blind to the very substitution it exists to catch.
+const FIRST_CODE: u32 = 0x21;
+
+/// The `(code, expected character)` sequence a document of this `mapping` draws
+/// for `text`: one code per distinct character, in first-seen order.
+fn codes_for_text(mapping: Mapping, text: &str) -> Vec<(u32, char)> {
+    assert!(
+        mapping != Mapping::CidTable,
+        "CidTable draws CIDs, not text"
+    );
+    let mut table: Vec<(u32, char)> = Vec::new();
+    for ch in text.chars() {
+        if !table.iter().any(|(_, c)| *c == ch) {
+            table.push((FIRST_CODE + table.len() as u32, ch));
+        }
+    }
+    text.chars()
+        .map(|ch| *table.iter().find(|(_, c)| *c == ch).unwrap())
+        .collect()
+}
+
+/// The `(CID, expected character)` sequence for `cids`, resolved through the
+/// same collection table the document names in `/CIDSystemInfo`. The table is
+/// the shared reference: the property asserts the extraction *consults* it
+/// rather than discarding the decode and guessing.
+fn codes_for_cids(cids: &[u16]) -> Vec<(u32, char)> {
+    let collection = oxidize_pdf::text::cid_to_unicode::CidCollection::from_ordering(CID_ORDERING)
+        .expect("known CID collection");
+    cids.iter()
+        .map(|cid| {
+            (
+                *cid as u32,
+                collection.cid_to_unicode(*cid).expect("CID is mapped"),
+            )
+        })
+        .collect()
+}
+
+/// One-page PDF drawing `drawn` (one text-showing operator per code) through a
+/// font that defines what those codes mean the way `mapping` says.
+fn mapped_pdf(mapping: Mapping, drawn: &[(u32, char)]) -> Vec<u8> {
+    let mut table: Vec<(u32, char)> = Vec::new();
+    for pair in drawn {
+        if !table.contains(pair) {
+            table.push(*pair);
+        }
+    }
+    let code_bytes = match mapping {
+        Mapping::ToUnicodeSubset => 1,
+        Mapping::IdentityH | Mapping::CidTable => 2,
+    };
+
+    let mut content = Vec::from(&b"BT\n/F1 12 Tf\n50 700 Td\n"[..]);
+    for (code, _) in drawn {
+        match code_bytes {
+            1 => writeln!(content, "<{code:02x}> Tj").unwrap(),
+            _ => writeln!(content, "<{code:04x}> Tj").unwrap(),
+        }
+    }
+    content.extend_from_slice(b"ET\n");
+
+    let widths: String = table.iter().map(|_| "500 ").collect();
+    let (font_body, extra): (Vec<u8>, Vec<Vec<u8>>) = match mapping {
+        Mapping::ToUnicodeSubset => (
+            format!(
+                "<< /Type /Font /Subtype /TrueType /BaseFont /AAAAAA+Subset \
+                 /FirstChar {} /LastChar {} /Widths [{}] /ToUnicode 6 0 R >>",
+                FIRST_CODE,
+                FIRST_CODE as usize + table.len() - 1,
+                widths.trim_end()
+            )
+            .into_bytes(),
+            vec![stream_body(&to_unicode_stream(&table, 1))],
+        ),
+        Mapping::IdentityH => (
+            b"<< /Type /Font /Subtype /Type0 /BaseFont /BBBBBB+CidFont \
+              /Encoding /Identity-H /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
+                .to_vec(),
+            vec![
+                stream_body(&to_unicode_stream(&table, 2)),
+                b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /BBBBBB+CidFont \
+                  /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+                  /DW 500 >>"
+                    .to_vec(),
+            ],
+        ),
+        // No /ToUnicode anywhere: the only thing that explains a code is the
+        // named CID collection, which routes the decode through a different
+        // decoder (and, before the #438 fix, a second copy of the same
+        // "does this decode look like garbage?" rule).
+        Mapping::CidTable => (
+            b"<< /Type /Font /Subtype /Type0 /BaseFont /CCCCCC+CidFont \
+              /Encoding /Identity-H /DescendantFonts [6 0 R] >>"
+                .to_vec(),
+            vec![format!(
+                "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /CCCCCC+CidFont \
+                 /CIDSystemInfo << /Registry (Adobe) /Ordering ({CID_ORDERING}) /Supplement 0 >> \
+                 /DW 500 >>"
+            )
+            .into_bytes()],
+        ),
+    };
+
+    let mut bodies = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /MediaBox [0 0 595 842] /Contents 4 0 R >>"
+            .to_vec(),
+        stream_body(&content),
+        font_body,
+    ];
+    bodies.extend(extra);
+    assemble_pdf(bodies)
+}
+
+/// Deterministic pin for #438, reproducing the reported shape: a subsetted font
+/// whose `FirstChar` glyph maps to U+0020, shown in a text-showing operator of
+/// its own between two letters. Reported as `PROSPECTO!PRELIMINAR` where the
+/// document said `PROSPECTO PRELIMINAR`; here, `A A` came back as `A"A`.
+#[test]
+fn issue_438_lone_space_between_letters_survives() {
+    let drawn = codes_for_text(Mapping::ToUnicodeSubset, "A A");
+    let extracted = extract(&mapped_pdf(Mapping::ToUnicodeSubset, &drawn));
+    assert_eq!(
+        extracted.split_whitespace().collect::<Vec<_>>(),
+        vec!["A", "A"],
+        "a lone mapped space must stay a space, got {extracted:?}"
+    );
+}
+
+fn mapped_string() -> impl Strategy<Value = String> {
+    prop::collection::vec(prop::sample::select(MAPPED_ALPHABET), 1..16)
+        .prop_map(|cs| cs.into_iter().collect())
+}
+
+/// Every character the document defines a mapping for extracts as itself.
+/// Nothing outside the mapped set may appear: a '?', a `.notdef` replacement, or
+/// the literal ASCII of a code all mean the extraction overrode the mapping the
+/// document declared.
+///
+/// One property per mapping mechanism rather than one with the mechanism as a
+/// generated axis: with a single property, a failure on one path shrinks and
+/// stops there, hiding whether the others also break.
+fn assert_mapping_honoured(mapping: Mapping, drawn: &[(u32, char)]) -> Result<(), TestCaseError> {
+    let expected: String = drawn.iter().map(|(_, c)| *c).collect();
+    let extracted = extract(&mapped_pdf(mapping, drawn));
+
+    let defined: std::collections::HashSet<char> = expected.chars().collect();
+    for c in extracted.chars() {
+        prop_assert!(
+            c.is_whitespace() || defined.contains(&c),
+            "{mapping:?}: extracted {c:?}, which the document maps no code to \
+             (mapped set {defined:?}); drew {expected:?}, got {extracted:?}"
+        );
+    }
+
+    // Collapse whitespace runs rather than deleting whitespace: a mapped space
+    // that disappears entirely must still fail (it is the #438 symptom seen from
+    // the other side), while layout adding its own spacing must not.
+    let normalize = |s: &str| {
+        s.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string()
+    };
+    prop_assert_eq!(
+        normalize(&extracted),
+        normalize(&expected),
+        "{:?}: mapped characters must survive in order; drew {:?}, got {:?}",
+        mapping,
+        expected,
+        extracted
+    );
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Subsetted simple font whose codes only the `/ToUnicode` CMap explains.
+    ///
+    /// This is where #438 lived: the property reproduced it from the contract
+    /// and shrank it below the reported case — drawing the single mapped
+    /// character `" "` came back as `"!"`, because `decode_text` treated a
+    /// decode whose `trim()` is empty as garbage and re-read the code through a
+    /// guessed encoding. In a subset with no `/Encoding` there is nothing to
+    /// guess from.
+    #[test]
+    fn to_unicode_subset_mapping_is_honoured(text in mapped_string()) {
+        let drawn = codes_for_text(Mapping::ToUnicodeSubset, &text);
+        assert_mapping_honoured(Mapping::ToUnicodeSubset, &drawn)?;
+    }
+
+    /// Type0 `/Identity-H` with a CID descendant and a two-byte `/ToUnicode`.
+    ///
+    /// Also broken by #438 — verified by reverting the fix with this test in
+    /// place. Worth recording how nearly it was missed: a first version of this
+    /// property numbered its codes from 1 and compared with all whitespace
+    /// stripped from both sides. Under the bug, the fallback then decoded
+    /// `[0x00, 0x01]` into control characters that sanitization deletes, and a
+    /// space that vanishes entirely is invisible to an assertion that deletes
+    /// spaces anyway. It passed 300 cases against broken code. Both details in
+    /// `FIRST_CODE` and in the whitespace-collapsing comparison exist to keep
+    /// the substitution observable.
+    #[test]
+    fn identity_h_mapping_is_honoured(text in mapped_string()) {
+        let drawn = codes_for_text(Mapping::IdentityH, &text);
+        assert_mapping_honoured(Mapping::IdentityH, &drawn)?;
+    }
+
+    /// Type0 `/Identity-H` with NO `/ToUnicode`: the code means whatever the
+    /// named CID collection says. This is a different decoder from the two
+    /// above (which both resolve through the `/ToUnicode` CMap), with its own
+    /// copy of the acceptance rule — so it needs its own property or it stays
+    /// unguarded no matter how many cases the others run.
+    ///
+    /// The drawn CIDs include CID 1, which in Adobe-Japan1 is U+00A0: a
+    /// whitespace character reached through this decoder, the same shape as the
+    /// #438 trigger on the other path.
+    ///
+    /// FALSIFIABILITY, stated honestly: unlike the two above, this property
+    /// passes both with and without the #438 fix — checked by reverting it. This
+    /// decoder's own acceptance rule already tolerated U+00A0 (it tested
+    /// `is_ascii_control`, which a no-break space is not), so the bug never
+    /// reached here. It guards the path going forward — the two rules are now
+    /// one shared predicate, and this is what stops it from drifting back — but
+    /// it did not catch #438 and is not evidence that it would have.
+    #[test]
+    fn cid_table_mapping_is_honoured(
+        cids in prop::collection::vec(prop::sample::select(cid_sample()), 1..16),
+    ) {
+        let drawn = codes_for_cids(&cids);
+        assert_mapping_honoured(Mapping::CidTable, &drawn)?;
+    }
+}
+
+// ---------- Invariant 3b: the coverage report does not lie ----------
+//
+// The other half of the same contract. When a character genuinely has no glyph,
+// rendering it as `.notdef` is correct PDF behaviour — what is not acceptable is
+// a green light that turns out to be false. `font_missing_glyphs` exists so a
+// caller can know beforehand, so a character it does NOT list has to come back
+// out of the document. #392 is exactly that disagreement: `[]` reported while
+// the glyphs came out as '?'.
+//
+// SCOPE, stated rather than implied: extraction reads the text, not the paint.
+// A character whose glyph is `.notdef` but whose `/ToUnicode` is right still
+// extracts fine — verified: Roboto reports 漢/字/✓ missing and all three still
+// extract. So this property guards the direction that matters for a silent data
+// loss (reported present ⇒ must survive) and CANNOT see the reverse (reported
+// missing ⇒ blank box actually painted). Detecting a painted `.notdef` needs the
+// rendered page, not the extracted text; that is left unguarded here on purpose.
+
+const ROBOTO_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+
+fn roboto() -> Vec<u8> {
+    std::fs::read(ROBOTO_PATH).expect("read Roboto fixture")
+}
+
+/// Latin (surely covered), Cyrillic and CJK (the ranges an embedded Latin subset
+/// may or may not carry). The property does not assume which side each falls on
+/// — that is precisely what the report is supposed to tell the caller.
+const COVERAGE_ALPHABET: &[char] = &['A', 'z', 'á', 'ñ', 'Э', 'ч', 'ф', '漢', '字', '€', '✓'];
+
+proptest! {
+    // Each case embeds and subsets a real TTF, which is costly; 48 is a
+    // cost tradeoff, not a coverage ceiling on the invariant.
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    /// A character the coverage report does not list must survive being drawn:
+    /// reporting nothing missing while the glyph comes out as '?' (or not at
+    /// all) is the false all-clear of #392.
+    #[test]
+    fn coverage_report_agrees_with_what_survives(
+        text in prop::collection::vec(prop::sample::select(COVERAGE_ALPHABET), 1..12)
+            .prop_map(|cs| cs.into_iter().collect::<String>()),
+    ) {
+        let mut doc = oxidize_pdf::Document::new();
+        doc.add_font_from_bytes("F", roboto()).expect("embed font");
+        let missing: std::collections::HashSet<char> =
+            doc.font_missing_glyphs("F", &text).into_iter().collect();
+
+        let mut page = oxidize_pdf::Page::a4();
+        page.text()
+            .set_font(Font::Custom("F".to_string()), 24.0)
+            .at(50.0, 700.0)
+            .write(&text)
+            .expect("write text");
+        doc.add_page(page);
+        let extracted = extract(&doc.to_bytes().expect("serialize"));
+
+        let survived: std::collections::HashSet<char> = extracted.chars().collect();
+        for ch in text.chars().filter(|c| !c.is_whitespace()) {
+            if missing.contains(&ch) {
+                continue; // declared unrenderable up front — honest.
+            }
+            prop_assert!(
+                survived.contains(&ch),
+                "{ch:?} was not reported missing (report: {missing:?}) yet did not \
+                 survive drawing; drew {text:?}, extracted {extracted:?}"
+            );
+        }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -14,6 +14,8 @@
 //! grouping path with its own section logic and is NOT covered here (it needs an
 //! `ElementGraph`). Example guards live in `hybrid_chunking_graph_test.rs`.
 
+#[cfg(feature = "tiktoken")]
+use oxidize_pdf::pipeline::TiktokenCounter;
 use oxidize_pdf::pipeline::{
     ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
     HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, RagChunk, TableElementData,
@@ -21,6 +23,8 @@ use oxidize_pdf::pipeline::{
 };
 use proptest::prelude::*;
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "tiktoken")]
+use std::sync::{Arc, OnceLock};
 
 /// A generated element, before it is given its position-derived marker.
 #[derive(Debug, Clone)]
@@ -264,6 +268,54 @@ proptest! {
             let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
             let actual: BTreeSet<u32> = rag.page_numbers.iter().copied().collect();
             prop_assert_eq!(actual, expected, "chunk {} page set", i);
+        }
+    }
+}
+
+/// cl100k_base ships multi-MB rank tables; load once for the whole suite rather
+/// than per generated case.
+#[cfg(feature = "tiktoken")]
+fn tiktoken() -> Arc<TiktokenCounter> {
+    static C: OnceLock<Arc<TiktokenCounter>> = OnceLock::new();
+    C.get_or_init(|| Arc::new(TiktokenCounter::cl100k_base()))
+        .clone()
+}
+
+// Fewer cases than the other blocks: every case runs real BPE over the whole
+// chunk set, which is orders of magnitude slower than the word proxy.
+#[cfg(feature = "tiktoken")]
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I3-BPE — BUDGET UNDER THE INJECTED COUNTER: no chunk the chunker did not
+    /// itself flag oversized may exceed `max_tokens` when measured with the very
+    /// counter that governed the split.
+    ///
+    /// The split decision sums per-element counts while the stamp counts the
+    /// joined text (`hybrid_chunking.rs:296,308` vs `:271-277`). That identity
+    /// holds for whitespace counting and not for BPE.
+    #[test]
+    fn no_chunk_exceeds_its_budget_under_bpe(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let counter = tiktoken();
+        let max_tokens = config.max_tokens;
+        let chunks = HybridChunker::new(config)
+            .with_token_counter(counter.clone())
+            .chunk(&elements);
+        for (i, c) in chunks.iter().enumerate() {
+            if c.is_oversized() {
+                continue;
+            }
+            let measured = counter.count(&c.text());
+            prop_assert!(
+                measured <= max_tokens,
+                "chunk {}: {} BPE tokens over a {}-token budget",
+                i,
+                measured,
+                max_tokens
+            );
         }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -91,6 +91,34 @@ fn make_element(s: &ElemSpec, idx: usize) -> Element {
     }
 }
 
+/// As [`element_seq`], but some elements carry EMPTY text.
+///
+/// Only used by the BPE budget property, which is feature-gated.
+///
+/// `ElementData.text` is a plain `pub String` with no non-empty invariant, so an
+/// element with no display text is reachable through the public API. It is also
+/// the case that separates two things a budget decision must never conflate:
+/// "the buffer holds no elements" and "the buffer's accumulated text is empty".
+/// A decision keyed on the second grows the emitted chunk while measuring zero.
+///
+/// The marker-based properties cannot use this generator (they identify elements
+/// by a marker in their text), which is exactly why the budget property carries
+/// its own: the gap was invisible to a generator that always writes a marker.
+#[cfg(feature = "tiktoken")]
+fn element_seq_with_empty_texts() -> impl Strategy<Value = Vec<Element>> {
+    (element_seq(), prop::collection::vec(any::<bool>(), 12)).prop_map(|(mut els, blank)| {
+        for (i, el) in els.iter_mut().enumerate() {
+            if blank.get(i).copied().unwrap_or(false) {
+                match el {
+                    Element::Paragraph(d) | Element::ListItem(d) => d.text.clear(),
+                    _ => {}
+                }
+            }
+        }
+        els
+    })
+}
+
 fn element_seq() -> impl Strategy<Value = Vec<Element>> {
     prop::collection::vec(elem_spec(), 1..=12).prop_map(|specs| {
         specs
@@ -148,6 +176,50 @@ fn word_multiset(s: &str) -> BTreeMap<&str, usize> {
     m
 }
 
+/// Deterministic pin: a run of elements whose display text is empty must not
+/// slip past the budget check.
+///
+/// Found by review, not by the property — the generator wrote a marker into
+/// every element, so "buffer has no elements" and "buffer text is empty" never
+/// came apart. They are different questions, and a budget decision that asks the
+/// second one measures zero while the emitted chunk keeps growing: `make_chunk`
+/// joins with `"\n"`, and those separators are real tokens under BPE.
+#[cfg(feature = "tiktoken")]
+#[test]
+fn empty_text_elements_do_not_escape_the_budget() {
+    let max_tokens = 4;
+    let elements: Vec<Element> = (0..200)
+        .map(|_| {
+            Element::Paragraph(ElementData {
+                text: String::new(),
+                metadata: ElementMetadata::default(),
+            })
+        })
+        .collect();
+    let counter = tiktoken();
+    let chunks = HybridChunker::new(HybridChunkConfig {
+        max_tokens,
+        overlap_tokens: 0,
+        merge_adjacent: true,
+        propagate_headings: false,
+        merge_policy: MergePolicy::SameTypeOnly,
+        context_mode: ContextMode::None,
+    })
+    .with_token_counter(counter.clone())
+    .chunk(&elements);
+
+    for (i, c) in chunks.iter().enumerate() {
+        if c.is_oversized() {
+            continue;
+        }
+        let measured = counter.count(&c.text());
+        assert!(
+            measured <= max_tokens,
+            "chunk {i}: {measured} BPE tokens over a {max_tokens}-token budget"
+        );
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -190,22 +262,30 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
-    /// I3 — HONEST BUDGET: the number stamped as a chunk's cost counts exactly
-    /// the text the library designates as embeddable.
+    /// I3 — HONEST BUDGET: the stamped cost counts exactly the text the budget
+    /// governs, which is the chunk's CONTENT (`text`) — never the metadata
+    /// wrapped around it.
     ///
-    /// `RagChunk::full_text` is that designated text (`rag.rs:23`:
-    /// "use this for embedding generation") and `token_estimate` is documented
-    /// as its token count. If they disagree, a consumer sizing against a real
-    /// embedding model's hard limit is silently over budget: the provider
-    /// truncates the tail, the tail never reaches the vector, and that content
-    /// becomes unretrievable while still sitting in the store.
+    /// The vector represents the content. Heading context, breadcrumb, document
+    /// title and page span are there to filter and to rebuild neighbourhood at
+    /// query time; embedding them dilutes the signal and spends the model's
+    /// input budget on text repeated across every chunk of a section. So
+    /// `max_tokens`, `token_estimate` and the split decision all refer to
+    /// `text`, and `full_text` is a presentation concern that no count follows.
     ///
-    /// PINNED: fails today — see issue #434. The property states the contract;
-    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
-    /// this becomes a permanent guard. Precedent: #430.
+    /// HISTORY — why this property is stated this way. It previously asserted
+    /// the opposite: that the stamp had to measure `full_text`, "the text
+    /// designated for embedding". That phrase came from a doc-comment
+    /// (`rag.rs:23`), not from the contract, and the doc-comment was wrong. The
+    /// property inherited its error, failed against correct code, and was filed
+    /// as bug #434 — which was closed as invalid, and the doc-comment fixed.
+    ///
+    /// The lesson is the catalogue's own rule, violated here: an invariant is
+    /// derived from the contract, and a doc-comment is not the contract. When a
+    /// property fails, the possibility that the PROPERTY is wrong has to be
+    /// eliminated before the failure is written up as a defect in the code.
     #[test]
-    #[ignore = "issue #434: token_estimate does not measure full_text"]
-    fn stamped_count_measures_the_text_designated_for_embedding(
+    fn stamped_count_measures_the_content_the_budget_governs(
         elements in element_seq(),
         config in chunk_config(),
     ) {
@@ -213,11 +293,11 @@ proptest! {
         let chunks = chunk(&elements, config);
         for (i, c) in chunks.iter().enumerate() {
             let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
-            let measured = WordProxyCounter.count(&rag.full_text);
+            let measured = WordProxyCounter.count(&rag.text);
             prop_assert_eq!(
                 rag.token_estimate,
                 measured,
-                "chunk {}: stamped {} tokens, full_text measures {}",
+                "chunk {}: stamped {} tokens, content measures {}",
                 i,
                 rag.token_estimate,
                 measured
@@ -302,17 +382,21 @@ proptest! {
     /// itself flag oversized may exceed `max_tokens` when measured with the very
     /// counter that governed the split.
     ///
-    /// The split decision sums per-element counts while the stamp counts the
-    /// joined text (`hybrid_chunking.rs:296,308` vs `:271-277`). That identity
-    /// holds for whitespace counting and not for BPE.
+    /// This caught #435 (fixed): the split decision summed per-element counts
+    /// while the emitted chunk counted the joined text. Sum equals join only for
+    /// a counter that is additive across the separator — true of the whitespace
+    /// proxy, false of BPE — so the budget approved chunks whose real cost was
+    /// never measured. The decision now measures the joined text it is about to
+    /// emit, in all three places that used to do arithmetic instead: the merge
+    /// check, `split_by_sentences`, and the oversize flag on split fragments.
     ///
-    /// PINNED: fails today — see issue #435. The property states the contract;
-    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
-    /// this becomes a permanent guard. Precedent: #430.
+    /// Generated over [`element_seq_with_empty_texts`] rather than
+    /// [`element_seq`]: an element with empty display text is what separates
+    /// "the buffer holds no elements" from "the buffered text is empty", and the
+    /// first fix conflated them. See `empty_text_elements_do_not_escape_the_budget`.
     #[test]
-    #[ignore = "issue #435: split decision sums per-element counts; BPE is not additive across the join"]
     fn no_chunk_exceeds_its_budget_under_bpe(
-        elements in element_seq(),
+        elements in element_seq_with_empty_texts(),
         config in chunk_config(),
     ) {
         let counter = tiktoken();

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -1,0 +1,180 @@
+//! Chunking-layer invariants, stated from the RAG contract (`the chunk set is a
+//! faithful partition of the input text, and every chunk is fit to be
+//! vectorized`), not from a reported bug. `HybridChunker::chunk` is a pure
+//! function of (elements, config), so the generator is cheap and the input space
+//! is large: element types × lengths × headings × five config dimensions × two
+//! token counters.
+//!
+//! Layer rule (see spec §4): an invariant lives at the cheapest layer where it
+//! is NOT tautological. `chunk_index` and `heading_path` are supplied by the
+//! caller at this layer, so asserting them here would test the test. They live
+//! in `prop_rag_e2e_invariants.rs`.
+//!
+//! Known gap, accepted: `HybridChunker::chunk_with_graph` is a second public
+//! grouping path with its own section logic and is NOT covered here (it needs an
+//! `ElementGraph`). Example guards live in `hybrid_chunking_graph_test.rs`.
+
+use oxidize_pdf::pipeline::{
+    ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
+    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, TableElementData,
+};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+/// A generated element, before it is given its position-derived marker.
+#[derive(Debug, Clone)]
+struct ElemSpec {
+    /// 0=Paragraph 1=ListItem 2=KeyValue (inline, mergeable);
+    /// 3=Title 4=Table 5=CodeBlock (structural, always start a new chunk).
+    kind: u8,
+    words: usize,
+    page: u32,
+    has_heading: bool,
+}
+
+fn elem_spec() -> impl Strategy<Value = ElemSpec> {
+    (0u8..6u8, 1usize..=60usize, 0u32..=3u32, any::<bool>()).prop_map(
+        |(kind, words, page, has_heading)| ElemSpec {
+            kind,
+            words,
+            page,
+            has_heading,
+        },
+    )
+}
+
+/// Build the element for `s` at input position `idx`.
+///
+/// The text opens with the unique marker `E{idx}_`. Markers are prefix-free
+/// thanks to the trailing `_` and a body that never contains `_`, so
+/// `text.contains("E1_")` cannot be satisfied by `E11_`.
+///
+/// Every fifth word ends in `.` so the text carries real sentence boundaries —
+/// without them `split_by_sentences` returns the whole text as one fragment and
+/// the oversized-split path (`hybrid_chunking.rs:337-356`) is never exercised.
+fn make_element(s: &ElemSpec, idx: usize) -> Element {
+    let body = (0..s.words)
+        .map(|w| {
+            if w % 5 == 4 {
+                format!("w{w}.")
+            } else {
+                format!("w{w}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let text = format!("E{idx}_ {body}");
+    let metadata = ElementMetadata {
+        page: s.page,
+        parent_heading: s.has_heading.then(|| format!("H{idx}")),
+        ..Default::default()
+    };
+    match s.kind {
+        0 => Element::Paragraph(ElementData { text, metadata }),
+        1 => Element::ListItem(ElementData { text, metadata }),
+        2 => Element::KeyValue(KeyValueElementData {
+            key: text,
+            value: String::from("v"),
+            metadata,
+        }),
+        3 => Element::Title(ElementData { text, metadata }),
+        4 => Element::Table(TableElementData::new(vec![vec![text]], metadata)),
+        _ => Element::CodeBlock(ElementData { text, metadata }),
+    }
+}
+
+fn element_seq() -> impl Strategy<Value = Vec<Element>> {
+    prop::collection::vec(elem_spec(), 1..=12).prop_map(|specs| {
+        specs
+            .iter()
+            .enumerate()
+            .map(|(i, s)| make_element(s, i))
+            .collect()
+    })
+}
+
+/// `max_tokens` in 4..=64 against elements of 1..=60 words: the budget is
+/// routinely smaller than a single element, so the flush, the type-boundary and
+/// the oversized-split paths all fire.
+fn chunk_config() -> impl Strategy<Value = HybridChunkConfig> {
+    (
+        4usize..=64usize,
+        any::<bool>(),
+        any::<bool>(),
+        prop_oneof![
+            Just(MergePolicy::SameTypeOnly),
+            Just(MergePolicy::AnyInlineContent)
+        ],
+        prop_oneof![
+            Just(ContextMode::None),
+            Just(ContextMode::Heading),
+            Just(ContextMode::Contextual(ContextFormat::Labeled)),
+            Just(ContextMode::Contextual(ContextFormat::Prose)),
+        ],
+    )
+        .prop_map(
+            |(max_tokens, merge_adjacent, propagate_headings, merge_policy, context_mode)| {
+                HybridChunkConfig {
+                    max_tokens,
+                    overlap_tokens: 0,
+                    merge_adjacent,
+                    propagate_headings,
+                    merge_policy,
+                    context_mode,
+                }
+            },
+        )
+}
+
+fn chunk(elements: &[Element], config: HybridChunkConfig) -> Vec<HybridChunk> {
+    HybridChunker::new(config).chunk(elements)
+}
+
+/// Word -> occurrence count. Whitespace-split, so it is robust to the chunker's
+/// legitimate reflow of separators but still catches a dropped or duplicated word.
+fn word_multiset(s: &str) -> BTreeMap<&str, usize> {
+    let mut m = BTreeMap::new();
+    for w in s.split_whitespace() {
+        *m.entry(w).or_insert(0) += 1;
+    }
+    m
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I2a — IDENTITY: each input element's marker lands in exactly one chunk.
+    /// When an oversized element is split, its marker rides the first fragment,
+    /// so the count stays 1 either way.
+    #[test]
+    fn every_element_marker_lands_in_exactly_one_chunk(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let chunks = chunk(&elements, config);
+        for idx in 0..elements.len() {
+            let marker = format!("E{idx}_");
+            let hits = chunks.iter().filter(|c| c.text().contains(&marker)).count();
+            prop_assert_eq!(hits, 1, "marker {} landed in {} chunks", marker, hits);
+        }
+    }
+
+    /// I2b — CONSERVATION: the chunk set carries every input word exactly as
+    /// often as the input did. Identity alone (I2a) is satisfiable by dropping
+    /// everything but the first word of each element; conservation alone does
+    /// not localize. Both are required.
+    #[test]
+    fn chunk_text_conserves_every_input_word(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let input = elements
+            .iter()
+            .map(|e| e.display_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let chunks = chunk(&elements, config);
+        let output = chunks.iter().map(|c| c.text()).collect::<Vec<_>>().join("\n");
+        prop_assert_eq!(word_multiset(&output), word_multiset(&input));
+    }
+}

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -16,7 +16,8 @@
 
 use oxidize_pdf::pipeline::{
     ContextFormat, ContextMode, Element, ElementData, ElementMetadata, HybridChunk,
-    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, TableElementData,
+    HybridChunkConfig, HybridChunker, KeyValueElementData, MergePolicy, RagChunk, TableElementData,
+    TokenCounter, WordProxyCounter,
 };
 use proptest::prelude::*;
 use std::collections::BTreeMap;
@@ -176,5 +177,44 @@ proptest! {
         let chunks = chunk(&elements, config);
         let output = chunks.iter().map(|c| c.text()).collect::<Vec<_>>().join("\n");
         prop_assert_eq!(word_multiset(&output), word_multiset(&input));
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I3 — HONEST BUDGET: the number stamped as a chunk's cost counts exactly
+    /// the text the library designates as embeddable.
+    ///
+    /// `RagChunk::full_text` is that designated text (`rag.rs:23`:
+    /// "use this for embedding generation") and `token_estimate` is documented
+    /// as its token count. If they disagree, a consumer sizing against a real
+    /// embedding model's hard limit is silently over budget: the provider
+    /// truncates the tail, the tail never reaches the vector, and that content
+    /// becomes unretrievable while still sitting in the store.
+    ///
+    /// PINNED: fails today — see issue #434. The property states the contract;
+    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
+    /// this becomes a permanent guard. Precedent: #430.
+    #[test]
+    #[ignore = "issue #434: token_estimate does not measure full_text"]
+    fn stamped_count_measures_the_text_designated_for_embedding(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let mode = config.context_mode;
+        let chunks = chunk(&elements, config);
+        for (i, c) in chunks.iter().enumerate() {
+            let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
+            let measured = WordProxyCounter.count(&rag.full_text);
+            prop_assert_eq!(
+                rag.token_estimate,
+                measured,
+                "chunk {}: stamped {} tokens, full_text measures {}",
+                i,
+                rag.token_estimate,
+                measured
+            );
+        }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -255,6 +255,12 @@ proptest! {
     /// I4b — PAGE TRACEABILITY: a chunk's `page_numbers` is exactly the union of
     /// its elements' pages. It is a filter field in the vector store: if it
     /// lies, a page-scoped query returns incomplete results and never errors.
+    ///
+    /// Scope: this guards the union/dedup/sort of pages the chunk carries, not
+    /// whether each element's page was assigned correctly — the chunker does not
+    /// assign pages, partition does. A mis-assigned page is I1's territory (E2E),
+    /// not observable here where both sides read `metadata().page` from the same
+    /// elements.
     #[test]
     fn chunk_pages_are_the_union_of_its_elements_pages(
         elements in element_seq(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -93,7 +93,7 @@ fn make_element(s: &ElemSpec, idx: usize) -> Element {
 
 /// As [`element_seq`], but some elements carry EMPTY text.
 ///
-/// Only used by the BPE budget property, which is feature-gated.
+/// Only used by the two budget properties.
 ///
 /// `ElementData.text` is a plain `pub String` with no non-empty invariant, so an
 /// element with no display text is reachable through the public API. It is also
@@ -104,7 +104,6 @@ fn make_element(s: &ElemSpec, idx: usize) -> Element {
 /// The marker-based properties cannot use this generator (they identify elements
 /// by a marker in their text), which is exactly why the budget property carries
 /// its own: the gap was invisible to a generator that always writes a marker.
-#[cfg(feature = "tiktoken")]
 fn element_seq_with_empty_texts() -> impl Strategy<Value = Vec<Element>> {
     (element_seq(), prop::collection::vec(any::<bool>(), 12)).prop_map(|(mut els, blank)| {
         for (i, el) in els.iter_mut().enumerate() {
@@ -359,6 +358,102 @@ proptest! {
             let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
             let actual: BTreeSet<u32> = rag.page_numbers.iter().copied().collect();
             prop_assert_eq!(actual, expected, "chunk {} page set", i);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I3-DEFAULT — BUDGET UNDER THE DEFAULT COUNTER: same invariant as
+    /// `no_chunk_exceeds_its_budget_under_bpe`, measured with the word proxy.
+    ///
+    /// Not a duplicate of the BPE property: the two exercise different code. The
+    /// chunker takes an O(1) accumulation path for a counter that declares itself
+    /// additive over the join separator, and a re-measure path for one that does
+    /// not. The word proxy is the only counter that declares additivity, so
+    /// without this property the entire fast path — the branch that ships by
+    /// default — is unguarded, and an arithmetic error there would surface as
+    /// exactly the over-budget chunk of #435.
+    #[test]
+    fn no_chunk_exceeds_its_budget_under_the_default_counter(
+        elements in element_seq_with_empty_texts(),
+        config in chunk_config(),
+    ) {
+        let counter = WordProxyCounter;
+        let max_tokens = config.max_tokens;
+        let chunks = HybridChunker::new(config).chunk(&elements);
+        for (i, c) in chunks.iter().enumerate() {
+            if c.is_oversized() {
+                continue;
+            }
+            let measured = counter.count(&c.text());
+            prop_assert!(
+                measured <= max_tokens,
+                "chunk {}: {} word-proxy tokens over a {}-token budget",
+                i,
+                measured,
+                max_tokens
+            );
+        }
+    }
+}
+
+/// Whether `text` holds more than one of the generator's sentences.
+///
+/// The generator writes `". "` between sentences and nowhere else, so this reads
+/// the input's own structure rather than re-deriving production's sentence
+/// parser — a test that reimplemented `split_into_sentences` would agree with it
+/// by construction and catch nothing.
+fn spans_multiple_sentences(text: &str) -> bool {
+    text.trim_end().contains(". ")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I3-SPLIT — AN OVERSIZED FRAGMENT MUST BE IRREDUCIBLE: a chunk the splitter
+    /// flagged oversized may hold at most ONE sentence.
+    ///
+    /// The budget properties cannot see this. A fragment that exceeds
+    /// `max_tokens` is emitted with `oversized: true`, and both budget properties
+    /// skip flagged chunks — correctly, since a single sentence longer than the
+    /// budget has to come out whole. But that exemption also means a splitter
+    /// that packs two sentences past the budget produces no failure anywhere: the
+    /// flag makes the overrun honest, and honesty is all the budget properties
+    /// ask for.
+    ///
+    /// So the contract is stated where it bites: the splitter is only permitted
+    /// to exceed the budget when it has no break left to take. One sentence
+    /// over budget is irreducible; two is a packing decision that went past the
+    /// budget with a break available.
+    ///
+    /// This is the property that guards the accumulation fast path in
+    /// `split_by_sentences` — verified by breaking that sum and watching this
+    /// test, and only this test, fail.
+    #[test]
+    fn an_oversized_fragment_holds_at_most_one_sentence(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let chunks = HybridChunker::new(config).chunk(&elements);
+        for (i, c) in chunks.iter().enumerate() {
+            // Only fragments of splittable elements come from the sentence
+            // splitter. A table, code block or key-value pair is emitted whole
+            // and oversized by design, with no break available to take.
+            let from_splitter = matches!(
+                c.elements(),
+                [Element::Paragraph(_)] | [Element::ListItem(_)]
+            );
+            if !c.is_oversized() || !from_splitter {
+                continue;
+            }
+            let text = c.text();
+            prop_assert!(
+                !spans_multiple_sentences(&text),
+                "chunk {i} is flagged oversized yet holds a sentence break it \
+                 could have split at: {text:?}"
+            );
         }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -294,7 +294,12 @@ proptest! {
     /// The split decision sums per-element counts while the stamp counts the
     /// joined text (`hybrid_chunking.rs:296,308` vs `:271-277`). That identity
     /// holds for whitespace counting and not for BPE.
+    ///
+    /// PINNED: fails today — see issue #435. The property states the contract;
+    /// the code does not honor it yet. Remove `#[ignore]` when the fix ships and
+    /// this becomes a permanent guard. Precedent: #430.
     #[test]
+    #[ignore = "issue #435: split decision sums per-element counts; BPE is not additive across the join"]
     fn no_chunk_exceeds_its_budget_under_bpe(
         elements in element_seq(),
         config in chunk_config(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -6,9 +6,12 @@
 //! token counters.
 //!
 //! Layer rule (see spec §4): an invariant lives at the cheapest layer where it
-//! is NOT tautological. `chunk_index` and `heading_path` are supplied by the
-//! caller at this layer, so asserting them here would test the test. They live
-//! in `prop_rag_e2e_invariants.rs`.
+//! is NOT tautological. `heading_path` is supplied by the caller at this layer,
+//! so asserting it here would test the test; it is guarded end-to-end by the
+//! breadcrumb property in `prop_rag_e2e_invariants.rs`. `chunk_index` is not
+//! separately guarded: production assigns it by `enumerate()`, so a
+//! contiguity assertion at any layer is structurally trivial (there is no input
+//! that makes it non-sequential) — not worth a property.
 //!
 //! Known gap, accepted: `HybridChunker::chunk_with_graph` is a second public
 //! grouping path with its own section logic and is NOT covered here (it needs an
@@ -256,11 +259,13 @@ proptest! {
     /// its elements' pages. It is a filter field in the vector store: if it
     /// lies, a page-scoped query returns incomplete results and never errors.
     ///
-    /// Scope: this guards the union/dedup/sort of pages the chunk carries, not
-    /// whether each element's page was assigned correctly — the chunker does not
-    /// assign pages, partition does. A mis-assigned page is I1's territory (E2E),
-    /// not observable here where both sides read `metadata().page` from the same
-    /// elements.
+    /// Scope: because both sides are compared as `BTreeSet`s, this guards
+    /// membership — no page dropped, none foreign — but not the dedup/ordering
+    /// of the production `Vec` (the set re-sorts and re-dedups both sides). Nor
+    /// does it guard whether each element's page was assigned correctly: the
+    /// chunker does not assign pages, partition does, so a mis-assigned page is
+    /// I1's territory (E2E), not observable here where both sides read
+    /// `metadata().page` from the same elements.
     #[test]
     fn chunk_pages_are_the_union_of_its_elements_pages(
         elements in element_seq(),

--- a/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_chunking_invariants.rs
@@ -20,7 +20,7 @@ use oxidize_pdf::pipeline::{
     TokenCounter, WordProxyCounter,
 };
 use proptest::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A generated element, before it is given its position-derived marker.
 #[derive(Debug, Clone)]
@@ -215,6 +215,55 @@ proptest! {
                 rag.token_estimate,
                 measured
             );
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// I4a — ORDER: chunks come out in input-element order. Consumers rebuild
+    /// context from neighbouring chunks, so a reordering silently changes what
+    /// an LLM is handed as "the surrounding text".
+    ///
+    /// Fragments of a split element carry no marker (only the first fragment
+    /// does), so they are skipped here; they are contiguous with their marked
+    /// head by construction.
+    #[test]
+    fn chunks_come_out_in_input_element_order(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let n = elements.len();
+        let chunks = chunk(&elements, config);
+        let firsts: Vec<usize> = chunks
+            .iter()
+            .filter_map(|c| {
+                let t = c.text();
+                (0..n).find(|i| t.contains(&format!("E{i}_")))
+            })
+            .collect();
+        let mut sorted = firsts.clone();
+        sorted.sort_unstable();
+        prop_assert_eq!(&firsts, &sorted, "chunk order does not follow input order");
+    }
+
+    /// I4b — PAGE TRACEABILITY: a chunk's `page_numbers` is exactly the union of
+    /// its elements' pages. It is a filter field in the vector store: if it
+    /// lies, a page-scoped query returns incomplete results and never errors.
+    #[test]
+    fn chunk_pages_are_the_union_of_its_elements_pages(
+        elements in element_seq(),
+        config in chunk_config(),
+    ) {
+        let mode = config.context_mode;
+        let chunks = chunk(&elements, config);
+        for (i, c) in chunks.iter().enumerate() {
+            let expected: BTreeSet<u32> =
+                c.elements().iter().map(|e| e.metadata().page).collect();
+            let rag = RagChunk::from_hybrid_chunk_with_mode(i, c, mode);
+            let actual: BTreeSet<u32> = rag.page_numbers.iter().copied().collect();
+            prop_assert_eq!(actual, expected, "chunk {} page set", i);
         }
     }
 }

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -56,14 +56,13 @@ fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
 /// Geometry: at most 3 sections × 3 paragraphs = 3 × (40 + 3×20) = 300pt from
 /// y=760, so the content never runs off an A4 page.
 ///
-/// The 40pt title→body gap (vs. 20pt between body lines) is the plan's
-/// original, realistic geometry: more space-before-heading than intra-
-/// paragraph line spacing, as in a real document. At this gap,
-/// `merge_into_paragraphs` (src/text/extraction.rs) folds the title into its
-/// body — see issue #436 — because its merge threshold
-/// (`1.5 * median(line_height)`) has no check on font-size/weight change
-/// between lines. Left at 40pt deliberately so the property keeps exercising
-/// (and failing against) that real bug instead of walking around it.
+/// The 40pt title→body gap (vs. 20pt between body lines) is realistic
+/// geometry: more space-before-heading than intra-paragraph line spacing, as
+/// in a real document. It is also the gap that exposed #436 — at 40pt the
+/// vertical threshold of `merge_into_paragraphs` (`1.5 * median(line_height)`)
+/// does not separate title from body, so only the font-size/weight check does.
+/// Kept at 40pt deliberately: widening it would walk around the bug this
+/// property exists to guard.
 fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
     let mut doc = Document::new();
     let mut page = Page::a4();
@@ -150,13 +149,12 @@ proptest! {
     /// hard chunk boundary, so no chunk spans two sections. This property's
     /// falsifiability is instead demonstrated by the real bug #436 it catches.
     ///
-    /// PINNED: fails today — see issue #436 (text extraction merges a heading
-    /// into the following body when they are close, corrupting heading_path).
-    /// The property states the contract; extraction does not honor it yet.
-    /// Remove `#[ignore]` when #436 ships and this becomes a permanent guard.
-    /// Precedent: #430, #434, #435.
+    /// History: this property caught #436 against production code — extraction
+    /// merged a heading into the following body whenever they sat close
+    /// together, so the merged fragment inherited the heading's size and became
+    /// the breadcrumb of every section after it. Fixed by the style check in
+    /// `same_paragraph_style` (src/text/extraction.rs); now a permanent guard.
     #[test]
-    #[ignore = "issue #436: font-blind paragraph merge swallows headings into body"]
     fn breadcrumb_never_names_a_later_heading(
         paras_per_section in prop::collection::vec(1usize..=3usize, 1..=3),
     ) {

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -46,6 +46,60 @@ fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
     doc.to_bytes().expect("serialize")
 }
 
+/// Build a single-page document of `paras_per_section.len()` sections. Each
+/// section is a 20pt bold title `T{s}_HEADING` followed by its 10pt paragraphs
+/// `S{n}_ ...`, where `n` is a document-global paragraph counter.
+///
+/// Returns the bytes plus `para_section[n] = s`, the true section of paragraph
+/// `n` — the ground truth the property checks the breadcrumb against.
+///
+/// Geometry: at most 3 sections × 3 paragraphs = 3 × (60 + 3×20) = 360pt from
+/// y=760, so the content never runs off an A4 page.
+///
+/// The 60pt title→body gap (vs. 20pt between body lines) is deliberate, not
+/// cosmetic: `merge_into_paragraphs` (src/text/extraction.rs) folds adjacent
+/// lines into one fragment using a threshold of `1.5 * median(line_height)`
+/// with no check on font-size/weight change between them. In a section with
+/// only 1-2 body paragraphs, title lines are a large enough fraction of the
+/// page that the median skews toward the *title's* line height, inflating the
+/// threshold enough to bridge a 40pt title→body gap and merge the title into
+/// its body (and, for the shortest documents, into the *next* section's title
+/// too) — producing a self-referential `heading_path` (the whole merged blob,
+/// not a heading string) that this property then correctly flags as a
+/// violation. 60pt clears that inflated threshold across the whole generated
+/// input space (verified: 1-3 sections × 1-3 paragraphs). This is a real,
+/// reproducible defect in the paragraph-merge heuristic — tracked in the task
+/// report, not papered over here.
+fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    let mut y = 760.0;
+    let mut para_section = Vec::new();
+    let mut n = 0usize;
+
+    for (s, &count) in paras_per_section.iter().enumerate() {
+        page.text()
+            .set_font(Font::HelveticaBold, 20.0)
+            .at(72.0, y)
+            .write(&format!("T{s}_HEADING"))
+            .expect("write title");
+        y -= 60.0;
+        for _ in 0..count {
+            page.text()
+                .set_font(Font::Helvetica, 10.0)
+                .at(72.0, y)
+                .write(&format!("S{n}_ body text of this paragraph"))
+                .expect("write paragraph");
+            para_section.push(s);
+            n += 1;
+            y -= 20.0;
+        }
+    }
+
+    doc.add_page(page);
+    (doc.to_bytes().expect("serialize"), para_section)
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(64))]
 
@@ -79,6 +133,57 @@ proptest! {
             for m in markers {
                 let hits = chunks.iter().filter(|c| c.text.contains(m.as_str())).count();
                 prop_assert_eq!(hits, 1, "run {} landed in {} chunks", m, hits);
+            }
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I5 — BREADCRUMB FIDELITY: a chunk's `heading_path` never names a heading
+    /// that appears after the chunk's own content. `heading_path` is a filter
+    /// field in the vector store; a breadcrumb naming the wrong section returns
+    /// wrong passages for a section-scoped query and never errors.
+    ///
+    /// Honest precondition: the property only asserts on chunks that actually
+    /// carry a breadcrumb. If the classifier did not promote our 20pt bold runs
+    /// to `Title`, the case proves nothing about breadcrumbs and is discarded —
+    /// discarded here, in the open, not hidden behind a weaker assertion.
+    #[test]
+    fn breadcrumb_never_names_a_later_heading(
+        paras_per_section in prop::collection::vec(1usize..=3usize, 1..=3),
+    ) {
+        let (bytes, para_section) = build_titled_doc(&paras_per_section);
+        let doc = open(bytes);
+        let chunks = doc.rag_chunks().expect("rag_chunks");
+
+        prop_assume!(chunks.iter().any(|c| !c.metadata.heading_path.is_empty()));
+
+        for c in &chunks {
+            if c.metadata.heading_path.is_empty() {
+                continue;
+            }
+            // Lowest section index among the paragraphs this chunk carries.
+            let own_section = (0..para_section.len())
+                .filter(|n| c.text.contains(&format!("S{n}_")))
+                .map(|n| para_section[n])
+                .min();
+            let Some(own_section) = own_section else {
+                continue; // title-only chunk: no paragraph to anchor against
+            };
+            for h in &c.metadata.heading_path {
+                for s in 0..paras_per_section.len() {
+                    if h.contains(&format!("T{s}_")) {
+                        prop_assert!(
+                            s <= own_section,
+                            "chunk in section {} carries breadcrumb {:?} from later section {}",
+                            own_section,
+                            h,
+                            s
+                        );
+                    }
+                }
             }
         }
     }

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -53,23 +53,17 @@ fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
 /// Returns the bytes plus `para_section[n] = s`, the true section of paragraph
 /// `n` — the ground truth the property checks the breadcrumb against.
 ///
-/// Geometry: at most 3 sections × 3 paragraphs = 3 × (60 + 3×20) = 360pt from
+/// Geometry: at most 3 sections × 3 paragraphs = 3 × (40 + 3×20) = 300pt from
 /// y=760, so the content never runs off an A4 page.
 ///
-/// The 60pt title→body gap (vs. 20pt between body lines) is deliberate, not
-/// cosmetic: `merge_into_paragraphs` (src/text/extraction.rs) folds adjacent
-/// lines into one fragment using a threshold of `1.5 * median(line_height)`
-/// with no check on font-size/weight change between them. In a section with
-/// only 1-2 body paragraphs, title lines are a large enough fraction of the
-/// page that the median skews toward the *title's* line height, inflating the
-/// threshold enough to bridge a 40pt title→body gap and merge the title into
-/// its body (and, for the shortest documents, into the *next* section's title
-/// too) — producing a self-referential `heading_path` (the whole merged blob,
-/// not a heading string) that this property then correctly flags as a
-/// violation. 60pt clears that inflated threshold across the whole generated
-/// input space (verified: 1-3 sections × 1-3 paragraphs). This is a real,
-/// reproducible defect in the paragraph-merge heuristic — tracked in the task
-/// report, not papered over here.
+/// The 40pt title→body gap (vs. 20pt between body lines) is the plan's
+/// original, realistic geometry: more space-before-heading than intra-
+/// paragraph line spacing, as in a real document. At this gap,
+/// `merge_into_paragraphs` (src/text/extraction.rs) folds the title into its
+/// body — see issue #436 — because its merge threshold
+/// (`1.5 * median(line_height)`) has no check on font-size/weight change
+/// between lines. Left at 40pt deliberately so the property keeps exercising
+/// (and failing against) that real bug instead of walking around it.
 fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
     let mut doc = Document::new();
     let mut page = Page::a4();
@@ -83,7 +77,7 @@ fn build_titled_doc(paras_per_section: &[usize]) -> (Vec<u8>, Vec<usize>) {
             .at(72.0, y)
             .write(&format!("T{s}_HEADING"))
             .expect("write title");
-        y -= 60.0;
+        y -= 40.0;
         for _ in 0..count {
             page.text()
                 .set_font(Font::Helvetica, 10.0)
@@ -150,7 +144,19 @@ proptest! {
     /// carry a breadcrumb. If the classifier did not promote our 20pt bold runs
     /// to `Title`, the case proves nothing about breadcrumbs and is discarded —
     /// discarded here, in the open, not hidden behind a weaker assertion.
+    ///
+    /// The plan's `.first()`/`.last()` ablation is structurally unreachable
+    /// through `rag_chunks()`: `HybridChunker::chunk()` treats `Title` as a
+    /// hard chunk boundary, so no chunk spans two sections. This property's
+    /// falsifiability is instead demonstrated by the real bug #436 it catches.
+    ///
+    /// PINNED: fails today — see issue #436 (text extraction merges a heading
+    /// into the following body when they are close, corrupting heading_path).
+    /// The property states the contract; extraction does not honor it yet.
+    /// Remove `#[ignore]` when #436 ships and this becomes a permanent guard.
+    /// Precedent: #430, #434, #435.
     #[test]
+    #[ignore = "issue #436: font-blind paragraph merge swallows headings into body"]
     fn breadcrumb_never_names_a_later_heading(
         paras_per_section in prop::collection::vec(1usize..=3usize, 1..=3),
     ) {

--- a/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_rag_e2e_invariants.rs
@@ -1,0 +1,85 @@
+//! End-to-end RAG invariants: from PDF bytes through `rag_chunks_with`.
+//!
+//! These state the two contract properties that are tautological one layer down
+//! (see spec §4). A property over `HybridChunker::chunk` takes the `Element`s it
+//! is handed as ground truth, so it cannot see that partition dropped a
+//! paragraph — for it, that paragraph never existed. Only this layer can.
+//!
+//! The generator is deliberately narrow (documents this crate's writer can
+//! build) and the properties assert over injected markers rather than the whole
+//! extracted string: the pipeline reflows separators legitimately.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::pipeline::HybridChunkConfig;
+use oxidize_pdf::{Document, Font, Page};
+use proptest::prelude::*;
+use std::io::Cursor;
+
+/// Printable, non-space ASCII with no `_`: survives a WinAnsi `write()`, extracts
+/// as one contiguous run, and keeps the `_`-terminated markers prefix-free.
+fn marker() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9]{4,24}"
+}
+
+fn open(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("re-parse written PDF");
+    PdfDocument::new(reader)
+}
+
+/// One page per inner Vec; each marker on its own baseline, 60pt apart so each
+/// extracts as its own run and classifies as its own element.
+fn build_marker_doc(pages: &[Vec<String>]) -> Vec<u8> {
+    let mut doc = Document::new();
+    for markers in pages {
+        let mut page = Page::a4();
+        let mut y = 760.0;
+        for m in markers {
+            page.text()
+                .set_font(Font::Helvetica, 12.0)
+                .at(72.0, y)
+                .write(m)
+                .expect("write marker");
+            y -= 60.0;
+        }
+        doc.add_page(page);
+    }
+    doc.to_bytes().expect("serialize")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I1 — CONSERVATION: every text run written to the document lands in the
+    /// `text` of exactly one chunk. Not "at least one": duplication at the
+    /// partition layer is invisible to the chunking-layer property, which would
+    /// see two distinct elements, place each in its own chunk, and pass clean.
+    ///
+    /// The `P{p}M{j}_` prefix makes every marker unique and prefix-free, so a
+    /// `contains` hit is exact.
+    #[test]
+    fn every_written_run_lands_in_exactly_one_chunk(
+        raw in prop::collection::vec(prop::collection::vec(marker(), 1..=3), 1..=3),
+    ) {
+        let pages: Vec<Vec<String>> = raw
+            .iter()
+            .enumerate()
+            .map(|(p, ms)| {
+                ms.iter()
+                    .enumerate()
+                    .map(|(j, m)| format!("P{p}M{j}_{m}"))
+                    .collect()
+            })
+            .collect();
+
+        let doc = open(build_marker_doc(&pages));
+        let config = HybridChunkConfig { max_tokens: 512, ..Default::default() };
+        let chunks = doc.rag_chunks_with(config).expect("rag_chunks_with");
+
+        for markers in &pages {
+            for m in markers {
+                let hits = chunks.iter().filter(|c| c.text.contains(m.as_str())).count();
+                prop_assert_eq!(hits, 1, "run {} landed in {} chunks", m, hits);
+            }
+        }
+    }
+}

--- a/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
@@ -5,6 +5,7 @@
 //! dimension + a deterministic issue_N pin per class.
 
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
 use oxidize_pdf::{Document, Font, Page};
 use proptest::prelude::*;
 use std::io::Cursor;
@@ -28,9 +29,28 @@ fn write_marker_page(doc: &mut Document, marker: &str) {
 
 // Printable, non-space ASCII marker: survives a WinAnsi write() and extracts as
 // one contiguous run. Space and PDF delimiters excluded on purpose.
-#[allow(dead_code)] // used from Task 2 onward
 fn marker() -> impl Strategy<Value = String> {
     "[A-Za-z0-9]{4,24}"
+}
+
+/// Build a document: one page per inner Vec, each marker on its own well-separated
+/// baseline (≥ 40pt apart), standard-14. Returns serialized bytes.
+fn build_text_pages(pages: &[Vec<String>]) -> Vec<u8> {
+    let mut doc = Document::new();
+    for markers in pages {
+        let mut page = Page::a4();
+        let mut y = 760.0;
+        for m in markers {
+            page.text()
+                .set_font(Font::Helvetica, 12.0)
+                .at(72.0, y)
+                .write(m)
+                .expect("write marker");
+            y -= 60.0; // ≥ 40pt separation → each marker extracts as its own run
+        }
+        doc.add_page(page);
+    }
+    doc.to_bytes().expect("serialize")
 }
 
 proptest! {
@@ -47,4 +67,47 @@ proptest! {
         let document = reparse(bytes);
         prop_assert_eq!(document.page_count().expect("page_count"), k as u32);
     }
+
+    /// Every written marker is recoverable from its page's extracted text (#364).
+    #[test]
+    fn text_content_preserved(
+        pages in prop::collection::vec(
+            prop::collection::vec(marker(), 1..=3),
+            1..=4,
+        ),
+    ) {
+        let bytes = build_text_pages(&pages);
+        let document = reparse(bytes);
+        let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+        for (i, markers) in pages.iter().enumerate() {
+            let text = extractor
+                .extract_from_page(&document, i as u32)
+                .expect("extract")
+                .text;
+            for m in markers {
+                // contains, not order: extraction may reorder/space fragments.
+                prop_assert!(
+                    text.contains(m.as_str()),
+                    "page {i} lost marker {m:?}; got {text:?}"
+                );
+            }
+        }
+    }
+}
+
+/// #364 pin: a written marker must read back non-empty and present.
+#[test]
+fn issue_364_written_text_reads_back() {
+    let bytes = build_text_pages(&[vec!["MARKER364".to_string()]]);
+    let document = reparse(bytes);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    let text = extractor
+        .extract_from_page(&document, 0)
+        .expect("extract")
+        .text;
+    assert!(!text.is_empty(), "#364: written page read back empty");
+    assert!(
+        text.contains("MARKER364"),
+        "#364: marker lost; got {text:?}"
+    );
 }

--- a/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
@@ -5,7 +5,7 @@
 //! dimension + a deterministic issue_N pin per class.
 
 use oxidize_pdf::graphics::Image;
-use oxidize_pdf::parser::objects::{PdfName, PdfObject};
+use oxidize_pdf::parser::objects::PdfObject;
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
 use oxidize_pdf::{Document, Font, Page};
@@ -58,7 +58,9 @@ fn page_base_fonts(page_index: u32, doc: &PdfDocument<Cursor<Vec<u8>>>) -> Vec<S
 }
 
 /// Build a one-page doc with an RGBA image drawn on it. Returns None if the
-/// image has no transparency (the SMask invariant then does not apply).
+/// image reports no transparency — a defensive guard, since `from_rgba_data`
+/// always attaches an alpha channel today, so this branch does not fire for the
+/// current generator; it keeps the invariant honest if that ever changes.
 fn build_rgba_image_doc(w: u32, h: u32, rgba: Vec<u8>) -> Option<Vec<u8>> {
     let image = Image::from_rgba_data(rgba, w, h).ok()?;
     if !image.has_transparency() {
@@ -101,7 +103,7 @@ fn page_xobject_smask_flags(page_index: u32, doc: &PdfDocument<Cursor<Vec<u8>>>)
             if !is_image {
                 continue;
             }
-            let smask_is_stream = match stream.dict.0.get(&PdfName::new("SMask".to_string())) {
+            let smask_is_stream = match stream.dict.get("SMask") {
                 Some(sm) => matches!(
                     doc.resolve(sm).expect("resolve smask"),
                     PdfObject::Stream(_)
@@ -169,11 +171,26 @@ proptest! {
     /// Every written marker is recoverable from its page's extracted text (#364).
     #[test]
     fn text_content_preserved(
-        pages in prop::collection::vec(
+        raw in prop::collection::vec(
             prop::collection::vec(marker(), 1..=3),
             1..=4,
         ),
     ) {
+        // Prefix each marker with its per-page index (`M{j}_`). The generated
+        // markers never contain '_', so `M{j}_...` matches exactly one marker
+        // and no marker can be a substring of another on the same page — a
+        // `contains` check would otherwise pass for a dropped marker that another
+        // one happens to embed (e.g. "Ab12" inside "XAb12Y").
+        let pages: Vec<Vec<String>> = raw
+            .iter()
+            .map(|markers| {
+                markers
+                    .iter()
+                    .enumerate()
+                    .map(|(j, m)| format!("M{j}_{m}"))
+                    .collect()
+            })
+            .collect();
         let bytes = build_text_pages(&pages);
         let document = reparse(bytes);
         let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
@@ -196,8 +213,9 @@ proptest! {
     /// round-trip (#156).
     #[test]
     fn image_smask_preserved(w in 2u32..=16, h in 2u32..=16, seed in any::<u64>()) {
-        // Deterministic RGBA from the seed; pixel 0 is fully transparent so the
-        // image always has an alpha channel (and thus a soft mask).
+        // Deterministic RGBA from the seed. `from_rgba_data` always attaches an
+        // alpha channel (so the writer always emits an /SMask); pixel 0 is forced
+        // to alpha=0 only to keep the data visibly non-opaque for a reader.
         let n = (w * h) as usize;
         let mut rgba = Vec::with_capacity(n * 4);
         let mut s = seed | 1;

--- a/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
@@ -4,6 +4,8 @@
 //! (preserved-font collision), #156 (SMask dropped). One property per
 //! dimension + a deterministic issue_N pin per class.
 
+use oxidize_pdf::graphics::Image;
+use oxidize_pdf::parser::objects::{PdfName, PdfObject};
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
 use oxidize_pdf::{Document, Font, Page};
@@ -53,6 +55,63 @@ fn page_base_fonts(page_index: u32, doc: &PdfDocument<Cursor<Vec<u8>>>) -> Vec<S
         }
     }
     out
+}
+
+/// Build a one-page doc with an RGBA image drawn on it. Returns None if the
+/// image has no transparency (the SMask invariant then does not apply).
+fn build_rgba_image_doc(w: u32, h: u32, rgba: Vec<u8>) -> Option<Vec<u8>> {
+    let image = Image::from_rgba_data(rgba, w, h).ok()?;
+    if !image.has_transparency() {
+        return None;
+    }
+    let mut doc = Document::new();
+    let mut page = Page::a4();
+    page.add_image("Img", image);
+    page.draw_image("Img", 100.0, 100.0, w as f64, h as f64)
+        .expect("draw");
+    doc.add_page(page);
+    Some(doc.to_bytes().expect("serialize"))
+}
+
+/// For each image XObject on the page, whether its /SMask resolves to a stream.
+/// Mirrors the walk in overlay_smask_test.rs.
+fn page_xobject_smask_flags(page_index: u32, doc: &PdfDocument<Cursor<Vec<u8>>>) -> Vec<bool> {
+    let page = doc.get_page(page_index).expect("get_page");
+    let resources = match page.get_resources() {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let xobj = match resources
+        .get("XObject")
+        .map(|o| doc.resolve(o).expect("resolve xobj"))
+    {
+        Some(PdfObject::Dictionary(d)) => d,
+        _ => return Vec::new(),
+    };
+    let mut flags = Vec::new();
+    for (_name, obj) in xobj.0.iter() {
+        if let PdfObject::Stream(stream) = doc.resolve(obj).expect("resolve stream") {
+            // Only image XObjects carry /SMask.
+            let is_image = stream
+                .dict
+                .get("Subtype")
+                .and_then(|s| s.as_name())
+                .map(|n| n.0 == "Image")
+                .unwrap_or(false);
+            if !is_image {
+                continue;
+            }
+            let smask_is_stream = match stream.dict.0.get(&PdfName::new("SMask".to_string())) {
+                Some(sm) => matches!(
+                    doc.resolve(sm).expect("resolve smask"),
+                    PdfObject::Stream(_)
+                ),
+                None => false,
+            };
+            flags.push(smask_is_stream);
+        }
+    }
+    flags
 }
 
 /// Append one A4 page carrying a single text marker at a fixed position.
@@ -131,6 +190,31 @@ proptest! {
                 );
             }
         }
+    }
+
+    /// An image with transparency keeps a resolvable /SMask through the
+    /// round-trip (#156).
+    #[test]
+    fn image_smask_preserved(w in 2u32..=16, h in 2u32..=16, seed in any::<u64>()) {
+        // Deterministic RGBA from the seed; pixel 0 is fully transparent so the
+        // image always has an alpha channel (and thus a soft mask).
+        let n = (w * h) as usize;
+        let mut rgba = Vec::with_capacity(n * 4);
+        let mut s = seed | 1;
+        for i in 0..n {
+            for _ in 0..3 {
+                s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+                rgba.push((s >> 33) as u8);
+            }
+            rgba.push(if i == 0 { 0 } else { ((s >> 40) as u8) | 1 });
+        }
+        let Some(bytes) = build_rgba_image_doc(w, h, rgba) else {
+            return Ok(()); // no transparency (shouldn't happen given alpha=0 above)
+        };
+        let document = reparse(bytes);
+        let flags = page_xobject_smask_flags(0, &document);
+        prop_assert!(!flags.is_empty(), "no image XObject found after round-trip");
+        prop_assert!(flags.iter().all(|&f| f), "an image lost its /SMask: {flags:?}");
     }
 }
 
@@ -247,4 +331,25 @@ fn issue_395_two_distinct_embedded_fonts_no_collision() {
         bases.iter().any(|b| b.contains("SourceSans")),
         "#395: SourceSans collapsed or lost: {bases:?}"
     );
+}
+
+/// #156 pin: an RGBA image with partial alpha keeps a resolvable /SMask stream.
+#[test]
+fn issue_156_rgba_image_keeps_smask() {
+    // 2x2 RGBA, one fully transparent pixel.
+    let rgba = vec![
+        255, 0, 0, 0, // transparent red
+        0, 255, 0, 128, // semi green
+        0, 0, 255, 200, // mostly blue
+        255, 255, 0, 255, // opaque yellow
+    ];
+    let bytes = build_rgba_image_doc(2, 2, rgba).expect("image has transparency");
+    let document = reparse(bytes);
+    let flags = page_xobject_smask_flags(0, &document);
+    assert_eq!(
+        flags.len(),
+        1,
+        "#156: expected exactly one image XObject: {flags:?}"
+    );
+    assert!(flags[0], "#156: image lost its /SMask after round-trip");
 }

--- a/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
@@ -1,0 +1,50 @@
+//! Round-trip invariant, stated from the write→read fidelity contract, not a
+//! bug: a document built with the writer, serialized, and re-parsed preserves
+//! what was put in it. Guards #364 (write-then-read empty/garbage), #395
+//! (preserved-font collision), #156 (SMask dropped). One property per
+//! dimension + a deterministic issue_N pin per class.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::{Document, Font, Page};
+use proptest::prelude::*;
+use std::io::Cursor;
+
+/// Serialize `doc` and re-parse it back into a navigable document.
+fn reparse(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("re-parse written PDF");
+    PdfDocument::new(reader)
+}
+
+/// Append one A4 page carrying a single text marker at a fixed position.
+fn write_marker_page(doc: &mut Document, marker: &str) {
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 700.0)
+        .write(marker)
+        .expect("write marker");
+    doc.add_page(page);
+}
+
+// Printable, non-space ASCII marker: survives a WinAnsi write() and extracts as
+// one contiguous run. Space and PDF delimiters excluded on purpose.
+#[allow(dead_code)] // used from Task 2 onward
+fn marker() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9]{4,24}"
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Page count survives the round-trip for any 1..=8 pages.
+    #[test]
+    fn page_count_preserved(k in 1usize..=8) {
+        let mut doc = Document::new();
+        for i in 0..k {
+            write_marker_page(&mut doc, &format!("PAGE{i}"));
+        }
+        let bytes = doc.to_bytes().expect("serialize");
+        let document = reparse(bytes);
+        prop_assert_eq!(document.page_count().expect("page_count"), k as u32);
+    }
+}

--- a/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_roundtrip_invariants.rs
@@ -10,10 +10,49 @@ use oxidize_pdf::{Document, Font, Page};
 use proptest::prelude::*;
 use std::io::Cursor;
 
+const ROBOTO_PATH: &str = "../test-pdfs/Roboto-Regular.ttf";
+const SOURCE_SANS_PATH: &str = "../test-pdfs/SourceSans3-Regular.otf";
+
+fn roboto() -> Vec<u8> {
+    std::fs::read(ROBOTO_PATH).expect("read Roboto fixture")
+}
+
+fn source_sans() -> Vec<u8> {
+    std::fs::read(SOURCE_SANS_PATH).expect("read SourceSans fixture")
+}
+
 /// Serialize `doc` and re-parse it back into a navigable document.
 fn reparse(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
     let reader = PdfReader::new(Cursor::new(bytes)).expect("re-parse written PDF");
     PdfDocument::new(reader)
+}
+
+/// Walk the page's /Font resource dict and return each resolved font's BaseFont
+/// (empty string if a font dict has no BaseFont). Mirrors the walk in
+/// issue_395_font_collision_test.rs.
+fn page_base_fonts(page_index: u32, doc: &PdfDocument<Cursor<Vec<u8>>>) -> Vec<String> {
+    let page = doc.get_page(page_index).expect("get_page");
+    let resources = match page.get_resources() {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let font_dict = match resources.get("Font").and_then(|f| f.as_dict()) {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for (_name, obj) in font_dict.0.iter() {
+        let resolved = doc.resolve(obj).expect("resolve font");
+        if let Some(fd) = resolved.as_dict() {
+            let base = fd
+                .get("BaseFont")
+                .and_then(|b| b.as_name())
+                .map(|n| n.0.clone())
+                .unwrap_or_default();
+            out.push(base);
+        }
+    }
+    out
 }
 
 /// Append one A4 page carrying a single text marker at a fixed position.
@@ -95,6 +134,71 @@ proptest! {
     }
 }
 
+proptest! {
+    // Reduced case count: each case embeds and subsets a TTF (and sometimes an
+    // OTF), which is costly. 64 is a coverage/cost tradeoff, not a coverage
+    // ceiling on the invariant.
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Embedded fonts survive the round-trip, distinct and uncollapsed (#395).
+    ///
+    /// Note: the writer always emits the full standard-14 set into every page's
+    /// /Font dict regardless of use, so a *count* over all fonts is meaningless
+    /// here. #395 was a collision of preserved *embedded* fonts, so the guard
+    /// embeds one or two distinct custom fonts and asserts each survives by name
+    /// — a collision would drop or merge one of them.
+    #[test]
+    fn embedded_fonts_preserved(
+        use_second in any::<bool>(),
+        std_marker in marker(),
+    ) {
+        let mut doc = Document::new();
+        doc.add_font_from_bytes("Roboto", roboto()).expect("embed Roboto");
+        if use_second {
+            doc.add_font_from_bytes("SourceSans", source_sans())
+                .expect("embed SourceSans");
+        }
+        let mut page = Page::a4();
+        page.text()
+            .set_font(Font::Custom("Roboto".to_string()), 12.0)
+            .at(72.0, 760.0)
+            .write("Robo")
+            .expect("write");
+        if use_second {
+            page.text()
+                .set_font(Font::Custom("SourceSans".to_string()), 12.0)
+                .at(72.0, 720.0)
+                .write("Sans")
+                .expect("write");
+        }
+        // A standard-14 line too, to mix embedded and builtin on one page.
+        page.text()
+            .set_font(Font::Helvetica, 12.0)
+            .at(72.0, 680.0)
+            .write(&std_marker)
+            .expect("write");
+        doc.add_page(page);
+
+        let document = reparse(doc.to_bytes().expect("serialize"));
+        let bases = page_base_fonts(0, &document);
+        prop_assert!(
+            bases.iter().any(|b| b.contains("Roboto")),
+            "embedded Roboto lost: {bases:?}"
+        );
+        if use_second {
+            prop_assert!(
+                bases.iter().any(|b| b.contains("SourceSans")),
+                "second embedded font collapsed or lost: {bases:?}"
+            );
+        }
+        // Helvetica (builtin) is always present too.
+        prop_assert!(
+            bases.iter().any(|b| b == "Helvetica"),
+            "Helvetica missing: {bases:?}"
+        );
+    }
+}
+
 /// #364 pin: a written marker must read back non-empty and present.
 #[test]
 fn issue_364_written_text_reads_back() {
@@ -109,5 +213,38 @@ fn issue_364_written_text_reads_back() {
     assert!(
         text.contains("MARKER364"),
         "#364: marker lost; got {text:?}"
+    );
+}
+
+/// #395 pin: two distinct embedded fonts on one page must both survive the
+/// round-trip without collapsing into one.
+#[test]
+fn issue_395_two_distinct_embedded_fonts_no_collision() {
+    let mut doc = Document::new();
+    doc.add_font_from_bytes("Roboto", roboto())
+        .expect("embed Roboto");
+    doc.add_font_from_bytes("SourceSans", source_sans())
+        .expect("embed SourceSans");
+    let mut page = Page::a4();
+    page.text()
+        .set_font(Font::Custom("Roboto".to_string()), 12.0)
+        .at(72.0, 760.0)
+        .write("Robo")
+        .expect("write");
+    page.text()
+        .set_font(Font::Custom("SourceSans".to_string()), 12.0)
+        .at(72.0, 720.0)
+        .write("Sans")
+        .expect("write");
+    doc.add_page(page);
+    let document = reparse(doc.to_bytes().expect("serialize"));
+    let bases = page_base_fonts(0, &document);
+    assert!(
+        bases.iter().any(|b| b.contains("Roboto")),
+        "#395: Roboto lost: {bases:?}"
+    );
+    assert!(
+        bases.iter().any(|b| b.contains("SourceSans")),
+        "#395: SourceSans collapsed or lost: {bases:?}"
     );
 }

--- a/oxidize-pdf-core/tests/prop_token_counter_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_token_counter_invariants.rs
@@ -1,15 +1,19 @@
 //! Token-counter invariants, stated from the trait's contract.
 //!
-//! `TokenCounter::is_additive_over_newline` is a promise the chunker acts on: it
-//! is what lets the budget decision accumulate a sum instead of re-counting the
-//! joined text. An over-claim is not a slow path, it is a silently wrong budget
-//! — exactly the shape of #435, where a sum approved a chunk whose real cost was
-//! never measured.
+//! `TokenCounter::is_additive_over_whitespace_join` is a promise the chunker
+//! acts on: it is what lets the budget decision accumulate a sum instead of
+//! re-counting the joined text. An over-claim is not a slow path, it is a
+//! silently wrong budget — exactly the shape of #435, where a sum approved a
+//! chunk whose real cost was never measured.
 //!
 //! So the promise is verified, not trusted:
 //!
 //!   1. ADDITIVITY IS TRUE WHEN CLAIMED. For a counter that answers `true`,
-//!      `count(a) + count(b) == count("a\nb")` for generated `a`, `b`.
+//!      `count(a) + count(b) == count("a{sep}b")` for generated `a`, `b` and
+//!      EVERY separator the promise covers, not just the newline the chunker
+//!      happens to use between elements. The sentence-split path joins with a
+//!      space, and a property that only ever generated `"\n"` would leave that
+//!      caller's fast path resting on an unverified claim.
 //!   2. COUNTING IS SANE. Counts are deterministic, and empty text costs
 //!      nothing — a counter that charges for `""` would make the chunker's
 //!      empty-element accounting drift.
@@ -20,6 +24,23 @@
 use oxidize_pdf::pipeline::{TokenCounter, WordProxyCounter};
 use proptest::prelude::*;
 use std::sync::OnceLock;
+
+/// Every separator the additivity promise covers: a single whitespace
+/// character. `"\n"` is what the chunker joins elements with, `" "` what
+/// `split_by_sentences` joins sentences with; the rest are in the contract, so
+/// they are generated too.
+fn separator() -> impl Strategy<Value = char> {
+    prop_oneof![
+        Just('\n'),
+        Just(' '),
+        Just('\t'),
+        Just('\r'),
+        // U+000B LINE TABULATION and U+00A0 NO-BREAK SPACE: `char::is_whitespace`
+        // is wider than ASCII, and so is the promise.
+        Just('\u{000B}'),
+        Just('\u{00A0}'),
+    ]
+}
 
 /// Text fragments that stress the join boundary: words, punctuation, leading and
 /// trailing whitespace, empty strings, and multi-byte characters.
@@ -60,22 +81,23 @@ fn counters() -> &'static [Box<dyn TokenCounter>] {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
-    /// A counter that claims additivity must actually be additive: the chunker
-    /// skips measuring the joined text on that promise alone.
+    /// A counter that claims additivity must actually be additive, over every
+    /// separator the promise covers: the chunker skips measuring the joined text
+    /// on that promise alone, and it joins with more than one character.
     #[test]
-    fn claimed_additivity_holds(a in fragment(), b in fragment()) {
+    fn claimed_additivity_holds(a in fragment(), b in fragment(), sep in separator()) {
         for c in counters() {
-            if !c.is_additive_over_newline() {
+            if !c.is_additive_over_whitespace_join() {
                 continue;
             }
-            let joined = c.count(&format!("{a}\n{b}"));
+            let joined = c.count(&format!("{a}{sep}{b}"));
             let summed = c.count(&a) + c.count(&b);
             prop_assert_eq!(
                 joined,
                 summed,
                 "{} claims additivity but count({:?}) = {} != {} + {}",
                 c.name(),
-                format!("{a}\n{b}"),
+                format!("{a}{sep}{b}"),
                 joined,
                 c.count(&a),
                 c.count(&b)
@@ -91,13 +113,17 @@ proptest! {
         }
     }
 
-    /// Empty text costs nothing. The chunker accounts for elements with no
-    /// display text; a non-zero cost for `""` would drift its budget.
-    #[test]
-    fn empty_text_costs_nothing(_ in fragment()) {
-        for c in counters() {
-            prop_assert_eq!(c.count(""), 0, "{} charges for empty text", c.name());
-        }
+}
+
+/// Empty text costs nothing. The chunker accounts for elements with no display
+/// text; a non-zero cost for `""` would drift its budget.
+///
+/// A plain test, not a property: there is exactly one input to check, and
+/// generating 256 cases to assert the same equality would only hide that.
+#[test]
+fn empty_text_costs_nothing() {
+    for c in counters() {
+        assert_eq!(c.count(""), 0, "{} charges for empty text", c.name());
     }
 }
 
@@ -106,7 +132,7 @@ proptest! {
 #[test]
 fn word_proxy_declares_additivity() {
     assert!(
-        WordProxyCounter.is_additive_over_newline(),
+        WordProxyCounter.is_additive_over_whitespace_join(),
         "the default counter must stay additive: the chunker's fast path is \
          conditioned on this answer"
     );
@@ -120,7 +146,7 @@ fn word_proxy_declares_additivity() {
 fn bpe_does_not_claim_additivity() {
     let c = oxidize_pdf::pipeline::TiktokenCounter::cl100k_base();
     assert!(
-        !c.is_additive_over_newline(),
+        !c.is_additive_over_whitespace_join(),
         "cl100k_base must not claim additivity: count(a) + count(b) != \
          count(a\\nb) at the join boundary (#435)"
     );

--- a/oxidize-pdf-core/tests/prop_token_counter_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_token_counter_invariants.rs
@@ -1,0 +1,144 @@
+//! Token-counter invariants, stated from the trait's contract.
+//!
+//! `TokenCounter::is_additive_over_newline` is a promise the chunker acts on: it
+//! is what lets the budget decision accumulate a sum instead of re-counting the
+//! joined text. An over-claim is not a slow path, it is a silently wrong budget
+//! — exactly the shape of #435, where a sum approved a chunk whose real cost was
+//! never measured.
+//!
+//! So the promise is verified, not trusted:
+//!
+//!   1. ADDITIVITY IS TRUE WHEN CLAIMED. For a counter that answers `true`,
+//!      `count(a) + count(b) == count("a\nb")` for generated `a`, `b`.
+//!   2. COUNTING IS SANE. Counts are deterministic, and empty text costs
+//!      nothing — a counter that charges for `""` would make the chunker's
+//!      empty-element accounting drift.
+//!
+//! The BPE counter is expected to answer `false`; a test pins that, since a
+//! future "optimization" flipping it would reintroduce #435 wholesale.
+
+use oxidize_pdf::pipeline::{TokenCounter, WordProxyCounter};
+use proptest::prelude::*;
+use std::sync::OnceLock;
+
+/// Text fragments that stress the join boundary: words, punctuation, leading and
+/// trailing whitespace, empty strings, and multi-byte characters.
+fn fragment() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just(" ".to_string()),
+        Just("\n".to_string()),
+        "[a-z]{1,8}",
+        "[a-z]{1,5} [a-z]{1,5}",
+        "[a-z]{1,5}\\.",
+        " [a-z]{1,5} ",
+        "[áéñü]{1,4}",
+        "[0-9]{1,6}",
+        "[a-z]{1,4}-[a-z]{1,4}",
+    ]
+}
+
+/// Every counter this crate ships, as trait objects, so the properties run over
+/// all of them without naming each one twice.
+///
+/// Built once for the whole suite: cl100k_base loads multi-MB rank tables, and
+/// rebuilding it per generated case costs orders of magnitude more than the
+/// property itself.
+fn counters() -> &'static [Box<dyn TokenCounter>] {
+    static COUNTERS: OnceLock<Vec<Box<dyn TokenCounter>>> = OnceLock::new();
+    COUNTERS.get_or_init(|| {
+        #[allow(unused_mut)]
+        let mut v: Vec<Box<dyn TokenCounter>> = vec![Box::new(WordProxyCounter)];
+        #[cfg(feature = "tiktoken")]
+        v.push(Box::new(
+            oxidize_pdf::pipeline::TiktokenCounter::cl100k_base(),
+        ));
+        v
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// A counter that claims additivity must actually be additive: the chunker
+    /// skips measuring the joined text on that promise alone.
+    #[test]
+    fn claimed_additivity_holds(a in fragment(), b in fragment()) {
+        for c in counters() {
+            if !c.is_additive_over_newline() {
+                continue;
+            }
+            let joined = c.count(&format!("{a}\n{b}"));
+            let summed = c.count(&a) + c.count(&b);
+            prop_assert_eq!(
+                joined,
+                summed,
+                "{} claims additivity but count({:?}) = {} != {} + {}",
+                c.name(),
+                format!("{a}\n{b}"),
+                joined,
+                c.count(&a),
+                c.count(&b)
+            );
+        }
+    }
+
+    /// Counting is a pure function of the text.
+    #[test]
+    fn counting_is_deterministic(a in fragment()) {
+        for c in counters() {
+            prop_assert_eq!(c.count(&a), c.count(&a), "{} is not deterministic", c.name());
+        }
+    }
+
+    /// Empty text costs nothing. The chunker accounts for elements with no
+    /// display text; a non-zero cost for `""` would drift its budget.
+    #[test]
+    fn empty_text_costs_nothing(_ in fragment()) {
+        for c in counters() {
+            prop_assert_eq!(c.count(""), 0, "{} charges for empty text", c.name());
+        }
+    }
+}
+
+/// The word proxy is the default counter and the one whose additivity the fast
+/// path depends on. Pinned explicitly so the answer cannot be flipped silently.
+#[test]
+fn word_proxy_declares_additivity() {
+    assert!(
+        WordProxyCounter.is_additive_over_newline(),
+        "the default counter must stay additive: the chunker's fast path is \
+         conditioned on this answer"
+    );
+}
+
+/// BPE is not additive across a join — the join boundary re-tokenizes. This is
+/// the whole reason #435 existed, so the answer is pinned: flipping it to `true`
+/// as an optimization would restore the bug.
+#[cfg(feature = "tiktoken")]
+#[test]
+fn bpe_does_not_claim_additivity() {
+    let c = oxidize_pdf::pipeline::TiktokenCounter::cl100k_base();
+    assert!(
+        !c.is_additive_over_newline(),
+        "cl100k_base must not claim additivity: count(a) + count(b) != \
+         count(a\\nb) at the join boundary (#435)"
+    );
+}
+
+/// A concrete witness that BPE really is non-additive, so the pin above guards
+/// something real rather than a hypothetical.
+#[cfg(feature = "tiktoken")]
+#[test]
+fn bpe_non_additivity_has_a_witness() {
+    let c = oxidize_pdf::pipeline::TiktokenCounter::cl100k_base();
+    let found = (0..200).find_map(|i| {
+        let a = format!("token{i}");
+        let b = format!("{i}suffix");
+        (c.count(&a) + c.count(&b) != c.count(&format!("{a}\n{b}"))).then_some((a, b))
+    });
+    assert!(
+        found.is_some(),
+        "expected at least one pair where BPE is non-additive across the join"
+    );
+}


### PR DESCRIPTION
Release 4.2.0. MINOR: adds public API and changes observable output, breaks nothing.

## Contents

Two merged cycles since v4.1.1:

- **#433** — round-trip writer↔parser invariants (P2): page count, text (#364), distinct embedded fonts (#395), image SMask (#156). Tests only.
- **#439** — RAG and font invariants, plus the three bugs they found: #438 (a lone space decoded from `/ToUnicode` discarded as garbage, corrupting word boundaries in subsetted-font PDFs), #435 (chunk budget decided on a sum of per-element counts, which BPE does not honour), #436 (paragraphs ran together across a font change).

Full detail in CHANGELOG.md.

## Why MINOR

- New public API: `TokenCounter::is_additive_over_whitespace_join`, defaulted to `false`. Existing implementors keep the measured, always-correct path unchanged.
- Observable output changes: extraction ends a paragraph on a font size or weight change (#436); `is_oversized` is now set on sentence-split fragments that genuinely exceed the budget (#435), where it previously always reported `false`.

CI's SemVer check confirms no undeclared breaking changes.

## Verification

All nine CI checks green on #439 (3 OS, MSRV 1.88, SemVer, examples, T0+T1).

Corpus T2–T6 run locally (they never run on PRs), and diffed against `develop` as a baseline:

| Tier | PDFs | Result vs baseline |
|---|---|---|
| T2 real-world | 484 | identical — 481 parsed, 446 with text |
| T3 stress | 1802 | 1761 parsed; text extracted **1597 → 1598** |
| T4 AI/RAG | 130 | 100% parsed, 0 panics |
| T5 quality | 2907 | identical — 2899 parsed, 2895 with text, 99.6% |
| T6 adversarial | 161 | 153 parsed, 0 panics |

Zero panics and zero timeouts across all tiers. The one difference is a gain: one more T3 document now yields text, which is #438 — a decode previously thrown away for being a space.

## Gate not met, stated plainly

The two corpus tests that compare extracted text against a reference — `t4_text_accuracy_vs_ground_truth` and T5's accuracy report — **did not run**, here or in CI. They skip silently because the ground-truth data they expect (PubMed XML for T4) is not provisioned by any `download.sh`; the T4 script fetches arXiv papers only. This is a pre-existing hole in the corpus harness, not something this release introduced, but it is worth naming: those are the tests that would catch a *quality* regression in extracted text, which is precisely what #436 and #438 touch.

What guards the text content instead: the character-conservation and text-conservation property invariants, and the pinned regression tests for #436 and #438. The corpus "text extracted" counts are binary — text or no text — and cannot see text that comes out worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
