### PR TITLE
fix(operations): preserve page content verbatim instead of reconstructing it (#453)

### DIFF
--- a/oxidize-pdf-core/src/operations/page_extraction.rs
+++ b/oxidize-pdf-core/src/operations/page_extraction.rs
@@ -5,7 +5,7 @@
 //! API specifically for page extraction use cases.
 
 use super::{OperationError, OperationResult, PageRange};
-use crate::parser::{ContentOperation, ContentParser, ParsedPage, PdfDocument, PdfReader};
+use crate::parser::{ParsedPage, PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -155,155 +155,17 @@ impl PageExtractor {
         Ok(doc)
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources (fonts, images,
+    /// XObjects) unchanged via [`Page::from_parsed_with_content`], the path
+    /// `merge` uses, instead of re-emitting the page through the high-level API
+    /// — which mapped every font to one of the standard 14, decoded bytes with
+    /// `from_utf8`, and dropped images and unrecognized operators (#453).
+    /// `/Rotate` is carried over by `from_parsed_with_content`.
     fn convert_page(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Apply rotation if needed
-        if parsed_page.rotation != 0 {
-            page.set_rotation(parsed_page.rotation);
-        }
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    // Log warning but continue with other streams
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // Handle annotations if preservation is enabled
-        if self.options.preserve_annotations {
-            // Note: Annotation preservation requires annotation support implementation
-        }
-
-        // Handle form fields if preservation is enabled
-        if self.options.preserve_forms {
-            // Note: Form field preservation requires form support implementation
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page extracted]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // This is a simplified implementation that handles basic text and graphics
-        // A full implementation would handle all PDF operators
-
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    current_font = self.map_font_name(name);
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(x, y) => {
-                    current_x = *x;
-                    current_y = *y;
-                }
-                ContentOperation::ShowText(text) => {
-                    if text_object {
-                        if let Ok(text_str) = String::from_utf8(text.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text_str)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Rectangle(x, y, w, h) => {
-                    page.graphics()
-                        .rectangle(*x as f64, *y as f64, *w as f64, *h as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::Color::rgb(*r as f64, *g as f64, *b as f64));
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_fill_color(crate::Color::rgb(*r as f64, *g as f64, *b as f64));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                _ => {
-                    // Other operators not yet implemented
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Map PDF font names to our font enum
-    fn map_font_name(&self, name: &str) -> crate::text::Font {
-        match name {
-            "Times-Roman" => crate::text::Font::TimesRoman,
-            "Times-Bold" => crate::text::Font::TimesBold,
-            "Times-Italic" => crate::text::Font::TimesItalic,
-            "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-            "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-            "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-            "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-            "Courier" => crate::text::Font::Courier,
-            "Courier-Bold" => crate::text::Font::CourierBold,
-            "Courier-Oblique" => crate::text::Font::CourierOblique,
-            "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-            _ => crate::text::Font::Helvetica, // Default fallback
-        }
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 
@@ -643,38 +505,6 @@ mod tests {
         // When metadata is not preserved, the document should have default/empty metadata
         assert_eq!(extracted_doc.pages.len(), 1);
         // Note: Document doesn't have getter methods for metadata in current API
-    }
-
-    #[test]
-    fn test_map_font_name() {
-        let temp_dir = TempDir::new().unwrap();
-        let mut doc = create_test_pdf("Test", 1);
-        let path = save_test_pdf(&mut doc, &temp_dir, "test.pdf");
-
-        let reader = PdfReader::open(&path).unwrap();
-        let document = PdfDocument::new(reader);
-        let extractor = PageExtractor::new(document);
-
-        assert_eq!(
-            extractor.map_font_name("Times-Roman"),
-            crate::text::Font::TimesRoman
-        );
-        assert_eq!(
-            extractor.map_font_name("Times-Bold"),
-            crate::text::Font::TimesBold
-        );
-        assert_eq!(
-            extractor.map_font_name("Helvetica-Bold"),
-            crate::text::Font::HelveticaBold
-        );
-        assert_eq!(
-            extractor.map_font_name("Courier"),
-            crate::text::Font::Courier
-        );
-        assert_eq!(
-            extractor.map_font_name("Unknown"),
-            crate::text::Font::Helvetica
-        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -4,7 +4,7 @@
 
 use super::{OperationError, OperationResult};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -124,123 +124,16 @@ impl PageReorderer {
         Ok(())
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources unchanged via
+    /// [`Page::from_parsed_with_content`] (the path `merge` uses) instead of
+    /// re-emitting the page through the high-level API, which mapped every font
+    /// to one of the standard 14, decoded bytes with `from_utf8_lossy`, and
+    /// dropped images, XObjects and unrecognized operators (#453).
     fn convert_page(&self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page reordered - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica,
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text) => {
-                    if text_object && !text.is_empty() {
-                        page.text()
-                            .set_font(current_font.clone(), current_font_size as f64)
-                            .at(current_x as f64, current_y as f64)
-                            .write(&String::from_utf8_lossy(text))
-                            .map_err(OperationError::PdfError)?;
-                    }
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::Rectangle(x, y, w, h) => {
-                    page.graphics()
-                        .rectangle(*x as f64, *y as f64, *w as f64, *h as f64);
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 

--- a/oxidize-pdf-core/src/operations/rotate.rs
+++ b/oxidize-pdf-core/src/operations/rotate.rs
@@ -4,7 +4,7 @@
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -73,7 +73,11 @@ pub struct RotateOptions {
     pub pages: PageRange,
     /// Rotation angle
     pub angle: RotationAngle,
-    /// Whether to preserve the original page size (vs adjusting for rotated content)
+    /// No longer has any effect (since the switch to the native `/Rotate`
+    /// attribute in #453). Rotation is now a viewing transform: the stored
+    /// MediaBox never changes under `/Rotate` (ISO 32000-1 §7.7.3.3), so there
+    /// is no page-size adjustment to opt out of. Retained for API
+    /// compatibility; a candidate for removal in the next major release.
     pub preserve_page_size: bool,
 }
 
@@ -145,245 +149,35 @@ impl PageRotator {
         Ok(output_doc)
     }
 
-    /// Create a rotated copy of a page
+    /// Create a rotated copy of a page using the native `/Rotate` attribute.
+    ///
+    /// Rotation in PDF is a viewing transform, not a content edit: the page's
+    /// `/Rotate` entry (a multiple of 90) tells the viewer how to display the
+    /// unchanged content and MediaBox (ISO 32000-1 §7.7.3.3). So the content is
+    /// copied verbatim via [`Page::from_parsed_with_content`] and the new angle
+    /// is composed onto whatever rotation the source already had.
+    ///
+    /// The former implementation baked a rotation matrix into a *reconstructed*
+    /// content stream, which lost images and mangled text (#453) and, unlike
+    /// `/Rotate`, could not be undone losslessly. `preserve_page_size` no longer
+    /// has any effect: `/Rotate` never changes the stored page size.
     fn create_rotated_page(
         &mut self,
         parsed_page: &ParsedPage,
         angle: RotationAngle,
-        preserve_size: bool,
+        _preserve_page_size: bool,
     ) -> OperationResult<Page> {
-        // Calculate the effective rotation
-        let current_rotation = parsed_page.rotation;
-        let _new_rotation = (current_rotation + angle.to_degrees()) % 360;
-
-        // Get original dimensions
-        let orig_width = parsed_page.media_box[2] - parsed_page.media_box[0];
-        let orig_height = parsed_page.media_box[3] - parsed_page.media_box[1];
-
-        // Calculate new dimensions based on rotation
-        let (new_width, new_height) = if preserve_size {
-            (orig_width, orig_height)
-        } else {
-            match angle {
-                RotationAngle::None | RotationAngle::Rotate180 => (orig_width, orig_height),
-                RotationAngle::Clockwise90 | RotationAngle::Clockwise270 => {
-                    (orig_height, orig_width)
-                }
-            }
-        };
-
-        let mut page = Page::new(new_width, new_height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
+        let mut page = Page::from_parsed_with_content(parsed_page, &self.document)
             .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Add rotation transformation
-        match angle {
-            RotationAngle::None => {
-                // No rotation needed
-            }
-            RotationAngle::Clockwise90 => {
-                // Rotate 90 degrees clockwise
-                // Transform: x' = y, y' = width - x
-                page.graphics()
-                    .save_state()
-                    .transform(0.0, 1.0, -1.0, 0.0, new_width, 0.0);
-            }
-            RotationAngle::Rotate180 => {
-                // Rotate 180 degrees
-                // Transform: x' = width - x, y' = height - y
-                page.graphics()
-                    .save_state()
-                    .transform(-1.0, 0.0, 0.0, -1.0, new_width, new_height);
-            }
-            RotationAngle::Clockwise270 => {
-                // Rotate 270 degrees clockwise (90 counter-clockwise)
-                // Transform: x' = height - y, y' = x
-                page.graphics()
-                    .save_state()
-                    .transform(0.0, -1.0, 1.0, 0.0, 0.0, new_height);
-            }
-        }
-
-        // Parse and process content streams with rotation
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    // Process the operators with rotation transformation already applied
-                    self.process_operators_with_rotation(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, new_height - 50.0)
-                .write(&format!(
-                    "[Page rotated {} degrees - content reconstruction in progress]",
-                    angle.to_degrees()
-                ))
-                .map_err(OperationError::PdfError)?;
-        }
-
-        // Restore graphics state if we transformed
-        if angle != RotationAngle::None {
-            page.graphics().restore_state();
-        }
-
+        let combined = (parsed_page.rotation + angle.to_degrees()).rem_euclid(360);
+        page.set_rotation(combined);
         Ok(page)
     }
 
-    /// Create a copy of a page without rotation
+    /// Copy a page unchanged, content and existing `/Rotate` preserved verbatim.
     fn create_page_copy(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in content_streams {
-            match ContentParser::parse_content(&stream_data) {
-                Ok(operators) => {
-                    self.process_operators_with_rotation(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page copied - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators (rotation transformation already applied via graphics state)
-    fn process_operators_with_rotation(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica,
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text_bytes) => {
-                    if text_object {
-                        if let Ok(text) = String::from_utf8(text_bytes.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::Rectangle(x, y, width, height) => {
-                    page.graphics()
-                        .rect(*x as f64, *y as f64, *width as f64, *height as f64);
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics().set_fill_color(crate::graphics::Color::Rgb(
-                        *r as f64, *g as f64, *b as f64,
-                    ));
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::graphics::Color::Rgb(
-                            *r as f64, *g as f64, *b as f64,
-                        ));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                // Graphics state operators are important for rotation
-                ContentOperation::SaveGraphicsState => {
-                    page.graphics().save_state();
-                }
-                ContentOperation::RestoreGraphicsState => {
-                    page.graphics().restore_state();
-                }
-                ContentOperation::SetTransformMatrix(a, b, c, d, e, f) => {
-                    page.graphics().transform(
-                        *a as f64, *b as f64, *c as f64, *d as f64, *e as f64, *f as f64,
-                    );
-                }
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 

--- a/oxidize-pdf-core/src/operations/split.rs
+++ b/oxidize-pdf-core/src/operations/split.rs
@@ -5,7 +5,7 @@
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -170,145 +170,18 @@ impl PdfSplitter {
         Ok(())
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources (fonts, images,
+    /// XObjects) unchanged via [`Page::from_parsed_with_content`], the same path
+    /// `merge` uses. The former implementation re-emitted the page through the
+    /// high-level API — mapping every font to one of the standard 14, decoding
+    /// bytes with `from_utf8`, and dropping every operator it did not recognize
+    /// — so it lost images and mangled any non-ASCII or CID-encoded text
+    /// (#453). `/Rotate` is carried over by `from_parsed_with_content`.
     fn convert_page(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Set rotation if needed
-        if parsed_page.rotation != 0 {
-            page.set_rotation(parsed_page.rotation);
-        }
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    // Process the operators to recreate content
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    // If parsing fails, fall back to placeholder
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page extracted - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica, // Default fallback
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text_bytes) => {
-                    if text_object {
-                        // Convert bytes to string (assuming ASCII/UTF-8 for now)
-                        if let Ok(text) = String::from_utf8(text_bytes.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::Rectangle(x, y, width, height) => {
-                    page.graphics()
-                        .rect(*x as f64, *y as f64, *width as f64, *height as f64);
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics().set_fill_color(crate::graphics::Color::Rgb(
-                        *r as f64, *g as f64, *b as f64,
-                    ));
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::graphics::Color::Rgb(
-                            *r as f64, *g as f64, *b as f64,
-                        ));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                // Note: Additional operators can be implemented on demand
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 
     /// Format the output path based on the pattern

--- a/oxidize-pdf-core/src/streaming/text_streamer.rs
+++ b/oxidize-pdf-core/src/streaming/text_streamer.rs
@@ -54,6 +54,9 @@ pub struct TextStreamer {
     current_font_size: f64,
     current_x: f64,
     current_y: f64,
+    /// Text leading, in unscaled text-space units; consumed by `T*`, `'`, `"`
+    /// and set by `TL`/`TD`.
+    current_leading: f64,
 }
 
 impl TextStreamer {
@@ -66,7 +69,23 @@ impl TextStreamer {
             current_font_size: 12.0,
             current_x: 0.0,
             current_y: 0.0,
+            current_leading: 0.0,
         }
+    }
+
+    /// Emit one text-showing operator's bytes as a chunk at the current
+    /// position, honoring the minimum-font-size filter.
+    fn emit_text(&self, bytes: &[u8], chunks: &mut Vec<TextChunk>) {
+        if self.current_font_size < self.options.min_font_size {
+            return;
+        }
+        chunks.push(TextChunk {
+            text: String::from_utf8_lossy(bytes).to_string(),
+            x: self.current_x,
+            y: self.current_y,
+            font_size: self.current_font_size,
+            font_name: self.current_font.clone(),
+        });
     }
 
     /// Process a content stream chunk
@@ -82,28 +101,67 @@ impl TextStreamer {
                     self.current_font = Some(name);
                     self.current_font_size = size as f64;
                 }
+                // Td: move to the start of the next line, offset from the
+                // current line origin (§9.4.2).
                 ContentOperation::MoveText(x, y) => {
                     self.current_x += x as f64;
                     self.current_y += y as f64;
                 }
+                // TD: like Td, and also set the leading to -ty (§9.4.2). Without
+                // this and the operators below, every line placed by anything
+                // other than Td landed on the previous line's baseline (#453).
+                ContentOperation::MoveTextSetLeading(x, y) => {
+                    self.current_leading = -(y as f64);
+                    self.current_x += x as f64;
+                    self.current_y += y as f64;
+                }
+                // TL: set the leading consumed by T*, ', and ".
+                ContentOperation::SetLeading(leading) => {
+                    self.current_leading = leading as f64;
+                }
+                // T*: move down one leading to the next line (§9.4.2).
+                ContentOperation::NextLine => {
+                    self.current_y -= self.current_leading;
+                }
+                // Tm: set the text (line) matrix absolutely; this streamer tracks
+                // only translation, which is its origin (§9.4.2).
+                ContentOperation::SetTextMatrix(_a, _b, _c, _d, e, f) => {
+                    self.current_x = e as f64;
+                    self.current_y = f as f64;
+                }
                 ContentOperation::ShowText(bytes) => {
-                    if self.current_font_size >= self.options.min_font_size {
-                        let text = String::from_utf8_lossy(&bytes).to_string();
-                        let chunk = TextChunk {
-                            text,
-                            x: self.current_x,
-                            y: self.current_y,
-                            font_size: self.current_font_size,
-                            font_name: self.current_font.clone(),
-                        };
-                        chunks.push(chunk);
+                    self.emit_text(&bytes, &mut chunks);
+                }
+                // TJ: an array of strings and numeric position adjustments. The
+                // adjustments nudge glyphs horizontally within the line; this
+                // streamer does not measure glyph advances, so it concatenates
+                // the strings at the line position rather than dropping them.
+                ContentOperation::ShowTextArray(elements) => {
+                    let mut text = Vec::new();
+                    for el in elements {
+                        if let crate::parser::content::TextElement::Text(bytes) = el {
+                            text.extend_from_slice(&bytes);
+                        }
                     }
+                    self.emit_text(&text, &mut chunks);
+                }
+                // ': move to the next line, then show (§9.4.3).
+                ContentOperation::NextLineShowText(bytes) => {
+                    self.current_y -= self.current_leading;
+                    self.emit_text(&bytes, &mut chunks);
+                }
+                // ": set word/char spacing, move to the next line, then show. The
+                // spacings affect glyph advance, which this streamer does not
+                // track; the line move and the text must not be lost (§9.4.3).
+                ContentOperation::SetSpacingNextLineShowText(_aw, _ac, bytes) => {
+                    self.current_y -= self.current_leading;
+                    self.emit_text(&bytes, &mut chunks);
                 }
                 ContentOperation::BeginText => {
                     self.current_x = 0.0;
                     self.current_y = 0.0;
                 }
-                _ => {} // Ignore other operations
+                _ => {} // Non-text operators do not affect extraction.
             }
         }
 

--- a/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
@@ -1,0 +1,269 @@
+//! #453: the page operations (rotate, split, reorder, page extraction) must
+//! preserve page content, not reconstruct it.
+//!
+//! Each operation used to walk the content stream with its own operator `match`
+//! and re-emit text through the high-level page API — mapping every font to one
+//! of the standard 14, decoding bytes with `from_utf8`, and dropping every
+//! operator it did not recognize (images, XObjects, curves, and any positioning
+//! operator beyond `Td`). The produced PDF was therefore wrong: text at the
+//! wrong place or gone, images gone. The correct behavior is to copy the
+//! original content streams and resources verbatim, exactly as `merge` does.
+//!
+//! The oracle is poppler (`pdftotext` / `pdfimages`), independent of this
+//! crate's own extractor: it reads the *bytes we wrote*, so a passing test means
+//! the written PDF is correct for any reader, not just ours.
+
+use oxidize_pdf::operations::PageRange;
+use oxidize_pdf::operations::{
+    extract_page_to_file, reorder_pdf_pages, rotate_pdf_pages, split_into_pages, RotateOptions,
+    RotationAngle,
+};
+use std::path::Path;
+use std::process::Command;
+
+const FIXTURE: &str = "tests/fixtures/Cold_Email_Hacks.pdf";
+
+/// The fixture's title page (index 0) is image-only; page 16 (1-based) is the
+/// first that carries both substantial prose and images, so it exercises text
+/// and raster preservation together. Verified against poppler: 100 words, 2
+/// images, `/Rotate` absent.
+const RICH_PAGE_1BASED: u32 = 16;
+const RICH_PAGE_0BASED: usize = 15;
+const PAGE_COUNT: usize = 44;
+
+/// Words of 4+ letters that poppler extracts from a 1-based page range of a file.
+fn poppler_words(path: &Path, first: u32, last: u32) -> Option<Vec<String>> {
+    let out = Command::new("pdftotext")
+        .args([
+            "-f",
+            &first.to_string(),
+            "-l",
+            &last.to_string(),
+            path.to_str()?,
+            "-",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    Some(
+        text.split_whitespace()
+            .filter(|w| w.chars().filter(|c| c.is_alphabetic()).count() >= 4)
+            .map(|w| w.to_string())
+            .collect(),
+    )
+}
+
+/// Number of raster images (type `image`) poppler finds in a 1-based page
+/// range. Soft masks (type `smask`) are excluded on purpose: preserving an
+/// image XObject's nested `/SMask` stream is a separate resource-embedding gap
+/// in the verbatim-copy path (it affects `merge` too), not part of the
+/// operator-dispatch defect #453 fixes.
+fn poppler_image_count(path: &Path, first: u32, last: u32) -> Option<usize> {
+    let out = Command::new("pdfimages")
+        .args([
+            "-list",
+            "-f",
+            &first.to_string(),
+            "-l",
+            &last.to_string(),
+            path.to_str()?,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // Header is two lines; the `type` column (index 2) is `image` for a raster.
+    Some(
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .skip(2)
+            .filter(|l| l.split_whitespace().nth(2) == Some("image"))
+            .count(),
+    )
+}
+
+/// `/Rotate` value poppler reports for a 1-based page (0 when absent).
+fn poppler_rotation(path: &Path, page: u32) -> Option<i32> {
+    let out = Command::new("pdfinfo")
+        .args([
+            "-f",
+            &page.to_string(),
+            "-l",
+            &page.to_string(),
+            path.to_str()?,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    // `Page N rot: 90`
+    for line in text.lines() {
+        if let Some(rest) = line.split("rot:").nth(1) {
+            return rest.trim().parse().ok();
+        }
+    }
+    Some(0)
+}
+
+fn poppler_available() -> bool {
+    Command::new("pdftotext").arg("-v").output().is_ok()
+        && Command::new("pdfimages").arg("-v").output().is_ok()
+        && Command::new("pdfinfo").arg("-v").output().is_ok()
+}
+
+/// Fraction of `want` present in `got`.
+fn retention(want: &[String], got: &[String]) -> f64 {
+    if want.is_empty() {
+        return 1.0;
+    }
+    let set: std::collections::HashSet<&String> = got.iter().collect();
+    want.iter().filter(|w| set.contains(w)).count() as f64 / want.len() as f64
+}
+
+#[test]
+fn extract_page_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+    assert!(
+        want_words.len() > 20 && want_images >= 1,
+        "fixture rich page must have prose and an image to make this test meaningful: \
+         {} words, {} images",
+        want_words.len(),
+        want_images
+    );
+
+    let out = std::env::temp_dir().join("issue453_extract.pdf");
+    extract_page_to_file(src, RICH_PAGE_0BASED, &out).expect("extract");
+
+    let got_words = poppler_words(&out, 1, 1).expect("output words");
+    let got_images = poppler_image_count(&out, 1, 1).expect("output images");
+
+    let r = retention(&want_words, &got_words);
+    assert!(
+        r > 0.99,
+        "extracted page lost text: retention {r:.4} ({}/{} words)",
+        (r * want_words.len() as f64) as usize,
+        want_words.len()
+    );
+    assert_eq!(
+        got_images, want_images,
+        "extracted page lost the image(s): {got_images} vs {want_images}"
+    );
+}
+
+#[test]
+fn split_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+
+    let dir = std::env::temp_dir().join("issue453_split");
+    std::fs::create_dir_all(&dir).unwrap();
+    let pattern = dir.join("page_{}.pdf");
+    let paths = split_into_pages(src, pattern.to_str().unwrap()).expect("split");
+    let rich = &paths[RICH_PAGE_0BASED];
+
+    let got_words = poppler_words(rich, 1, 1).expect("output words");
+    let got_images = poppler_image_count(rich, 1, 1).expect("output images");
+
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "split rich page lost text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+    assert_eq!(
+        got_images, want_images,
+        "split rich page lost the image(s): {got_images} vs {want_images}"
+    );
+}
+
+#[test]
+fn reorder_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+
+    let out = std::env::temp_dir().join("issue453_reorder.pdf");
+    // Reorder needs a full permutation; reverse the whole document.
+    let order: Vec<usize> = (0..PAGE_COUNT).rev().collect();
+    reorder_pdf_pages(src, &out, order).expect("reorder");
+
+    // After reversal the rich source page (0-based RICH_PAGE_0BASED) lands at
+    // output 0-based PAGE_COUNT-1-RICH_PAGE_0BASED.
+    let dest_1based = (PAGE_COUNT - 1 - RICH_PAGE_0BASED + 1) as u32;
+    let got_words = poppler_words(&out, dest_1based, dest_1based).expect("output words");
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "reorder mislaid the rich page's text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+}
+
+#[test]
+fn rotate_sets_native_rotate_and_preserves_content() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+    assert_eq!(
+        poppler_rotation(src, RICH_PAGE_1BASED),
+        Some(0),
+        "fixture rich page is expected unrotated"
+    );
+
+    let out = std::env::temp_dir().join("issue453_rotate.pdf");
+    rotate_pdf_pages(
+        src,
+        &out,
+        RotateOptions {
+            angle: RotationAngle::Clockwise90,
+            pages: PageRange::All,
+            preserve_page_size: false,
+        },
+    )
+    .expect("rotate");
+
+    // Native /Rotate, not a baked-in content transform.
+    assert_eq!(
+        poppler_rotation(&out, RICH_PAGE_1BASED),
+        Some(90),
+        "rotate did not set the native /Rotate entry"
+    );
+    // Content is untouched by a /Rotate rotation: same text, same image.
+    let got_words = poppler_words(&out, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("output words");
+    let got_images =
+        poppler_image_count(&out, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("output images");
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "rotate lost text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+    assert_eq!(
+        got_images, want_images,
+        "rotate lost the image(s): {got_images} vs {want_images}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_453_text_streamer_positioning_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_text_streamer_positioning_test.rs
@@ -1,0 +1,86 @@
+//! #453: `TextStreamer`, a public extraction path, tracked only `Td`. It
+//! ignored `TD`, `T*`, `Tm`, and the `'`/`"` show-and-move operators, so every
+//! line placed with one of them landed at the previous line's coordinates —
+//! lines fused, positions wrong. This mirrors the `PlainTextExtractor` defect of
+//! #451, on the third extractor.
+//!
+//! The oracle is the y-coordinate of each emitted chunk: a content stream that
+//! places four lines with four different positioning operators must yield four
+//! chunks at four descending y values.
+
+use oxidize_pdf::streaming::{TextStreamOptions, TextStreamer};
+
+/// A content stream that draws one word per line, each line reached by a
+/// different positioning operator:
+///   line 1: `Td` (absolute-ish move from the BT origin)
+///   line 2: `T*` (uses the leading set by `TL`)
+///   line 3: `TD` (moves and sets a new leading in one operator)
+///   line 4: `Tm` (absolute text matrix)
+const STREAM: &[u8] = b"BT\n\
+/F1 12 Tf\n\
+14 TL\n\
+100 700 Td\n\
+(Alpha) Tj\n\
+T*\n\
+(Bravo) Tj\n\
+0 -20 TD\n\
+(Charlie) Tj\n\
+1 0 0 1 200 500 Tm\n\
+(Delta) Tj\n\
+ET\n";
+
+fn chunk_ys(stream: &[u8]) -> Vec<(String, f64)> {
+    let mut s = TextStreamer::new(TextStreamOptions::default());
+    let chunks = s.process_chunk(stream).expect("parses");
+    chunks.into_iter().map(|c| (c.text, c.y)).collect()
+}
+
+#[test]
+fn text_streamer_honors_td_tstar_tm_positioning() {
+    let got = chunk_ys(STREAM);
+    let texts: Vec<&str> = got.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["Alpha", "Bravo", "Charlie", "Delta"],
+        "every line must be emitted as its own chunk"
+    );
+
+    let y = |name: &str| got.iter().find(|(t, _)| t == name).unwrap().1;
+
+    // Td placed line 1 at y = 700.
+    assert!((y("Alpha") - 700.0).abs() < 0.01, "Td y = {}", y("Alpha"));
+    // T* dropped one leading (14) → 686. Before the fix T* was ignored and this
+    // stayed at 700, fused onto line 1.
+    assert!((y("Bravo") - 686.0).abs() < 0.01, "T* y = {}", y("Bravo"));
+    // TD set leading 20 and moved down 20 from 686 → 666.
+    assert!(
+        (y("Charlie") - 666.0).abs() < 0.01,
+        "TD y = {}",
+        y("Charlie")
+    );
+    // Tm placed line 4 absolutely at y = 500.
+    assert!((y("Delta") - 500.0).abs() < 0.01, "Tm y = {}", y("Delta"));
+
+    // Distinct y for every line: the defect collapsed them.
+    let mut ys: Vec<f64> = got.iter().map(|(_, y)| *y).collect();
+    ys.sort_by(|a, b| a.total_cmp(b));
+    ys.dedup_by(|a, b| (*a - *b).abs() < 0.01);
+    assert_eq!(
+        ys.len(),
+        4,
+        "lines collapsed onto shared y coordinates: {got:?}"
+    );
+}
+
+#[test]
+fn text_streamer_apostrophe_operator_moves_to_next_line() {
+    // `'` is "T* then show": it must both emit the text and advance one leading.
+    let stream = b"BT\n/F1 12 Tf\n10 TL\n50 400 Td\n(First) Tj\n(Second) '\n(Third) '\nET\n";
+    let got = chunk_ys(stream);
+    let texts: Vec<&str> = got.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(texts, vec!["First", "Second", "Third"]);
+    let y = |name: &str| got.iter().find(|(t, _)| t == name).unwrap().1;
+    assert!((y("First") - 400.0).abs() < 0.01);
+    assert!((y("Second") - 390.0).abs() < 0.01, "' y = {}", y("Second"));
+    assert!((y("Third") - 380.0).abs() < 0.01, "' y = {}", y("Third"));
+}


### PR DESCRIPTION
Addresses #453.

## What

Five `ContentOperation` dispatchers each re-implemented operator handling with their own `match` + `_ => {}`, so a newly relevant operator was silently ignored at each site (#451 was one instance; this is the class). Two distinct fixes.

### Group A — the four page operations (split, reorder, page_extraction, rotate)

They reconstructed each page by re-emitting content through the high-level API: every font mapped to one of the standard 14, bytes decoded with `from_utf8`, and every unrecognized operator dropped (images, XObjects, curves, positioning beyond `Td`). The output PDF was **wrong**, not merely poorly extracted.

They now copy content and resources **verbatim** via `Page::from_parsed_with_content` — the path `merge` already uses. The three reconstruction dispatchers (`process_operators`, `process_operators_with_rotation`, `map_font_name`) and their tests are deleted. Net −556 lines.

`rotate` additionally switches from baking a rotation matrix into reconstructed content to the native **`/Rotate`** attribute, accumulated as `(source + angle) % 360`. `preserve_page_size` is now inert — MediaBox never changes under `/Rotate` (ISO 32000-1 §7.7.3.3) — and its doc says so; candidate for removal in the next major.

### Group B — TextStreamer

A public extraction path that handled only `Td`. Now handles `TD`/`TL`/`T*`/`Tm` and the `'`/`"` show-and-move operators, plus `TJ` which it also dropped. Scalar x/y model preserved (consistent with its existing design); `Tm` uses the translation components, a disclosed limitation for rotated/scaled matrices.

## Verification

Independent oracle (poppler `pdftotext`/`pdfimages`/`pdfinfo`), so a pass means the bytes we wrote are correct for any reader:

- `tests/issue_453_page_ops_preserve_content_test.rs` (4): word retention >99% and raster image preserved through extract/split/reorder; native `/Rotate=90` after rotate.
- `tests/issue_453_text_streamer_positioning_test.rs` (2): each line placed by a different positioning operator lands at its own y; `'` advances one leading.
- All RED before / GREEN after; ablation-verified.
- Full suite **9343 passed / 0 failed**; operations units 411/0; `cargo build --all-targets` no warnings.
- Differential gates pass and cannot be affected — they measure the flat `TextExtractor`, untouched here.

QR (quality-rust): **PASS**, independently verified (own ablation of two lines, Kripteia, dead-code grep). The one non-blocking item — the `preserve_page_size` field doc — is fixed in this branch.

## Recurrence guard

The issue suggested a shared positioning state machine or a non-exhaustive-match guard. Instead the four page-op sites no longer dispatch operators **at all** (verbatim copy) — the strongest possible guarantee, since you cannot ignore an operator you never inspect. The three text extractors keep independent models by necessity (scalar streamer vs matrix-based `TextExtractor`/`PlainTextExtractor`).

## Known adjacent gap (separate issue)

The verbatim path (and thus `merge`) does not embed an image's nested `/SMask` — transparency is lost. Pre-existing, filed as **#465**. These tests assert the raster `image` survives and exclude `smask` rows, deferring transparency to that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
