### PR TITLE
fix(extraction): restore the text state when a graphics state block closes (addresses #452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The text state was not restored when a graphics state block closed** (#452).
+  Leading, character and word spacing, horizontal scaling, font and size, text
+  rise and render mode are text state parameters, and the text state is part of
+  the graphics state (ISO 32000-1 §9.3, Table 52) — so `Q` must put them back.
+  Only the CTM and the fill colour were restored, so a leading, font or scale
+  set inside a `q … Q` block kept driving extraction after the block closed.
+  The same omission applied to the implicit save/restore that surrounds a Form
+  XObject (§8.10.1): after `Do` the page continued with whatever text state the
+  XObject had left behind, which meant text after the `Do` could be decoded
+  with the XObject's font instead of the page's. Both sites now share one
+  snapshot routine. Additionally, a Form XObject now gets its own graphics
+  state stack: a stray `Q` inside it used to pop the *page's* saved state,
+  which truncation afterwards could not undo, so the page's own `Q` restored
+  from nothing.
+
+  Measured over 8552 corpus PDFs across all six tiers: 26 documents change,
+  every one of them for the better. Text that was being decoded with a leaked
+  font now decodes correctly (one document goes from 464 to 1420 characters,
+  another from `N n Chinese` to `Name in Chinese`, another from `6R` to
+  `Sound.`); the rest are a handful of spurious spaces and newlines that the
+  separator heuristic no longer synthesises, because the pen advance is now
+  computed with the correct font size and scale. No document loses a word and
+  none stops extracting. `PlainTextExtractor`, which had no `q`/`Q` handling at
+  all, now saves and restores the three text state parameters it tracks.
+
+  The text matrices are deliberately not restored: they are text *object*
+  state, established by `BT` and discarded by `ET` (§9.4.1).
+
 - **`PlainTextExtractor` silently dropped all text shown by the `'` and `"`
   operators.** Both are show-text operators (ISO 32000-1 §9.4.3, Table 109):
   `'` is "next line, then show", `"` is "set word and character spacing, next

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -320,11 +320,75 @@ struct TextState {
     pending_actualtext: Option<PendingActualText>,
 }
 
-/// Subset of graphics state saved by `q` and restored by `Q` (issue #262).
-#[derive(Clone)]
+/// Graphics state saved by `q` and restored by `Q` (issues #262, #452).
+///
+/// Holds the CTM, the fill colour, and the TEXT STATE parameters. The text
+/// state is graphics state per ISO 32000-1 §9.3 and Table 52 — leading,
+/// character and word spacing, horizontal scaling, font and size, text rise
+/// and render mode all live there, so `Q` must put them back. Before #452 only
+/// the CTM and the colour were restored, and a leading set inside a `q … Q`
+/// block kept driving line breaks after the block closed.
+///
+/// `text_matrix` and `text_line_matrix` are deliberately NOT here: they are
+/// text OBJECT state, established by `BT` and discarded by `ET` (§9.4.1), not
+/// graphics state. Restoring them on `Q` would be a different bug.
+///
+/// Four of the text-state fields — `char_space`, `word_space`, `text_rise` and
+/// `render_mode` — are currently written by their operators but never read by
+/// the extractor, so restoring them changes no output today and no test can
+/// guard them. They are here because they are graphics state: whoever wires
+/// them into the pen advance, the y offset or invisible-text filtering should
+/// not have to rediscover this bug.
 struct SavedGraphicsState {
     ctm: [f64; 6],
     fill_color: Option<Color>,
+    leading: f64,
+    char_space: f64,
+    word_space: f64,
+    horizontal_scale: f64,
+    text_rise: f64,
+    font_size: f64,
+    font_name: Option<String>,
+    render_mode: u8,
+}
+
+impl SavedGraphicsState {
+    /// Snapshot the graphics state, for `q` and for the implicit save around
+    /// `Do` (§8.10.1). Both callers go through here so the two can never drift
+    /// into disagreeing about what the graphics state contains.
+    fn capture(state: &TextState) -> Self {
+        Self {
+            ctm: state.ctm,
+            fill_color: state.fill_color,
+            leading: state.leading,
+            char_space: state.char_space,
+            word_space: state.word_space,
+            horizontal_scale: state.horizontal_scale,
+            text_rise: state.text_rise,
+            font_size: state.font_size,
+            font_name: state.font_name.clone(),
+            render_mode: state.render_mode,
+        }
+    }
+
+    /// Put the snapshot back. Consumes it, so the `String` moves instead of
+    /// being cloned.
+    ///
+    /// Note the fields it does NOT touch: the text matrices (text object state,
+    /// §9.4.1), the marked-content stack (its nesting is independent of
+    /// `q`/`Q`, §14.6) and the saved-state stack itself.
+    fn restore_into(self, state: &mut TextState) {
+        state.ctm = self.ctm;
+        state.fill_color = self.fill_color;
+        state.leading = self.leading;
+        state.char_space = self.char_space;
+        state.word_space = self.word_space;
+        state.horizontal_scale = self.horizontal_scale;
+        state.text_rise = self.text_rise;
+        state.font_size = self.font_size;
+        state.font_name = self.font_name;
+        state.render_mode = self.render_mode;
+    }
 }
 
 /// Mutable accumulator threaded through `process_operations` so the op loop
@@ -1480,18 +1544,16 @@ impl TextExtractor {
                 // CTM forever, producing absurd page-space coordinates and
                 // wrong font_size scaling on PDFs that nest graphics state.
                 ContentOperation::SaveGraphicsState => {
-                    state.saved_states.push(SavedGraphicsState {
-                        ctm: state.ctm,
-                        fill_color: state.fill_color,
-                    });
+                    state.saved_states.push(SavedGraphicsState::capture(&state));
                 }
                 ContentOperation::RestoreGraphicsState => {
+                    // Text state is graphics state (§9.3, Table 52): a leading,
+                    // font or scale set inside the block dies with it (issue
+                    // #452). Unbalanced Q (pop on empty stack) is silently
+                    // ignored to keep extraction robust to malformed PDFs.
                     if let Some(saved) = state.saved_states.pop() {
-                        state.ctm = saved.ctm;
-                        state.fill_color = saved.fill_color;
+                        saved.restore_into(&mut state);
                     }
-                    // Unbalanced Q (pop on empty stack) is silently ignored
-                    // to keep extraction robust to malformed PDFs.
                 }
 
                 // Color operations (Phase 4: Color extraction)
@@ -1620,10 +1682,20 @@ impl TextExtractor {
                         if let Some((xobj_ops, xobj_res, matrix)) =
                             self.load_form_xobject(resources, &name, document)
                         {
-                            let saved_ctm = state.ctm;
-                            let saved_fill = state.fill_color;
-                            let saved_stack = state.saved_states.len();
+                            // `Do` paints inside an IMPLICIT q/Q (§8.10.1),
+                            // so the whole graphics state — text state included
+                            // (issue #452) — comes back afterwards. Same
+                            // snapshot the `q` arm takes, so the two cannot
+                            // disagree about what that state is.
+                            let outer = SavedGraphicsState::capture(&state);
                             let saved_fonts = self.font_cache.clone();
+                            // The form gets its own save-state stack: a stray
+                            // `Q` inside it must not pop the page's snapshots.
+                            // Truncating afterwards could not undo that — a
+                            // popped entry is gone — and with the text state
+                            // now in each snapshot, a mispaired restore
+                            // corrupts font decoding, not just the CTM.
+                            let outer_stack = std::mem::take(&mut state.saved_states);
 
                             if let Some(m) = matrix {
                                 let [a0, b0, c0, d0, e0, f0] = state.ctm;
@@ -1659,9 +1731,8 @@ impl TextExtractor {
                                 depth + 1,
                             )?;
 
-                            out.state.ctm = saved_ctm;
-                            out.state.fill_color = saved_fill;
-                            out.state.saved_states.truncate(saved_stack);
+                            outer.restore_into(&mut out.state);
+                            out.state.saved_states = outer_stack;
                             self.font_cache = saved_fonts;
 
                             state = out.state;

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -25,6 +25,25 @@ struct TextState {
     leading: f64,
     font_size: f64,
     font_name: Option<String>,
+    /// Stack for `q`/`Q`. This extractor tracks no CTM, so the only graphics
+    /// state it can lose is the text state (issue #452).
+    saved_states: Vec<SavedTextState>,
+}
+
+/// The text state parameters this extractor tracks, saved by `q` and restored
+/// by `Q`.
+///
+/// Text state is graphics state per ISO 32000-1 §9.3 and Table 52, so a leading
+/// or font set inside a `q … Q` block dies with the block. Before #452 this
+/// extractor had no `q`/`Q` handling at all and every such value leaked out.
+///
+/// The text matrices are absent on purpose: they are text OBJECT state, set by
+/// `BT` and discarded by `ET` (§9.4.1), and `Q` must not touch them.
+#[derive(Debug, Clone)]
+struct SavedTextState {
+    leading: f64,
+    font_size: f64,
+    font_name: Option<String>,
 }
 
 impl Default for TextState {
@@ -35,6 +54,7 @@ impl Default for TextState {
             leading: 0.0,
             font_size: 0.0,
             font_name: None,
+            saved_states: Vec::new(),
         }
     }
 }
@@ -373,6 +393,28 @@ impl PlainTextExtractor {
 
                     ContentOperation::SetLeading(leading) => {
                         state.leading = leading as f64;
+                    }
+
+                    // Text state is graphics state (ISO 32000-1 §9.3, Table
+                    // 52), so a leading or font set inside a `q … Q` block must
+                    // not survive it (issue #452). The text matrices are not
+                    // saved: they are text object state, owned by `BT`/`ET`.
+                    ContentOperation::SaveGraphicsState => {
+                        state.saved_states.push(SavedTextState {
+                            leading: state.leading,
+                            font_size: state.font_size,
+                            font_name: state.font_name.clone(),
+                        });
+                    }
+
+                    ContentOperation::RestoreGraphicsState => {
+                        // An unbalanced `Q` is ignored rather than fatal, to
+                        // stay robust on malformed documents.
+                        if let Some(saved) = state.saved_states.pop() {
+                            state.leading = saved.leading;
+                            state.font_size = saved.font_size;
+                            state.font_name = saved.font_name;
+                        }
                     }
 
                     _ => {

--- a/oxidize-pdf-core/tests/issue_452_text_state_graphics_state_test.rs
+++ b/oxidize-pdf-core/tests/issue_452_text_state_graphics_state_test.rs
@@ -1,0 +1,371 @@
+//! Issue #452 — el estado de TEXTO forma parte del estado gráfico y `Q` tiene
+//! que restaurarlo.
+//!
+//! ISO 32000-1 §9.3 y Tabla 52: interlineado (`TL`), espaciado de carácter
+//! (`Tc`) y de palabra (`Tw`), escala horizontal (`Tz`), fuente y tamaño
+//! (`Tf`), desplazamiento vertical (`Ts`) y modo de pintado (`Tr`) son
+//! parámetros del estado gráfico. `q` los apila y `Q` los restaura.
+//!
+//! El extractor guardaba solo la CTM y el color de relleno, así que todo lo
+//! anterior se escapaba del bloque: un interlineado fijado dentro de un
+//! `q … Q` seguía gobernando los saltos de línea después de cerrarlo.
+//!
+//! `Tm` y `Tlm` NO son estado gráfico (son estado del objeto de texto, que `BT`
+//! reinicia), así que `Q` no debe restaurarlos. Eso no se asierta aquí porque
+//! el propio `BT` posterior los fija; se documenta en el código.
+//!
+//! Oráculo: coordenadas de fragmento bajo `preserve_layout` para lo que es
+//! aritmética exacta (el interlineado), y comparación diferencial contra el
+//! mismo documento SIN el bloque `q … Q` para lo que depende de métricas de
+//! fuente (la escala horizontal).
+
+#[path = "common/mod.rs"]
+mod common;
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::plaintext::{LineBreakMode, PlainTextConfig, PlainTextExtractor};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// `(text, x, y, font_size)` de cada fragmento bajo `preserve_layout`.
+fn fragments_of(content: &[u8]) -> Vec<(String, f64, f64, f64)> {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .fragments
+        .into_iter()
+        .map(|f| (f.text, f.x, f.y, f.font_size))
+        .collect()
+}
+
+fn fragment_named<'a>(
+    frags: &'a [(String, f64, f64, f64)],
+    text: &str,
+) -> &'a (String, f64, f64, f64) {
+    frags
+        .iter()
+        .find(|f| f.0 == text)
+        .unwrap_or_else(|| panic!("no fragment {text:?} among {frags:?}"))
+}
+
+/// El caso del issue: un `TL` de 40 dentro del bloque no puede seguir vigente
+/// al salir. La última línea la mueve un `T*`, que avanza por el interlineado
+/// EN VIGOR: 20, el de fuera. Con la fuga avanzaría 40.
+#[test]
+fn q_restores_the_leading_set_inside_the_block() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n20 TL\n(one)Tj\nT*\n(two)Tj\nET\n\
+                    q\nBT\n/F1 12 Tf\n100 600 Td\n40 TL\n(three)Tj\nET\nQ\n\
+                    BT\n/F1 12 Tf\n100 400 Td\n(four)Tj\nT*\n(five)Tj\nET\n";
+    let frags = fragments_of(content);
+
+    let two = fragment_named(&frags, "two");
+    assert!(
+        (two.2 - 680.0).abs() < 0.01,
+        "sanity: inside the first block the leading is 20, so `two` sits at 680; got {two:?}"
+    );
+
+    let five = fragment_named(&frags, "five");
+    assert!(
+        (five.2 - 380.0).abs() < 0.01,
+        "after Q the leading must be the outer 20, so `five` sits at 380; got y = {} \
+         (360 means the 40 set inside the q…Q block leaked out)",
+        five.2
+    );
+}
+
+/// Sin ningún `TL` fuera del bloque, el interlineado que vuelve es el inicial
+/// (0): el `T*` posterior no mueve nada. Pin de que `Q` restaura el valor
+/// guardado y no simplemente "el último que vio antes del bloque".
+#[test]
+fn q_restores_the_initial_leading_when_none_was_set_outside() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n\
+                    q\nBT\n/F1 12 Tf\n100 600 Td\n40 TL\n(two)Tj\nET\nQ\n\
+                    BT\n/F1 12 Tf\n100 400 Td\n(three)Tj\nT*\n(four)Tj\nET\n";
+    let frags = fragments_of(content);
+    let four = fragment_named(&frags, "four");
+    assert!(
+        (four.2 - 400.0).abs() < 0.01,
+        "with no leading in force outside the block, T* must not move; got y = {} \
+         (360 means the inner 40 leaked)",
+        four.2
+    );
+}
+
+/// El tamaño de fuente también es estado gráfico. El último bloque no emite
+/// `Tf`, así que hereda el que `Q` haya restaurado.
+#[test]
+fn q_restores_the_font_size_set_inside_the_block() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n\
+                    q\nBT\n/F1 30 Tf\n100 600 Td\n(two)Tj\nET\nQ\n\
+                    BT\n100 400 Td\n(three)Tj\nET\n";
+    let frags = fragments_of(content);
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.3 - 12.0).abs() < 0.01,
+        "after Q the font size must be the outer 12; got {} (30 means it leaked)",
+        three.3
+    );
+}
+
+/// La escala horizontal gobierna el avance de la pluma, así que su fuga mueve
+/// la x de todo lo que venga después. El oráculo es diferencial: el mismo
+/// documento sin el bloque `q … Q` tiene que dar exactamente las mismas
+/// coordenadas, sin depender de las métricas de la fuente.
+#[test]
+fn q_restores_the_horizontal_scale_set_inside_the_block() {
+    let with_block = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n\
+                       q\nBT\n/F1 12 Tf\n200 Tz\n100 600 Td\n(two)Tj\nET\nQ\n\
+                       BT\n/F1 12 Tf\n100 400 Td\n(three)Tj\n(four)Tj\nET\n";
+    let without_block = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n\
+                          BT\n/F1 12 Tf\n100 400 Td\n(three)Tj\n(four)Tj\nET\n";
+
+    // Toda la línea de abajo, en las dos versiones del documento. Con la fuga,
+    // el avance de la pluma se duplica: los dos `Tj` dejan de tocarse, así que
+    // ni se fusionan en un fragmento ni caen en la misma x.
+    let line_of = |content: &[u8]| -> Vec<(String, f64)> {
+        fragments_of(content)
+            .into_iter()
+            .filter(|f| (f.2 - 400.0).abs() < 0.01)
+            .map(|f| (f.0, (f.1 * 100.0).round() / 100.0))
+            .collect()
+    };
+
+    let expected = line_of(without_block);
+    assert!(
+        !expected.is_empty(),
+        "the oracle produced no fragments at y = 400 — comparing two empty lists would pass \
+         while measuring nothing"
+    );
+    assert_eq!(
+        line_of(with_block),
+        expected,
+        "the pen after Q must advance as if `200 Tz` had never happened; a leaked scale \
+         doubles the advance, which splits the run and moves it right"
+    );
+}
+
+/// Los dos extractores públicos tienen que coincidir: el plano no expone
+/// coordenadas, pero sí la estructura de línea que produce el interlineado, y
+/// es una implementación independiente del mismo contrato.
+#[test]
+fn both_public_extractors_restore_the_leading_on_q() {
+    // Con el interlineado restaurado a 0, el `T*` final no mueve la pluma, así
+    // que las dos últimas palabras quedan en la misma línea. Con la fuga de 40
+    // se separan.
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n\
+                    q\nBT\n/F1 12 Tf\n100 600 Td\n40 TL\n(two)Tj\nET\nQ\n\
+                    BT\n/F1 12 Tf\n100 400 Td\n(three)Tj\nT*\n(four)Tj\nET\n";
+
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut plain = PlainTextExtractor::with_config(PlainTextConfig {
+        line_break_mode: LineBreakMode::PreserveAll,
+        ..Default::default()
+    });
+    let plain_text = plain.extract(&document, 0).expect("extract page 0").text;
+
+    // La negativa sola pasaría con la salida vacía o con una decodificación
+    // rota, así que se fija además lo que TIENE que salir.
+    assert!(
+        plain_text.contains("threefour"),
+        "with the leading restored to 0 the final T* does not move, so the last two runs share \
+         a line; got {plain_text:?}"
+    );
+    assert!(
+        !plain_text.contains("three\nfour"),
+        "PlainTextExtractor must restore the leading on Q too: a 40-unit leading from inside \
+         the block broke the last line; got {plain_text:?}"
+    );
+}
+
+/// Un `Q` sin `q` sigue siendo tolerado: los PDF mal formados no deben tumbar
+/// la extracción. Cubre los DOS extractores: el `pop` del extractor plano es
+/// código nuevo de este cambio y es el único que no tenía guarda de pila vacía.
+#[test]
+fn an_unbalanced_q_does_not_break_either_extractor() {
+    let content = b"Q\nBT\n/F1 12 Tf\n100 700 Td\n20 TL\n(one)Tj\nT*\n(two)Tj\nET\nQ\nQ\n";
+
+    let frags = fragments_of(content);
+    let two = fragment_named(&frags, "two");
+    assert!(
+        (two.2 - 680.0).abs() < 0.01,
+        "extraction must survive unbalanced Q and keep the leading in force; got {two:?}"
+    );
+
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut plain = PlainTextExtractor::with_config(PlainTextConfig {
+        line_break_mode: LineBreakMode::PreserveAll,
+        ..Default::default()
+    });
+    let plain_text = plain.extract(&document, 0).expect("extract page 0").text;
+    assert!(
+        plain_text.contains("one\ntwo"),
+        "PlainTextExtractor must survive unbalanced Q and still apply the leading; got \
+         {plain_text:?}"
+    );
+}
+
+/// Anidamiento de más de un nivel: cada `Q` tiene que emparejar con SU `q`. Un
+/// error de emparejamiento (guardar de menos, restaurar de más) solo se ve con
+/// dos niveles y tres valores distintos de interlineado.
+#[test]
+fn nested_q_blocks_restore_their_own_leading_at_each_level() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n10 TL\n(a)Tj\nET\n\
+                    q\n20 TL\n\
+                      q\n40 TL\n\
+                        BT\n/F1 12 Tf\n100 650 Td\n(inner)Tj\nET\n\
+                      Q\n\
+                      BT\n/F1 12 Tf\n100 550 Td\n(mid)Tj\nT*\n(mid2)Tj\nET\n\
+                    Q\n\
+                    BT\n/F1 12 Tf\n100 400 Td\n(out)Tj\nT*\n(out2)Tj\nET\n";
+    let frags = fragments_of(content);
+
+    let mid2 = fragment_named(&frags, "mid2");
+    assert!(
+        (mid2.2 - 530.0).abs() < 0.01,
+        "the inner Q must restore the middle level's leading of 20, so `mid2` sits at 530; \
+         got y = {} (510 means the innermost 40 survived its own Q)",
+        mid2.2
+    );
+
+    let out2 = fragment_named(&frags, "out2");
+    assert!(
+        (out2.2 - 390.0).abs() < 0.01,
+        "the outer Q must restore the page's leading of 10, so `out2` sits at 390; got y = {}",
+        out2.2
+    );
+}
+
+/// `q`/`Q` dentro de un objeto de texto: la norma no lo bendice (§8.2), pero es
+/// abundantísimo en documentos reales, y ahora importa porque un `Q` a mitad de
+/// un `BT … ET` cambia la fuente. La restauración no puede tocar la matriz de
+/// texto: las palabras siguen en la línea donde estaban.
+#[test]
+fn a_q_block_inside_a_text_object_restores_state_without_moving_the_pen() {
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n20 TL\n(one)Tj\n\
+                    q\n/F1 30 Tf\n40 TL\n(two)Tj\nQ\n\
+                    T*\n(three)Tj\nET\n";
+    let frags = fragments_of(content);
+
+    // `q` no toca la matriz de texto, así que `two` continúa la línea de `one`:
+    // quedan lo bastante juntos como para fusionarse en un solo fragmento en el
+    // mismo origen. Si la restauración moviera la pluma, `two` saldría aparte.
+    let joined = fragment_named(&frags, "onetwo");
+    assert!(
+        (joined.2 - 700.0).abs() < 0.01 && (joined.1 - 100.0).abs() < 0.01,
+        "the q/Q must not move the pen: the two runs stay on the line that started at \
+         (100, 700); got {joined:?}"
+    );
+
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.3 - 12.0).abs() < 0.01,
+        "after Q the font size is the outer 12 again; got {}",
+        three.3
+    );
+    assert!(
+        (three.2 - 680.0).abs() < 0.01,
+        "and the T* advances by the restored leading of 20, landing at 680; got y = {} \
+         (660 means the inner 40 leaked past the Q)",
+        three.2
+    );
+}
+
+/// Ensambla una página con un Form XObject en sus recursos. `page_content` se
+/// ejecuta en la página; `xobject_content` dentro del `Do`.
+fn pdf_with_form_xobject(page_content: &[u8], xobject_content: &[u8]) -> Vec<u8> {
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> \
+           /XObject << /X1 6 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", page_content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            xobject_content,
+        ),
+    ])
+}
+
+fn fragments_of_pdf(pdf: Vec<u8>) -> Vec<(String, f64, f64, f64)> {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("assembled PDF must parse");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .fragments
+        .into_iter()
+        .map(|f| (f.text, f.x, f.y, f.font_size))
+        .collect()
+}
+
+/// `Do` pinta un Form XObject dentro de un `q`/`Q` IMPLÍCITO (§8.10.1), así que
+/// el estado gráfico completo — y por tanto el de texto — vuelve al salir. Un
+/// `TL` puesto dentro del XObject no puede gobernar el `T*` de la página.
+#[test]
+fn a_form_xobject_does_not_leak_its_text_state_into_the_page() {
+    let pdf = pdf_with_form_xobject(
+        b"BT /F1 12 Tf 100 700 Td 20 TL (one)Tj ET\n/X1 Do\n\
+          BT /F1 12 Tf 100 400 Td (two)Tj T* (three)Tj ET\n",
+        b"BT /F1 12 Tf 100 600 Td 40 TL (inner)Tj ET\n",
+    );
+    let frags = fragments_of_pdf(pdf);
+    assert!(
+        frags.iter().any(|f| f.0 == "inner"),
+        "sanity: the XObject's own text must be extracted, or this proves nothing; got {frags:?}"
+    );
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.2 - 380.0).abs() < 0.01,
+        "the leading of 40 set inside the XObject must die with the implicit Q, leaving the \
+         page's 20: expected y = 380, got {}",
+        three.2
+    );
+}
+
+/// Un `Q` de más dentro del XObject no puede consumir el estado guardado por la
+/// PÁGINA. Con la pila compartida, ese `Q` huérfano se llevaba la instantánea
+/// del `q` de la página y el `Q` posterior de la página restauraba desde una
+/// pila vacía, es decir, no restauraba nada.
+///
+/// El XObject cambia el interlineado DESPUÉS de su `Q` huérfano a propósito: si
+/// no lo hiciera, ese `Q` restauraría por casualidad el mismo valor que el `Q`
+/// de la página debía restaurar, y el test pasaría sin discriminar nada.
+#[test]
+fn an_unbalanced_q_inside_a_form_xobject_cannot_consume_the_pages_saved_state() {
+    let pdf = pdf_with_form_xobject(
+        b"BT /F1 12 Tf 100 700 Td 10 TL (one)Tj ET\n\
+          q\n30 TL\n/X1 Do\nQ\n\
+          BT /F1 12 Tf 100 400 Td (two)Tj T* (three)Tj ET\n",
+        b"Q\n50 TL\nBT /F1 12 Tf 100 600 Td (inner)Tj ET\n",
+    );
+    let frags = fragments_of_pdf(pdf);
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.2 - 390.0).abs() < 0.01,
+        "the page's Q must restore the leading of 10 it saved, whatever the XObject did to \
+         the stack: expected y = 390, got {} (370 means the stray Q ate the page's snapshot)",
+        three.2
+    );
+}


### PR DESCRIPTION
## What

The text state is part of the graphics state (ISO 32000-1 §9.3, Table 52), so `Q` must restore it. Only the CTM and the fill colour were restored, so a leading, font, size or horizontal scale set inside a `q … Q` block kept driving extraction after the block closed.

Addresses #452. Closes nothing — the issue is mine to close, and the follow-ups this uncovered are #455 and #456.

## Three instances of the same omission

1. **`q` / `Q`.** Eight text state parameters are now snapshotted and restored: leading, character and word spacing, horizontal scaling, text rise, font, size and render mode.

2. **The implicit save/restore around `Do`.** A Form XObject is painted inside an implicit save/restore of the *whole* graphics state (§8.10.1). After `Do` the page continued with whatever text state the XObject had left behind — including its font, while the font cache had already been swapped back to the page's, so subsequent text could be decoded with the wrong font or with none. Both sites now go through one snapshot routine, so they cannot drift apart again.

3. **The shared save-state stack across the XObject boundary.** A stray `Q` inside a form used to pop the *page's* saved state. Truncating the stack afterwards cannot undo that — a popped entry is gone — so the page's own `Q` restored from nothing. The form now gets its own stack.

`PlainTextExtractor` had no `q`/`Q` handling at all; it now saves and restores the three text state parameters it tracks.

The text matrices are deliberately **not** restored: they are text *object* state, established by `BT` and discarded by `ET` (§9.4.1).

## Measured, not assumed

Over **8552 corpus PDFs across all six tiers, 26 documents change and every one improves.** The interesting cases are all text that was being decoded with a leaked font:

- a verapdf document goes from 464 to 1420 characters — `•"\n\n#!•$%&\t%'` becomes `•An arbitrary name that shall be mapped to one of the standard names by the document's role map…`
- `N n Chinese` → `Name in Chinese`
- `6R` → `Sound.`

The remainder are a handful of spurious spaces and newlines the separator heuristic no longer synthesises, because the pen advance is now computed with the correct font size and scale (`Y -AXIS` → `Y-AXIS`; table cells padded with three spaces instead of two). **No document loses a word and none stops extracting.** The poppler word-fusion gate over the 1802-PDF stress corpus is unchanged at 6298.

Worth stating plainly: the corpus is silent on instances 2 and 3 above — the same 26 documents change with or without them. Those two are covered by the synthetic tests, not by measurement.

## Tests

Ten, and nine are attributable to a specific production line by ablation. Reverting the `Q` restore turns seven red; the three that survive are exactly the ones exercising the other paths (the plaintext extractor, the `Do` restore, the unbalanced-`Q` robustness pin).

Coverage: the issue's own reproducer; restoration of the initial value when nothing was set outside; font size; horizontal scale (differential oracle against the same document without the block, with a non-emptiness guard so it cannot pass on two empty lists); nesting depth 2 with three distinct leadings; `q`/`Q` *inside* a text object (forbidden by §8.2, ubiquitous in practice, and now behaviourally significant since a mid-object `Q` swaps the font); an unbalanced `Q` through **both** extractors; and the two XObject cases, each built with a hand-assembled PDF carrying a real form.

Four of the restored fields (`Tc`, `Tw`, `Ts`, `Tr`) are written by their operators but never read by the extractor, so no test can guard their restoration. They are saved because they are graphics state, and the struct doc says so rather than leaving a future reader to rediscover this bug. #456 tracks wiring them up.

## Not in this PR

- **#455** — the graphics state stack is unbounded in both extractors, and this change roughly doubled the per-entry cost.
- **#456** — the four text state parameters that are tracked but never used; the invisible-text render mode is the one with user-visible consequences.

## SemVer

PATCH. Bug fix, no public API change.

## Gates

- 7327 tests across the library and the extraction / XObject / RAG / property suites: 0 failures
- `cargo fmt --check` clean; `clippy --all-features -D warnings` clean on the touched targets
- MSRV 1.88 with `--tests --all-features --locked`
- Corpus measurement above, plus the poppler differential gate unchanged

## Merge order

This branch and #454 (the `TD` operator) both touch `src/text/extraction.rs` and `src/text/plaintext/extractor.rs`, in different regions. Whichever merges second will need a small textual conflict resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)