### PR TITLE
fix(extraction): measure flat-path pen deltas in the text baseline frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flat-path separator heuristics measured pen movement in post-CTM user
+  space, corrupting line structure under a rotated or sheared CTM** (#443).
+  A plain forward advance along a rotated baseline changes the user-space y,
+  which the newline gate misread as a line change (spurious newlines
+  everywhere), and the rotation gave every same-baseline glyph a nonzero Δy,
+  defeating the #441 same-line gate. Pen deltas are now projected onto the
+  current text baseline direction (the image of the text-space x-axis under
+  `Tm × CTM`): Δx along the baseline, Δy perpendicular to it. For
+  axis-aligned content the projection is exactly the previous Δx/Δy — no
+  behavior change — and under rotation it recovers the text's own line
+  geometry, so all the `Tj`/`TJ` separator gates (newline threshold, space
+  threshold, backward-jump wrap) now hold for rotated text. The tracked pen
+  position is the full post-advance point, so rotated baselines advance y as
+  well as x. Degenerate (zero-length or non-finite) baselines fall back to
+  raw user-space deltas. The two line-structure invariants pinned to #443
+  (rotation property + 20° deterministic pin) flip from `#[ignore]` to
+  permanent guards.
 - **A same-line backward X jump was misread as a line wrap** (#441). The
   flat-path heuristic added for #390 treated any backward pen jump beyond
   2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
@@ -17,9 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a spurious newline mid-word. In axis-aligned text a wrap always lands on a
   different baseline: the heuristic now also requires a nonzero Δy, in both
   the `Tj` and `TJ` handlers. Tight-leading wraps (small but nonzero Δy, the
-  #390 class) still break. Δy is measured in post-CTM user space, so text
-  under a rotated/sheared CTM is not protected by this gate (a preexisting
-  limitation of the flat-path heuristic, unchanged by this fix). A new
+  #390 class) still break. (Rotated/sheared CTMs were initially outside this
+  gate's reach; closed by the #443 fix above in this same release.) A new
   line-structure property invariant guards both directions —
   spurious and missing newlines — against generated layouts whose true line
   structure is known by construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Flat-path separator heuristics measured pen movement in post-CTM user
-  space, corrupting line structure under a rotated or sheared CTM** (#443).
+  space, corrupting line structure under a rotated CTM** (#443).
   A plain forward advance along a rotated baseline changes the user-space y,
   which the newline gate misread as a line change (spurious newlines
   everywhere), and the rotation gave every same-baseline glyph a nonzero Δy,
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   axis-aligned content the projection is exactly the previous Δx/Δy — no
   behavior change — and under rotation it recovers the text's own line
   geometry, so all the `Tj`/`TJ` separator gates (newline threshold, space
-  threshold, backward-jump wrap) now hold for rotated text. The tracked pen
-  position is the full post-advance point, so rotated baselines advance y as
-  well as x. Degenerate (zero-length or non-finite) baselines fall back to
-  raw user-space deltas. The two line-structure invariants pinned to #443
+  threshold, backward-jump wrap) now hold for rotated text. Mirrored
+  (negative-x-scale) baselines now measure Δx along the text's own advance
+  direction, so plain forward advances no longer misfire the backward-jump
+  wrap gate. Axis-aligned shear projects exactly; shear combined with a
+  rotated baseline is approximated. The tracked pen position is the full
+  post-advance point, so rotated baselines advance y as well as x.
+  Degenerate (zero-length or non-finite) baselines fall back to raw
+  user-space deltas. The two line-structure invariants pinned to #443
   (rotation property + 20° deterministic pin) flip from `#[ignore]` to
   permanent guards.
 - **A same-line backward X jump was misread as a line wrap** (#441). The

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2532,10 +2532,20 @@ const SAME_LINE_EPS: f64 = 1e-6;
 /// text rendering matrix `Tm × CTM`. For an axis-aligned matrix
 /// (identity/translation/positive scale — the overwhelming majority of
 /// content) the baseline IS the user-space x-axis and this returns exactly
-/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated or sheared CTM the
-/// projection recovers the text's own line geometry, which raw user-space
-/// deltas conflate: a plain forward advance along a rotated baseline changes
-/// the user-space y, which the separator heuristics misread as a line change.
+/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated CTM (and any
+/// similarity transform) the projection recovers the text's own line
+/// geometry exactly, which raw user-space deltas conflate: a plain forward
+/// advance along a rotated baseline changes the user-space y, which the
+/// separator heuristics misread as a line change. Axis-aligned shear
+/// (`b == 0`, `c != 0`) also projects exactly (the perpendicular reduces to
+/// the y-axis); a shear COMBINED with a rotated baseline is approximated —
+/// the perpendicular is built by rotating the baseline 90°, not from the
+/// true image of the text-space y-axis.
+///
+/// A mirrored baseline (negative x-scale) measures `dx` along the text's own
+/// advance direction, so a forward advance is positive `dx` — the spacing
+/// and wrap gates apply as for unmirrored text (pre-#443 they saw a raw
+/// negative `dx` and misfired the wrap gate on plain advances).
 ///
 /// A degenerate baseline (zero-length or non-finite) falls back to the raw
 /// user-space deltas, preserving pre-#443 behavior for malformed matrices.
@@ -2983,6 +2993,58 @@ fn standard_14_space_width(base_font: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── issue #443: baseline-frame pen deltas ────────────────────────────────
+
+    fn state_with_ctm(ctm: [f64; 6]) -> TextState {
+        TextState {
+            ctm,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pen_delta_identity_matrix_returns_raw_deltas() {
+        let state = state_with_ctm([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (10.0, 20.0), (14.5, 17.0));
+        assert_eq!((dx, dy), (4.5, -3.0), "axis-aligned = raw Δx/Δy exactly");
+    }
+
+    #[test]
+    fn pen_delta_rotation_recovers_text_space_advance() {
+        // 30° rotation; the pen advances 5 units along the rotated baseline.
+        let (s30, c30) = 30f64.to_radians().sin_cos();
+        let state = state_with_ctm([c30, s30, -s30, c30, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (0.0, 0.0), (5.0 * c30, 5.0 * s30));
+        assert!((dx - 5.0).abs() < 1e-12, "advance recovered: {dx}");
+        assert!(dy.abs() < 1e-12, "same baseline → dy ≈ 0: {dy}");
+        assert!(
+            dy.abs() < SAME_LINE_EPS,
+            "noise below the same-line epsilon"
+        );
+    }
+
+    #[test]
+    fn pen_delta_mirrored_baseline_measures_advance_direction() {
+        // Horizontal mirror: a forward text-space advance moves the pen LEFT
+        // in user space. dx must still be positive (the text's own advance
+        // direction), so the wrap gate does not misfire on plain advances.
+        let state = state_with_ctm([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (100.0, 50.0), (95.0, 50.0));
+        assert_eq!(dx, 5.0, "forward advance is positive along the baseline");
+        assert_eq!(dy.abs(), 0.0, "same baseline");
+    }
+
+    #[test]
+    fn pen_delta_degenerate_matrix_falls_back_to_raw_deltas() {
+        // Zero baseline (a=b=0): projection impossible → raw user-space
+        // deltas, the pre-#443 behavior.
+        let state = state_with_ctm([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        assert_eq!(pen_delta(&state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+        // Non-finite baseline: same fallback.
+        let nan_state = state_with_ctm([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        assert_eq!(pen_delta(&nan_state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+    }
 
     // ── issue #382: per-page byte-budget helper ──────────────────────────────
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1028,8 +1028,11 @@ impl TextExtractor {
                         // Add spacing based on position change
                         if !skip_text {
                             let separator = if !extracted_text.is_empty() {
-                                let dx = x - last_x;
-                                let dy = (y - last_y).abs();
+                                // Baseline-frame deltas (issue #443): identical
+                                // to raw Δx/Δy for axis-aligned matrices,
+                                // rotation-normalized otherwise.
+                                let (dx, dy_signed) = pen_delta(&state, (last_x, last_y), (x, y));
+                                let dy = dy_signed.abs();
 
                                 // A large backward jump in x is a line wrap: the
                                 // pen returns to the left margin on a new line.
@@ -1037,16 +1040,14 @@ impl TextExtractor {
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
                                 // conservative) as a newline even when dy is small
-                                // (issue #390). In axis-aligned text a wrap always
-                                // lands on a different baseline, so require a
-                                // nonzero dy: a strictly same-line backward jump
-                                // is glyph repositioning, not a wrap (issue #441).
-                                // Note: dy is measured in post-CTM user space, so
-                                // a rotated/sheared CTM gives same-baseline glyphs
-                                // a nonzero dy and this gate does not protect
-                                // rotated text (preexisting limitation).
-                                let line_wrap =
-                                    dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
+                                // (issue #390). A wrap always lands on a different
+                                // baseline, so require a nonzero dy: a strictly
+                                // same-line backward jump is glyph repositioning,
+                                // not a wrap (issue #441). dy is baseline-relative
+                                // (issue #443), so this holds under rotation too;
+                                // the epsilon absorbs projection rounding noise.
+                                let line_wrap = dy > SAME_LINE_EPS
+                                    && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.options.space_threshold * state.font_size {
@@ -1102,10 +1103,9 @@ impl TextExtractor {
                         }
 
                         // Advance the text matrix and track the true post-advance
-                        // pen x (folds in Tz and CTM x-scale, issue #386). `last_y`
-                        // stays the shown-text origin y for line detection.
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        // pen point (folds in Tz and CTM scale, issue #386; a
+                        // full point so rotated baselines advance y too, #443).
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -1137,18 +1137,20 @@ impl TextExtractor {
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
                                     // kern, so it is safe to break there — but only when
-                                    // the pen also moved vertically: in axis-aligned
-                                    // text a wrap always lands on a different baseline,
-                                    // so a strictly same-line backward jump is glyph
-                                    // repositioning, not a wrap (issue #441). dy is
-                                    // post-CTM user space, so this gate does not
-                                    // protect rotated text (preexisting limitation).
-                                    let line_wrap = (y - last_y).abs() > 0.0
-                                        && (x - last_x) < -(self.options.newline_threshold * 2.0);
+                                    // the pen also moved vertically: a wrap always lands
+                                    // on a different baseline, so a strictly same-line
+                                    // backward jump is glyph repositioning, not a wrap
+                                    // (issue #441). Deltas are baseline-relative (issue
+                                    // #443), so both gates hold under rotation; the
+                                    // epsilon absorbs projection rounding noise.
+                                    let (dx, dy_signed) =
+                                        pen_delta(&state, (last_x, last_y), (x, y));
+                                    let dy = dy_signed.abs();
+                                    let line_wrap = dy > SAME_LINE_EPS
+                                        && dx < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {
                                         let separator = if !extracted_text.is_empty()
-                                            && ((y - last_y).abs() > self.options.newline_threshold
-                                                || line_wrap)
+                                            && (dy > self.options.newline_threshold || line_wrap)
                                         {
                                             Some('\n')
                                         } else {
@@ -1196,9 +1198,8 @@ impl TextExtractor {
                                     // Keep the pen position in sync so a following
                                     // `Tj`/`TJ` measures its gap from the right origin
                                     // (issue #381: a stale `last_y` dropped newlines;
-                                    // issue #386: `last_x` must fold in Tz/CTM scale).
-                                    last_x = advance_pen(&mut state, text_width);
-                                    last_y = y;
+                                    // issue #386: the pen must fold in Tz/CTM scale).
+                                    (last_x, last_y) = advance_pen(&mut state, text_width);
                                 }
                                 TextElement::Spacing(adjustment) => {
                                     // Text position adjustment (negative = move left,
@@ -1329,8 +1330,7 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -1397,8 +1397,7 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -2510,10 +2509,47 @@ fn text_origin(state: &TextState) -> (f64, f64) {
 /// space decisions) must therefore come from the post-advance pen origin, not
 /// from `origin_x + text_width`, which ignores both factors and trails the
 /// real pen whenever `Tz != 100` or the CTM scales x (issue #386).
-fn advance_pen(state: &mut TextState, text_width: f64) -> f64 {
+fn advance_pen(state: &mut TextState, text_width: f64) -> (f64, f64) {
     let tx = text_width * state.horizontal_scale / 100.0;
     state.text_matrix = multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
-    text_origin(state).0
+    text_origin(state)
+}
+
+/// Projection-noise floor for the perpendicular pen delta. Same-baseline
+/// glyph runs produce a `dy` that is exactly 0 in real arithmetic but can
+/// carry ~1e-13 of float rounding after the baseline projection; anything
+/// below this epsilon is "the same baseline". The smallest meaningful
+/// leading in real documents is orders of magnitude above it.
+const SAME_LINE_EPS: f64 = 1e-6;
+
+/// Pen movement from the previous post-advance pen point `last` to the
+/// current glyph origin `cur` (both user space), measured in the frame of the
+/// current text baseline (issue #443): `dx` along the baseline direction,
+/// `dy` perpendicular to it (signed; callers take `.abs()` for line
+/// detection).
+///
+/// The baseline direction is the image of the text-space x-axis under the
+/// text rendering matrix `Tm × CTM`. For an axis-aligned matrix
+/// (identity/translation/positive scale — the overwhelming majority of
+/// content) the baseline IS the user-space x-axis and this returns exactly
+/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated or sheared CTM the
+/// projection recovers the text's own line geometry, which raw user-space
+/// deltas conflate: a plain forward advance along a rotated baseline changes
+/// the user-space y, which the separator heuristics misread as a line change.
+///
+/// A degenerate baseline (zero-length or non-finite) falls back to the raw
+/// user-space deltas, preserving pre-#443 behavior for malformed matrices.
+fn pen_delta(state: &TextState, last: (f64, f64), cur: (f64, f64)) -> (f64, f64) {
+    let dxu = cur.0 - last.0;
+    let dyu = cur.1 - last.1;
+    let m = multiply_matrix(&state.text_matrix, &state.ctm);
+    let (bx, by) = (m[0], m[1]);
+    let norm = (bx * bx + by * by).sqrt();
+    if !norm.is_finite() || norm <= f64::EPSILON {
+        return (dxu, dyu);
+    }
+    let (ux, uy) = (bx / norm, by / norm);
+    (dxu * ux + dyu * uy, -dxu * uy + dyu * ux)
 }
 
 /// Multiply two transformation matrices

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -232,7 +232,6 @@ fn output_line_structure(text: &str) -> Vec<String> {
 /// #441 gate (the rotated advance gives every glyph a nonzero user-space Δy)
 /// and the output splits into several lines.
 #[test]
-#[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
 fn issue_443_rotated_page_keeps_single_line() {
     let lines = vec![(vec![0, 1], Some((2, 35.0)), 13.0)];
     let (pdf, drawn) = build_rotated_line_structure_page(&lines, 20.0);
@@ -375,7 +374,6 @@ proptest! {
     /// plain forward advance exceed `newline_threshold` vertically. Becomes a
     /// permanent guard when #443 is fixed (pen deltas measured in text space).
     #[test]
-    #[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
     fn flat_line_structure_survives_rotation(
         lines in prop::collection::vec(
             (

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -243,6 +243,36 @@ fn issue_443_rotated_page_keeps_single_line() {
     );
 }
 
+/// Deterministic pin for the mirrored-baseline behavior change of the #443
+/// fix: under a negative-x-scale CTM, `dx` is measured along the text's own
+/// advance direction, so a plain forward advance no longer misfires the
+/// backward-jump wrap gate (pre-#443 it saw raw `dx < 0` and inserted a
+/// newline once the advance exceeded 2× the threshold). One drawn baseline
+/// must come out as exactly one line, glyphs in draw order.
+#[test]
+fn mirrored_baseline_stays_a_single_line() {
+    let (inner, drawn) = emit_line_structure(&[(vec![0, 1, 2], None, 13.0)]);
+    let mut content = Vec::new();
+    content.extend_from_slice(b"q\n-1 0 0 1 612 0 cm\n");
+    content.extend_from_slice(&inner);
+    content.extend_from_slice(b"Q\n");
+    let flat = extract(&wrap_pdf(&content), false);
+    assert_eq!(
+        output_line_structure(&flat),
+        drawn,
+        "mirrored single-baseline page must extract as one line\n--- flat ---\n{flat}"
+    );
+    // The observable delta vs the pre-#443 code: word gaps advance the pen
+    // LEFT in raw user space, so the old dx-based space gate never fired and
+    // words came out glued ("loremipsum"). Projected onto the baseline the
+    // gap is a positive forward dx and the space is inserted.
+    let (w0, w1) = (WORDS[0], WORDS[1]);
+    assert!(
+        flat.contains(&format!("{w0} {w1}")),
+        "mirrored word gap must still produce a space\n--- flat ---\n{flat}"
+    );
+}
+
 // ---- Drift-chain builder for the #425 token-contiguity property. ----------
 
 fn build_drift_page(n_lines: usize, token_line: usize, token: &str, drift_step: f64) -> Vec<u8> {


### PR DESCRIPTION
Addresses #443. Supersedes #444 (this branch contains its detector commits; #444 can be closed once this merges).

## Problem

The flat-path `Tj`/`TJ` separator heuristics compared pen positions in post-CTM user space. Under a rotated CTM: (a) plain forward advance changes user-space y → the newline-threshold gate fired on text that never changed lines; (b) every same-baseline glyph carried nonzero Δy → the #441 same-line gate was defeated. The #443 repro extracted `"AGR\no\nX"`.

## Fix

`pen_delta`: project the pen delta onto the current baseline direction (image of the text-space x-axis under `Tm × CTM`) — dx along the baseline, dy perpendicular. Properties:

- **Axis-aligned matrices project to exactly the old raw Δx/Δy** (bit-for-bit, verified) — no behavior change for the overwhelming majority of content.
- Rotation (any similarity transform) recovers text-space geometry exactly; axis-aligned shear exact by reduction; shear+rotation approximated (documented).
- Mirrored (negative-x-scale) baselines: dx now measures the text's own advance direction — word gaps insert spaces (pre-fix: glued words), plain advances can't misfire the wrap gate. Pinned by test + ablation.
- `advance_pen` returns the full post-advance point (rotated baselines advance y too). Degenerate/NaN baselines fall back to raw deltas (pre-fix behavior).
- #441's `dy > 0` gate becomes `dy > 1e-6` (projection noise ~1e-13; real leading orders of magnitude above).

The two invariants pinned to #443 flip from `#[ignore]` to permanent guards (INV-6 rotation property ±0.5°..90°, 20° deterministic pin).

## Verification

- TDD: pins un-ignored first → RED (2 failed) → fix → GREEN 8/8; ablation of the projection fails 3 guards (rotation property, 20° pin, mirrored pin)
- The exact #443 repro: rotated and identity now extract identically (`"AGRo X"`, 0 newlines)
- 19 extraction suites 83/0 · full lib 6671/0 · `prop_extraction_invariants` 9/9
- **Corpus local** (CI does not run it on PRs): **T2 484/481 parsed, 0 panics, 0 timeouts, 446 text — identical to the 4.2.0 baseline; T3 1802/1761, 0 panics, 0 timeouts, 1598 text — identical**
- fmt · clippy `-D warnings` (lib all-features + targets) · MSRV 1.88 `--all-features --locked`
- QR (quality-rust) two rounds: 0 Critical; both Importants addressed in follow-up commit `8e780cf` (scoped shear claim, mirrored pin, `pen_delta` unit tests incl. degenerate/NaN branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
