### PR TITLE
chore(release): 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flat-path separator heuristics measured pen movement in post-CTM user
+  space, corrupting line structure under a rotated or sheared CTM** (#443).
+  A plain forward advance along a rotated baseline changes the user-space y,
+  which the newline gate misread as a line change (spurious newlines
+  everywhere), and the rotation gave every same-baseline glyph a nonzero Δy,
+  defeating the #441 same-line gate. Pen deltas are now projected onto the
+  current text baseline direction (the image of the text-space x-axis under
+  `Tm × CTM`): Δx along the baseline, Δy perpendicular to it. For
+  axis-aligned content the projection is exactly the previous Δx/Δy — no
+  behavior change — and under rotation it recovers the text's own line
+  geometry, so all the `Tj`/`TJ` separator gates (newline threshold, space
+  threshold, backward-jump wrap) now hold for rotated text. The tracked pen
+  position is the full post-advance point, so rotated baselines advance y as
+  well as x. Degenerate (zero-length or non-finite) baselines fall back to
+  raw user-space deltas. The two line-structure invariants pinned to #443
+  (rotation property + 20° deterministic pin) flip from `#[ignore]` to
+  permanent guards.
 - **A same-line backward X jump was misread as a line wrap** (#441). The
   flat-path heuristic added for #390 treated any backward pen jump beyond
   2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
@@ -17,9 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a spurious newline mid-word. In axis-aligned text a wrap always lands on a
   different baseline: the heuristic now also requires a nonzero Δy, in both
   the `Tj` and `TJ` handlers. Tight-leading wraps (small but nonzero Δy, the
-  #390 class) still break. Δy is measured in post-CTM user space, so text
-  under a rotated/sheared CTM is not protected by this gate (a preexisting
-  limitation of the flat-path heuristic, unchanged by this fix). A new
+  #390 class) still break. (Rotated/sheared CTMs were initially outside this
+  gate's reach; closed by the #443 fix above in this same release.) A new
   line-structure property invariant guards both directions —
   spurious and missing newlines — against generated layouts whose true line
   structure is known by construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Flat-path separator heuristics measured pen movement in post-CTM user
-  space, corrupting line structure under a rotated or sheared CTM** (#443).
+  space, corrupting line structure under a rotated CTM** (#443).
   A plain forward advance along a rotated baseline changes the user-space y,
   which the newline gate misread as a line change (spurious newlines
   everywhere), and the rotation gave every same-baseline glyph a nonzero Δy,
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   axis-aligned content the projection is exactly the previous Δx/Δy — no
   behavior change — and under rotation it recovers the text's own line
   geometry, so all the `Tj`/`TJ` separator gates (newline threshold, space
-  threshold, backward-jump wrap) now hold for rotated text. The tracked pen
-  position is the full post-advance point, so rotated baselines advance y as
-  well as x. Degenerate (zero-length or non-finite) baselines fall back to
-  raw user-space deltas. The two line-structure invariants pinned to #443
+  threshold, backward-jump wrap) now hold for rotated text. Mirrored
+  (negative-x-scale) baselines now measure Δx along the text's own advance
+  direction, so plain forward advances no longer misfire the backward-jump
+  wrap gate. Axis-aligned shear projects exactly; shear combined with a
+  rotated baseline is approximated. The tracked pen position is the full
+  post-advance point, so rotated baselines advance y as well as x.
+  Degenerate (zero-length or non-finite) baselines fall back to raw
+  user-space deltas. The two line-structure invariants pinned to #443
   (rotation property + 20° deterministic pin) flip from `#[ignore]` to
   permanent guards.
 - **A same-line backward X jump was misread as a line wrap** (#441). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [Unreleased]
+## [4.2.1] - 2026-07-22
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flat-path heuristic added for #390 treated any backward pen jump beyond
   2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
   backward on the same baseline (justification, out-of-order emission) gained
-  a spurious newline mid-word. A wrap always lands on a different baseline:
-  the heuristic now also requires a nonzero Δy, in both the `Tj` and `TJ`
-  handlers. Tight-leading wraps (small but nonzero Δy, the #390 class) still
-  break. A new line-structure property invariant guards both directions —
+  a spurious newline mid-word. In axis-aligned text a wrap always lands on a
+  different baseline: the heuristic now also requires a nonzero Δy, in both
+  the `Tj` and `TJ` handlers. Tight-leading wraps (small but nonzero Δy, the
+  #390 class) still break. Δy is measured in post-CTM user space, so text
+  under a rotated/sheared CTM is not protected by this gate (a preexisting
+  limitation of the flat-path heuristic, unchanged by this fix). A new
+  line-structure property invariant guards both directions —
   spurious and missing newlines — against generated layouts whose true line
   structure is known by construction.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+
+- **A same-line backward X jump was misread as a line wrap** (#441). The
+  flat-path heuristic added for #390 treated any backward pen jump beyond
+  2× `newline_threshold` as a wrap, ignoring Δy — so glyphs repositioned
+  backward on the same baseline (justification, out-of-order emission) gained
+  a spurious newline mid-word. A wrap always lands on a different baseline:
+  the heuristic now also requires a nonzero Δy, in both the `Tj` and `TJ`
+  handlers. Tight-leading wraps (small but nonzero Δy, the #390 class) still
+  break. A new line-structure property invariant guards both directions —
+  spurious and missing newlines — against generated layouts whose true line
+  structure is known by construction.
+
 ## [4.2.0] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2532,10 +2532,20 @@ const SAME_LINE_EPS: f64 = 1e-6;
 /// text rendering matrix `Tm × CTM`. For an axis-aligned matrix
 /// (identity/translation/positive scale — the overwhelming majority of
 /// content) the baseline IS the user-space x-axis and this returns exactly
-/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated or sheared CTM the
-/// projection recovers the text's own line geometry, which raw user-space
-/// deltas conflate: a plain forward advance along a rotated baseline changes
-/// the user-space y, which the separator heuristics misread as a line change.
+/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated CTM (and any
+/// similarity transform) the projection recovers the text's own line
+/// geometry exactly, which raw user-space deltas conflate: a plain forward
+/// advance along a rotated baseline changes the user-space y, which the
+/// separator heuristics misread as a line change. Axis-aligned shear
+/// (`b == 0`, `c != 0`) also projects exactly (the perpendicular reduces to
+/// the y-axis); a shear COMBINED with a rotated baseline is approximated —
+/// the perpendicular is built by rotating the baseline 90°, not from the
+/// true image of the text-space y-axis.
+///
+/// A mirrored baseline (negative x-scale) measures `dx` along the text's own
+/// advance direction, so a forward advance is positive `dx` — the spacing
+/// and wrap gates apply as for unmirrored text (pre-#443 they saw a raw
+/// negative `dx` and misfired the wrap gate on plain advances).
 ///
 /// A degenerate baseline (zero-length or non-finite) falls back to the raw
 /// user-space deltas, preserving pre-#443 behavior for malformed matrices.
@@ -2983,6 +2993,58 @@ fn standard_14_space_width(base_font: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── issue #443: baseline-frame pen deltas ────────────────────────────────
+
+    fn state_with_ctm(ctm: [f64; 6]) -> TextState {
+        TextState {
+            ctm,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pen_delta_identity_matrix_returns_raw_deltas() {
+        let state = state_with_ctm([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (10.0, 20.0), (14.5, 17.0));
+        assert_eq!((dx, dy), (4.5, -3.0), "axis-aligned = raw Δx/Δy exactly");
+    }
+
+    #[test]
+    fn pen_delta_rotation_recovers_text_space_advance() {
+        // 30° rotation; the pen advances 5 units along the rotated baseline.
+        let (s30, c30) = 30f64.to_radians().sin_cos();
+        let state = state_with_ctm([c30, s30, -s30, c30, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (0.0, 0.0), (5.0 * c30, 5.0 * s30));
+        assert!((dx - 5.0).abs() < 1e-12, "advance recovered: {dx}");
+        assert!(dy.abs() < 1e-12, "same baseline → dy ≈ 0: {dy}");
+        assert!(
+            dy.abs() < SAME_LINE_EPS,
+            "noise below the same-line epsilon"
+        );
+    }
+
+    #[test]
+    fn pen_delta_mirrored_baseline_measures_advance_direction() {
+        // Horizontal mirror: a forward text-space advance moves the pen LEFT
+        // in user space. dx must still be positive (the text's own advance
+        // direction), so the wrap gate does not misfire on plain advances.
+        let state = state_with_ctm([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let (dx, dy) = pen_delta(&state, (100.0, 50.0), (95.0, 50.0));
+        assert_eq!(dx, 5.0, "forward advance is positive along the baseline");
+        assert_eq!(dy.abs(), 0.0, "same baseline");
+    }
+
+    #[test]
+    fn pen_delta_degenerate_matrix_falls_back_to_raw_deltas() {
+        // Zero baseline (a=b=0): projection impossible → raw user-space
+        // deltas, the pre-#443 behavior.
+        let state = state_with_ctm([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        assert_eq!(pen_delta(&state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+        // Non-finite baseline: same fallback.
+        let nan_state = state_with_ctm([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        assert_eq!(pen_delta(&nan_state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+    }
 
     // ── issue #382: per-page byte-budget helper ──────────────────────────────
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1028,8 +1028,11 @@ impl TextExtractor {
                         // Add spacing based on position change
                         if !skip_text {
                             let separator = if !extracted_text.is_empty() {
-                                let dx = x - last_x;
-                                let dy = (y - last_y).abs();
+                                // Baseline-frame deltas (issue #443): identical
+                                // to raw Δx/Δy for axis-aligned matrices,
+                                // rotation-normalized otherwise.
+                                let (dx, dy_signed) = pen_delta(&state, (last_x, last_y), (x, y));
+                                let dy = dy_signed.abs();
 
                                 // A large backward jump in x is a line wrap: the
                                 // pen returns to the left margin on a new line.
@@ -1037,16 +1040,14 @@ impl TextExtractor {
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
                                 // conservative) as a newline even when dy is small
-                                // (issue #390). In axis-aligned text a wrap always
-                                // lands on a different baseline, so require a
-                                // nonzero dy: a strictly same-line backward jump
-                                // is glyph repositioning, not a wrap (issue #441).
-                                // Note: dy is measured in post-CTM user space, so
-                                // a rotated/sheared CTM gives same-baseline glyphs
-                                // a nonzero dy and this gate does not protect
-                                // rotated text (preexisting limitation).
-                                let line_wrap =
-                                    dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
+                                // (issue #390). A wrap always lands on a different
+                                // baseline, so require a nonzero dy: a strictly
+                                // same-line backward jump is glyph repositioning,
+                                // not a wrap (issue #441). dy is baseline-relative
+                                // (issue #443), so this holds under rotation too;
+                                // the epsilon absorbs projection rounding noise.
+                                let line_wrap = dy > SAME_LINE_EPS
+                                    && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.options.space_threshold * state.font_size {
@@ -1102,10 +1103,9 @@ impl TextExtractor {
                         }
 
                         // Advance the text matrix and track the true post-advance
-                        // pen x (folds in Tz and CTM x-scale, issue #386). `last_y`
-                        // stays the shown-text origin y for line detection.
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        // pen point (folds in Tz and CTM scale, issue #386; a
+                        // full point so rotated baselines advance y too, #443).
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -1137,18 +1137,20 @@ impl TextExtractor {
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
                                     // kern, so it is safe to break there — but only when
-                                    // the pen also moved vertically: in axis-aligned
-                                    // text a wrap always lands on a different baseline,
-                                    // so a strictly same-line backward jump is glyph
-                                    // repositioning, not a wrap (issue #441). dy is
-                                    // post-CTM user space, so this gate does not
-                                    // protect rotated text (preexisting limitation).
-                                    let line_wrap = (y - last_y).abs() > 0.0
-                                        && (x - last_x) < -(self.options.newline_threshold * 2.0);
+                                    // the pen also moved vertically: a wrap always lands
+                                    // on a different baseline, so a strictly same-line
+                                    // backward jump is glyph repositioning, not a wrap
+                                    // (issue #441). Deltas are baseline-relative (issue
+                                    // #443), so both gates hold under rotation; the
+                                    // epsilon absorbs projection rounding noise.
+                                    let (dx, dy_signed) =
+                                        pen_delta(&state, (last_x, last_y), (x, y));
+                                    let dy = dy_signed.abs();
+                                    let line_wrap = dy > SAME_LINE_EPS
+                                        && dx < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {
                                         let separator = if !extracted_text.is_empty()
-                                            && ((y - last_y).abs() > self.options.newline_threshold
-                                                || line_wrap)
+                                            && (dy > self.options.newline_threshold || line_wrap)
                                         {
                                             Some('\n')
                                         } else {
@@ -1196,9 +1198,8 @@ impl TextExtractor {
                                     // Keep the pen position in sync so a following
                                     // `Tj`/`TJ` measures its gap from the right origin
                                     // (issue #381: a stale `last_y` dropped newlines;
-                                    // issue #386: `last_x` must fold in Tz/CTM scale).
-                                    last_x = advance_pen(&mut state, text_width);
-                                    last_y = y;
+                                    // issue #386: the pen must fold in Tz/CTM scale).
+                                    (last_x, last_y) = advance_pen(&mut state, text_width);
                                 }
                                 TextElement::Spacing(adjustment) => {
                                     // Text position adjustment (negative = move left,
@@ -1329,8 +1330,7 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -1397,8 +1397,7 @@ impl TextExtractor {
                             );
                         }
 
-                        last_x = advance_pen(&mut state, text_width);
-                        last_y = y;
+                        (last_x, last_y) = advance_pen(&mut state, text_width);
                     }
                 }
 
@@ -2510,10 +2509,47 @@ fn text_origin(state: &TextState) -> (f64, f64) {
 /// space decisions) must therefore come from the post-advance pen origin, not
 /// from `origin_x + text_width`, which ignores both factors and trails the
 /// real pen whenever `Tz != 100` or the CTM scales x (issue #386).
-fn advance_pen(state: &mut TextState, text_width: f64) -> f64 {
+fn advance_pen(state: &mut TextState, text_width: f64) -> (f64, f64) {
     let tx = text_width * state.horizontal_scale / 100.0;
     state.text_matrix = multiply_matrix(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &state.text_matrix);
-    text_origin(state).0
+    text_origin(state)
+}
+
+/// Projection-noise floor for the perpendicular pen delta. Same-baseline
+/// glyph runs produce a `dy` that is exactly 0 in real arithmetic but can
+/// carry ~1e-13 of float rounding after the baseline projection; anything
+/// below this epsilon is "the same baseline". The smallest meaningful
+/// leading in real documents is orders of magnitude above it.
+const SAME_LINE_EPS: f64 = 1e-6;
+
+/// Pen movement from the previous post-advance pen point `last` to the
+/// current glyph origin `cur` (both user space), measured in the frame of the
+/// current text baseline (issue #443): `dx` along the baseline direction,
+/// `dy` perpendicular to it (signed; callers take `.abs()` for line
+/// detection).
+///
+/// The baseline direction is the image of the text-space x-axis under the
+/// text rendering matrix `Tm × CTM`. For an axis-aligned matrix
+/// (identity/translation/positive scale — the overwhelming majority of
+/// content) the baseline IS the user-space x-axis and this returns exactly
+/// `(Δx, Δy)`, the pre-#443 behavior. Under a rotated or sheared CTM the
+/// projection recovers the text's own line geometry, which raw user-space
+/// deltas conflate: a plain forward advance along a rotated baseline changes
+/// the user-space y, which the separator heuristics misread as a line change.
+///
+/// A degenerate baseline (zero-length or non-finite) falls back to the raw
+/// user-space deltas, preserving pre-#443 behavior for malformed matrices.
+fn pen_delta(state: &TextState, last: (f64, f64), cur: (f64, f64)) -> (f64, f64) {
+    let dxu = cur.0 - last.0;
+    let dyu = cur.1 - last.1;
+    let m = multiply_matrix(&state.text_matrix, &state.ctm);
+    let (bx, by) = (m[0], m[1]);
+    let norm = (bx * bx + by * by).sqrt();
+    if !norm.is_finite() || norm <= f64::EPSILON {
+        return (dxu, dyu);
+    }
+    let (ux, uy) = (bx / norm, by / norm);
+    (dxu * ux + dyu * uy, -dxu * uy + dyu * ux)
 }
 
 /// Multiply two transformation matrices

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1037,10 +1037,14 @@ impl TextExtractor {
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
                                 // conservative) as a newline even when dy is small
-                                // (issue #390). A wrap always lands on a different
-                                // baseline, so require a nonzero dy: a strictly
-                                // same-line backward jump is glyph repositioning,
-                                // never a wrap (issue #441).
+                                // (issue #390). In axis-aligned text a wrap always
+                                // lands on a different baseline, so require a
+                                // nonzero dy: a strictly same-line backward jump
+                                // is glyph repositioning, not a wrap (issue #441).
+                                // Note: dy is measured in post-CTM user space, so
+                                // a rotated/sheared CTM gives same-baseline glyphs
+                                // a nonzero dy and this gate does not protect
+                                // rotated text (preexisting limitation).
                                 let line_wrap =
                                     dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
@@ -1133,10 +1137,12 @@ impl TextExtractor {
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
                                     // kern, so it is safe to break there — but only when
-                                    // the pen also moved vertically: a wrap always lands
-                                    // on a different baseline, so a strictly same-line
-                                    // backward jump is glyph repositioning, never a wrap
-                                    // (issue #441).
+                                    // the pen also moved vertically: in axis-aligned
+                                    // text a wrap always lands on a different baseline,
+                                    // so a strictly same-line backward jump is glyph
+                                    // repositioning, not a wrap (issue #441). dy is
+                                    // post-CTM user space, so this gate does not
+                                    // protect rotated text (preexisting limitation).
                                     let line_wrap = (y - last_y).abs() > 0.0
                                         && (x - last_x) < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1036,9 +1036,13 @@ impl TextExtractor {
                                 // When the line height is below `newline_threshold`
                                 // the dy check alone misses it, so treat a backward
                                 // dx beyond one line-height (2× the threshold,
-                                // conservative) as a newline regardless of dy
-                                // (issue #390).
-                                let line_wrap = dx < -(self.options.newline_threshold * 2.0);
+                                // conservative) as a newline even when dy is small
+                                // (issue #390). A wrap always lands on a different
+                                // baseline, so require a nonzero dy: a strictly
+                                // same-line backward jump is glyph repositioning,
+                                // never a wrap (issue #441).
+                                let line_wrap =
+                                    dy > 0.0 && dx < -(self.options.newline_threshold * 2.0);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.options.space_threshold * state.font_size {
@@ -1128,9 +1132,13 @@ impl TextExtractor {
                                     // word that a TJ array draws as several positioned
                                     // pieces. A *backward* dx beyond one line-height
                                     // (2× the threshold, conservative) is a wrap, not a
-                                    // kern, so it is safe to break there.
-                                    let line_wrap =
-                                        (x - last_x) < -(self.options.newline_threshold * 2.0);
+                                    // kern, so it is safe to break there — but only when
+                                    // the pen also moved vertically: a wrap always lands
+                                    // on a different baseline, so a strictly same-line
+                                    // backward jump is glyph repositioning, never a wrap
+                                    // (issue #441).
+                                    let line_wrap = (y - last_y).abs() > 0.0
+                                        && (x - last_x) < -(self.options.newline_threshold * 2.0);
                                     if !skip_text {
                                         let separator = if !extracted_text.is_empty()
                                             && ((y - last_y).abs() > self.options.newline_threshold

--- a/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
+++ b/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
@@ -115,13 +115,15 @@ fn tj_array_same_line_backward_jump_gets_no_newline() {
 
 #[test]
 fn backward_jump_with_small_nonzero_dy_still_breaks_line() {
-    // Boundary pin: the #390 class (tight leading, Δy = 2pt nonzero but far
-    // below newline_threshold = 10, plus a big backward jump) must STILL be
-    // treated as a wrap. The #441 fix only excludes Δy == 0.
+    // Boundary pin: the #441 fix excludes exactly Δy == 0, nothing more. A
+    // backward jump with Δy = 0.1pt — barely nonzero, far below
+    // newline_threshold = 10 — must STILL be treated as a wrap (the #390
+    // class). Pinning this close to the cutoff means a future regression to
+    // e.g. `dy > 1.0` fails here instead of slipping through.
     let content = concat!(
         "BT\n/F1 8 Tf\n",
         "1 0 0 1 300 700 Tm\n(tail) Tj\n",
-        "1 0 0 1 50 698 Tm\n(head) Tj\nET"
+        "1 0 0 1 50 699.9 Tm\n(head) Tj\nET"
     );
     let text = extract_flat(content);
     assert!(

--- a/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
+++ b/oxidize-pdf-core/tests/issue_441_same_line_backward_jump_test.rs
@@ -1,0 +1,131 @@
+//! Regression tests for issue #441.
+//!
+//! The flat-text line-wrap heuristic added for issue #390 fires on a large
+//! backward horizontal jump (`dx < -(newline_threshold * 2)`) regardless of
+//! Δy. Real-world PDFs reposition glyphs backward *on the same line*
+//! (justification, kerned overlays, out-of-order emission); with Δy exactly 0
+//! there is no wrap, yet the heuristic inserted a spurious newline mid-word.
+//!
+//! Fix: a backward jump only counts as a wrap when the pen also moved
+//! vertically (`dy > 0`). A strictly same-line backward jump can never be a
+//! wrap — a wrapped line always lands on a different baseline. Tight-leading
+//! wraps (small but nonzero Δy, the #390 class) still break.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false (the affected flat path).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_operator_same_line_backward_jump_gets_no_newline() {
+    // The exact signature from issue #441: three `Tj` calls all at y=562.50.
+    // "o" jumps backward by ~-35pt (beyond -newline_threshold*2 = -20), then
+    // "X" continues forward. Δy is exactly 0 for all three, so nothing
+    // wrapped; before the fix the output was "AGR\no X".
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 356.17 562.50 Tm\n(AGR) Tj\n",
+        "1 0 0 1 335.83 562.50 Tm\n(o) Tj\n",
+        "1 0 0 1 400.00 562.50 Tm\n(X) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "same-line backward jump must not insert a newline (issue #441): {text:?}"
+    );
+    let glyphs: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert_eq!(
+        glyphs, "AGRoX",
+        "all glyphs must survive in draw order: {text:?}"
+    );
+}
+
+#[test]
+fn tj_array_same_line_backward_jump_gets_no_newline() {
+    // Same signature through the `TJ` (ShowTextArray) handler, which
+    // duplicates the line-wrap heuristic.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 356.17 562.50 Tm\n[(AGR)] TJ\n",
+        "1 0 0 1 335.83 562.50 Tm\n[(o)] TJ\n",
+        "1 0 0 1 400.00 562.50 Tm\n[(X)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "TJ path must not insert a newline on a same-line backward jump: {text:?}"
+    );
+    let glyphs: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert_eq!(
+        glyphs, "AGRoX",
+        "all glyphs must survive in draw order: {text:?}"
+    );
+}
+
+#[test]
+fn backward_jump_with_small_nonzero_dy_still_breaks_line() {
+    // Boundary pin: the #390 class (tight leading, Δy = 2pt nonzero but far
+    // below newline_threshold = 10, plus a big backward jump) must STILL be
+    // treated as a wrap. The #441 fix only excludes Δy == 0.
+    let content = concat!(
+        "BT\n/F1 8 Tf\n",
+        "1 0 0 1 300 700 Tm\n(tail) Tj\n",
+        "1 0 0 1 50 698 Tm\n(head) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("tail\nhead"),
+        "nonzero-dy backward wrap must still break (the #390 guarantee): {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -232,7 +232,6 @@ fn output_line_structure(text: &str) -> Vec<String> {
 /// #441 gate (the rotated advance gives every glyph a nonzero user-space Δy)
 /// and the output splits into several lines.
 #[test]
-#[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
 fn issue_443_rotated_page_keeps_single_line() {
     let lines = vec![(vec![0, 1], Some((2, 35.0)), 13.0)];
     let (pdf, drawn) = build_rotated_line_structure_page(&lines, 20.0);
@@ -375,7 +374,6 @@ proptest! {
     /// plain forward advance exceed `newline_threshold` vertically. Becomes a
     /// permanent guard when #443 is fixed (pen deltas measured in text space).
     #[test]
-    #[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
     fn flat_line_structure_survives_rotation(
         lines in prop::collection::vec(
             (

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -24,6 +24,10 @@
 //!      geometrically detectable (no missing newline, #390). Unlike #1-#4,
 //!      this oracle does NOT filter whitespace away — it is the only invariant
 //!      that can see separator bugs, the class where #438 and #441 escaped.
+//!   6. LINE STRUCTURE UNDER ROTATION — the same oracle under a rotated CTM:
+//!      a rigid page rotation must not change the extracted line structure.
+//!      PINNED `#[ignore]` to open issue #443 (separator heuristics measure
+//!      post-CTM user space); flips to a permanent guard when it is fixed.
 
 use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
@@ -157,7 +161,7 @@ type LineSpec = (Vec<usize>, Option<(usize, f64)>, f64);
 /// class. A correction re-draws a word backward ON THE SAME baseline
 /// (dy = 0, dx < -(2 × threshold)) mid-line — the #441 class — and must NOT
 /// break the line.
-fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
+fn emit_line_structure(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
     let mut content = Vec::new();
     let mut drawn_lines = Vec::new();
     let mut y = 760.0;
@@ -185,7 +189,32 @@ fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
         drawn_lines.push(line);
         y -= leading;
     }
-    (wrap_pdf(&content), drawn_lines)
+    (content, drawn_lines)
+}
+
+fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
+    let (content, drawn) = emit_line_structure(lines);
+    (wrap_pdf(&content), drawn)
+}
+
+/// Same page under a CTM rotated by `theta_deg`. A rigid page rotation
+/// changes nothing about the text's logical structure — glyphs that share a
+/// text-space baseline still share it — so the drawn-lines oracle is
+/// unchanged. What rotation DOES change is every post-CTM user-space delta
+/// the flat-path separator heuristics currently measure (issue #443).
+///
+/// The rotation pivots on the content-stream origin, so glyphs may land
+/// outside the MediaBox or at negative coordinates. Harmless by design: the
+/// flat extraction path performs no MediaBox clipping (verified), and the
+/// oracle only cares about line structure, not placement.
+fn build_rotated_line_structure_page(lines: &[LineSpec], theta_deg: f64) -> (Vec<u8>, Vec<String>) {
+    let (inner, drawn) = emit_line_structure(lines);
+    let (s, c) = theta_deg.to_radians().sin_cos();
+    let mut content = Vec::new();
+    write!(content, "q\n{c:.6} {s:.6} {:.6} {c:.6} 0 0 cm\n", -s).unwrap();
+    content.extend_from_slice(&inner);
+    content.extend_from_slice(b"Q\n");
+    (wrap_pdf(&content), drawn)
 }
 
 /// Non-whitespace glyph runs per output line. Empty entries are kept: a
@@ -195,6 +224,24 @@ fn output_line_structure(text: &str) -> Vec<String> {
     text.lines()
         .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
         .collect()
+}
+
+/// Deterministic pin for #443: a single baseline with a same-line backward
+/// correction (the #441 shape), under a 20° page rotation. One line was
+/// drawn, so exactly one line must come out. Today the rotation defeats the
+/// #441 gate (the rotated advance gives every glyph a nonzero user-space Δy)
+/// and the output splits into several lines.
+#[test]
+#[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
+fn issue_443_rotated_page_keeps_single_line() {
+    let lines = vec![(vec![0, 1], Some((2, 35.0)), 13.0)];
+    let (pdf, drawn) = build_rotated_line_structure_page(&lines, 20.0);
+    let flat = extract(&pdf, false);
+    assert_eq!(
+        output_line_structure(&flat),
+        drawn,
+        "rotated single-baseline page must extract as one line (#443)\n--- flat ---\n{flat}"
+    );
 }
 
 // ---- Drift-chain builder for the #425 token-contiguity property. ----------
@@ -317,6 +364,41 @@ proptest! {
             &got, &drawn,
             "extracted line structure differs from drawn lines\n--- flat ---\n{}",
             flat
+        );
+    }
+
+    /// INV-6 LINE STRUCTURE UNDER ROTATION (#443, pinned): a rigid page
+    /// rotation does not change the text's logical line structure, so the
+    /// drawn-lines oracle of INV-5 must hold under any rotated CTM. Fails
+    /// today: the flat-path separator heuristics measure post-CTM user-space
+    /// deltas, so rotation both defeats the #441 same-baseline gate AND makes
+    /// plain forward advance exceed `newline_threshold` vertically. Becomes a
+    /// permanent guard when #443 is fixed (pen deltas measured in text space).
+    #[test]
+    #[ignore = "issue #443: flat-path separator heuristics measure post-CTM user space; rotated text gains spurious newlines"]
+    fn flat_line_structure_survives_rotation(
+        lines in prop::collection::vec(
+            (
+                prop::collection::vec(0usize..10, 2..5),
+                prop::option::of((0usize..10, 30.0f64..60.0)),
+                prop_oneof![2.0f64..9.5, 12.0f64..30.0],
+            ),
+            3..12,
+        ),
+        theta_deg in prop_oneof![
+            0.5f64..90.0,
+            -90.0f64..-0.5,
+            Just(90.0f64),
+            Just(-90.0f64)
+        ],
+    ) {
+        let (pdf, drawn) = build_rotated_line_structure_page(&lines, theta_deg);
+        let flat = extract(&pdf, false);
+        let got = output_line_structure(&flat);
+        prop_assert_eq!(
+            &got, &drawn,
+            "line structure changed under a {}° page rotation\n--- flat ---\n{}",
+            theta_deg, flat
         );
     }
 

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -188,11 +188,12 @@ fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
     (wrap_pdf(&content), drawn_lines)
 }
 
-/// Non-whitespace glyph runs per output line, empty lines dropped.
+/// Non-whitespace glyph runs per output line. Empty entries are kept: a
+/// blank output line (e.g. a doubled newline) is itself a structure defect
+/// and must surface as a mismatch, not be silently absorbed.
 fn output_line_structure(text: &str) -> Vec<String> {
     text.lines()
         .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
-        .filter(|l| !l.is_empty())
         .collect()
 }
 

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -243,6 +243,36 @@ fn issue_443_rotated_page_keeps_single_line() {
     );
 }
 
+/// Deterministic pin for the mirrored-baseline behavior change of the #443
+/// fix: under a negative-x-scale CTM, `dx` is measured along the text's own
+/// advance direction, so a plain forward advance no longer misfires the
+/// backward-jump wrap gate (pre-#443 it saw raw `dx < 0` and inserted a
+/// newline once the advance exceeded 2× the threshold). One drawn baseline
+/// must come out as exactly one line, glyphs in draw order.
+#[test]
+fn mirrored_baseline_stays_a_single_line() {
+    let (inner, drawn) = emit_line_structure(&[(vec![0, 1, 2], None, 13.0)]);
+    let mut content = Vec::new();
+    content.extend_from_slice(b"q\n-1 0 0 1 612 0 cm\n");
+    content.extend_from_slice(&inner);
+    content.extend_from_slice(b"Q\n");
+    let flat = extract(&wrap_pdf(&content), false);
+    assert_eq!(
+        output_line_structure(&flat),
+        drawn,
+        "mirrored single-baseline page must extract as one line\n--- flat ---\n{flat}"
+    );
+    // The observable delta vs the pre-#443 code: word gaps advance the pen
+    // LEFT in raw user space, so the old dx-based space gate never fired and
+    // words came out glued ("loremipsum"). Projected onto the baseline the
+    // gap is a positive forward dx and the space is inserted.
+    let (w0, w1) = (WORDS[0], WORDS[1]);
+    assert!(
+        flat.contains(&format!("{w0} {w1}")),
+        "mirrored word gap must still produce a space\n--- flat ---\n{flat}"
+    );
+}
+
 // ---- Drift-chain builder for the #425 token-contiguity property. ----------
 
 fn build_drift_page(n_lines: usize, token_line: usize, token: &str, drift_step: f64) -> Vec<u8> {

--- a/oxidize-pdf-core/tests/prop_extraction_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_extraction_invariants.rs
@@ -17,6 +17,13 @@
 //!      (#389, #403, #408, #417, #422, #425). (Distinct from #2: scattering a
 //!      token preserves the character multiset but breaks contiguity.)
 //!   4. DETERMINISM — extracting the same bytes twice yields identical text.
+//!   5. LINE STRUCTURE — the newline structure of the flat extraction matches
+//!      the lines actually drawn: glyphs drawn on one baseline stay on one
+//!      output line (no spurious newline, #441), and glyphs drawn on distinct
+//!      baselines end up on distinct output lines whenever the transition is
+//!      geometrically detectable (no missing newline, #390). Unlike #1-#4,
+//!      this oracle does NOT filter whitespace away — it is the only invariant
+//!      that can see separator bugs, the class where #438 and #441 escaped.
 
 use oxidize_pdf::parser::{ParseOptions, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
@@ -74,9 +81,9 @@ fn wrap_pdf(content: &[u8]) -> Vec<u8> {
         b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
     );
     let xref_pos = pdf.len();
-    write!(pdf, "xref\n0 6\n0000000000 65535 f \n").unwrap();
+    writeln!(pdf, "xref\n0 6\n0000000000 65535 f ").unwrap();
     for off in &offsets {
-        write!(pdf, "{off:010} 00000 n \n").unwrap();
+        writeln!(pdf, "{off:010} 00000 n ").unwrap();
     }
     write!(
         pdf,
@@ -132,6 +139,61 @@ fn build_page(spec: &[(Vec<usize>, Option<usize>)]) -> (Vec<u8>, String) {
         y -= LEADING;
     }
     (wrap_pdf(&content), drawn)
+}
+
+// ---- Line-structure builder for the #390/#441 separator property. ----------
+
+/// One generated line: word indices, an optional same-line backward
+/// "correction" (word index + backward jump in pt), and the leading below it.
+type LineSpec = (Vec<usize>, Option<(usize, f64)>, f64);
+
+/// Build a page whose line structure is known by construction, and return
+/// (pdf_bytes, glyphs-per-line in draw order).
+///
+/// Every line starts at x=50 and ends with its pen well right of the margin
+/// (≥ 2 words), so each line transition is geometrically detectable: either
+/// dy > newline_threshold (10pt), or a tight leading (dy < 10pt, nonzero)
+/// combined with a wrap back to x=50 of more than 2× the threshold — the #390
+/// class. A correction re-draws a word backward ON THE SAME baseline
+/// (dy = 0, dx < -(2 × threshold)) mid-line — the #441 class — and must NOT
+/// break the line.
+fn build_line_structure_page(lines: &[LineSpec]) -> (Vec<u8>, Vec<String>) {
+    let mut content = Vec::new();
+    let mut drawn_lines = Vec::new();
+    let mut y = 760.0;
+    for (word_idxs, correction, leading) in lines {
+        let mut x = 50.0;
+        let mut line = String::new();
+        for (pos, &wi) in word_idxs.iter().enumerate() {
+            let w = WORDS[wi % WORDS.len()];
+            x = emit_glyphs(&mut content, w, x, y);
+            line.push_str(w);
+            x += 8.0;
+            // After the first word, optionally jump BACKWARD on the same
+            // baseline and draw a correction word there (the #441 signature),
+            // then resume forward past everything drawn so far.
+            if pos == 0 {
+                if let Some((ci, back)) = correction {
+                    let w2 = WORDS[ci % WORDS.len()];
+                    let corr_x = (x - back).max(5.0);
+                    emit_glyphs(&mut content, w2, corr_x, y);
+                    line.push_str(w2);
+                    x += 30.0;
+                }
+            }
+        }
+        drawn_lines.push(line);
+        y -= leading;
+    }
+    (wrap_pdf(&content), drawn_lines)
+}
+
+/// Non-whitespace glyph runs per output line, empty lines dropped.
+fn output_line_structure(text: &str) -> Vec<String> {
+    text.lines()
+        .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
+        .filter(|l| !l.is_empty())
+        .collect()
 }
 
 // ---- Drift-chain builder for the #425 token-contiguity property. ----------
@@ -230,6 +292,31 @@ proptest! {
                 token, flat, reordered
             );
         }
+    }
+
+    /// INV-5 LINE STRUCTURE: flat extraction reproduces exactly the lines that
+    /// were drawn — one output line per baseline, glyphs in draw order. Fails
+    /// on a spurious newline (same-line backward jump misread as a wrap, #441)
+    /// AND on a missing newline (tight-leading wrap glued, #390).
+    #[test]
+    fn flat_line_structure_matches_drawn_lines(
+        lines in prop::collection::vec(
+            (
+                prop::collection::vec(0usize..10, 2..5),
+                prop::option::of((0usize..10, 30.0f64..60.0)),
+                prop_oneof![2.0f64..9.5, 12.0f64..30.0],
+            ),
+            3..12,
+        ),
+    ) {
+        let (pdf, drawn) = build_line_structure_page(&lines);
+        let flat = extract(&pdf, false);
+        let got = output_line_structure(&flat);
+        prop_assert_eq!(
+            &got, &drawn,
+            "extracted line structure differs from drawn lines\n--- flat ---\n{}",
+            flat
+        );
     }
 
     /// INV-4 DETERMINISM: extracting the same bytes twice is identical.


### PR DESCRIPTION
Release 4.2.1 (PATCH). Two extraction fixes, no public API change.

## Contents (since 4.2.0)

- **#441** — same-line backward X jump misread as a line wrap: the flat-path wrap heuristic now requires a nonzero Δy (`Tj` + `TJ`). Addresses #441 (reporter closes).
- **#443** — flat-path separator heuristics measured pen movement in post-CTM user space: pen deltas are now projected onto the current text baseline (axis-aligned content bit-identical; rotated CTMs recover correct line structure; mirrored baselines gain correct word spacing). Addresses #443.
- New guards: INV-5 line-structure oracle (first whitespace-visible invariant — the class where #438/#441 escaped), INV-6 rotation property (±0.5°..90°), deterministic pins (20° rotation, mirrored baseline, Δy=0.1 boundary), 4 `pen_delta` unit tests.

## Release gates (local)

- semver-checks vs crates.io 4.2.0: **223/223, "no semver update required"** → PATCH
- Corpus (CI does not run it on PRs): **T2 484/481, 0 panics, 446 text — baseline-identical · T3 1802/1761, 0 panics, 1598 text — baseline-identical · T4 25/25 · T5 26/26 · T6 23/23** (known preexisting gap: T4/T5 ground-truth accuracy tests skip silently, unchanged)
- Kripteia: 100 (`issue_441` file) / 97 (`prop_extraction_invariants`; proptest blocks invisible to the tool — audited manually via QR)
- Full lib 6671/0 · fmt · clippy `-D warnings` all-features · MSRV 1.88 `--all-features --locked`
- QR (quality-rust) on both fixes: 0 Critical, all actionables applied

After merge: tag `v4.2.1` on main → release.yml publishes to crates.io → back-merge to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)