### PR TITLE
fix(extraction): bound the q/Q graphics state stack without unpairing it (addresses #455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `q`/`Q` graphics state stack was unbounded in both text extractors**
+  (#455). Nothing in a content stream limits how deep `q` nesting goes, so a
+  stream of one million `q` operators — about 2 MB — pushed one million
+  snapshots. Since #452 each snapshot also carries the text state, including a
+  heap allocation for the font name whenever a font is set, so the per-entry
+  cost of that flood had roughly doubled. Both extractors now cap the stack at
+  1024 entries; Annex C of ISO 32000-1 gives 28 as the historical
+  implementation limit for graphics state nesting, so no real document comes
+  near it.
+
+  The cap counts the pushes it refuses and answers exactly that many `Q`
+  operators with no restore, so every `Q` still pairs with its own `q`. Dropping
+  pushes while honouring every `Q` would have been worse than the flood: each
+  restore past the cap would hand back the state of a level further out than the
+  one it closes, and with the text state now inside each snapshot that changes
+  the font in force. Levels within the cap keep restoring exactly; only levels
+  deeper than 1024 stop restoring. The count is part of the stack value, so it
+  changes hands with it at a Form XObject boundary, where the form already gets
+  its own stack.
+
+  This bounds the extractors' own contribution, not the whole path: the content
+  parser still materialises a `Vec<ContentOperation>` — 80 bytes per operator —
+  for the same stream before either extractor runs.
+
 - **The text state was not restored when a graphics state block closed** (#452).
   Leading, character and word spacing, horizontal scaling, font and size, text
   rise and render mode are text state parameters, and the text state is part of

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -10,6 +10,7 @@ use crate::parser::objects::{PdfDictionary, PdfObject};
 use crate::parser::page_tree::ParsedPage;
 use crate::parser::ParseResult;
 use crate::text::extraction_cmap::{CMapTextExtractor, FontInfo};
+use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
@@ -310,7 +311,10 @@ struct TextState {
     /// and other graphics state items that the text extractor needs to restore.
     /// Per PDF spec §8.4.4, `q` pushes the full graphics state and `Q` pops it;
     /// here we save only the fields that influence text extraction.
-    saved_states: Vec<SavedGraphicsState>,
+    ///
+    /// Bounded: see [`GraphicsStateStack`] for the depth cap and for why the
+    /// pushes it refuses have to be counted (issue #455).
+    saved_states: GraphicsStateStack<SavedGraphicsState>,
     /// Marked-content stack (issue #269 Phase 1). Pushed on BMC/BDC,
     /// popped on EMC. Empty on entry to each page.
     mc_stack: Vec<MarkedContentEntry>,
@@ -318,6 +322,28 @@ struct TextState {
     /// At most one active run at a time — nested ActualText replaces the
     /// outer (innermost wins, per spec §4).
     pending_actualtext: Option<PendingActualText>,
+}
+
+impl TextState {
+    /// `q` (§8.4.4): snapshot the graphics state.
+    ///
+    /// The snapshot is built lazily so that past the depth cap it is not built
+    /// at all: a `q` flood must not pay for the font-name clone of an entry the
+    /// stack is about to refuse (issue #455).
+    ///
+    /// That laziness is what forces the stack out of the state and back: the
+    /// closure calls [`SavedGraphicsState::capture`], which borrows the WHOLE
+    /// `TextState` — the ten fields of the snapshot are defined in one place on
+    /// purpose, so the `q` path and the implicit save around `Do` cannot drift
+    /// apart — and that borrow overlaps the mutable borrow of `saved_states`.
+    /// Moving a four-word stack twice per `q` is the price of not duplicating
+    /// the snapshot definition. The plain extractor reads its three fields
+    /// inline instead, so its borrows are disjoint and it needs none of this.
+    fn save_graphics_state(&mut self) {
+        let mut stack = std::mem::take(&mut self.saved_states);
+        stack.push_with(|| SavedGraphicsState::capture(self));
+        self.saved_states = stack;
+    }
 }
 
 /// Graphics state saved by `q` and restored by `Q` (issues #262, #452).
@@ -423,7 +449,7 @@ impl Default for TextState {
             font_name: None,
             render_mode: 0,
             fill_color: None,
-            saved_states: Vec::new(),
+            saved_states: GraphicsStateStack::default(),
             mc_stack: Vec::new(),
             pending_actualtext: None,
         }
@@ -1544,7 +1570,7 @@ impl TextExtractor {
                 // CTM forever, producing absurd page-space coordinates and
                 // wrong font_size scaling on PDFs that nest graphics state.
                 ContentOperation::SaveGraphicsState => {
-                    state.saved_states.push(SavedGraphicsState::capture(&state));
+                    state.save_graphics_state();
                 }
                 ContentOperation::RestoreGraphicsState => {
                     // Text state is graphics state (§9.3, Table 52): a leading,
@@ -1695,6 +1721,12 @@ impl TextExtractor {
                             // popped entry is gone — and with the text state
                             // now in each snapshot, a mispaired restore
                             // corrupts font decoding, not just the CTM.
+                            //
+                            // The count of pushes the depth cap refused is part
+                            // of the stack, so it changes hands here too: a
+                            // form that inherited the page's count would let its
+                            // own `Q` consume it, and the page would come back
+                            // short (issue #455).
                             let outer_stack = std::mem::take(&mut state.saved_states);
 
                             if let Some(m) = matrix {

--- a/oxidize-pdf-core/src/text/graphics_state_stack.rs
+++ b/oxidize-pdf-core/src/text/graphics_state_stack.rs
@@ -1,0 +1,158 @@
+//! Bounded save-state stack for the `q`/`Q` operators (issue #455).
+//!
+//! Both text extractors snapshot graphics state on `q` and restore it on `Q`.
+//! Nothing in the content stream limits how deep that nesting goes, so a stream
+//! of one million `q` operators — about 2 MB — used to push one million
+//! snapshots. Since #452 each snapshot also carries the text state, including a
+//! heap allocation for the font name whenever a font is set, so the per-entry
+//! cost of that flood roughly doubled.
+//!
+//! Annex C of ISO 32000-1 gives 28 as the historical implementation limit for
+//! graphics state nesting, so [`MAX_DEPTH`] is generous by a wide margin and no
+//! real document reaches it.
+//!
+//! # Why the dropped pushes are counted
+//!
+//! The subtle part is not the cap, it is the pairing. A stack that silently
+//! dropped pushes but honoured every `Q` would keep restoring — from the wrong
+//! entry. Every `Q` past the cap would hand back the state of a level further
+//! out than the one it closes, and every later `Q` would stay shifted by the
+//! same amount. With the text state inside each snapshot (#452), that
+//! mispairing changes the font in force, so it corrupts decoding rather than
+//! just the CTM.
+//!
+//! So [`GraphicsStateStack`] counts what it drops and answers exactly that many
+//! pops with `None`. Levels deeper than the cap stop restoring — a documented
+//! loss, only reachable by documents no viewer renders — while every level
+//! within the cap keeps restoring exactly.
+//!
+//! # Why the counter lives here
+//!
+//! The count is part of the stack, not a field beside it, because both are
+//! saved and restored together at a Form XObject boundary: `Do` gives the form
+//! its own stack so a stray `Q` inside it cannot pop the page's snapshots. A
+//! counter left outside that swap would let the form consume the page's dropped
+//! pushes, which is the very mispairing this type exists to prevent. Keeping
+//! them in one value makes `std::mem::take` at that boundary correct by
+//! construction.
+
+/// Maximum number of `q` snapshots either extractor keeps.
+///
+/// Annex C of ISO 32000-1 lists 28 as the historical nesting limit for the
+/// graphics state stack; this is two orders of magnitude above that.
+pub(crate) const MAX_DEPTH: usize = 1024;
+
+/// A `q`/`Q` save-state stack that stops growing at [`MAX_DEPTH`] without ever
+/// letting a `Q` restore the wrong entry.
+#[derive(Debug, Clone)]
+pub(crate) struct GraphicsStateStack<T> {
+    entries: Vec<T>,
+    /// Pushes refused because `entries` was already at [`MAX_DEPTH`]. The next
+    /// `dropped` pops restore nothing, so each `Q` still pairs with its own `q`.
+    dropped: usize,
+}
+
+impl<T> Default for GraphicsStateStack<T> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            dropped: 0,
+        }
+    }
+}
+
+impl<T> GraphicsStateStack<T> {
+    /// Push a snapshot for `q`, unless the stack is full.
+    ///
+    /// The snapshot is built lazily because building it is what costs: a
+    /// snapshot clones the font name, so a flood must not pay for entries the
+    /// stack is about to refuse.
+    pub(crate) fn push_with(&mut self, capture: impl FnOnce() -> T) {
+        if self.entries.len() < MAX_DEPTH {
+            self.entries.push(capture());
+        } else {
+            // Saturating because a wrap would turn a refused push into a
+            // restore from the wrong entry. Unreachable in practice — each `q`
+            // costs at least one byte of content stream — but the failure mode
+            // is bad enough not to leave it to arithmetic.
+            self.dropped = self.dropped.saturating_add(1);
+        }
+    }
+
+    /// Pop the snapshot for a `Q`.
+    ///
+    /// Returns `None` when this `Q` closes a level whose push was refused, and
+    /// also when the stack is empty: an unbalanced `Q` is ignored rather than
+    /// fatal, so malformed documents still extract.
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        if self.dropped > 0 {
+            self.dropped -= 1;
+            return None;
+        }
+        self.entries.pop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Un desenrollado equilibrado devuelve cada nivel dentro del tope, en
+    /// orden LIFO, y los de más allá del tope no devuelven nada.
+    #[test]
+    fn a_balanced_unwind_past_the_cap_pairs_every_push_with_its_own_pop() {
+        let overflow = 7;
+        let mut stack = GraphicsStateStack::default();
+        for level in 0..MAX_DEPTH + overflow {
+            stack.push_with(|| level);
+        }
+
+        // Los `overflow` primeros `Q` cierran niveles cuyo empuje se descartó.
+        for _ in 0..overflow {
+            assert_eq!(
+                stack.pop(),
+                None,
+                "a pop closing a dropped push must restore nothing"
+            );
+        }
+        // Y a partir de ahí, cada nivel guardado sale exactamente una vez y en
+        // orden inverso: el tope recorta los niveles internos, no desplaza los
+        // que sí caben.
+        for level in (0..MAX_DEPTH).rev() {
+            assert_eq!(stack.pop(), Some(level));
+        }
+        assert_eq!(stack.pop(), None, "the stack is empty after a full unwind");
+    }
+
+    /// Los `pop` de más no dejan la cuenta en negativo ni resucitan entradas.
+    #[test]
+    fn extra_pops_are_ignored_and_do_not_corrupt_the_count() {
+        let mut stack = GraphicsStateStack::default();
+        stack.push_with(|| 1);
+        for _ in 0..MAX_DEPTH + 3 {
+            let _ = stack.pop();
+        }
+        stack.push_with(|| 2);
+        assert_eq!(
+            stack.pop(),
+            Some(2),
+            "after over-popping, a fresh push must still be the next thing restored"
+        );
+    }
+
+    /// El tope no puede pagar la instantánea que va a rechazar.
+    #[test]
+    fn a_refused_push_never_builds_its_snapshot() {
+        let mut captures = 0usize;
+        let mut stack = GraphicsStateStack::default();
+        for _ in 0..MAX_DEPTH + 500 {
+            stack.push_with(|| {
+                captures += 1;
+            });
+        }
+        assert_eq!(
+            captures, MAX_DEPTH,
+            "only the pushes that fit may build a snapshot"
+        );
+    }
+}

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -8,6 +8,7 @@ mod flow;
 mod font;
 pub mod font_manager;
 pub mod fonts;
+pub(crate) mod graphics_state_stack;
 mod header_footer;
 pub mod invoice;
 mod layout;

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -11,6 +11,7 @@ use crate::parser::page_tree::ParsedPage;
 use crate::parser::ParseResult;
 use crate::text::encoding::TextEncoding;
 use crate::text::extraction_cmap::{CMapTextExtractor, FontInfo};
+use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
@@ -27,7 +28,25 @@ struct TextState {
     font_name: Option<String>,
     /// Stack for `q`/`Q`. This extractor tracks no CTM, so the only graphics
     /// state it can lose is the text state (issue #452).
-    saved_states: Vec<SavedTextState>,
+    ///
+    /// Bounded: see [`GraphicsStateStack`] for the depth cap and for why the
+    /// pushes it refuses have to be counted (issue #455).
+    saved_states: GraphicsStateStack<SavedTextState>,
+}
+
+impl TextState {
+    /// `q` (§8.4.4): snapshot the text state.
+    ///
+    /// The snapshot is built lazily: past the depth cap it is never built at
+    /// all, so a `q` flood does not pay for the font-name clone of an entry
+    /// the stack is about to refuse (issue #455).
+    fn save_graphics_state(&mut self) {
+        self.saved_states.push_with(|| SavedTextState {
+            leading: self.leading,
+            font_size: self.font_size,
+            font_name: self.font_name.clone(),
+        });
+    }
 }
 
 /// The text state parameters this extractor tracks, saved by `q` and restored
@@ -54,7 +73,7 @@ impl Default for TextState {
             leading: 0.0,
             font_size: 0.0,
             font_name: None,
-            saved_states: Vec::new(),
+            saved_states: GraphicsStateStack::default(),
         }
     }
 }
@@ -400,11 +419,7 @@ impl PlainTextExtractor {
                     // not survive it (issue #452). The text matrices are not
                     // saved: they are text object state, owned by `BT`/`ET`.
                     ContentOperation::SaveGraphicsState => {
-                        state.saved_states.push(SavedTextState {
-                            leading: state.leading,
-                            font_size: state.font_size,
-                            font_name: state.font_name.clone(),
-                        });
+                        state.save_graphics_state();
                     }
 
                     ContentOperation::RestoreGraphicsState => {

--- a/oxidize-pdf-core/tests/issue_455_graphics_state_stack_cap_test.rs
+++ b/oxidize-pdf-core/tests/issue_455_graphics_state_stack_cap_test.rs
@@ -1,0 +1,249 @@
+//! Issue #455 — la pila de `q`/`Q` está acotada, y el recorte NO puede
+//! desemparejar los operadores.
+//!
+//! Un flujo de contenido de 2 MB hecho de `q` repetidos apila un millón de
+//! instantáneas. Desde #452 cada instantánea lleva el estado de texto —una
+//! reserva de heap por `q` cuando hay fuente activa—, así que el factor de
+//! amplificación creció. El anexo C de ISO 32000-1 da 28 como límite histórico
+//! de anidamiento del estado gráfico, así que un tope holgado no toca ningún
+//! documento real.
+//!
+//! El contrato que fijan estos tests es el del recorte CORRECTO:
+//!
+//! 1. Los `q` que exceden el tope no guardan instantánea, pero se CUENTAN, y
+//!    los primeros `Q` del desenrollado consumen esa cuenta sin restaurar nada.
+//!    Un tope que descartara empujes y honrase todos los `Q` restauraría desde
+//!    la instantánea equivocada: cada `Q` a partir de ahí devolvería el estado
+//!    de un nivel más externo del que le toca, y con el estado de texto dentro
+//!    (#452) eso corrompe la decodificación de fuentes, no solo la CTM.
+//! 2. Los niveles que SÍ caben siguen siendo exactos: el desenrollado completo
+//!    devuelve el estado con el que se abrió el primer `q`.
+//!
+//! El oráculo es la y de los fragmentos bajo `preserve_layout`: el interlineado
+//! en vigor es aritmética exacta sobre el avance de `T*`, no depende de las
+//! métricas de la fuente.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::plaintext::{LineBreakMode, PlainTextConfig, PlainTextExtractor};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Profundidad a la que ambos extractores dejan de guardar instantáneas.
+/// Duplicada aquí a propósito: el test fija el contrato observable, no lee la
+/// constante del código, así que un cambio del tope tiene que ser deliberado.
+const CAP: usize = 1024;
+
+/// Empujes por encima del tope en los casos de este fichero.
+const OVERFLOW: usize = 976;
+
+/// `q` repetido `n` veces, en un flujo de contenido.
+fn q_flood(n: usize) -> Vec<u8> {
+    b"q\n".repeat(n)
+}
+
+/// `Q` repetido `n` veces.
+fn q_unwind(n: usize) -> Vec<u8> {
+    b"Q\n".repeat(n)
+}
+
+/// `(text, x, y, font_size)` de cada fragmento bajo `preserve_layout`.
+fn fragments_of_pdf(pdf: Vec<u8>) -> Vec<(String, f64, f64, f64)> {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .fragments
+        .into_iter()
+        .map(|f| (f.text, f.x, f.y, f.font_size))
+        .collect()
+}
+
+fn fragments_of(content: &[u8]) -> Vec<(String, f64, f64, f64)> {
+    fragments_of_pdf(build_pdf_with_content_stream(content))
+}
+
+fn fragment_named<'a>(
+    frags: &'a [(String, f64, f64, f64)],
+    text: &str,
+) -> &'a (String, f64, f64, f64) {
+    frags
+        .iter()
+        .find(|f| f.0 == text)
+        .unwrap_or_else(|| panic!("no fragment {text:?} among {frags:?}"))
+}
+
+fn plain_text_of(pdf: Vec<u8>) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut plain = PlainTextExtractor::with_config(PlainTextConfig {
+        line_break_mode: LineBreakMode::PreserveAll,
+        ..Default::default()
+    });
+    plain.extract(&document, 0).expect("extract page 0").text
+}
+
+/// Documento testigo de los dos extractores: interlineado 10 fuera, avalancha
+/// de `CAP + OVERFLOW` empujes, interlineado 50 dentro, y solo los `OVERFLOW`
+/// `Q` que corresponden a los empujes descartados.
+///
+/// El interlineado se cambia DESPUÉS de la avalancha a propósito: todas las
+/// instantáneas guardan 10, así que restaurar una sola de más es directamente
+/// visible como un avance de `T*` de 10 en vez de 50.
+fn overflow_only_unwind_content() -> Vec<u8> {
+    let mut content = b"BT\n/F1 12 Tf\n100 700 Td\n10 TL\n(one)Tj\nET\n".to_vec();
+    content.extend_from_slice(&q_flood(CAP + OVERFLOW));
+    content.extend_from_slice(b"50 TL\n");
+    content.extend_from_slice(&q_unwind(OVERFLOW));
+    content.extend_from_slice(b"BT\n/F1 12 Tf\n100 400 Td\n(two)Tj\nT*\n(three)Tj\nET\n");
+    content
+}
+
+/// Los `Q` que corresponden a empujes descartados no pueden restaurar nada.
+#[test]
+fn q_operators_matching_dropped_pushes_restore_nothing() {
+    let frags = fragments_of(&overflow_only_unwind_content());
+
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.2 - 350.0).abs() < 0.01,
+        "the {OVERFLOW} Q operators that pair with dropped pushes must restore nothing, so the \
+         leading in force is still the 50 set inside the flood and `three` sits at 350; got \
+         y = {} (390 means a Q consumed a snapshot that belongs to an outer level, restoring \
+         the leading of 10)",
+        three.2
+    );
+}
+
+/// Y los niveles que sí caben en el tope siguen siendo exactos: desenrollar del
+/// todo devuelve el estado con el que se abrió el primer `q`.
+#[test]
+fn the_levels_within_the_cap_still_restore_exactly() {
+    let mut content = overflow_only_unwind_content();
+    content.extend_from_slice(&q_unwind(CAP));
+    content.extend_from_slice(b"BT\n/F1 12 Tf\n100 200 Td\n(four)Tj\nT*\n(five)Tj\nET\n");
+    let frags = fragments_of(&content);
+
+    let five = fragment_named(&frags, "five");
+    assert!(
+        (five.2 - 190.0).abs() < 0.01,
+        "after unwinding the whole flood the leading is the outer 10 again, so `five` sits at \
+         190; got y = {} (150 means the 50 set inside the flood survived the last Q)",
+        five.2
+    );
+}
+
+/// Desenrollar de más tras la avalancha sigue siendo tolerado: la cuenta de
+/// descartes no puede quedar en negativo ni convertir un `Q` huérfano en una
+/// restauración fantasma.
+#[test]
+fn unbalanced_q_after_a_flood_does_not_break_extraction() {
+    let mut content = overflow_only_unwind_content();
+    content.extend_from_slice(&q_unwind(CAP + 5));
+    content.extend_from_slice(b"20 TL\n");
+    content.extend_from_slice(&q_unwind(3));
+    content.extend_from_slice(b"BT\n/F1 12 Tf\n100 200 Td\n(four)Tj\nT*\n(five)Tj\nET\n");
+    let frags = fragments_of(&content);
+
+    let five = fragment_named(&frags, "five");
+    assert!(
+        (five.2 - 180.0).abs() < 0.01,
+        "with the stack empty, the extra Q operators must be ignored and the leading of 20 set \
+         after the unwind stays in force, so `five` sits at 180; got y = {}",
+        five.2
+    );
+}
+
+/// El extractor plano es una implementación independiente del mismo contrato y
+/// también apila una instantánea por `q` desde #452.
+///
+/// No expone coordenadas, pero sí la estructura de línea: con el interlineado
+/// en 50 el `T*` final salta de línea; con el 10 restaurado de más, el salto es
+/// menor que el umbral de línea nueva y las dos palabras se pegan.
+#[test]
+fn the_plain_extractor_also_keeps_q_and_q_paired_under_a_flood() {
+    let mut content = b"BT\n/F1 12 Tf\n100 700 Td\n(one)Tj\nET\n".to_vec();
+    content.extend_from_slice(&q_flood(CAP + OVERFLOW));
+    content.extend_from_slice(b"50 TL\n");
+    content.extend_from_slice(&q_unwind(OVERFLOW));
+    content.extend_from_slice(b"BT\n/F1 12 Tf\n100 400 Td\n(two)Tj\nT*\n(three)Tj\nET\n");
+
+    let text = plain_text_of(build_pdf_with_content_stream(&content));
+    assert!(
+        text.contains("two\nthree"),
+        "the {OVERFLOW} Q operators pair with dropped pushes, so the leading of 50 is still in \
+         force and the final T* breaks the line; got {text:?} (\"twothree\" means a Q restored \
+         the outer leading of 0 and the T* stopped moving the pen)"
+    );
+}
+
+/// Ensambla una página con un Form XObject en sus recursos.
+fn pdf_with_form_xobject(page_content: &[u8], xobject_content: &[u8]) -> Vec<u8> {
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> \
+           /XObject << /X1 6 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", page_content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            xobject_content,
+        ),
+    ])
+}
+
+/// El caso que el tope hace fácil de romper: la cuenta de empujes descartados
+/// tiene que viajar con la pila al entrar y salir de un Form XObject.
+///
+/// `Do` da al formulario su propia pila para que un `Q` huérfano suyo no se
+/// coma las instantáneas de la página. Si la cuenta de descartes se quedara
+/// fuera de ese relevo, el formulario heredaría los descartes de la página —su
+/// propio `Q` los consumiría— y la página volvería con la cuenta mermada: uno
+/// de sus `Q` de desbordamiento acabaría restaurando una instantánea real.
+#[test]
+fn the_overflow_count_does_not_cross_a_form_xobject_boundary() {
+    let mut page = b"BT /F1 12 Tf 100 700 Td 10 TL (one)Tj ET\n".to_vec();
+    page.extend_from_slice(&q_flood(CAP + OVERFLOW));
+    page.extend_from_slice(b"50 TL\n/X1 Do\n");
+    page.extend_from_slice(&q_unwind(OVERFLOW));
+    page.extend_from_slice(b"BT /F1 12 Tf 100 400 Td (two)Tj T* (three)Tj ET\n");
+
+    // El formulario abre y cierra su propio bloque, y cambia el interlineado
+    // dentro: si sus `Q` consumieran descartes de la página, ese 70 sobreviviría
+    // a su propio `Q` y además mermaría la cuenta que la página necesita.
+    let xobject = b"q\n70 TL\nBT /F1 12 Tf 100 600 Td (inner)Tj T* (inner2)Tj ET\nQ\n";
+
+    let frags = fragments_of_pdf(pdf_with_form_xobject(&page, xobject));
+
+    let inner2 = fragment_named(&frags, "inner2");
+    assert!(
+        (inner2.2 - 530.0).abs() < 0.01,
+        "sanity: inside the form its own leading of 70 is in force, so `inner2` sits at 530; \
+         got y = {} (a form that inherited the page's overflow count would have its own q \
+         dropped or its Q eaten)",
+        inner2.2
+    );
+
+    let three = fragment_named(&frags, "three");
+    assert!(
+        (three.2 - 350.0).abs() < 0.01,
+        "back on the page, the {OVERFLOW} Q operators still pair with the page's dropped \
+         pushes, so the leading is the 50 set before the Do and `three` sits at 350; got \
+         y = {} (390 means the form ate part of the page's overflow count and a Q restored a \
+         real snapshot)",
+        three.2
+    );
+}


### PR DESCRIPTION
Nothing in a content stream limits how deep `q` nesting goes, so a stream of one
million `q` operators — about 2 MB — pushed one million snapshots. Since #452
each snapshot also carries the text state, including a heap allocation for the
font name whenever a font is set, so the per-entry cost of that flood had roughly
doubled. Both text extractors now cap the stack at 1024 entries; Annex C of
ISO 32000-1 gives 28 as the historical implementation limit for graphics state
nesting, so no real document comes near it.

The cap counts the pushes it refuses and answers exactly that many `Q` operators
with no restore, so every `Q` still pairs with its own `q`. Dropping pushes while
honouring every `Q` would have been worse than the flood: each restore past the
cap would hand back the state of a level further out than the one it closes, and
with the text state now inside each snapshot that changes the font in force.
Levels within the cap keep restoring exactly.

The refused-push count lives inside the stack value rather than beside it, so it
changes hands with the stack at the Form XObject boundary, where the form already
gets its own stack. A counter left outside that swap would let the form consume
the page's refused pushes and send the page back short — the very mispairing this
bounds. That boundary only exists in `TextExtractor`: `PlainTextExtractor` has no
`Do`/`PaintXObject` handling at all, so it never enters a form. The depth cap
applies to both extractors; the swap is only reachable in one.

This bounds the extractors' own contribution, not the whole path: the content
parser still materialises a `Vec<ContentOperation>` — 80 bytes per operator — for
the same stream before either extractor runs.

## Stacked PR

Based on `fix/issue-452-text-state-graphics-state` (#457), not on `develop`. The
diff shown here is only the #455 commit once #457 merges; review #457 first.

## Verification

- `cargo build --workspace --all-features` — 0 warnings
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p oxidize-pdf --all-features --lib` and on both new test targets — 0 warnings
- `cargo test` on both issue test files — 15/15 pass, plus 3 unit tests in the new module

Pre-existing and unrelated: `cargo clippy --workspace --all-targets` fails on four
`approx_constant` literals in `tests/parser_objects_coverage.rs`, byte-identical on
`develop`.

addresses #455
