### PR TITLE
fix(extraction): same-line backward X jump no longer misread as a line wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flat-path heuristic added for #390 treated any backward pen jump beyond
   2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
   backward on the same baseline (justification, out-of-order emission) gained
-  a spurious newline mid-word. A wrap always lands on a different baseline:
-  the heuristic now also requires a nonzero Δy, in both the `Tj` and `TJ`
-  handlers. Tight-leading wraps (small but nonzero Δy, the #390 class) still
-  break. A new line-structure property invariant guards both directions —
+  a spurious newline mid-word. In axis-aligned text a wrap always lands on a
+  different baseline: the heuristic now also requires a nonzero Δy, in both
+  the `Tj` and `TJ` handlers. Tight-leading wraps (small but nonzero Δy, the
+  #390 class) still break. Δy is measured in post-CTM user space, so text
+  under a rotated/sheared CTM is not protected by this gate (a preexisting
+  limitation of the flat-path heuristic, unchanged by this fix). A new
+  line-structure property invariant guards both directions —
   spurious and missing newlines — against generated layouts whose true line
   structure is known by construction.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+
+- **A same-line backward X jump was misread as a line wrap** (#441). The
+  flat-path heuristic added for #390 treated any backward pen jump beyond
+  2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
+  backward on the same baseline (justification, out-of-order emission) gained
+  a spurious newline mid-word. A wrap always lands on a different baseline:
+  the heuristic now also requires a nonzero Δy, in both the `Tj` and `TJ`
+  handlers. Tight-leading wraps (small but nonzero Δy, the #390 class) still
+  break. A new line-structure property invariant guards both directions —
+  spurious and missing newlines — against generated layouts whose true line
+  structure is known by construction.
+
 ## [4.2.0] - 2026-07-21
 
 ### Fixed

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1037,10 +1037,14 @@ impl TextExtractor {
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
                                 // conservative) as a newline even when dy is small
-                                // (issue #390). A wrap always lands on a different
-                                // baseline, so require a nonzero dy: a strictly
-                                // same-line backward jump is glyph repositioning,
-                                // never a wrap (issue #441).
+                                // (issue #390). In axis-aligned text a wrap always
+                                // lands on a different baseline, so require a
+                                // nonzero dy: a strictly same-line backward jump
+                                // is glyph repositioning, not a wrap (issue #441).
+                                // Note: dy is measured in post-CTM user space, so
+                                // a rotated/sheared CTM gives same-baseline glyphs
+                                // a nonzero dy and this gate does not protect
+                                // rotated text (preexisting limitation).
                                 let line_wrap =
                                     dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
@@ -1133,10 +1137,12 @@ impl TextExtractor {
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
                                     // kern, so it is safe to break there — but only when
-                                    // the pen also moved vertically: a wrap always lands
-                                    // on a different baseline, so a strictly same-line
-                                    // backward jump is glyph repositioning, never a wrap
-                                    // (issue #441).
+                                    // the pen also moved vertically: in axis-aligned
+                                    // text a wrap always lands on a different baseline,
+                                    // so a strictly same-line backward jump is glyph
+                                    // repositioning, not a wrap (issue #441). dy is
+                                    // post-CTM user space, so this gate does not
+                                    // protect rotated text (preexisting limitation).
                                     let line_wrap = (y - last_y).abs() > 0.0
                                         && (x - last_x) < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1036,9 +1036,13 @@ impl TextExtractor {
                                 // When the line height is below `newline_threshold`
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
-                                // conservative) as a newline regardless of dy
-                                // (issue #390).
-                                let line_wrap = dx < -(self.options.newline_threshold * 2.0);
+                                // conservative) as a newline even when dy is small
+                                // (issue #390). A wrap always lands on a different
+                                // baseline, so require a nonzero dy: a strictly
+                                // same-line backward jump is glyph repositioning,
+                                // never a wrap (issue #441).
+                                let line_wrap =
+                                    dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.options.space_threshold * state.font_size {
@@ -1128,9 +1132,13 @@ impl TextExtractor {
                                     // word that a TJ array draws as several positioned
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
-                                    // kern, so it is safe to break there.
-                                    let line_wrap =
-                                        (x - last_x) < -(self.options.newline_threshold * 2.0);
+                                    // kern, so it is safe to break there — but only when
+                                    // the pen also moved vertically: a wrap always lands
+                                    // on a different baseline, so a strictly same-line
+                                    // backward jump is glyph repositioning, never a wrap
+                                    // (issue #441).
+                                    let line_wrap = (y - last_y).abs() > 0.0
+                                        && (x - last_x) < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {
                                         let separator = if !extracted_text.is_empty()
                                             && ((y - last_y).abs() > self.options.newline_threshold

--- a/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
+++ b/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
@@ -115,13 +115,15 @@ fn tj_array_same_line_backward_jump_gets_no_newline() {
 
 #[test]
 fn backward_jump_with_small_nonzero_dy_still_breaks_line() {
-    // Boundary pin: the #390 class (tight leading, Δy = 2pt nonzero but far
-    // below newline_threshold = 10, plus a big backward jump) must STILL be
-    // treated as a wrap. The #441 fix only excludes Δy == 0.
+    // Boundary pin: the #441 fix excludes exactly Δy == 0, nothing more. A
+    // backward jump with Δy = 0.1pt — barely nonzero, far below
+    // newline_threshold = 10 — must STILL be treated as a wrap (the #390
+    // class). Pinning this close to the cutoff means a future regression to
+    // e.g. `dy > 1.0` fails here instead of slipping through.
     let content = concat!(
         "BT\n/F1 8 Tf\n",
         "1 0 0 1 300 700 Tm\n(tail) Tj\n",
-        "1 0 0 1 50 698 Tm\n(head) Tj\nET"
+        "1 0 0 1 50 699.9 Tm\n(head) Tj\nET"
     );
     let text = extract_flat(content);
     assert!(

--- a/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
+++ b/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
@@ -1,0 +1,131 @@
+//! Regression tests for issue #441.
+//!
+//! The flat-text line-wrap heuristic added for issue #390 fires on a large
+//! backward horizontal jump (`dx < -(newline_threshold * 2)`) regardless of
+//! Δy. Real-world PDFs reposition glyphs backward *on the same line*
+//! (justification, kerned overlays, out-of-order emission); with Δy exactly 0
+//! there is no wrap, yet the heuristic inserted a spurious newline mid-word.
+//!
+//! Fix: a backward jump only counts as a wrap when the pen also moved
+//! vertically (`dy > 0`). A strictly same-line backward jump can never be a
+//! wrap — a wrapped line always lands on a different baseline. Tight-leading
+//! wraps (small but nonzero Δy, the #390 class) still break.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false (the affected flat path).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_operator_same_line_backward_jump_gets_no_newline() {
+    // The exact signature from issue #441: three `Tj` calls all at y=562.50.
+    // "o" jumps backward by ~-35pt (beyond -newline_threshold*2 = -20), then
+    // "X" continues forward. Δy is exactly 0 for all three, so nothing
+    // wrapped; before the fix the output was "AGR\no X".
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 356.17 562.50 Tm\n(AGR) Tj\n",
+        "1 0 0 1 335.83 562.50 Tm\n(o) Tj\n",
+        "1 0 0 1 400.00 562.50 Tm\n(X) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "same-line backward jump must not insert a newline (issue #441): {text:?}"
+    );
+    let glyphs: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert_eq!(
+        glyphs, "AGRoX",
+        "all glyphs must survive in draw order: {text:?}"
+    );
+}
+
+#[test]
+fn tj_array_same_line_backward_jump_gets_no_newline() {
+    // Same signature through the `TJ` (ShowTextArray) handler, which
+    // duplicates the line-wrap heuristic.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 356.17 562.50 Tm\n[(AGR)] TJ\n",
+        "1 0 0 1 335.83 562.50 Tm\n[(o)] TJ\n",
+        "1 0 0 1 400.00 562.50 Tm\n[(X)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "TJ path must not insert a newline on a same-line backward jump: {text:?}"
+    );
+    let glyphs: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert_eq!(
+        glyphs, "AGRoX",
+        "all glyphs must survive in draw order: {text:?}"
+    );
+}
+
+#[test]
+fn backward_jump_with_small_nonzero_dy_still_breaks_line() {
+    // Boundary pin: the #390 class (tight leading, Δy = 2pt nonzero but far
+    // below newline_threshold = 10, plus a big backward jump) must STILL be
+    // treated as a wrap. The #441 fix only excludes Δy == 0.
+    let content = concat!(
+        "BT\n/F1 8 Tf\n",
+        "1 0 0 1 300 700 Tm\n(tail) Tj\n",
+        "1 0 0 1 50 698 Tm\n(head) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("tail\nhead"),
+        "nonzero-dy backward wrap must still break (the #390 guarantee): {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -188,11 +188,12 @@ fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
     (wrap_pdf(&content), drawn_lines)
 }
 
-/// Non-whitespace glyph runs per output line, empty lines dropped.
+/// Non-whitespace glyph runs per output line. Empty entries are kept: a
+/// blank output line (e.g. a doubled newline) is itself a structure defect
+/// and must surface as a mismatch, not be silently absorbed.
 fn output_line_structure(text: &str) -> Vec<String> {
     text.lines()
         .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
-        .filter(|l| !l.is_empty())
         .collect()
 }
 

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -17,6 +17,13 @@
 //!      (#389, #403, #408, #417, #422, #425). (Distinct from #2: scattering a
 //!      token preserves the character multiset but breaks contiguity.)
 //!   4. DETERMINISM — extracting the same bytes twice yields identical text.
+//!   5. LINE STRUCTURE — the newline structure of the flat extraction matches
+//!      the lines actually drawn: glyphs drawn on one baseline stay on one
+//!      output line (no spurious newline, #441), and glyphs drawn on distinct
+//!      baselines end up on distinct output lines whenever the transition is
+//!      geometrically detectable (no missing newline, #390). Unlike #1-#4,
+//!      this oracle does NOT filter whitespace away — it is the only invariant
+//!      that can see separator bugs, the class where #438 and #441 escaped.
 
 use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
@@ -74,9 +81,9 @@ fn wrap_pdf(content: &[u8]) -> Vec<u8> {
         b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
     );
     let xref_pos = pdf.len();
-    write!(pdf, "xref\n0 6\n0000000000 65535 f \n").unwrap();
+    writeln!(pdf, "xref\n0 6\n0000000000 65535 f ").unwrap();
     for off in &offsets {
-        write!(pdf, "{off:010} 00000 n \n").unwrap();
+        writeln!(pdf, "{off:010} 00000 n ").unwrap();
     }
     write!(
         pdf,
@@ -132,6 +139,61 @@ fn build_page(spec: &[(Vec<usize>, Option<usize>)]) -> (Vec<u8>, String) {
         y -= LEADING;
     }
     (wrap_pdf(&content), drawn)
+}
+
+// ---- Line-structure builder for the #390/#441 separator property. ----------
+
+/// One generated line: word indices, an optional same-line backward
+/// "correction" (word index + backward jump in pt), and the leading below it.
+type LineSpec = (Vec<usize>, Option<(usize, f64)>, f64);
+
+/// Build a page whose line structure is known by construction, and return
+/// (pdf_bytes, glyphs-per-line in draw order).
+///
+/// Every line starts at x=50 and ends with its pen well right of the margin
+/// (≥ 2 words), so each line transition is geometrically detectable: either
+/// dy > newline_threshold (10pt), or a tight leading (dy < 10pt, nonzero)
+/// combined with a wrap back to x=50 of more than 2× the threshold — the #390
+/// class. A correction re-draws a word backward ON THE SAME baseline
+/// (dy = 0, dx < -(2 × threshold)) mid-line — the #441 class — and must NOT
+/// break the line.
+fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
+    let mut content = Vec::new();
+    let mut drawn_lines = Vec::new();
+    let mut y = 760.0;
+    for (word_idxs, correction, leading) in lines {
+        let mut x = 50.0;
+        let mut line = String::new();
+        for (pos, &wi) in word_idxs.iter().enumerate() {
+            let w = WORDS[wi % WORDS.len()];
+            x = emit_glyphs(&mut content, w, x, y);
+            line.push_str(w);
+            x += 8.0;
+            // After the first word, optionally jump BACKWARD on the same
+            // baseline and draw a correction word there (the #441 signature),
+            // then resume forward past everything drawn so far.
+            if pos == 0 {
+                if let Some((ci, back)) = correction {
+                    let w2 = WORDS[ci % WORDS.len()];
+                    let corr_x = (x - back).max(5.0);
+                    emit_glyphs(&mut content, w2, corr_x, y);
+                    line.push_str(w2);
+                    x += 30.0;
+                }
+            }
+        }
+        drawn_lines.push(line);
+        y -= leading;
+    }
+    (wrap_pdf(&content), drawn_lines)
+}
+
+/// Non-whitespace glyph runs per output line, empty lines dropped.
+fn output_line_structure(text: &str) -> Vec<String> {
+    text.lines()
+        .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
+        .filter(|l| !l.is_empty())
+        .collect()
 }
 
 // ---- Drift-chain builder for the #425 token-contiguity property. ----------
@@ -230,6 +292,31 @@ proptest! {
                 token, flat, reordered
             );
         }
+    }
+
+    /// INV-5 LINE STRUCTURE: flat extraction reproduces exactly the lines that
+    /// were drawn — one output line per baseline, glyphs in draw order. Fails
+    /// on a spurious newline (same-line backward jump misread as a wrap, #441)
+    /// AND on a missing newline (tight-leading wrap glued, #390).
+    #[test]
+    fn flat_line_structure_matches_drawn_lines(
+        lines in prop::collection::vec(
+            (
+                prop::collection::vec(0usize..10, 2..5),
+                prop::option::of((0usize..10, 30.0f64..60.0)),
+                prop_oneof![2.0f64..9.5, 12.0f64..30.0],
+            ),
+            3..12,
+        ),
+    ) {
+        let (pdf, drawn) = build_line_structure_page(&lines);
+        let flat = extract(&pdf, false);
+        let got = output_line_structure(&flat);
+        prop_assert_eq!(
+            &got, &drawn,
+            "extracted line structure differs from drawn lines\n--- flat ---\n{}",
+            flat
+        );
     }
 
     /// INV-4 DETERMINISM: extracting the same bytes twice is identical.


### PR DESCRIPTION
Addresses #441.

## Problem

The flat-path line-wrap heuristic (added for #390) fired on any backward X jump beyond 2× `newline_threshold`, ignoring Δy. Glyphs repositioned backward on the **same baseline** (justification, out-of-order emission — the reporter's real-world file) gained a spurious newline mid-word: `"AGR\no X"`.

## Fix

A wrap in axis-aligned text always lands on a different baseline, so `line_wrap` now also requires a nonzero Δy — in both the `Tj` and `TJ` handlers. The #390 guarantee (tight-leading wraps, Δy small but nonzero) is preserved and pinned by a boundary test at Δy = 0.1.

## Class guard: INV-5 LINE STRUCTURE

New property in `prop_extraction_invariants.rs`: the newline structure of the flat extraction must equal the lines actually drawn, checked against generated pages whose line structure is known by construction (same-line backward corrections + tight-leading wraps). Unlike INV-1..4, this oracle does **not** filter whitespace — it is the first invariant that can see separator bugs, the class where #438 and #441 escaped.

Falsability verified by ablation:
- reverting the #441 gate → INV-5 fails (spurious newline);
- disabling the #390 `line_wrap` entirely → INV-5 fails (missing newline).

## Known residual (preexisting, out of this diff)

Δy is measured in post-CTM user space: under a rotated/sheared CTM, same-baseline glyphs get a nonzero Δy from the rotation itself, so the gate does not protect rotated text. This limitation predates this fix (the old heuristic ignored Δy entirely) and is now documented in code comments and CHANGELOG. Candidate for its own issue.

## Verification

- `issue_441_same_line_backward_jump_test` 3/3 (RED→GREEN), `issue_390_flat_line_wrap_test` 3/3, `prop_extraction_invariants` 6/6 (300 cases/property)
- Neighboring extraction suites (issues 302/330/381/386/389/390/403/408/417 + two-column roundtrip + ActualText + TJ implicit space): 56/0
- Full lib: 6671/0
- fmt, clippy `-D warnings` (lib all-features + new test targets) clean
- MSRV 1.88 `--tests --all-features --locked` exit 0
- QR (quality-rust): 0 Critical; 1 Important (the rotated-CTM residual above — scoped, documented) and the actionable Minors applied in `06d69e9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)