### PR TITLE
fix(parser): read literal strings as bytes, and password entries as Acrobat writes them (addresses #459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hex-string form of those entries survived. That is why the qpdf-generated
   fixtures in this suite all passed while real Acrobat output failed.
 
+  The consumers that read a string as text decode it explicitly now: AcroForm
+  field names (`/T`) and default appearance strings (`/DA`), and the `/T`,
+  `/Reason`, `/Location`, `/ContactInfo` and `/M` of a signature. A field named
+  with accented characters is addressed by that name, so leaving it undecoded
+  would have made the field unfillable.
+
 - **`/U` and `/O` entries longer than 48 bytes were rejected instead of read**
   (#459). ISO 32000-2 §7.6.4.3.3 defines the R5/R6 entries as 48 bytes — a
   32-byte hash and two 8-byte salts — but Acrobat writes them as 127-byte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as UTF-8. For a text string that is harmless; for a binary one it is
   destruction — byte `0xB2` came back as `0xC2 0xB2`. Literal strings now reach
   the object model unchanged, and the strings a PDF defines as *text* are decoded
-  where they are read as text, by the new `PdfString::as_text` (ISO 32000-1
+  where they are read as text, by the new `PdfString::to_text` (ISO 32000-1
   §7.9.2.2: UTF-16BE when a byte order mark is present, PDFDocEncoding
   otherwise).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A literal string reached the object model as a text round-trip of its bytes,
+  not as its bytes** (#459). The lexer ran every `(...)` string through an
+  encoding-recovery pass that decoded the bytes as text and re-encoded the result
+  as UTF-8. For a text string that is harmless; for a binary one it is
+  destruction — byte `0xB2` came back as `0xC2 0xB2`. Literal strings now reach
+  the object model unchanged, and the strings a PDF defines as *text* are decoded
+  where they are read as text, by the new `PdfString::as_text` (ISO 32000-1
+  §7.9.2.2: UTF-16BE when a byte order mark is present, PDFDocEncoding
+  otherwise).
+
+  Two consequences beyond the reported symptom. Document metadata now decodes
+  UTF-16BE `/Title`, `/Author` and the rest, which previously surfaced as
+  `þÿ`-prefixed mojibake. And any binary string — `/U`, `/O`, `/Perms`, `/ID`,
+  every string in an encrypted document — is now readable, where before only the
+  hex-string form of those entries survived. That is why the qpdf-generated
+  fixtures in this suite all passed while real Acrobat output failed.
+
+- **`/U` and `/O` entries longer than 48 bytes were rejected instead of read**
+  (#459). ISO 32000-2 §7.6.4.3.3 defines the R5/R6 entries as 48 bytes — a
+  32-byte hash and two 8-byte salts — but Acrobat writes them as 127-byte
+  strings, zero-padded past byte 48, and those documents open in every
+  conforming reader. Both revisions, on the user and the owner path, now read
+  the defined 48-byte prefix and ignore what follows. Shorter than 48 is still
+  an error: the salts would not fit. The `compute_*` functions build our own
+  entries and keep requiring exactly 48 bytes.
+
+  Together with the string fix above, this reopens documents whose *correct*
+  password — often the empty one — was reported as `WrongPassword`: the
+  reporter's file was a public annual report that opens in any browser.
+
+- **A malformed encryption dictionary was reported as a wrong password** (#459).
+  `PdfReader::unlock` collapsed every failure from the encryption handler into
+  `WrongPassword`, so a truncated `/U` or an unsupported revision sent the caller
+  hunting for a password that does not exist. Errors now surface with their own
+  message; a password that merely does not match still yields `WrongPassword`,
+  and the owner password still gets its turn before any error is raised.
+
 - **The `q`/`Q` graphics state stack was unbounded in both text extractors**
   (#455). Nothing in a content stream limits how deep `q` nesting goes, so a
   stream of one million `q` operators — about 2 MB — pushed one million

--- a/oxidize-pdf-core/src/encryption/standard_security.rs
+++ b/oxidize-pdf-core/src/encryption/standard_security.rs
@@ -738,13 +738,7 @@ impl StandardSecurityHandler {
         password: &UserPassword,
         u_entry: &[u8],
     ) -> Result<bool> {
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R5 U entry must be {} bytes, got {}",
-                U_ENTRY_LENGTH,
-                u_entry.len()
-            )));
-        }
+        let u_entry = defined_entry_prefix(u_entry, "R5 U")?;
 
         // Extract validation_salt from U
         let validation_salt = &u_entry[U_VALIDATION_SALT_START..U_VALIDATION_SALT_END];
@@ -840,12 +834,7 @@ impl StandardSecurityHandler {
                 ue_entry.len()
             )));
         }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "U entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
+        let u_entry = defined_entry_prefix(u_entry, "U")?;
 
         // Extract key_salt from U
         let key_salt = &u_entry[U_KEY_SALT_START..U_KEY_SALT_END];
@@ -930,13 +919,7 @@ impl StandardSecurityHandler {
         password: &UserPassword,
         u_entry: &[u8],
     ) -> Result<bool> {
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R6 U entry must be {} bytes, got {}",
-                U_ENTRY_LENGTH,
-                u_entry.len()
-            )));
-        }
+        let u_entry = defined_entry_prefix(u_entry, "R6 U")?;
 
         // Extract validation_salt from U[32..40]
         let validation_salt = &u_entry[U_VALIDATION_SALT_START..U_VALIDATION_SALT_END];
@@ -1020,12 +1003,7 @@ impl StandardSecurityHandler {
                 ue_entry.len()
             )));
         }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "U entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
+        let u_entry = defined_entry_prefix(u_entry, "U")?;
 
         // Extract key_salt from U[40..48]
         let key_salt = &u_entry[U_KEY_SALT_START..U_KEY_SALT_END];
@@ -1264,20 +1242,8 @@ impl StandardSecurityHandler {
         o_entry: &[u8],
         u_entry: &[u8],
     ) -> Result<bool> {
-        if o_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R5 O entry must be {} bytes, got {}",
-                U_ENTRY_LENGTH,
-                o_entry.len()
-            )));
-        }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R5 U entry must be {} bytes, got {}",
-                U_ENTRY_LENGTH,
-                u_entry.len()
-            )));
-        }
+        let o_entry = defined_entry_prefix(o_entry, "R5 O")?;
+        let u_entry = defined_entry_prefix(u_entry, "R5 U")?;
 
         // Extract validation_salt from O (bytes 32-39)
         let validation_salt = &o_entry[U_VALIDATION_SALT_START..U_VALIDATION_SALT_END];
@@ -1358,18 +1324,8 @@ impl StandardSecurityHandler {
         u_entry: &[u8],
         oe_entry: &[u8],
     ) -> Result<Vec<u8>> {
-        if o_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "O entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "U entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
+        let o_entry = defined_entry_prefix(o_entry, "O")?;
+        let u_entry = defined_entry_prefix(u_entry, "U")?;
         if oe_entry.len() != UE_ENTRY_LENGTH {
             return Err(crate::error::PdfError::EncryptionError(format!(
                 "OE entry must be {} bytes",
@@ -1452,18 +1408,8 @@ impl StandardSecurityHandler {
         o_entry: &[u8],
         u_entry: &[u8],
     ) -> Result<bool> {
-        if o_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R6 O entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "R6 U entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
+        let o_entry = defined_entry_prefix(o_entry, "R6 O")?;
+        let u_entry = defined_entry_prefix(u_entry, "R6 U")?;
 
         // Extract validation_salt from O (bytes 32-39)
         let validation_salt = &o_entry[U_VALIDATION_SALT_START..U_VALIDATION_SALT_END];
@@ -1535,18 +1481,8 @@ impl StandardSecurityHandler {
         u_entry: &[u8],
         oe_entry: &[u8],
     ) -> Result<Vec<u8>> {
-        if o_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "O entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
-        if u_entry.len() != U_ENTRY_LENGTH {
-            return Err(crate::error::PdfError::EncryptionError(format!(
-                "U entry must be {} bytes",
-                U_ENTRY_LENGTH
-            )));
-        }
+        let o_entry = defined_entry_prefix(o_entry, "O")?;
+        let u_entry = defined_entry_prefix(u_entry, "U")?;
         if oe_entry.len() != UE_ENTRY_LENGTH {
             return Err(crate::error::PdfError::EncryptionError(format!(
                 "OE entry must be {} bytes",
@@ -1979,6 +1915,31 @@ const U_KEY_SALT_END: usize = 48;
 
 /// Total length of U entry for R5/R6
 const U_ENTRY_LENGTH: usize = 48;
+
+/// Narrows a `/U` or `/O` entry read from a document to the bytes ISO 32000-2
+/// §7.6.4.3.3 defines for it: a 32-byte hash, an 8-byte validation salt and an
+/// 8-byte key salt.
+///
+/// Acrobat writes those entries as 127-byte strings, zero-padding everything
+/// past byte 48 — the length the pre-R5 revisions used for `/U` and `/O`. Such
+/// documents open in every conforming reader, so trailing bytes are ignored
+/// rather than treated as a malformed entry, which is what turned a correct
+/// empty password into `WrongPassword` in issue #459. Anything shorter than 48
+/// bytes is still an error: the salts would not fit.
+///
+/// This applies to entries parsed from a file. The `compute_*` functions build
+/// our own entries and keep requiring exactly 48 bytes.
+fn defined_entry_prefix<'a>(entry: &'a [u8], label: &str) -> Result<&'a [u8]> {
+    if entry.len() < U_ENTRY_LENGTH {
+        return Err(crate::error::PdfError::EncryptionError(format!(
+            "{} entry must be at least {} bytes, got {}",
+            label,
+            U_ENTRY_LENGTH,
+            entry.len()
+        )));
+    }
+    Ok(&entry[..U_ENTRY_LENGTH])
+}
 
 /// Length of UE entry (encrypted encryption key)
 const UE_ENTRY_LENGTH: usize = 32;
@@ -2711,18 +2672,25 @@ mod tests {
     }
 
     #[test]
-    fn test_r5_user_hash_invalid_entry_length() {
+    fn test_r5_user_hash_entry_shorter_than_the_salts_is_rejected() {
         let handler = StandardSecurityHandler::aes_256_r5();
         let password = UserPassword("test".to_string());
 
-        // Try to validate with wrong length U entry
-        let short_entry = vec![0u8; 32]; // Too short
+        // 32 bytes hold the hash but neither salt.
+        let short_entry = vec![0u8; 32];
         let result = handler.validate_r5_user_password(&password, &short_entry);
         assert!(result.is_err(), "Short U entry must fail");
 
-        let long_entry = vec![0u8; 64]; // Too long
-        let result = handler.validate_r5_user_password(&password, &long_entry);
-        assert!(result.is_err(), "Long U entry must fail");
+        // Longer than 48 is what Acrobat writes (127 bytes, zero-padded): the
+        // entry is evaluated on its defined prefix rather than rejected on its
+        // length (issue #459). An all-zero entry still fails to validate.
+        let long_entry = vec![0u8; 64];
+        assert!(
+            !handler
+                .validate_r5_user_password(&password, &long_entry)
+                .expect("a longer entry is read, not refused"),
+            "an all-zero entry must not authenticate any password"
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/operations/overlay.rs
+++ b/oxidize-pdf-core/src/operations/overlay.rs
@@ -149,7 +149,11 @@ fn convert_parser_obj_to_objects_obj<R: Read + Seek>(
         PObj::Boolean(b) => WObj::Boolean(*b),
         PObj::Integer(i) => WObj::Integer(*i),
         PObj::Real(r) => WObj::Real(*r),
-        PObj::String(s) => WObj::String(String::from_utf8_lossy(s.as_bytes()).to_string()),
+        // The writer's string is a Rust `String`, so it cannot carry a binary
+        // string; decoding as text at least keeps the text strings of a copied
+        // resource readable (issue #459). A resource holding genuinely binary
+        // string data still cannot survive this conversion.
+        PObj::String(s) => WObj::String(s.to_text()),
         PObj::Name(n) => WObj::Name(n.as_str().to_string()),
         PObj::Array(arr) => {
             let items: Vec<WObj> = arr

--- a/oxidize-pdf-core/src/parser/lexer.rs
+++ b/oxidize-pdf-core/src/parser/lexer.rs
@@ -363,7 +363,7 @@ impl<R: Read> Lexer<R> {
         // — that is what rejected a correct empty password in issue #459. The
         // bytes therefore reach the object model unchanged; the strings that ARE
         // text are decoded where they are read as text, by
-        // [`PdfString::as_text`](super::objects::PdfString::as_text).
+        // [`PdfString::to_text`](super::objects::PdfString::to_text).
         Ok(Token::String(string))
     }
 

--- a/oxidize-pdf-core/src/parser/lexer.rs
+++ b/oxidize-pdf-core/src/parser/lexer.rs
@@ -357,14 +357,14 @@ impl<R: Read> Lexer<R> {
             }
         }
 
-        // Apply character encoding recovery if enabled
-        let processed_string = if self.options.lenient_encoding {
-            self.process_string_with_encoding_recovery(&string)?
-        } else {
-            string
-        };
-
-        Ok(Token::String(processed_string))
+        // A literal string carries bytes, not text. `/U`, `/O`, `/Perms` and the
+        // strings of an encrypted document are binary, and decoding them as text
+        // to re-encode the result as UTF-8 changes their length and their content
+        // — that is what rejected a correct empty password in issue #459. The
+        // bytes therefore reach the object model unchanged; the strings that ARE
+        // text are decoded where they are read as text, by
+        // [`PdfString::as_text`](super::objects::PdfString::as_text).
+        Ok(Token::String(string))
     }
 
     /// Read angle bracket tokens (hex strings or dict markers)
@@ -882,179 +882,6 @@ impl<R: Read> Lexer<R> {
         let saved_pos = self.save_position()?;
         let result = self.next_token();
         self.restore_position(saved_pos)?;
-        result
-    }
-
-    /// Process string bytes with enhanced character encoding recovery
-    fn process_string_with_encoding_recovery(
-        &mut self,
-        string_bytes: &[u8],
-    ) -> ParseResult<Vec<u8>> {
-        use super::encoding::{CharacterDecoder, EncodingOptions, EncodingType, EnhancedDecoder};
-
-        // First check for common problematic bytes that need special handling
-        let has_problematic_chars = string_bytes.iter().any(|&b| {
-            // Control characters and Latin-1 supplement range that often cause issues
-            (0x80..=0x9F).contains(&b)
-                || b == 0x07
-                || (b <= 0x1F && b != 0x09 && b != 0x0A && b != 0x0D)
-        });
-
-        let decoder = EnhancedDecoder::new();
-
-        // Use more aggressive encoding options if problematic characters detected
-        let encoding_options = if has_problematic_chars {
-            EncodingOptions {
-                lenient_mode: true, // Always use lenient mode for problematic chars
-                preferred_encoding: Some(EncodingType::Windows1252), // Try Windows-1252 first for control chars
-                max_replacements: std::cmp::max(100, string_bytes.len() / 10), // More generous replacement limit
-                log_issues: self.options.collect_warnings,
-            }
-        } else {
-            EncodingOptions {
-                lenient_mode: self.options.lenient_encoding,
-                preferred_encoding: self.options.preferred_encoding,
-                max_replacements: 50,
-                log_issues: self.options.collect_warnings,
-            }
-        };
-
-        match decoder.decode(string_bytes, &encoding_options) {
-            Ok(result) => {
-                // Log warning if replacements were made or problematic chars detected
-                if (result.replacement_count > 0 || has_problematic_chars)
-                    && self.options.collect_warnings
-                {
-                    self.warnings.push(ParseWarning::InvalidEncoding {
-                        position: self.position,
-                        recovered_text: if result.text.len() > 50 {
-                            // Ultra-safe character boundary truncation
-                            let truncate_at = result
-                                .text
-                                .char_indices()
-                                .map(|(i, _)| i)
-                                .nth(47)
-                                .unwrap_or_else(|| {
-                                    // Fallback: find last valid boundary within first 47 bytes
-                                    let limit = result.text.len().min(47);
-                                    let mut pos = limit;
-                                    while pos > 0 && !result.text.is_char_boundary(pos) {
-                                        pos -= 1;
-                                    }
-                                    pos
-                                });
-
-                            // Double-check the boundary before slicing
-                            let safe_text = if truncate_at <= result.text.len()
-                                && result.text.is_char_boundary(truncate_at)
-                            {
-                                result.text[..truncate_at].to_string()
-                            } else {
-                                // Emergency fallback: use chars().take() for absolute safety
-                                result.text.chars().take(47).collect::<String>()
-                            };
-
-                            format!(
-                                "{}... (truncated, {} chars total)",
-                                safe_text,
-                                result.text.chars().count()
-                            )
-                        } else {
-                            result.text.clone()
-                        },
-                        encoding_used: result.detected_encoding,
-                        replacement_count: result.replacement_count,
-                    });
-                }
-
-                // Convert back to bytes
-                Ok(result.text.into_bytes())
-            }
-            Err(encoding_error) => {
-                if self.options.lenient_encoding {
-                    // Enhanced fallback strategy
-                    let fallback_result = self.apply_fallback_encoding_strategy(string_bytes);
-
-                    if self.options.collect_warnings {
-                        self.warnings.push(ParseWarning::InvalidEncoding {
-                            position: self.position,
-                            recovered_text: format!(
-                                "Fallback strategy applied: {} -> {} chars",
-                                string_bytes.len(),
-                                fallback_result.len()
-                            ),
-                            encoding_used: None,
-                            replacement_count: string_bytes.len(),
-                        });
-                    }
-                    Ok(fallback_result)
-                } else {
-                    Err(ParseError::CharacterEncodingError {
-                        position: self.position,
-                        message: format!(
-                            "Failed to decode string with any supported encoding: {encoding_error}"
-                        ),
-                    })
-                }
-            }
-        }
-    }
-
-    /// Apply fallback encoding strategy for severely corrupted strings
-    fn apply_fallback_encoding_strategy(&self, string_bytes: &[u8]) -> Vec<u8> {
-        let mut result = Vec::with_capacity(string_bytes.len());
-
-        for &byte in string_bytes {
-            match byte {
-                // Replace common problematic control characters with safe alternatives
-                0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F => {
-                    result.push(b' '); // Replace control chars with space
-                }
-                0x80..=0x9F => {
-                    // Windows-1252 control character range - try to map to reasonable alternatives
-                    let replacement = match byte {
-                        0x80 => b'E',  // Euro sign -> E
-                        0x81 => b' ',  // Undefined -> space
-                        0x82 => b',',  // Single low-9 quotation mark -> comma
-                        0x83 => b'f',  // Latin small letter f with hook -> f
-                        0x84 => b'"',  // Double low-9 quotation mark -> quote
-                        0x85 => b'.',  // Horizontal ellipsis -> period
-                        0x86 => b'+',  // Dagger -> plus
-                        0x87 => b'+',  // Double dagger -> plus
-                        0x88 => b'^',  // Modifier letter circumflex accent -> caret
-                        0x89 => b'%',  // Per mille sign -> percent
-                        0x8A => b'S',  // Latin capital letter S with caron -> S
-                        0x8B => b'<',  // Single left-pointing angle quotation mark
-                        0x8C => b'O',  // Latin capital ligature OE -> O
-                        0x8D => b' ',  // Undefined -> space
-                        0x8E => b'Z',  // Latin capital letter Z with caron -> Z
-                        0x8F => b' ',  // Undefined -> space
-                        0x90 => b' ',  // Undefined -> space
-                        0x91 => b'\'', // Left single quotation mark
-                        0x92 => b'\'', // Right single quotation mark
-                        0x93 => b'"',  // Left double quotation mark
-                        0x94 => b'"',  // Right double quotation mark
-                        0x95 => b'*',  // Bullet -> asterisk
-                        0x96 => b'-',  // En dash -> hyphen
-                        0x97 => b'-',  // Em dash -> hyphen
-                        0x98 => b'~',  // Small tilde
-                        0x99 => b'T',  // Trade mark sign -> T
-                        0x9A => b's',  // Latin small letter s with caron -> s
-                        0x9B => b'>',  // Single right-pointing angle quotation mark
-                        0x9C => b'o',  // Latin small ligature oe -> o
-                        0x9D => b' ',  // Undefined -> space
-                        0x9E => b'z',  // Latin small letter z with caron -> z
-                        0x9F => b'Y',  // Latin capital letter Y with diaeresis -> Y
-                        _ => b'?',     // Fallback
-                    };
-                    result.push(replacement);
-                }
-                _ => {
-                    result.push(byte); // Keep valid bytes as-is
-                }
-            }
-        }
-
         result
     }
 

--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -1183,9 +1183,57 @@ impl PdfString {
         std::str::from_utf8(&self.0)
     }
 
+    /// Decode as a PDF *text string* (ISO 32000-1 §7.9.2.2).
+    ///
+    /// A text string is either UTF-16BE introduced by a `0xFE 0xFF` byte order
+    /// mark, or PDFDocEncoding. Bytes outside `0x80..=0x9F` decode identically
+    /// under PDFDocEncoding and Latin-1; inside that block this uses the WinAnsi
+    /// table, which is what producers writing typographic punctuation without a
+    /// BOM mean by those bytes.
+    ///
+    /// Use this for entries a PDF defines as text — `/Title`, `/Author`,
+    /// `/ActualText`. Entries that are binary — `/U`, `/O`, `/Perms`, `/ID` —
+    /// must be read with [`as_bytes`](Self::as_bytes): decoding them as text and
+    /// re-encoding the result changes their content (issue #459).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use oxidize_pdf::parser::objects::PdfString;
+    ///
+    /// // PDFDocEncoding
+    /// assert_eq!(PdfString::new(vec![b'a', 0xF1, b'o']).as_text(), "año");
+    ///
+    /// // UTF-16BE with a byte order mark
+    /// let utf16 = vec![0xFE, 0xFF, 0x00, b'A', 0x00, 0xF1, 0x00, b'o'];
+    /// assert_eq!(PdfString::new(utf16).as_text(), "Año");
+    /// ```
+    pub fn as_text(&self) -> String {
+        decode_text_string(&self.0)
+    }
+
     /// Get as bytes
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
+    }
+}
+
+/// Decodes the bytes of a PDF text string (ISO 32000-1 §7.9.2.2).
+///
+/// See [`PdfString::as_text`] for the encodings involved and for when a string
+/// must *not* be decoded this way.
+pub fn decode_text_string(bytes: &[u8]) -> String {
+    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+        let code_units: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect();
+        String::from_utf16_lossy(&code_units)
+    } else {
+        bytes
+            .iter()
+            .map(|&byte| crate::text::encoding::winansi_decode_char(byte))
+            .collect()
     }
 }
 

--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -1186,10 +1186,13 @@ impl PdfString {
     /// Decode as a PDF *text string* (ISO 32000-1 §7.9.2.2).
     ///
     /// A text string is either UTF-16BE introduced by a `0xFE 0xFF` byte order
-    /// mark, or PDFDocEncoding. Bytes outside `0x80..=0x9F` decode identically
-    /// under PDFDocEncoding and Latin-1; inside that block this uses the WinAnsi
-    /// table, which is what producers writing typographic punctuation without a
-    /// BOM mean by those bytes.
+    /// mark, or PDFDocEncoding. Without a BOM this decodes through the WinAnsi
+    /// (Windows-1252) table, which agrees with PDFDocEncoding across the Latin
+    /// letters and diverges only where few real documents go: PDFDocEncoding
+    /// puts typographic punctuation in `0x80..=0x9F` in a different order than
+    /// WinAnsi does, and maps `0xA0` to `€` where WinAnsi has a no-break space.
+    /// Producers that need those characters emit the BOM. Swapping in the full
+    /// PDFDocEncoding table would only change the reading of those slots.
     ///
     /// Use this for entries a PDF defines as text — `/Title`, `/Author`,
     /// `/ActualText`. Entries that are binary — `/U`, `/O`, `/Perms`, `/ID` —
@@ -1202,13 +1205,13 @@ impl PdfString {
     /// use oxidize_pdf::parser::objects::PdfString;
     ///
     /// // PDFDocEncoding
-    /// assert_eq!(PdfString::new(vec![b'a', 0xF1, b'o']).as_text(), "año");
+    /// assert_eq!(PdfString::new(vec![b'a', 0xF1, b'o']).to_text(), "año");
     ///
     /// // UTF-16BE with a byte order mark
     /// let utf16 = vec![0xFE, 0xFF, 0x00, b'A', 0x00, 0xF1, 0x00, b'o'];
-    /// assert_eq!(PdfString::new(utf16).as_text(), "Año");
+    /// assert_eq!(PdfString::new(utf16).to_text(), "Año");
     /// ```
-    pub fn as_text(&self) -> String {
+    pub fn to_text(&self) -> String {
         decode_text_string(&self.0)
     }
 
@@ -1220,9 +1223,9 @@ impl PdfString {
 
 /// Decodes the bytes of a PDF text string (ISO 32000-1 §7.9.2.2).
 ///
-/// See [`PdfString::as_text`] for the encodings involved and for when a string
+/// See [`PdfString::to_text`] for the encodings involved and for when a string
 /// must *not* be decoded this way.
-pub fn decode_text_string(bytes: &[u8]) -> String {
+pub(crate) fn decode_text_string(bytes: &[u8]) -> String {
     if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
         let code_units: Vec<u16> = bytes[2..]
             .chunks_exact(2)

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -2668,22 +2668,22 @@ impl<R: Read + Seek> PdfReader<R> {
 
         if let Some(info_dict) = self.info()? {
             if let Some(title) = info_dict.get("Title").and_then(|o| o.as_string()) {
-                metadata.title = Some(title.as_text());
+                metadata.title = Some(title.to_text());
             }
             if let Some(author) = info_dict.get("Author").and_then(|o| o.as_string()) {
-                metadata.author = Some(author.as_text());
+                metadata.author = Some(author.to_text());
             }
             if let Some(subject) = info_dict.get("Subject").and_then(|o| o.as_string()) {
-                metadata.subject = Some(subject.as_text());
+                metadata.subject = Some(subject.to_text());
             }
             if let Some(keywords) = info_dict.get("Keywords").and_then(|o| o.as_string()) {
-                metadata.keywords = Some(keywords.as_text());
+                metadata.keywords = Some(keywords.to_text());
             }
             if let Some(creator) = info_dict.get("Creator").and_then(|o| o.as_string()) {
-                metadata.creator = Some(creator.as_text());
+                metadata.creator = Some(creator.to_text());
             }
             if let Some(producer) = info_dict.get("Producer").and_then(|o| o.as_string()) {
-                metadata.producer = Some(producer.as_text());
+                metadata.producer = Some(producer.to_text());
             }
         }
 

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -185,14 +185,26 @@ impl<R: Read + Seek> PdfReader<R> {
     pub fn unlock_with_password(&mut self, password: &str) -> ParseResult<bool> {
         match &mut self.encryption_handler {
             Some(handler) => {
-                // Try user password first
-                if handler.unlock_with_user_password(password).unwrap_or(false) {
-                    Ok(true)
-                } else {
-                    // Try owner password
-                    Ok(handler
-                        .unlock_with_owner_password(password)
-                        .unwrap_or(false))
+                // A password that does not match returns Ok(false); an Err means
+                // the encryption dictionary itself could not be processed — a
+                // truncated /U, an unsupported revision. Both were collapsed into
+                // "wrong password", which is how the real cause of issue #459
+                // stayed invisible: the reporter was told to find a password for
+                // a document whose empty password was already correct.
+                //
+                // The owner password still gets its turn before any error is
+                // raised: a document whose /O is unusable can open on its /U.
+                let user = handler.unlock_with_user_password(password);
+                if matches!(user, Ok(true)) {
+                    return Ok(true);
+                }
+                let owner = handler.unlock_with_owner_password(password);
+                if matches!(owner, Ok(true)) {
+                    return Ok(true);
+                }
+                match (user, owner) {
+                    (Err(e), _) | (Ok(_), Err(e)) => Err(e),
+                    (Ok(_), Ok(_)) => Ok(false),
                 }
             }
             None => Ok(true), // Not encrypted
@@ -2656,22 +2668,22 @@ impl<R: Read + Seek> PdfReader<R> {
 
         if let Some(info_dict) = self.info()? {
             if let Some(title) = info_dict.get("Title").and_then(|o| o.as_string()) {
-                metadata.title = title.as_str().ok().map(|s| s.to_string());
+                metadata.title = Some(title.as_text());
             }
             if let Some(author) = info_dict.get("Author").and_then(|o| o.as_string()) {
-                metadata.author = author.as_str().ok().map(|s| s.to_string());
+                metadata.author = Some(author.as_text());
             }
             if let Some(subject) = info_dict.get("Subject").and_then(|o| o.as_string()) {
-                metadata.subject = subject.as_str().ok().map(|s| s.to_string());
+                metadata.subject = Some(subject.as_text());
             }
             if let Some(keywords) = info_dict.get("Keywords").and_then(|o| o.as_string()) {
-                metadata.keywords = keywords.as_str().ok().map(|s| s.to_string());
+                metadata.keywords = Some(keywords.as_text());
             }
             if let Some(creator) = info_dict.get("Creator").and_then(|o| o.as_string()) {
-                metadata.creator = creator.as_str().ok().map(|s| s.to_string());
+                metadata.creator = Some(creator.as_text());
             }
             if let Some(producer) = info_dict.get("Producer").and_then(|o| o.as_string()) {
-                metadata.producer = producer.as_str().ok().map(|s| s.to_string());
+                metadata.producer = Some(producer.as_text());
             }
         }
 

--- a/oxidize-pdf-core/src/signatures/detection.rs
+++ b/oxidize-pdf-core/src/signatures/detection.rs
@@ -173,7 +173,7 @@ fn extract_signature_field<R: Read + Seek>(
 
     // Extract optional field name from parent field dict
     if let Some(PdfObject::String(name)) = field_dict.get("T") {
-        sig.name = Some(String::from_utf8_lossy(name.as_bytes()).to_string());
+        sig.name = Some(name.to_text());
     }
 
     // Extract optional /SubFilter
@@ -183,22 +183,22 @@ fn extract_signature_field<R: Read + Seek>(
 
     // Extract optional /Reason
     if let Some(PdfObject::String(reason)) = sig_dict.get("Reason") {
-        sig.reason = Some(String::from_utf8_lossy(reason.as_bytes()).to_string());
+        sig.reason = Some(reason.to_text());
     }
 
     // Extract optional /Location
     if let Some(PdfObject::String(loc)) = sig_dict.get("Location") {
-        sig.location = Some(String::from_utf8_lossy(loc.as_bytes()).to_string());
+        sig.location = Some(loc.to_text());
     }
 
     // Extract optional /ContactInfo
     if let Some(PdfObject::String(contact)) = sig_dict.get("ContactInfo") {
-        sig.contact_info = Some(String::from_utf8_lossy(contact.as_bytes()).to_string());
+        sig.contact_info = Some(contact.to_text());
     }
 
     // Extract optional /M (signing time)
     if let Some(PdfObject::String(time)) = sig_dict.get("M") {
-        sig.signing_time = Some(String::from_utf8_lossy(time.as_bytes()).to_string());
+        sig.signing_time = Some(time.to_text());
     }
 
     Ok(Some(sig))

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2728,19 +2728,14 @@ fn multiply_matrix(a: &[f64; 6], b: &[f64; 6]) -> [f64; 6] {
 
 /// Decode a PDF string operand into Rust `String`.
 ///
-/// PDF strings inside marked-content properties (notably `/ActualText`)
-/// may be encoded as:
-///
-/// - **UTF-16BE with BOM**: leading `0xFE 0xFF`, then big-endian 16-bit
-///   code units. This is the canonical encoding for non-ASCII ActualText
-///   (e.g. `fi` ligature, Greek/math symbols). Decoded via `String::from_utf16_lossy`
-///   so invalid surrogate pairs become `U+FFFD` rather than panicking.
-/// - **PDFDocEncoding** (the catch-all for non-BOM bytes). For the ASCII
-///   subset (0x20-0x7E) PDFDocEncoding is identical to Latin-1. We
-///   conservatively map byte-by-byte to `char`. A future revision can
-///   plug in the full PDFDocEncoding table if a real PDF emerges with
-///   high-bit characters in ActualText *without* a UTF-16BE BOM (rare;
-///   most producers emit the BOM when going outside ASCII).
+/// A string inside marked-content properties (notably `/ActualText`) is a PDF
+/// text string like any other, so this is
+/// [`PdfString::to_text`](crate::parser::objects::PdfString::to_text): UTF-16BE
+/// when a byte order mark is present — the canonical encoding for non-ASCII
+/// `/ActualText`, e.g. an `fi` ligature or a Greek symbol — and the WinAnsi
+/// reading of PDFDocEncoding otherwise. Before that helper existed this mapped
+/// non-BOM bytes to `char` one by one, which is Latin-1 and wrong for the
+/// typographic punctuation WinAnsi puts in `0x80..=0x9F`.
 fn decode_pdf_string(bytes: &[u8]) -> String {
     crate::parser::objects::decode_text_string(bytes)
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2742,17 +2742,7 @@ fn multiply_matrix(a: &[f64; 6], b: &[f64; 6]) -> [f64; 6] {
 ///   high-bit characters in ActualText *without* a UTF-16BE BOM (rare;
 ///   most producers emit the BOM when going outside ASCII).
 fn decode_pdf_string(bytes: &[u8]) -> String {
-    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
-        let mut code_units: Vec<u16> = Vec::with_capacity((bytes.len() - 2) / 2);
-        let mut i = 2;
-        while i + 1 < bytes.len() {
-            code_units.push(u16::from_be_bytes([bytes[i], bytes[i + 1]]));
-            i += 2;
-        }
-        String::from_utf16_lossy(&code_units)
-    } else {
-        bytes.iter().map(|&b| b as char).collect()
-    }
+    crate::parser::objects::decode_text_string(bytes)
 }
 
 /// Resolve a `MarkedContentProps` to `(mcid, actual_text)`.

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -1,6 +1,6 @@
 pub mod cid_to_unicode;
 pub mod cmap;
-mod encoding;
+pub(crate) mod encoding;
 pub(crate) mod encoding_cmap;
 pub mod extraction;
 mod extraction_cmap;

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -144,7 +144,7 @@ fn collect_fields(
     let partial = node
         .get("T")
         .and_then(|o| o.as_string())
-        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned());
+        .map(|s| s.to_text());
 
     let full_name = match (&partial, parent_prefix.is_empty()) {
         (Some(t), true) => t.clone(),
@@ -434,7 +434,7 @@ fn rect_of(dict: &PdfDictionary) -> Option<[f64; 4]> {
 fn da_of(dict: &PdfDictionary) -> Option<String> {
     dict.get("DA")
         .and_then(|o| o.as_string())
-        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+        .map(|s| s.to_text())
 }
 
 /// Build the `/AP /N` content stream for a single-line text widget: a

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -894,8 +894,11 @@ impl<W: Write> PdfWriter<W> {
             PdfObj::Boolean(b) => WriterObj::Boolean(*b),
             PdfObj::Integer(i) => WriterObj::Integer(*i),
             PdfObj::Real(f) => WriterObj::Real(*f),
+            // As in `overlay`: the writer's string is a Rust `String`, so a
+            // binary string cannot survive; decoding as text keeps the text
+            // strings of a copied object readable (issue #459).
             PdfObj::String(s) => {
-                WriterObj::String(String::from_utf8_lossy(s.as_bytes()).to_string())
+                WriterObj::String(crate::parser::objects::decode_text_string(s.as_bytes()))
             }
             PdfObj::Name(n) => WriterObj::Name(n.as_str().to_string()),
             PdfObj::Array(arr) => {

--- a/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
+++ b/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
@@ -1,0 +1,269 @@
+//! Issue #459, second defect: a literal string must reach the object model as
+//! the bytes the file holds.
+//!
+//! The lexer ran every literal `(...)` string through an encoding-recovery pass
+//! that decodes the bytes as text and re-encodes the result as UTF-8. For a text
+//! string that is harmless; for a binary one it is destruction. The `/U` entry of
+//! the document in #459 is a literal string, and byte `0xB2` came back as the two
+//! bytes `0xC2 0xB2`, which grew the 127-byte entry to 151 bytes and made the
+//! hash comparison meaningless — so a correct empty password was rejected.
+//!
+//! Hex strings never went through that pass, which is why every qpdf-generated
+//! fixture in this suite passed while real Acrobat output failed.
+
+use oxidize_pdf::parser::{PdfObject, PdfReader};
+use std::io::Write;
+
+/// Escapes a byte string into PDF literal-string syntax.
+fn literal(bytes: &[u8]) -> Vec<u8> {
+    let mut out = vec![b'('];
+    for &b in bytes {
+        match b {
+            b'(' | b')' | b'\\' => {
+                out.push(b'\\');
+                out.push(b);
+            }
+            0x20..=0x7E => out.push(b),
+            _ => out.extend_from_slice(format!("\\{:03o}", b).as_bytes()),
+        }
+    }
+    out.push(b')');
+    out
+}
+
+/// Assembles a one-page PDF from object bodies, with a correct xref table.
+///
+/// `objects[i]` is the body of object `i + 1`; `trailer_extra` is appended to the
+/// trailer dictionary.
+fn build_pdf(objects: &[Vec<u8>], trailer_extra: &str) -> Vec<u8> {
+    let mut pdf = Vec::from(&b"%PDF-1.7\n"[..]);
+    let mut offsets = Vec::with_capacity(objects.len());
+
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        write!(pdf, "{} 0 obj\n", i + 1).unwrap();
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    let xref_offset = pdf.len();
+    write!(pdf, "xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).unwrap();
+    for offset in &offsets {
+        write!(pdf, "{:010} 00000 n \n", offset).unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R {} >>\nstartxref\n{}\n%%EOF\n",
+        objects.len() + 1,
+        trailer_extra,
+        xref_offset
+    )
+    .unwrap();
+    pdf
+}
+
+fn catalog_and_page() -> Vec<Vec<u8>> {
+    vec![
+        Vec::from(&b"<< /Type /Catalog /Pages 2 0 R >>"[..]),
+        Vec::from(&b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"[..]),
+        Vec::from(&b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>"[..]),
+    ]
+}
+
+fn write_temp_pdf(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!("oxidize_issue_459_{name}.pdf"));
+    std::fs::write(&path, bytes).expect("write temp pdf");
+    path
+}
+
+/// Reads a hex string entry out of a qpdf-written fixture.
+fn fixture_hex_entry(filename: &str, key: &str) -> Vec<u8> {
+    let pdf = std::fs::read(format!("tests/fixtures/{filename}")).expect("read fixture");
+    let text = String::from_utf8_lossy(&pdf);
+    let needle = format!("{key} <");
+    let start = text.find(&needle).expect("entry present") + needle.len();
+    let end = start + text[start..].find('>').expect("entry terminated");
+    let hex = &text[start..end];
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("hex"))
+        .collect()
+}
+
+#[test]
+fn a_literal_string_reaches_the_object_model_as_the_bytes_the_file_holds() {
+    // Every byte value, so nothing can pass by accident on the ASCII subset.
+    let payload: Vec<u8> = (0u8..=255).collect();
+
+    let mut objects = catalog_and_page();
+    let mut probe = Vec::from(&b"<< /Probe "[..]);
+    probe.extend_from_slice(&literal(&payload));
+    probe.extend_from_slice(b" >>");
+    objects.push(probe);
+
+    let path = write_temp_pdf("all_byte_values", &build_pdf(&objects, ""));
+    let mut reader = PdfReader::open(&path).expect("open");
+    let object = reader.get_object(4, 0).expect("probe object").clone();
+
+    let PdfObject::Dictionary(dict) = object else {
+        panic!("expected a dictionary");
+    };
+    let Some(PdfObject::String(string)) = dict.get("Probe") else {
+        panic!("expected /Probe to be a string");
+    };
+
+    assert_eq!(
+        string.as_bytes().len(),
+        payload.len(),
+        "a literal string must not change length: re-encoding high bytes as UTF-8 grows it"
+    );
+    assert_eq!(
+        string.as_bytes(),
+        payload.as_slice(),
+        "the object model must hold the file's bytes, not a text round-trip of them"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn an_encrypted_document_whose_u_entry_is_a_literal_string_unlocks_with_the_empty_password() {
+    // Real R6 entries from a qpdf fixture whose user password is empty, written
+    // the way Acrobat writes them: literal strings, zero-padded to 127 bytes.
+    let mut u = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/U");
+    let mut o = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/O");
+    let ue = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/UE");
+    let oe = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/OE");
+    let perms = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/Perms");
+    u.resize(127, 0);
+    o.resize(127, 0);
+
+    let mut encrypt = Vec::from(
+        &b"<< /Filter /Standard /V 5 /R 6 /Length 256 /P -4 /StmF /StdCF /StrF /StdCF /CF << /StdCF << /CFM /AESV3 /Length 32 >> >> /U "[..],
+    );
+    encrypt.extend_from_slice(&literal(&u));
+    encrypt.extend_from_slice(b" /O ");
+    encrypt.extend_from_slice(&literal(&o));
+    encrypt.extend_from_slice(b" /UE ");
+    encrypt.extend_from_slice(&literal(&ue));
+    encrypt.extend_from_slice(b" /OE ");
+    encrypt.extend_from_slice(&literal(&oe));
+    encrypt.extend_from_slice(b" /Perms ");
+    encrypt.extend_from_slice(&literal(&perms));
+    encrypt.extend_from_slice(b" >>");
+
+    let mut objects = catalog_and_page();
+    objects.push(encrypt);
+
+    let pdf = build_pdf(&objects, "/Encrypt 4 0 R /ID [<0102030405060708090a0b0c0d0e0f10> <0102030405060708090a0b0c0d0e0f10>]");
+    let path = write_temp_pdf("literal_u_entry", &pdf);
+
+    let mut reader = PdfReader::open(&path).expect("open");
+    assert!(reader.is_encrypted(), "the document declares /Encrypt");
+    reader
+        .unlock("")
+        .expect("the empty password is this document's user password");
+    assert!(
+        reader.is_unlocked(),
+        "unlocking must leave the reader holding the file key"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn a_malformed_encryption_entry_is_reported_as_such_instead_of_as_a_wrong_password() {
+    // 40 bytes cannot hold the 32-byte hash and both 8-byte salts, so this
+    // document cannot be authenticated at all. Reporting `WrongPassword` sends
+    // the reader hunting for a password that does not exist — it is what hid the
+    // real cause of #459 from the reporter.
+    let mut u = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/U");
+    u.truncate(40);
+    let o = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/O");
+    let ue = fixture_hex_entry("encrypted_aes256_r6_empty_user.pdf", "/UE");
+
+    let mut encrypt = Vec::from(
+        &b"<< /Filter /Standard /V 5 /R 6 /Length 256 /P -4 /StmF /StdCF /StrF /StdCF /CF << /StdCF << /CFM /AESV3 /Length 32 >> >> /U "[..],
+    );
+    encrypt.extend_from_slice(&literal(&u));
+    encrypt.extend_from_slice(b" /O ");
+    encrypt.extend_from_slice(&literal(&o));
+    encrypt.extend_from_slice(b" /UE ");
+    encrypt.extend_from_slice(&literal(&ue));
+    encrypt.extend_from_slice(b" >>");
+
+    let mut objects = catalog_and_page();
+    objects.push(encrypt);
+
+    let pdf = build_pdf(&objects, "/Encrypt 4 0 R");
+    let path = write_temp_pdf("truncated_u_entry", &pdf);
+
+    let mut reader = PdfReader::open(&path).expect("open");
+    let error = reader
+        .unlock("")
+        .expect_err("a 40-byte U entry cannot authenticate anything");
+    let message = error.to_string();
+    assert!(
+        !message.to_lowercase().contains("wrong password"),
+        "a structurally unusable entry is not a password mismatch, got: {message}"
+    );
+    assert!(
+        message.contains("48"),
+        "the error must say what is wrong with the entry, got: {message}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn latin1_metadata_still_decodes_to_text_when_the_bytes_are_preserved() {
+    // "Título — año" in Latin-1: the bytes a producer writes without a UTF-16 BOM.
+    let latin1: Vec<u8> = vec![
+        b'T', 0xED, b't', b'u', b'l', b'o', b' ', 0x97, b' ', b'a', 0xF1, b'o',
+    ];
+
+    let mut objects = catalog_and_page();
+    let mut info = Vec::from(&b"<< /Title "[..]);
+    info.extend_from_slice(&literal(&latin1));
+    info.extend_from_slice(b" >>");
+    objects.push(info);
+
+    let path = write_temp_pdf("latin1_title", &build_pdf(&objects, "/Info 4 0 R"));
+    let mut reader = PdfReader::open(&path).expect("open");
+    let metadata = reader.metadata().expect("metadata");
+
+    assert_eq!(
+        metadata.title.as_deref(),
+        Some("Título — año"),
+        "a text string without a BOM is PDFDocEncoding: preserving raw bytes must not lose the text"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn utf16be_metadata_decodes_through_the_same_boundary() {
+    // "Año" as UTF-16BE with the BOM PDF text strings use.
+    let mut utf16 = vec![0xFE, 0xFF];
+    for unit in "Año".encode_utf16() {
+        utf16.extend_from_slice(&unit.to_be_bytes());
+    }
+
+    let mut objects = catalog_and_page();
+    let mut info = Vec::from(&b"<< /Author "[..]);
+    info.extend_from_slice(&literal(&utf16));
+    info.extend_from_slice(b" >>");
+    objects.push(info);
+
+    let path = write_temp_pdf("utf16_author", &build_pdf(&objects, "/Info 4 0 R"));
+    let mut reader = PdfReader::open(&path).expect("open");
+    let metadata = reader.metadata().expect("metadata");
+
+    assert_eq!(
+        metadata.author.as_deref(),
+        Some("Año"),
+        "a BOM-prefixed text string must decode as UTF-16BE, not surface as raw bytes"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
+++ b/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
@@ -216,8 +216,10 @@ fn a_malformed_encryption_entry_is_reported_as_such_instead_of_as_a_wrong_passwo
 }
 
 #[test]
-fn latin1_metadata_still_decodes_to_text_when_the_bytes_are_preserved() {
-    // "Título — año" in Latin-1: the bytes a producer writes without a UTF-16 BOM.
+fn winansi_metadata_still_decodes_to_text_when_the_bytes_are_preserved() {
+    // "Título — año" in WinAnsi: the bytes a producer writes without a UTF-16
+    // BOM. The em dash at 0x97 is why this is WinAnsi and not ISO-8859-1, which
+    // has a C1 control character in that slot.
     let latin1: Vec<u8> = vec![
         b'T', 0xED, b't', b'u', b'l', b'o', b' ', 0x97, b' ', b'a', 0xF1, b'o',
     ];

--- a/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
+++ b/oxidize-pdf-core/tests/issue_459_literal_binary_string_test.rs
@@ -41,15 +41,15 @@ fn build_pdf(objects: &[Vec<u8>], trailer_extra: &str) -> Vec<u8> {
 
     for (i, body) in objects.iter().enumerate() {
         offsets.push(pdf.len());
-        write!(pdf, "{} 0 obj\n", i + 1).unwrap();
+        writeln!(pdf, "{} 0 obj", i + 1).unwrap();
         pdf.extend_from_slice(body);
         pdf.extend_from_slice(b"\nendobj\n");
     }
 
     let xref_offset = pdf.len();
-    write!(pdf, "xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).unwrap();
+    writeln!(pdf, "xref\n0 {}\n0000000000 65535 f ", objects.len() + 1).unwrap();
     for offset in &offsets {
-        write!(pdf, "{:010} 00000 n \n", offset).unwrap();
+        writeln!(pdf, "{:010} 00000 n ", offset).unwrap();
     }
     write!(
         pdf,

--- a/oxidize-pdf-core/tests/issue_459_padded_password_entries_test.rs
+++ b/oxidize-pdf-core/tests/issue_459_padded_password_entries_test.rs
@@ -1,0 +1,313 @@
+//! Issue #459: `/U` and `/O` padded past 48 bytes must still authenticate.
+//!
+//! ISO 32000-2 §7.6.4.3.3 defines the R5/R6 `/U` and `/O` entries as 48 bytes:
+//! a 32-byte hash, an 8-byte validation salt and an 8-byte key salt. Acrobat
+//! nonetheless writes them as 127-byte strings, zero-padded past byte 48 — the
+//! length the pre-R5 revisions used. A conforming reader takes the first 48
+//! bytes and ignores the rest; rejecting the entry on its length turns a correct
+//! password into `WrongPassword`, which is what the reporter of #459 saw on a
+//! public document that opens in every browser.
+//!
+//! The oracle here is a qpdf-generated fixture: every assertion compares the
+//! padded entry against the same entry unpadded, so a test can only pass by
+//! deriving the same file encryption key from both.
+
+use oxidize_pdf::parser::{EncryptionHandler, PdfDictionary, PdfName, PdfObject, PdfString};
+
+const FIXTURES_DIR: &str = "tests/fixtures";
+
+/// The length ISO 32000-2 gives for `/U` and `/O` under R5/R6.
+const SPEC_ENTRY_LEN: usize = 48;
+/// The length Acrobat actually writes, zero-padded past byte 48.
+const ACROBAT_ENTRY_LEN: usize = 127;
+
+/// Reads a hex string entry (`/U <a3550...>`) out of a qpdf-written PDF.
+fn hex_entry(pdf: &[u8], key: &str) -> Vec<u8> {
+    let text = String::from_utf8_lossy(pdf);
+    let needle = format!("{} <", key);
+    let start = text
+        .find(&needle)
+        .unwrap_or_else(|| panic!("fixture has no {key} entry"))
+        + needle.len();
+    let end = start
+        + text[start..]
+            .find('>')
+            .unwrap_or_else(|| panic!("unterminated {key} entry"));
+    let hex = &text[start..end];
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("entry is not hex"))
+        .collect()
+}
+
+/// Zero-pads an entry to the 127 bytes Acrobat writes.
+fn padded_to_acrobat_length(entry: &[u8]) -> Vec<u8> {
+    assert_eq!(
+        entry.len(),
+        SPEC_ENTRY_LEN,
+        "fixture entry should be the spec length before padding"
+    );
+    let mut padded = entry.to_vec();
+    padded.resize(ACROBAT_ENTRY_LEN, 0);
+    padded
+}
+
+/// Builds an R5/R6 encryption dictionary from raw entries.
+fn encrypt_dict(r: i64, u: &[u8], o: &[u8], ue: &[u8], oe: &[u8], perms: &[u8]) -> PdfDictionary {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".to_string(),
+        PdfObject::Name(PdfName("Standard".to_string())),
+    );
+    dict.insert("V".to_string(), PdfObject::Integer(5));
+    dict.insert("R".to_string(), PdfObject::Integer(r));
+    dict.insert("Length".to_string(), PdfObject::Integer(256));
+    dict.insert("P".to_string(), PdfObject::Integer(-4));
+    dict.insert(
+        "U".to_string(),
+        PdfObject::String(PdfString::new(u.to_vec())),
+    );
+    dict.insert(
+        "O".to_string(),
+        PdfObject::String(PdfString::new(o.to_vec())),
+    );
+    dict.insert(
+        "UE".to_string(),
+        PdfObject::String(PdfString::new(ue.to_vec())),
+    );
+    dict.insert(
+        "OE".to_string(),
+        PdfObject::String(PdfString::new(oe.to_vec())),
+    );
+    dict.insert(
+        "Perms".to_string(),
+        PdfObject::String(PdfString::new(perms.to_vec())),
+    );
+
+    let mut std_cf = PdfDictionary::new();
+    std_cf.insert(
+        "CFM".to_string(),
+        PdfObject::Name(PdfName("AESV3".to_string())),
+    );
+    std_cf.insert("Length".to_string(), PdfObject::Integer(32));
+    let mut cf = PdfDictionary::new();
+    cf.insert("StdCF".to_string(), PdfObject::Dictionary(std_cf));
+    dict.insert("CF".to_string(), PdfObject::Dictionary(cf));
+    dict.insert(
+        "StmF".to_string(),
+        PdfObject::Name(PdfName("StdCF".to_string())),
+    );
+    dict.insert(
+        "StrF".to_string(),
+        PdfObject::Name(PdfName("StdCF".to_string())),
+    );
+    dict
+}
+
+/// The five encryption entries of a fixture, spec-length.
+struct Entries {
+    u: Vec<u8>,
+    o: Vec<u8>,
+    ue: Vec<u8>,
+    oe: Vec<u8>,
+    perms: Vec<u8>,
+}
+
+fn fixture_entries(filename: &str) -> Entries {
+    let path = format!("{FIXTURES_DIR}/{filename}");
+    let pdf = std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    Entries {
+        u: hex_entry(&pdf, "/U"),
+        o: hex_entry(&pdf, "/O"),
+        ue: hex_entry(&pdf, "/UE"),
+        oe: hex_entry(&pdf, "/OE"),
+        perms: hex_entry(&pdf, "/Perms"),
+    }
+}
+
+/// Unlocks with a user password and returns the recovered file encryption key.
+fn user_key(dict: &PdfDictionary, password: &str) -> Option<Vec<u8>> {
+    let mut handler = EncryptionHandler::new(dict, None).expect("handler");
+    let unlocked = handler
+        .unlock_with_user_password(password)
+        .expect("user unlock must not error on a well-formed dictionary");
+    unlocked.then(|| {
+        handler
+            .encryption_key()
+            .expect("an unlocked handler holds the file key")
+            .as_bytes()
+            .to_vec()
+    })
+}
+
+/// Unlocks with an owner password and returns the recovered file encryption key.
+fn owner_key(dict: &PdfDictionary, password: &str) -> Option<Vec<u8>> {
+    let mut handler = EncryptionHandler::new(dict, None).expect("handler");
+    let unlocked = handler
+        .unlock_with_owner_password(password)
+        .expect("owner unlock must not error on a well-formed dictionary");
+    unlocked.then(|| {
+        handler
+            .encryption_key()
+            .expect("an unlocked handler holds the file key")
+            .as_bytes()
+            .to_vec()
+    })
+}
+
+#[test]
+fn r6_empty_user_password_recovers_the_same_key_from_a_padded_u_entry() {
+    let e = fixture_entries("encrypted_aes256_r6_empty_user.pdf");
+    let spec = encrypt_dict(6, &e.u, &e.o, &e.ue, &e.oe, &e.perms);
+    let acrobat = encrypt_dict(
+        6,
+        &padded_to_acrobat_length(&e.u),
+        &padded_to_acrobat_length(&e.o),
+        &e.ue,
+        &e.oe,
+        &e.perms,
+    );
+
+    let from_spec =
+        user_key(&spec, "").expect("the 48-byte entry authenticates the empty password");
+    let from_acrobat = user_key(&acrobat, "")
+        .expect("a 127-byte entry is the same entry zero-padded: it must authenticate too");
+
+    assert_eq!(
+        from_acrobat, from_spec,
+        "the padded entry must derive the same file key, not merely report success"
+    );
+    assert_eq!(from_spec.len(), 32, "AES-256 file key");
+}
+
+#[test]
+fn r6_owner_password_recovers_the_same_key_from_padded_o_and_u_entries() {
+    let e = fixture_entries("encrypted_aes256_r6_empty_user.pdf");
+    let spec = encrypt_dict(6, &e.u, &e.o, &e.ue, &e.oe, &e.perms);
+    let acrobat = encrypt_dict(
+        6,
+        &padded_to_acrobat_length(&e.u),
+        &padded_to_acrobat_length(&e.o),
+        &e.ue,
+        &e.oe,
+        &e.perms,
+    );
+
+    let from_spec =
+        owner_key(&spec, "owner6_empty").expect("the 48-byte entry authenticates the owner");
+    let from_acrobat =
+        owner_key(&acrobat, "owner6_empty").expect("the padded entry must authenticate the owner");
+
+    assert_eq!(
+        from_acrobat, from_spec,
+        "the owner path hashes the U entry as additional input; padding must not change the key"
+    );
+}
+
+#[test]
+fn r5_empty_user_password_recovers_the_same_key_from_a_padded_u_entry() {
+    let e = fixture_entries("encrypted_aes256_r5_empty_user.pdf");
+    let spec = encrypt_dict(5, &e.u, &e.o, &e.ue, &e.oe, &e.perms);
+    let acrobat = encrypt_dict(
+        5,
+        &padded_to_acrobat_length(&e.u),
+        &padded_to_acrobat_length(&e.o),
+        &e.ue,
+        &e.oe,
+        &e.perms,
+    );
+
+    let from_spec =
+        user_key(&spec, "").expect("the 48-byte entry authenticates the empty password");
+    let from_acrobat = user_key(&acrobat, "").expect("R5 pads the same way R6 does");
+
+    assert_eq!(
+        from_acrobat, from_spec,
+        "same file key from the padded entry"
+    );
+}
+
+#[test]
+fn r5_owner_password_recovers_the_same_key_from_padded_o_and_u_entries() {
+    let e = fixture_entries("encrypted_aes256_r5_empty_user.pdf");
+    let spec = encrypt_dict(5, &e.u, &e.o, &e.ue, &e.oe, &e.perms);
+    let acrobat = encrypt_dict(
+        5,
+        &padded_to_acrobat_length(&e.u),
+        &padded_to_acrobat_length(&e.o),
+        &e.ue,
+        &e.oe,
+        &e.perms,
+    );
+
+    let from_spec =
+        owner_key(&spec, "owner5_empty").expect("the 48-byte entry authenticates the owner");
+    let from_acrobat =
+        owner_key(&acrobat, "owner5_empty").expect("the padded entry must authenticate the owner");
+
+    assert_eq!(
+        from_acrobat, from_spec,
+        "same file key from the padded entry"
+    );
+}
+
+#[test]
+fn a_padded_entry_still_rejects_a_wrong_password() {
+    let e = fixture_entries("encrypted_aes256_r6_empty_user.pdf");
+    let acrobat = encrypt_dict(
+        6,
+        &padded_to_acrobat_length(&e.u),
+        &padded_to_acrobat_length(&e.o),
+        &e.ue,
+        &e.oe,
+        &e.perms,
+    );
+
+    assert_eq!(
+        user_key(&acrobat, "not-the-user-password"),
+        None,
+        "ignoring the padding must not weaken validation"
+    );
+    assert_eq!(
+        owner_key(&acrobat, "not-the-owner-password"),
+        None,
+        "ignoring the padding must not weaken owner validation"
+    );
+}
+
+#[test]
+fn trailing_bytes_of_a_padded_entry_are_ignored_even_when_they_are_not_zero() {
+    let e = fixture_entries("encrypted_aes256_r6_empty_user.pdf");
+    let mut noisy_u = padded_to_acrobat_length(&e.u);
+    let mut noisy_o = padded_to_acrobat_length(&e.o);
+    for (i, byte) in noisy_u[SPEC_ENTRY_LEN..].iter_mut().enumerate() {
+        *byte = (i as u8) ^ 0xA5;
+    }
+    for (i, byte) in noisy_o[SPEC_ENTRY_LEN..].iter_mut().enumerate() {
+        *byte = (i as u8) ^ 0x5A;
+    }
+    let noisy = encrypt_dict(6, &noisy_u, &noisy_o, &e.ue, &e.oe, &e.perms);
+    let spec = encrypt_dict(6, &e.u, &e.o, &e.ue, &e.oe, &e.perms);
+
+    assert_eq!(
+        user_key(&noisy, ""),
+        user_key(&spec, ""),
+        "only the first 48 bytes are defined; whatever follows must not reach the hash"
+    );
+}
+
+#[test]
+fn an_entry_shorter_than_the_spec_length_is_reported_as_malformed_not_as_a_wrong_password() {
+    let e = fixture_entries("encrypted_aes256_r6_empty_user.pdf");
+    let truncated = encrypt_dict(6, &e.u[..40], &e.o, &e.ue, &e.oe, &e.perms);
+    let mut handler = EncryptionHandler::new(&truncated, None).expect("handler");
+
+    let error = handler.unlock_with_user_password("").expect_err(
+        "a 40-byte U entry cannot hold the salts: this is malformed, not a bad password",
+    );
+    let message = error.to_string();
+    assert!(
+        message.contains("48"),
+        "the error must name the length requirement, got: {message}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_459_text_string_consumers_test.rs
+++ b/oxidize-pdf-core/tests/issue_459_text_string_consumers_test.rs
@@ -1,0 +1,159 @@
+//! Issue #459: the consumers that read a PDF string as text must decode it.
+//!
+//! Preserving the bytes of a literal string (see
+//! `issue_459_literal_binary_string_test.rs`) moves the decoding responsibility
+//! to whoever reads the string as text. Every consumer that used to receive
+//! bytes the lexer had already turned into UTF-8 now receives the file's bytes,
+//! and `String::from_utf8_lossy` on PDFDocEncoding text yields `U+FFFD` for
+//! every accented character. These are the two places where that is not
+//! cosmetic: an AcroForm field is addressed *by name*, so a mangled name cannot
+//! be filled at all, and signature metadata is shown to a person.
+
+use oxidize_pdf::signatures::detect_signature_fields;
+use oxidize_pdf::writer::IncrementalFormFiller;
+use std::io::{Cursor, Write};
+
+/// Escapes a byte string into PDF literal-string syntax.
+fn literal(bytes: &[u8]) -> Vec<u8> {
+    let mut out = vec![b'('];
+    for &b in bytes {
+        match b {
+            b'(' | b')' | b'\\' => {
+                out.push(b'\\');
+                out.push(b);
+            }
+            0x20..=0x7E => out.push(b),
+            _ => out.extend_from_slice(format!("\\{:03o}", b).as_bytes()),
+        }
+    }
+    out.push(b')');
+    out
+}
+
+/// Encodes text as the PDFDocEncoding bytes a producer writes without a BOM.
+///
+/// Every character used here lives in the Latin-1 range, where PDFDocEncoding
+/// and Latin-1 agree, so this is a byte-per-character mapping.
+fn pdfdoc(text: &str) -> Vec<u8> {
+    text.chars()
+        .map(|c| {
+            let code = c as u32;
+            assert!(code <= 0xFF, "{c:?} is outside the Latin-1 range");
+            code as u8
+        })
+        .collect()
+}
+
+/// Assembles a PDF from object bodies, with a correct xref table.
+fn build_pdf(objects: &[Vec<u8>], trailer_extra: &str) -> Vec<u8> {
+    let mut pdf = Vec::from(&b"%PDF-1.7\n"[..]);
+    let mut offsets = Vec::with_capacity(objects.len());
+
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        writeln!(pdf, "{} 0 obj", i + 1).unwrap();
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    let xref_offset = pdf.len();
+    writeln!(pdf, "xref\n0 {}\n0000000000 65535 f ", objects.len() + 1).unwrap();
+    for offset in &offsets {
+        writeln!(pdf, "{:010} 00000 n ", offset).unwrap();
+    }
+    write!(
+        pdf,
+        "trailer\n<< /Size {} /Root 1 0 R {} >>\nstartxref\n{}\n%%EOF\n",
+        objects.len() + 1,
+        trailer_extra,
+        xref_offset
+    )
+    .unwrap();
+    pdf
+}
+
+#[test]
+fn an_acroform_field_named_with_accents_is_still_addressable_by_that_name() {
+    let field_name = "Año de ejercicio";
+
+    let mut field = Vec::from(
+        &b"<< /Type /Annot /Subtype /Widget /FT /Tx /Ff 0 /Rect [100 100 300 130] /P 3 0 R /T "[..],
+    );
+    field.extend_from_slice(&literal(&pdfdoc(field_name)));
+    field.extend_from_slice(b" >>");
+
+    // An incremental fill requires /AcroForm to be an indirect reference, so it
+    // can be rewritten without rewriting the catalog.
+    let objects = vec![
+        Vec::from(&b"<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>"[..]),
+        Vec::from(&b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"[..]),
+        Vec::from(&b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [4 0 R] >>"[..]),
+        field,
+        Vec::from(&b"<< /Fields [4 0 R] >>"[..]),
+    ];
+    let pdf = build_pdf(&objects, "");
+
+    let filled = IncrementalFormFiller::new(&pdf)
+        .fill(field_name, "2026")
+        .expect("a field is addressed by the name the file gives it");
+
+    assert!(
+        filled.len() > pdf.len(),
+        "filling appends an incremental update"
+    );
+    let appended = String::from_utf8_lossy(&filled[pdf.len()..]).into_owned();
+    assert!(
+        appended.contains("2026"),
+        "the appended update must carry the new value, got: {appended}"
+    );
+
+    // The mangled form is what a lossy conversion produces: it must not resolve.
+    assert!(
+        IncrementalFormFiller::new(&pdf)
+            .fill("A\u{FFFD}o de ejercicio", "2026")
+            .is_err(),
+        "a name that is not in the document must not match a field"
+    );
+}
+
+#[test]
+fn signature_metadata_written_in_pdfdocencoding_reaches_the_caller_as_text() {
+    let name = "Firma del Interventor";
+    let reason = "Revisión anual de cuentas";
+    let location = "Bilbao, Bizkaia";
+    let contact = "interventoría@example.org";
+
+    let mut sig_dict = Vec::from(
+        &b"<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached /ByteRange [0 100 200 300] /Contents <deadbeef> /Reason "[..],
+    );
+    sig_dict.extend_from_slice(&literal(&pdfdoc(reason)));
+    sig_dict.extend_from_slice(b" /Location ");
+    sig_dict.extend_from_slice(&literal(&pdfdoc(location)));
+    sig_dict.extend_from_slice(b" /ContactInfo ");
+    sig_dict.extend_from_slice(&literal(&pdfdoc(contact)));
+    sig_dict.extend_from_slice(b" >>");
+
+    let mut field = Vec::from(&b"<< /FT /Sig /V 5 0 R /T "[..]);
+    field.extend_from_slice(&literal(&pdfdoc(name)));
+    field.extend_from_slice(b" >>");
+
+    let objects = vec![
+        Vec::from(&b"<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] >> >>"[..]),
+        Vec::from(&b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"[..]),
+        Vec::from(&b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>"[..]),
+        field,
+        sig_dict,
+    ];
+    let pdf = build_pdf(&objects, "");
+
+    let mut reader =
+        oxidize_pdf::parser::PdfReader::new(Cursor::new(pdf.as_slice())).expect("open");
+    let signatures = detect_signature_fields(&mut reader).expect("detect signatures");
+
+    assert_eq!(signatures.len(), 1, "the document holds one signed field");
+    let signature = &signatures[0];
+    assert_eq!(signature.name.as_deref(), Some(name));
+    assert_eq!(signature.reason.as_deref(), Some(reason));
+    assert_eq!(signature.location.as_deref(), Some(location));
+    assert_eq!(signature.contact_info.as_deref(), Some(contact));
+}


### PR DESCRIPTION
A public annual report that opens in every browser was rejected with
`WrongPassword` for its correct empty password. Three defects stacked on top of
each other; the one in the issue title was the least of them.

## The lexer destroyed binary strings

`read_literal_string` ran every `(...)` string through an encoding-recovery pass
that decoded the bytes as text and re-encoded the result as UTF-8. For a text
string that is harmless; for a binary one it is destruction — byte `0xB2` came
back as `0xC2 0xB2`, which grew the document's 127-byte `/U` entry to 151 bytes
and made the hash comparison meaningless.

Literal strings now reach the object model unchanged. The strings a PDF defines
as *text* are decoded where they are read as text, by the new
`PdfString::to_text`: UTF-16BE when a byte order mark is present, PDFDocEncoding
otherwise (ISO 32000-1 §7.9.2.2).

That pass never touched hex strings, which is why every qpdf-generated fixture in
this suite passed while real Acrobat output failed. All the fixtures are qpdf.

## `/U` and `/O` longer than 48 bytes were rejected instead of read

ISO 32000-2 §7.6.4.3.3 defines the R5/R6 entries as 48 bytes — a 32-byte hash and
two 8-byte salts — but Acrobat writes them as 127-byte strings, zero-padded past
byte 48, and conforming readers take the prefix. Both revisions, on the user and
the owner path, now read the defined 48 bytes and ignore what follows. Shorter
than 48 stays an error: the salts would not fit. The `compute_*` functions build
our own entries and keep requiring exactly 48.

## A malformed dictionary was reported as a wrong password

`PdfReader::unlock` collapsed every failure from the encryption handler into
`WrongPassword` via `unwrap_or(false)`, so the reporter was told to find a
password for a document whose empty password was already correct. Errors now
surface with their own message; a password that merely does not match still
yields `WrongPassword`, and the owner password still gets its turn before any
error is raised.

## Consequences beyond the reported symptom

Preserving the bytes moved the decoding responsibility to whoever reads a string
as text, so those consumers decode explicitly now: document metadata, AcroForm
field names (`/T`) and default appearance strings (`/DA`), and the `/T`,
`/Reason`, `/Location`, `/ContactInfo` and `/M` of a signature. A field is
addressed *by name*, so leaving `/T` undecoded would have made every field with
an accented name unfillable.

Two entries improve as a side effect. UTF-16BE `/Title` and `/Author` decode
instead of surfacing as `þÿ`-prefixed mojibake. And `/ActualText` no longer maps
bytes to `char` one by one — that is Latin-1, and wrong for the typographic
punctuation WinAnsi puts in `0x80..=0x9F`.

The `/V` of a text field and of a checkbox deliberately stay on
`from_utf8_lossy`: this crate writes those bytes a few lines earlier as the UTF-8
of the caller's `&str` and never reads them from the file, so the lossy
conversion is their exact inverse there.

## Verification

- The reporting document: unlocks with the empty password, 20 pages, real text
  extracted. It is not committed — 3.9 MB — so the regression tests build the
  same conditions from the qpdf fixtures already in the repo.
- 14 new tests across three files, each watched failing first.
- Integration suite 9123 passed / 0 failed; unit tests 6678/0; doctests 215/0.
- `cargo fmt --check` clean; `cargo build --workspace --all-features` with no
  warnings; clippy clean on `src/` and on the three new test files.
- Two quality reviews. The first found a real regression in the text consumers
  above and its verdict was "not ready"; the second, over the whole branch,
  passed with only documentation corrections, which are in the third commit.

Pre-existing and unrelated: `cargo clippy --workspace --all-targets` fails on
four `approx_constant` literals in `tests/parser_objects_coverage.rs`, identical
on `develop`.

## Follow-ups, not in this PR

- `parser::encoding` (`EnhancedDecoder` and friends, 618 lines) lost its only
  caller when the recovery pass went away, but it is public API — removing it is
  a breaking change.
- This crate writes an AcroForm `/V` as raw UTF-8, which is not a valid PDF text
  string; a value with accents written by us reads back wrong in other viewers.
- The writer's object model holds a Rust `String`, so a binary string cannot
  survive a parser-to-writer conversion. Documented in place.

addresses #459
