### PR TITLE
release: 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [Unreleased]
+## [4.2.3] - 2026-08-09
 
 ### Fixed
 
@@ -22,6 +22,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolution walk memoizes by source object id, so a shared stream resolves once
   and a cyclic or pathologically nested document terminates instead of blowing
   up.
+
+- **Page operations reconstructed the page by redrawing it instead of copying it
+  verbatim** (#453). Split, reorder, page extraction and rotate each ran the
+  content stream through a reconstruction dispatcher that redrew recognised
+  operators and silently dropped the rest — images, XObjects, curves — falling
+  back to `[content reconstruction in progress]` placeholders and remapping
+  fonts to the standard 14. The output was simply wrong. These operations now
+  copy the parsed page content verbatim (the same path `merge` uses), and
+  `rotate` sets the native `/Rotate` entry `(source + angle).rem_euclid(360)`
+  instead of re-rendering.
+
+- **Inline `/Font` resource entries were ignored, producing mojibake on
+  round-trip** (#463). A `/Font` resource entry may be a direct dictionary, not
+  only an indirect reference (ISO 32000-1 §7.3.7, and what this library's own
+  writer emits). All three text extractors cached only the reference form, so an
+  inline font dictionary was dropped, the font cache came up empty and text was
+  decoded byte-by-byte — every document round-tripped through this library
+  (`merge`, the page operations) came back unreadable to the library itself.
+  A shared resolver now handles both the reference and the inline-dictionary
+  form.
 
 ## [4.2.2] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
+
+### Fixed
+
+- **Verbatim page copy dropped an image's nested `/SMask`, losing transparency**
+  (#465). `Page::from_parsed_with_content` resolved only the top-level
+  `/XObject/<name>` reference; an image's soft-mask stream, referenced from
+  inside that image's own dictionary, kept pointing into the *source* document's
+  object table. The writer then emitted the image with a dangling `/SMask` and
+  never wrote the soft-mask stream, so `merge`, `split`, page extraction and
+  rotate all silently stripped transparency. Nested stream references (`/SMask`,
+  reference-form `/Mask`, ICCBased colour-space streams) are now inlined on read
+  and re-externalized as indirect objects on write, per ISO 32000-1 §7.3.8. The
+  resolution walk memoizes by source object id, so a shared stream resolves once
+  and a cyclic or pathologically nested document terminates instead of blowing
+  up.
+
 ## [4.2.2] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.2.2"
+version = "4.2.3"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.2.2"
+version = "4.2.3"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/operations/page_extraction.rs
+++ b/oxidize-pdf-core/src/operations/page_extraction.rs
@@ -5,7 +5,7 @@
 //! API specifically for page extraction use cases.
 
 use super::{OperationError, OperationResult, PageRange};
-use crate::parser::{ContentOperation, ContentParser, ParsedPage, PdfDocument, PdfReader};
+use crate::parser::{ParsedPage, PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -155,155 +155,17 @@ impl PageExtractor {
         Ok(doc)
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources (fonts, images,
+    /// XObjects) unchanged via [`Page::from_parsed_with_content`], the path
+    /// `merge` uses, instead of re-emitting the page through the high-level API
+    /// — which mapped every font to one of the standard 14, decoded bytes with
+    /// `from_utf8`, and dropped images and unrecognized operators (#453).
+    /// `/Rotate` is carried over by `from_parsed_with_content`.
     fn convert_page(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Apply rotation if needed
-        if parsed_page.rotation != 0 {
-            page.set_rotation(parsed_page.rotation);
-        }
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    // Log warning but continue with other streams
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // Handle annotations if preservation is enabled
-        if self.options.preserve_annotations {
-            // Note: Annotation preservation requires annotation support implementation
-        }
-
-        // Handle form fields if preservation is enabled
-        if self.options.preserve_forms {
-            // Note: Form field preservation requires form support implementation
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page extracted]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // This is a simplified implementation that handles basic text and graphics
-        // A full implementation would handle all PDF operators
-
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    current_font = self.map_font_name(name);
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(x, y) => {
-                    current_x = *x;
-                    current_y = *y;
-                }
-                ContentOperation::ShowText(text) => {
-                    if text_object {
-                        if let Ok(text_str) = String::from_utf8(text.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text_str)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Rectangle(x, y, w, h) => {
-                    page.graphics()
-                        .rectangle(*x as f64, *y as f64, *w as f64, *h as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::Color::rgb(*r as f64, *g as f64, *b as f64));
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_fill_color(crate::Color::rgb(*r as f64, *g as f64, *b as f64));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                _ => {
-                    // Other operators not yet implemented
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Map PDF font names to our font enum
-    fn map_font_name(&self, name: &str) -> crate::text::Font {
-        match name {
-            "Times-Roman" => crate::text::Font::TimesRoman,
-            "Times-Bold" => crate::text::Font::TimesBold,
-            "Times-Italic" => crate::text::Font::TimesItalic,
-            "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-            "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-            "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-            "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-            "Courier" => crate::text::Font::Courier,
-            "Courier-Bold" => crate::text::Font::CourierBold,
-            "Courier-Oblique" => crate::text::Font::CourierOblique,
-            "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-            _ => crate::text::Font::Helvetica, // Default fallback
-        }
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 
@@ -643,38 +505,6 @@ mod tests {
         // When metadata is not preserved, the document should have default/empty metadata
         assert_eq!(extracted_doc.pages.len(), 1);
         // Note: Document doesn't have getter methods for metadata in current API
-    }
-
-    #[test]
-    fn test_map_font_name() {
-        let temp_dir = TempDir::new().unwrap();
-        let mut doc = create_test_pdf("Test", 1);
-        let path = save_test_pdf(&mut doc, &temp_dir, "test.pdf");
-
-        let reader = PdfReader::open(&path).unwrap();
-        let document = PdfDocument::new(reader);
-        let extractor = PageExtractor::new(document);
-
-        assert_eq!(
-            extractor.map_font_name("Times-Roman"),
-            crate::text::Font::TimesRoman
-        );
-        assert_eq!(
-            extractor.map_font_name("Times-Bold"),
-            crate::text::Font::TimesBold
-        );
-        assert_eq!(
-            extractor.map_font_name("Helvetica-Bold"),
-            crate::text::Font::HelveticaBold
-        );
-        assert_eq!(
-            extractor.map_font_name("Courier"),
-            crate::text::Font::Courier
-        );
-        assert_eq!(
-            extractor.map_font_name("Unknown"),
-            crate::text::Font::Helvetica
-        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -4,7 +4,7 @@
 
 use super::{OperationError, OperationResult};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -124,123 +124,16 @@ impl PageReorderer {
         Ok(())
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources unchanged via
+    /// [`Page::from_parsed_with_content`] (the path `merge` uses) instead of
+    /// re-emitting the page through the high-level API, which mapped every font
+    /// to one of the standard 14, decoded bytes with `from_utf8_lossy`, and
+    /// dropped images, XObjects and unrecognized operators (#453).
     fn convert_page(&self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page reordered - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica,
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text) => {
-                    if text_object && !text.is_empty() {
-                        page.text()
-                            .set_font(current_font.clone(), current_font_size as f64)
-                            .at(current_x as f64, current_y as f64)
-                            .write(&String::from_utf8_lossy(text))
-                            .map_err(OperationError::PdfError)?;
-                    }
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::Rectangle(x, y, w, h) => {
-                    page.graphics()
-                        .rectangle(*x as f64, *y as f64, *w as f64, *h as f64);
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 

--- a/oxidize-pdf-core/src/operations/rotate.rs
+++ b/oxidize-pdf-core/src/operations/rotate.rs
@@ -4,7 +4,7 @@
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::Path;
@@ -73,7 +73,11 @@ pub struct RotateOptions {
     pub pages: PageRange,
     /// Rotation angle
     pub angle: RotationAngle,
-    /// Whether to preserve the original page size (vs adjusting for rotated content)
+    /// No longer has any effect (since the switch to the native `/Rotate`
+    /// attribute in #453). Rotation is now a viewing transform: the stored
+    /// MediaBox never changes under `/Rotate` (ISO 32000-1 §7.7.3.3), so there
+    /// is no page-size adjustment to opt out of. Retained for API
+    /// compatibility; a candidate for removal in the next major release.
     pub preserve_page_size: bool,
 }
 
@@ -145,245 +149,35 @@ impl PageRotator {
         Ok(output_doc)
     }
 
-    /// Create a rotated copy of a page
+    /// Create a rotated copy of a page using the native `/Rotate` attribute.
+    ///
+    /// Rotation in PDF is a viewing transform, not a content edit: the page's
+    /// `/Rotate` entry (a multiple of 90) tells the viewer how to display the
+    /// unchanged content and MediaBox (ISO 32000-1 §7.7.3.3). So the content is
+    /// copied verbatim via [`Page::from_parsed_with_content`] and the new angle
+    /// is composed onto whatever rotation the source already had.
+    ///
+    /// The former implementation baked a rotation matrix into a *reconstructed*
+    /// content stream, which lost images and mangled text (#453) and, unlike
+    /// `/Rotate`, could not be undone losslessly. `preserve_page_size` no longer
+    /// has any effect: `/Rotate` never changes the stored page size.
     fn create_rotated_page(
         &mut self,
         parsed_page: &ParsedPage,
         angle: RotationAngle,
-        preserve_size: bool,
+        _preserve_page_size: bool,
     ) -> OperationResult<Page> {
-        // Calculate the effective rotation
-        let current_rotation = parsed_page.rotation;
-        let _new_rotation = (current_rotation + angle.to_degrees()) % 360;
-
-        // Get original dimensions
-        let orig_width = parsed_page.media_box[2] - parsed_page.media_box[0];
-        let orig_height = parsed_page.media_box[3] - parsed_page.media_box[1];
-
-        // Calculate new dimensions based on rotation
-        let (new_width, new_height) = if preserve_size {
-            (orig_width, orig_height)
-        } else {
-            match angle {
-                RotationAngle::None | RotationAngle::Rotate180 => (orig_width, orig_height),
-                RotationAngle::Clockwise90 | RotationAngle::Clockwise270 => {
-                    (orig_height, orig_width)
-                }
-            }
-        };
-
-        let mut page = Page::new(new_width, new_height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
+        let mut page = Page::from_parsed_with_content(parsed_page, &self.document)
             .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Add rotation transformation
-        match angle {
-            RotationAngle::None => {
-                // No rotation needed
-            }
-            RotationAngle::Clockwise90 => {
-                // Rotate 90 degrees clockwise
-                // Transform: x' = y, y' = width - x
-                page.graphics()
-                    .save_state()
-                    .transform(0.0, 1.0, -1.0, 0.0, new_width, 0.0);
-            }
-            RotationAngle::Rotate180 => {
-                // Rotate 180 degrees
-                // Transform: x' = width - x, y' = height - y
-                page.graphics()
-                    .save_state()
-                    .transform(-1.0, 0.0, 0.0, -1.0, new_width, new_height);
-            }
-            RotationAngle::Clockwise270 => {
-                // Rotate 270 degrees clockwise (90 counter-clockwise)
-                // Transform: x' = height - y, y' = x
-                page.graphics()
-                    .save_state()
-                    .transform(0.0, -1.0, 1.0, 0.0, 0.0, new_height);
-            }
-        }
-
-        // Parse and process content streams with rotation
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    // Process the operators with rotation transformation already applied
-                    self.process_operators_with_rotation(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, new_height - 50.0)
-                .write(&format!(
-                    "[Page rotated {} degrees - content reconstruction in progress]",
-                    angle.to_degrees()
-                ))
-                .map_err(OperationError::PdfError)?;
-        }
-
-        // Restore graphics state if we transformed
-        if angle != RotationAngle::None {
-            page.graphics().restore_state();
-        }
-
+        let combined = (parsed_page.rotation + angle.to_degrees()).rem_euclid(360);
+        page.set_rotation(combined);
         Ok(page)
     }
 
-    /// Create a copy of a page without rotation
+    /// Copy a page unchanged, content and existing `/Rotate` preserved verbatim.
     fn create_page_copy(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in content_streams {
-            match ContentParser::parse_content(&stream_data) {
-                Ok(operators) => {
-                    self.process_operators_with_rotation(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page copied - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators (rotation transformation already applied via graphics state)
-    fn process_operators_with_rotation(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica,
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text_bytes) => {
-                    if text_object {
-                        if let Ok(text) = String::from_utf8(text_bytes.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::Rectangle(x, y, width, height) => {
-                    page.graphics()
-                        .rect(*x as f64, *y as f64, *width as f64, *height as f64);
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics().set_fill_color(crate::graphics::Color::Rgb(
-                        *r as f64, *g as f64, *b as f64,
-                    ));
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::graphics::Color::Rgb(
-                            *r as f64, *g as f64, *b as f64,
-                        ));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                // Graphics state operators are important for rotation
-                ContentOperation::SaveGraphicsState => {
-                    page.graphics().save_state();
-                }
-                ContentOperation::RestoreGraphicsState => {
-                    page.graphics().restore_state();
-                }
-                ContentOperation::SetTransformMatrix(a, b, c, d, e, f) => {
-                    page.graphics().transform(
-                        *a as f64, *b as f64, *c as f64, *d as f64, *e as f64, *f as f64,
-                    );
-                }
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 }
 

--- a/oxidize-pdf-core/src/operations/split.rs
+++ b/oxidize-pdf-core/src/operations/split.rs
@@ -5,7 +5,7 @@
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::page_tree::ParsedPage;
-use crate::parser::{ContentOperation, ContentParser, PdfDocument, PdfReader};
+use crate::parser::{PdfDocument, PdfReader};
 use crate::{Document, Page};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -170,145 +170,18 @@ impl PdfSplitter {
         Ok(())
     }
 
-    /// Convert a parsed page to a new page
+    /// Convert a parsed page to a new page, preserving its content verbatim.
+    ///
+    /// Copies the original content streams and resources (fonts, images,
+    /// XObjects) unchanged via [`Page::from_parsed_with_content`], the same path
+    /// `merge` uses. The former implementation re-emitted the page through the
+    /// high-level API — mapping every font to one of the standard 14, decoding
+    /// bytes with `from_utf8`, and dropping every operator it did not recognize
+    /// — so it lost images and mangled any non-ASCII or CID-encoded text
+    /// (#453). `/Rotate` is carried over by `from_parsed_with_content`.
     fn convert_page(&mut self, parsed_page: &ParsedPage) -> OperationResult<Page> {
-        // Create new page with same dimensions
-        let width = parsed_page.width();
-        let height = parsed_page.height();
-        let mut page = Page::new(width, height);
-
-        // Set rotation if needed
-        if parsed_page.rotation != 0 {
-            page.set_rotation(parsed_page.rotation);
-        }
-
-        // Get content streams
-        let content_streams = self
-            .document
-            .get_page_content_streams(parsed_page)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Parse and process content streams
-        let mut has_content = false;
-        for stream_data in &content_streams {
-            match ContentParser::parse_content(stream_data) {
-                Ok(operators) => {
-                    // Process the operators to recreate content
-                    self.process_operators(&mut page, &operators)?;
-                    has_content = true;
-                }
-                Err(e) => {
-                    // If parsing fails, fall back to placeholder
-                    tracing::debug!("Warning: Failed to parse content stream: {e}");
-                }
-            }
-        }
-
-        // If no content was successfully processed, add a placeholder
-        if !has_content {
-            page.text()
-                .set_font(crate::text::Font::Helvetica, 10.0)
-                .at(50.0, height - 50.0)
-                .write("[Page extracted - content reconstruction in progress]")
-                .map_err(OperationError::PdfError)?;
-        }
-
-        Ok(page)
-    }
-
-    /// Process content operators to recreate page content
-    fn process_operators(
-        &self,
-        page: &mut Page,
-        operators: &[ContentOperation],
-    ) -> OperationResult<()> {
-        // Track graphics state
-        let mut text_object = false;
-        let mut current_font = crate::text::Font::Helvetica;
-        let mut current_font_size = 12.0;
-        let mut current_x = 0.0;
-        let mut current_y = 0.0;
-
-        for operator in operators {
-            match operator {
-                ContentOperation::BeginText => {
-                    text_object = true;
-                }
-                ContentOperation::EndText => {
-                    text_object = false;
-                }
-                ContentOperation::SetFont(name, size) => {
-                    // Map PDF font names to our fonts
-                    current_font = match name.as_str() {
-                        "Times-Roman" => crate::text::Font::TimesRoman,
-                        "Times-Bold" => crate::text::Font::TimesBold,
-                        "Times-Italic" => crate::text::Font::TimesItalic,
-                        "Times-BoldItalic" => crate::text::Font::TimesBoldItalic,
-                        "Helvetica-Bold" => crate::text::Font::HelveticaBold,
-                        "Helvetica-Oblique" => crate::text::Font::HelveticaOblique,
-                        "Helvetica-BoldOblique" => crate::text::Font::HelveticaBoldOblique,
-                        "Courier" => crate::text::Font::Courier,
-                        "Courier-Bold" => crate::text::Font::CourierBold,
-                        "Courier-Oblique" => crate::text::Font::CourierOblique,
-                        "Courier-BoldOblique" => crate::text::Font::CourierBoldOblique,
-                        _ => crate::text::Font::Helvetica, // Default fallback
-                    };
-                    current_font_size = *size;
-                }
-                ContentOperation::MoveText(tx, ty) => {
-                    current_x += tx;
-                    current_y += ty;
-                }
-                ContentOperation::ShowText(text_bytes) => {
-                    if text_object {
-                        // Convert bytes to string (assuming ASCII/UTF-8 for now)
-                        if let Ok(text) = String::from_utf8(text_bytes.clone()) {
-                            page.text()
-                                .set_font(current_font.clone(), current_font_size as f64)
-                                .at(current_x as f64, current_y as f64)
-                                .write(&text)
-                                .map_err(OperationError::PdfError)?;
-                        }
-                    }
-                }
-                ContentOperation::Rectangle(x, y, width, height) => {
-                    page.graphics()
-                        .rect(*x as f64, *y as f64, *width as f64, *height as f64);
-                }
-                ContentOperation::MoveTo(x, y) => {
-                    page.graphics().move_to(*x as f64, *y as f64);
-                }
-                ContentOperation::LineTo(x, y) => {
-                    page.graphics().line_to(*x as f64, *y as f64);
-                }
-                ContentOperation::Stroke => {
-                    page.graphics().stroke();
-                }
-                ContentOperation::Fill => {
-                    page.graphics().fill();
-                }
-                ContentOperation::SetNonStrokingRGB(r, g, b) => {
-                    page.graphics().set_fill_color(crate::graphics::Color::Rgb(
-                        *r as f64, *g as f64, *b as f64,
-                    ));
-                }
-                ContentOperation::SetStrokingRGB(r, g, b) => {
-                    page.graphics()
-                        .set_stroke_color(crate::graphics::Color::Rgb(
-                            *r as f64, *g as f64, *b as f64,
-                        ));
-                }
-                ContentOperation::SetLineWidth(width) => {
-                    page.graphics().set_line_width(*width as f64);
-                }
-                // Note: Additional operators can be implemented on demand
-                _ => {
-                    // Silently skip unimplemented operators for now
-                }
-            }
-        }
-
-        Ok(())
+        Page::from_parsed_with_content(parsed_page, &self.document)
+            .map_err(|e| OperationError::ParseError(e.to_string()))
     }
 
     /// Format the output path based on the pattern

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -422,6 +422,11 @@ impl Page {
             {
                 let xobjects_clone = xobjects.clone();
                 let mut resolved_xobjects = crate::pdf_objects::Dictionary::new();
+                // Shared across every XObject on the page so a stream referenced
+                // by more than one image (e.g. a common ICCBased profile) is
+                // resolved once, not once per referrer.
+                let mut nested_memo: HashMap<(u32, u16), crate::pdf_objects::Object> =
+                    HashMap::new();
 
                 for (xobj_name, xobj_obj) in xobjects_clone.iter() {
                     let resolved = match xobj_obj {
@@ -439,6 +444,17 @@ impl Page {
                         }
                         _ => xobj_obj.clone(),
                     };
+                    // #465: the top-level XObject is now resolved, but any
+                    // indirect reference *nested inside* it still points into
+                    // the source document's object table — an image's `/SMask`
+                    // and reference-form `/Mask`, an ICCBased colour space, a
+                    // form XObject's `/Resources` streams. Left alone, the
+                    // writer emits those as dangling references and the target
+                    // stream is never written (transparency lost). Inline them
+                    // so the writer externalizes each as a fresh indirect
+                    // object.
+                    let resolved =
+                        Self::resolve_nested_stream_refs(resolved, document, 0, &mut nested_memo);
                     resolved_xobjects.set(xobj_name.clone(), resolved);
                 }
 
@@ -830,6 +846,142 @@ impl Page {
         }
 
         unified_dict
+    }
+
+    /// Reference-chain depth bound for [`resolve_nested_stream_refs`]. Real
+    /// documents nest at most a couple of levels (image → `/SMask` → its own
+    /// colour-space stream; form XObject → `/Resources` → nested XObject). A
+    /// small bound keeps a malformed or cyclic document from recursing without
+    /// end while covering every legitimate shape.
+    const NESTED_STREAM_MAX_DEPTH: usize = 8;
+
+    /// Inlines indirect references that resolve to *streams* anywhere inside a
+    /// resolved XObject (#465).
+    ///
+    /// [`from_parsed_with_content`](Self::from_parsed_with_content) resolves
+    /// only the top-level `/XObject/<name>` reference. A stream reference nested
+    /// inside — an image's `/SMask` or reference-form `/Mask`, an ICCBased
+    /// colour-space stream, a form XObject's `/Resources` streams — is left
+    /// pointing into the *source* document's object table, which is meaningless
+    /// in the output: the writer emits a dangling reference and the target
+    /// stream (e.g. the soft mask) is never written, so transparency is lost.
+    ///
+    /// This walks the owned object graph and replaces every reference that
+    /// resolves to a stream with that stream inline, recursing into it so its
+    /// own nested stream references are pulled in too. References that resolve
+    /// to non-stream objects (shared colour spaces, value dictionaries) are
+    /// left untouched — the per-category resolution above already handles the
+    /// ones that matter, and inlining them would needlessly duplicate shared
+    /// data. `depth` is incremented only when a reference is followed, so the
+    /// bound applies to reference chains, not to owned nesting.
+    ///
+    /// `memo` maps an already-resolved stream's source id to its inlined form.
+    /// It serves two purposes on adversarial input: it collapses a *shared*
+    /// object graph (one ICCBased profile referenced by every image) to a
+    /// single resolution instead of `O(fan-out^depth)` re-walks, and — via an
+    /// in-progress placeholder inserted before recursing — it breaks reference
+    /// *cycles* at the back-edge, so the depth bound is only a backstop, never
+    /// the primary cycle guard.
+    fn resolve_nested_stream_refs<R: std::io::Read + std::io::Seek>(
+        obj: crate::pdf_objects::Object,
+        document: &crate::parser::document::PdfDocument<R>,
+        depth: usize,
+        memo: &mut HashMap<(u32, u16), crate::pdf_objects::Object>,
+    ) -> crate::pdf_objects::Object {
+        use crate::pdf_objects::{Object, Stream};
+
+        match obj {
+            Object::Stream(stream) => {
+                let dict =
+                    Self::resolve_nested_stream_refs_in_dict(stream.dict, document, depth, memo);
+                Object::Stream(Stream::new(dict, stream.data))
+            }
+            Object::Dictionary(dict) => Object::Dictionary(
+                Self::resolve_nested_stream_refs_in_dict(dict, document, depth, memo),
+            ),
+            Object::Array(arr) => {
+                let mut out = crate::pdf_objects::Array::new();
+                for item in arr.iter() {
+                    out.push(Self::resolve_nested_stream_refs(
+                        item.clone(),
+                        document,
+                        depth,
+                        memo,
+                    ));
+                }
+                Object::Array(out)
+            }
+            Object::Reference(id) => {
+                let key = (id.number(), id.generation());
+                // Already resolved through another path (shared node), or the
+                // in-progress placeholder of a cycle back-edge: reuse it.
+                if let Some(cached) = memo.get(&key) {
+                    return cached.clone();
+                }
+                // Chain too deep (malformed input): degrade to a plain
+                // reference rather than serializing a half-resolved object
+                // whose own fields still point into the *source* document's
+                // object table.
+                if depth >= Self::NESTED_STREAM_MAX_DEPTH {
+                    return Object::Reference(id);
+                }
+                match document.get_object(id.number(), id.generation()) {
+                    Ok(resolved_obj) => {
+                        let unified = Self::convert_parser_object_to_unified(&resolved_obj);
+                        if matches!(unified, Object::Stream(_)) {
+                            // Mark in-progress so a cyclic back-edge to this
+                            // stream resolves to a plain reference instead of
+                            // recursing until the depth cap.
+                            memo.insert(key, Object::Reference(id));
+                            let resolved = Self::resolve_nested_stream_refs(
+                                unified,
+                                document,
+                                depth + 1,
+                                memo,
+                            );
+                            memo.insert(key, resolved.clone());
+                            resolved
+                        } else {
+                            // Non-stream target: leave as a reference (shared
+                            // value object; not our class of bug here).
+                            Object::Reference(id)
+                        }
+                    }
+                    // Unresolvable reference: leave as-is rather than drop it.
+                    // This is the path that leaves a dangling reference in the
+                    // output, so log it to aid diagnosing a silently missing
+                    // nested stream (e.g. a soft mask) on a malformed source.
+                    Err(e) => {
+                        tracing::debug!(
+                            "resolve_nested_stream_refs: cannot resolve {} {} R: {e}",
+                            id.number(),
+                            id.generation()
+                        );
+                        Object::Reference(id)
+                    }
+                }
+            }
+            other => other,
+        }
+    }
+
+    /// Applies [`resolve_nested_stream_refs`](Self::resolve_nested_stream_refs)
+    /// to every value of a dictionary. Kept separate so the `Stream` and
+    /// `Dictionary` arms share one implementation.
+    fn resolve_nested_stream_refs_in_dict<R: std::io::Read + std::io::Seek>(
+        dict: crate::pdf_objects::Dictionary,
+        document: &crate::parser::document::PdfDocument<R>,
+        depth: usize,
+        memo: &mut HashMap<(u32, u16), crate::pdf_objects::Object>,
+    ) -> crate::pdf_objects::Dictionary {
+        let mut out = crate::pdf_objects::Dictionary::new();
+        for (key, value) in dict.iter() {
+            out.set(
+                key.clone(),
+                Self::resolve_nested_stream_refs(value.clone(), document, depth, memo),
+            );
+        }
+        out
     }
 
     /// Converts a parser PdfObject to unified Object

--- a/oxidize-pdf-core/src/streaming/text_streamer.rs
+++ b/oxidize-pdf-core/src/streaming/text_streamer.rs
@@ -54,6 +54,9 @@ pub struct TextStreamer {
     current_font_size: f64,
     current_x: f64,
     current_y: f64,
+    /// Text leading, in unscaled text-space units; consumed by `T*`, `'`, `"`
+    /// and set by `TL`/`TD`.
+    current_leading: f64,
 }
 
 impl TextStreamer {
@@ -66,7 +69,23 @@ impl TextStreamer {
             current_font_size: 12.0,
             current_x: 0.0,
             current_y: 0.0,
+            current_leading: 0.0,
         }
+    }
+
+    /// Emit one text-showing operator's bytes as a chunk at the current
+    /// position, honoring the minimum-font-size filter.
+    fn emit_text(&self, bytes: &[u8], chunks: &mut Vec<TextChunk>) {
+        if self.current_font_size < self.options.min_font_size {
+            return;
+        }
+        chunks.push(TextChunk {
+            text: String::from_utf8_lossy(bytes).to_string(),
+            x: self.current_x,
+            y: self.current_y,
+            font_size: self.current_font_size,
+            font_name: self.current_font.clone(),
+        });
     }
 
     /// Process a content stream chunk
@@ -82,28 +101,67 @@ impl TextStreamer {
                     self.current_font = Some(name);
                     self.current_font_size = size as f64;
                 }
+                // Td: move to the start of the next line, offset from the
+                // current line origin (§9.4.2).
                 ContentOperation::MoveText(x, y) => {
                     self.current_x += x as f64;
                     self.current_y += y as f64;
                 }
+                // TD: like Td, and also set the leading to -ty (§9.4.2). Without
+                // this and the operators below, every line placed by anything
+                // other than Td landed on the previous line's baseline (#453).
+                ContentOperation::MoveTextSetLeading(x, y) => {
+                    self.current_leading = -(y as f64);
+                    self.current_x += x as f64;
+                    self.current_y += y as f64;
+                }
+                // TL: set the leading consumed by T*, ', and ".
+                ContentOperation::SetLeading(leading) => {
+                    self.current_leading = leading as f64;
+                }
+                // T*: move down one leading to the next line (§9.4.2).
+                ContentOperation::NextLine => {
+                    self.current_y -= self.current_leading;
+                }
+                // Tm: set the text (line) matrix absolutely; this streamer tracks
+                // only translation, which is its origin (§9.4.2).
+                ContentOperation::SetTextMatrix(_a, _b, _c, _d, e, f) => {
+                    self.current_x = e as f64;
+                    self.current_y = f as f64;
+                }
                 ContentOperation::ShowText(bytes) => {
-                    if self.current_font_size >= self.options.min_font_size {
-                        let text = String::from_utf8_lossy(&bytes).to_string();
-                        let chunk = TextChunk {
-                            text,
-                            x: self.current_x,
-                            y: self.current_y,
-                            font_size: self.current_font_size,
-                            font_name: self.current_font.clone(),
-                        };
-                        chunks.push(chunk);
+                    self.emit_text(&bytes, &mut chunks);
+                }
+                // TJ: an array of strings and numeric position adjustments. The
+                // adjustments nudge glyphs horizontally within the line; this
+                // streamer does not measure glyph advances, so it concatenates
+                // the strings at the line position rather than dropping them.
+                ContentOperation::ShowTextArray(elements) => {
+                    let mut text = Vec::new();
+                    for el in elements {
+                        if let crate::parser::content::TextElement::Text(bytes) = el {
+                            text.extend_from_slice(&bytes);
+                        }
                     }
+                    self.emit_text(&text, &mut chunks);
+                }
+                // ': move to the next line, then show (§9.4.3).
+                ContentOperation::NextLineShowText(bytes) => {
+                    self.current_y -= self.current_leading;
+                    self.emit_text(&bytes, &mut chunks);
+                }
+                // ": set word/char spacing, move to the next line, then show. The
+                // spacings affect glyph advance, which this streamer does not
+                // track; the line move and the text must not be lost (§9.4.3).
+                ContentOperation::SetSpacingNextLineShowText(_aw, _ac, bytes) => {
+                    self.current_y -= self.current_leading;
+                    self.emit_text(&bytes, &mut chunks);
                 }
                 ContentOperation::BeginText => {
                     self.current_x = 0.0;
                     self.current_y = 0.0;
                 }
-                _ => {} // Ignore other operations
+                _ => {} // Non-text operators do not affect extraction.
             }
         }
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2311,21 +2311,39 @@ impl TextExtractor {
         resources: &PdfDictionary,
         document: &PdfDocument<R>,
     ) {
-        let font_dict = match resources.get("Font") {
-            Some(PdfObject::Dictionary(dict)) => Some(dict.clone()),
-            Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
-                Ok(PdfObject::Dictionary(dict)) => Some(dict),
-                _ => None,
-            },
-            _ => None,
-        };
-
-        if let Some(font_dict) = font_dict {
-            for (font_name, font_obj) in font_dict.0.iter() {
-                if let Some(font_ref) = font_obj.as_reference() {
-                    self.cache_font_by_ref::<R>(&font_name.0, font_ref, document);
+        for (font_name, entry) in
+            crate::text::extraction_cmap::resolve_font_entries(resources, document)
+        {
+            match entry {
+                crate::text::extraction_cmap::FontEntry::Indirect(num, gen) => {
+                    self.cache_font_by_ref::<R>(&font_name, (num, gen), document);
+                }
+                crate::text::extraction_cmap::FontEntry::Inline(font_dict) => {
+                    self.cache_inline_font::<R>(&font_name, &font_dict, document);
                 }
             }
+        }
+    }
+
+    /// Cache a font written directly into the page's resources.
+    ///
+    /// Unlike [`Self::cache_font_by_ref`] this cannot touch the persistent
+    /// cache: an inline dictionary has no object id to key on, and two pages
+    /// may write different fonts under the same name. It is parsed per page.
+    fn cache_inline_font<R: Read + Seek>(
+        &mut self,
+        font_name: &str,
+        font_dict: &PdfDictionary,
+        document: &PdfDocument<R>,
+    ) {
+        let mut cmap_extractor: CMapTextExtractor<R> = CMapTextExtractor::new();
+        if let Ok(font_info) = cmap_extractor.extract_font_info(font_dict, document) {
+            tracing::debug!(
+                "Parsed inline font {} (ToUnicode: {})",
+                font_name,
+                font_info.to_unicode.is_some()
+            );
+            self.font_cache.insert(font_name.to_string(), font_info);
         }
     }
 
@@ -3569,7 +3587,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: None,
@@ -3611,7 +3628,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(32),
@@ -3668,7 +3684,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(1),
@@ -3713,7 +3728,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(65), // 'A'
@@ -3754,7 +3768,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(32),
@@ -3790,7 +3803,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(32),
@@ -3825,7 +3837,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(32),
@@ -3859,7 +3870,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(65), // 'A'
@@ -3898,7 +3908,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(105), // 'i'
@@ -3919,7 +3928,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(105),
@@ -3970,7 +3978,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics {
                 first_char: Some(32),
@@ -4115,7 +4122,7 @@ mod tests {
 
     #[test]
     fn test_parse_kern_table_no_kern_table() {
-        use crate::text::extraction_cmap::extract_truetype_kerning;
+        use crate::text::extraction_cmap::parse_truetype_kern_table;
 
         // TrueType font data WITHOUT a 'kern' table
         // Structure:
@@ -4140,7 +4147,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
-        let result = extract_truetype_kerning(&ttf_data);
+        let result = parse_truetype_kern_table(&ttf_data);
         assert!(
             result.is_ok(),
             "Should gracefully handle missing kern table"

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -8,13 +8,11 @@ use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
 use crate::parser::{ParseError, ParseOptions, ParseResult};
 use crate::text::cid_to_unicode::CidCollection;
 use crate::text::cmap::CMap;
-use crate::text::extraction::TextExtractor;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
 /// Font metrics for accurate text width calculation
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct FontMetrics {
     /// First character code in the Widths array
     pub first_char: Option<u32>,
@@ -42,7 +40,6 @@ impl Default for FontMetrics {
 
 /// Font information with CMap support
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct FontInfo {
     /// Font name
     pub name: String,
@@ -56,8 +53,6 @@ pub struct FontInfo {
     pub differences: Option<HashMap<u8, String>>,
     /// For Type0 fonts: descendant font
     pub descendant_font: Option<Box<FontInfo>>,
-    /// For CIDFonts: CIDToGIDMap
-    pub cid_to_gid_map: Option<Vec<u16>>,
     /// For CIDFonts: CIDSystemInfo Ordering (e.g., "CNS1", "GB1", "Japan1", "Korea1")
     pub cid_ordering: Option<String>,
     /// Font metrics (widths, kerning)
@@ -68,30 +63,24 @@ pub struct FontInfo {
     pub cid_encoding: Option<crate::text::encoding_cmap::CidEncoding>,
 }
 
-/// Enhanced text extractor with CMap support
-#[allow(dead_code)]
+/// Parser for a PDF font dictionary into the [`FontInfo`] the decoders read.
+///
+/// Stateless: it carries no cache and extracts no text. `R` names the reader
+/// type of the document whose indirect objects the parse resolves.
 pub struct CMapTextExtractor<R: Read + Seek> {
-    /// Base text extractor
-    base_extractor: TextExtractor,
-    /// Cached font information
-    font_cache: HashMap<String, FontInfo>,
     /// PDF document reference for resource lookup
     _phantom: std::marker::PhantomData<R>,
 }
 
 impl<R: Read + Seek> CMapTextExtractor<R> {
-    /// Create a new CMap-aware text extractor
-    #[allow(dead_code)]
+    /// Create a new CMap-aware font parser
     pub fn new() -> Self {
         Self {
-            base_extractor: TextExtractor::new(),
-            font_cache: HashMap::new(),
             _phantom: std::marker::PhantomData,
         }
     }
 
     /// Extract font information from a font dictionary
-    #[allow(dead_code)]
     pub fn extract_font_info(
         &mut self,
         font_dict: &PdfDictionary,
@@ -115,7 +104,6 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics::default(),
             cid_encoding: None,
@@ -205,7 +193,6 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
     }
 
     /// Parse encoding differences array
-    #[allow(dead_code)]
     fn parse_encoding_differences(
         &self,
         differences: &[PdfObject],
@@ -230,7 +217,6 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
     }
 
     /// Parse ToUnicode stream
-    #[allow(dead_code)]
     fn parse_tounicode_stream(
         &self,
         stream: &PdfStream,
@@ -241,7 +227,6 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
     }
 
     /// Extract font metrics (widths, kerning) from font dictionary
-    #[allow(dead_code)]
     fn extract_font_metrics(
         &self,
         font_dict: &PdfDictionary,
@@ -326,7 +311,7 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                         document.get_object(font_file_ref.0, font_file_ref.1)
                     {
                         // Try to extract kerning from TrueType font
-                        if let Ok(kerning_pairs) = self.extract_truetype_kerning(&font_stream) {
+                        if let Ok(kerning_pairs) = extract_truetype_kerning(&font_stream) {
                             if !kerning_pairs.is_empty() {
                                 metrics.kerning = Some(kerning_pairs);
                             }
@@ -338,216 +323,177 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
 
         Ok(metrics)
     }
+}
 
-    /// Extract kerning pairs from TrueType font stream (kern table)
-    ///
-    /// # Kerning Support
-    ///
-    /// **Implemented:**
-    /// - TrueType fonts (FontFile2): Extracts kerning from embedded `kern` table
-    ///
-    /// **NOT Implemented (by design):**
-    /// - Type1 fonts (FontFile): Type1 PFB (PostScript Font Binary) files embedded in PDFs
-    ///   only contain glyph outlines, NOT font metrics. Kerning data for Type1 fonts is stored
-    ///   separately in .afm (Adobe Font Metrics) or .pfm (PostScript Font Metrics) files,
-    ///   which are NOT embedded in PDF documents.
-    ///
-    /// For Type1 fonts requiring kerning, PDFs use TJ array position adjustments in content
-    /// streams (already handled by text extraction). There is no kerning data to extract
-    /// from embedded Type1 font programs.
-    ///
-    /// If a real-world edge case emerges where Type1 fonts DO embed kerning data, this can
-    /// be revisited. Current implementation handles 99.9% of PDFs correctly.
-    #[allow(dead_code)]
-    fn extract_truetype_kerning(
-        &self,
-        font_stream: &PdfStream,
-    ) -> ParseResult<HashMap<(u32, u32), f64>> {
-        // Decode the font stream
-        let font_data = match font_stream.decode(&ParseOptions::default()) {
-            Ok(data) => data,
-            Err(_) => return Ok(HashMap::new()), // Silently fail if can't decode
-        };
+/// Extract kerning pairs from TrueType font stream (kern table)
+///
+/// # Kerning Support
+///
+/// **Implemented:**
+/// - TrueType fonts (FontFile2): Extracts kerning from embedded `kern` table
+///
+/// **NOT Implemented (by design):**
+/// - Type1 fonts (FontFile): Type1 PFB (PostScript Font Binary) files embedded in PDFs
+///   only contain glyph outlines, NOT font metrics. Kerning data for Type1 fonts is stored
+///   separately in .afm (Adobe Font Metrics) or .pfm (PostScript Font Metrics) files,
+///   which are NOT embedded in PDF documents.
+///
+/// For Type1 fonts requiring kerning, PDFs use TJ array position adjustments in content
+/// streams (already handled by text extraction). There is no kerning data to extract
+/// from embedded Type1 font programs.
+///
+/// If a real-world edge case emerges where Type1 fonts DO embed kerning data, this can
+/// be revisited. Current implementation handles 99.9% of PDFs correctly.
+pub(crate) fn extract_truetype_kerning(
+    font_stream: &PdfStream,
+) -> ParseResult<HashMap<(u32, u32), f64>> {
+    // Decode the font stream
+    let font_data = match font_stream.decode(&ParseOptions::default()) {
+        Ok(data) => data,
+        Err(_) => return Ok(HashMap::new()), // Silently fail if can't decode
+    };
 
-        // Parse TrueType font tables
-        match self.parse_truetype_kern_table(&font_data) {
-            Ok(pairs) => Ok(pairs),
-            Err(_) => Ok(HashMap::new()), // Silently fail if parsing fails
+    // Parse TrueType font tables
+    match parse_truetype_kern_table(&font_data) {
+        Ok(pairs) => Ok(pairs),
+        Err(_) => Ok(HashMap::new()), // Silently fail if parsing fails
+    }
+}
+
+/// Parse TrueType kern table (Format 0 only)
+pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap<(u32, u32), f64>> {
+    // TrueType fonts start with a table directory
+    if font_data.len() < 12 {
+        return Err(ParseError::SyntaxError {
+            position: 0,
+            message: "Font data too short for TrueType header".to_string(),
+        });
+    }
+
+    // Read table directory offset (offset 12 + 16 * numTables)
+    let num_tables = u16::from_be_bytes([font_data[4], font_data[5]]) as usize;
+
+    // Find 'kern' table in table directory
+    let mut kern_offset = None;
+    let mut kern_length = None;
+
+    for i in 0..num_tables {
+        let table_offset = 12 + i * 16;
+        if table_offset + 16 > font_data.len() {
+            break;
+        }
+
+        // Read table tag (4 bytes)
+        let tag = &font_data[table_offset..table_offset + 4];
+
+        if tag == b"kern" {
+            // Read table offset and length
+            kern_offset = Some(u32::from_be_bytes([
+                font_data[table_offset + 8],
+                font_data[table_offset + 9],
+                font_data[table_offset + 10],
+                font_data[table_offset + 11],
+            ]) as usize);
+
+            kern_length = Some(u32::from_be_bytes([
+                font_data[table_offset + 12],
+                font_data[table_offset + 13],
+                font_data[table_offset + 14],
+                font_data[table_offset + 15],
+            ]) as usize);
+
+            break;
         }
     }
 
-    /// Parse TrueType kern table (Format 0 only)
-    #[allow(dead_code)]
-    fn parse_truetype_kern_table(&self, font_data: &[u8]) -> ParseResult<HashMap<(u32, u32), f64>> {
-        // TrueType fonts start with a table directory
-        if font_data.len() < 12 {
-            return Err(ParseError::SyntaxError {
-                position: 0,
-                message: "Font data too short for TrueType header".to_string(),
-            });
-        }
+    // If no kern table found, return empty map
+    let (offset, length) = match (kern_offset, kern_length) {
+        (Some(o), Some(l)) => (o, l),
+        _ => return Ok(HashMap::new()),
+    };
 
-        // Read table directory offset (offset 12 + 16 * numTables)
-        let num_tables = u16::from_be_bytes([font_data[4], font_data[5]]) as usize;
-
-        // Find 'kern' table in table directory
-        let mut kern_offset = None;
-        let mut kern_length = None;
-
-        for i in 0..num_tables {
-            let table_offset = 12 + i * 16;
-            if table_offset + 16 > font_data.len() {
-                break;
-            }
-
-            // Read table tag (4 bytes)
-            let tag = &font_data[table_offset..table_offset + 4];
-
-            if tag == b"kern" {
-                // Read table offset and length
-                kern_offset = Some(u32::from_be_bytes([
-                    font_data[table_offset + 8],
-                    font_data[table_offset + 9],
-                    font_data[table_offset + 10],
-                    font_data[table_offset + 11],
-                ]) as usize);
-
-                kern_length = Some(u32::from_be_bytes([
-                    font_data[table_offset + 12],
-                    font_data[table_offset + 13],
-                    font_data[table_offset + 14],
-                    font_data[table_offset + 15],
-                ]) as usize);
-
-                break;
-            }
-        }
-
-        // If no kern table found, return empty map
-        let (offset, length) = match (kern_offset, kern_length) {
-            (Some(o), Some(l)) => (o, l),
-            _ => return Ok(HashMap::new()),
-        };
-
-        if offset + length > font_data.len() {
-            return Err(ParseError::SyntaxError {
-                position: offset,
-                message: "Invalid kern table offset".to_string(),
-            });
-        }
-
-        // Parse kern table header
-        let kern_data = &font_data[offset..offset + length];
-        if kern_data.len() < 4 {
-            return Ok(HashMap::new());
-        }
-
-        // Version and nTables
-        // nTables is a u16 at bytes 2-3
-        let n_tables = u16::from_be_bytes([kern_data[2], kern_data[3]]) as usize;
-
-        let mut kerning_pairs = HashMap::new();
-        let mut table_offset = 4; // After header
-
-        // Parse each subtable (we only support Format 0)
-        for _ in 0..n_tables {
-            if table_offset + 6 > kern_data.len() {
-                break;
-            }
-
-            // Subtable header
-            let subtable_length = u32::from_be_bytes([
-                0,
-                0,
-                kern_data[table_offset + 2],
-                kern_data[table_offset + 3],
-            ]) as usize;
-
-            let coverage =
-                u16::from_be_bytes([kern_data[table_offset + 4], kern_data[table_offset + 5]]);
-
-            // Format is in the lower byte per TrueType spec (ISO 14496-22:2019)
-            let format = coverage & 0xFF;
-
-            // Only process Format 0 (ordered pair list)
-            if format == 0 && table_offset + subtable_length <= kern_data.len() {
-                let subtable_data = &kern_data[table_offset + 6..table_offset + subtable_length];
-
-                if subtable_data.len() >= 8 {
-                    let n_pairs = u16::from_be_bytes([subtable_data[0], subtable_data[1]]) as usize;
-
-                    // Skip searchRange, entrySelector, rangeShift (6 bytes)
-                    let mut pair_offset = 8;
-
-                    for _ in 0..n_pairs {
-                        if pair_offset + 6 > subtable_data.len() {
-                            break;
-                        }
-
-                        let left_glyph = u16::from_be_bytes([
-                            subtable_data[pair_offset],
-                            subtable_data[pair_offset + 1],
-                        ]) as u32;
-
-                        let right_glyph = u16::from_be_bytes([
-                            subtable_data[pair_offset + 2],
-                            subtable_data[pair_offset + 3],
-                        ]) as u32;
-
-                        let value = i16::from_be_bytes([
-                            subtable_data[pair_offset + 4],
-                            subtable_data[pair_offset + 5],
-                        ]) as f64;
-
-                        // Store kerning pair (value is in FUnits, typically 1/1000)
-                        kerning_pairs.insert((left_glyph, right_glyph), value);
-
-                        pair_offset += 6;
-                    }
-                }
-            }
-
-            table_offset += subtable_length;
-        }
-
-        Ok(kerning_pairs)
+    if offset + length > font_data.len() {
+        return Err(ParseError::SyntaxError {
+            position: offset,
+            message: "Invalid kern table offset".to_string(),
+        });
     }
 
-    /// Extract text from a page with CMap support
-    #[allow(dead_code)]
-    pub fn extract_text_from_page(
-        &mut self,
-        document: &PdfDocument<R>,
-        page_index: u32,
-    ) -> ParseResult<String> {
-        // Get page
-        let page = document.get_page(page_index)?;
+    // Parse kern table header
+    let kern_data = &font_data[offset..offset + length];
+    if kern_data.len() < 4 {
+        return Ok(HashMap::new());
+    }
 
-        // Extract font resources
-        if let Some(resources) = page.get_resources() {
-            if let Some(PdfObject::Dictionary(font_dict)) = resources.get("Font") {
-                // Cache all fonts from this page
-                for (font_name, font_obj) in font_dict.0.iter() {
-                    if let Some(font_ref) = font_obj.as_reference() {
-                        if let Ok(PdfObject::Dictionary(font_dict)) =
-                            document.get_object(font_ref.0, font_ref.1)
-                        {
-                            if let Ok(font_info) = self.extract_font_info(&font_dict, document) {
-                                self.font_cache.insert(font_name.0.clone(), font_info);
-                            }
-                        }
+    // Version and nTables
+    // nTables is a u16 at bytes 2-3
+    let n_tables = u16::from_be_bytes([kern_data[2], kern_data[3]]) as usize;
+
+    let mut kerning_pairs = HashMap::new();
+    let mut table_offset = 4; // After header
+
+    // Parse each subtable (we only support Format 0)
+    for _ in 0..n_tables {
+        if table_offset + 6 > kern_data.len() {
+            break;
+        }
+
+        // Subtable header
+        let subtable_length = u32::from_be_bytes([
+            0,
+            0,
+            kern_data[table_offset + 2],
+            kern_data[table_offset + 3],
+        ]) as usize;
+
+        let coverage =
+            u16::from_be_bytes([kern_data[table_offset + 4], kern_data[table_offset + 5]]);
+
+        // Format is in the lower byte per TrueType spec (ISO 14496-22:2019)
+        let format = coverage & 0xFF;
+
+        // Only process Format 0 (ordered pair list)
+        if format == 0 && table_offset + subtable_length <= kern_data.len() {
+            let subtable_data = &kern_data[table_offset + 6..table_offset + subtable_length];
+
+            if subtable_data.len() >= 8 {
+                let n_pairs = u16::from_be_bytes([subtable_data[0], subtable_data[1]]) as usize;
+
+                // Skip searchRange, entrySelector, rangeShift (6 bytes)
+                let mut pair_offset = 8;
+
+                for _ in 0..n_pairs {
+                    if pair_offset + 6 > subtable_data.len() {
+                        break;
                     }
+
+                    let left_glyph = u16::from_be_bytes([
+                        subtable_data[pair_offset],
+                        subtable_data[pair_offset + 1],
+                    ]) as u32;
+
+                    let right_glyph = u16::from_be_bytes([
+                        subtable_data[pair_offset + 2],
+                        subtable_data[pair_offset + 3],
+                    ]) as u32;
+
+                    let value = i16::from_be_bytes([
+                        subtable_data[pair_offset + 4],
+                        subtable_data[pair_offset + 5],
+                    ]) as f64;
+
+                    // Store kerning pair (value is in FUnits, typically 1/1000)
+                    kerning_pairs.insert((left_glyph, right_glyph), value);
+
+                    pair_offset += 6;
                 }
             }
         }
 
-        // Extract text using base extractor
-        // Note: This would need to be enhanced to use the cached font information
-        let extracted = self
-            .base_extractor
-            .extract_from_page(document, page_index)?;
-        Ok(extracted.text)
+        table_offset += subtable_length;
     }
+
+    Ok(kerning_pairs)
 }
 
 /// The whitespace `sanitize_extracted_text` keeps downstream. `decode_is_usable`
@@ -575,6 +521,68 @@ pub(crate) fn decode_is_usable(decoded: &str) -> bool {
         && !decoded
             .chars()
             .all(|c| c.is_control() && !is_preservable_whitespace(c))
+}
+
+/// How a page's `/Font` subdictionary names one font.
+///
+/// Both forms are legal: any dictionary value may be written directly
+/// (ISO 32000-1 §7.3.7), and §9.5 imposes no reference requirement on the
+/// entries of the font subdictionary. Real producers use both — our own writer
+/// emits them inline.
+pub(crate) enum FontEntry {
+    /// `/F1 12 0 R`. The font dictionary is its own object, so a caller may
+    /// cache the parsed font across pages keyed by that object id.
+    Indirect(u32, u16),
+    /// `/F1 << /Type /Font ... >>`. Written directly into the resources; there
+    /// is no object id to key a cross-page cache on, so it is parsed per page.
+    Inline(PdfDictionary),
+}
+
+/// Resolve a page's `/Font` resource subdictionary into its entries.
+///
+/// Resolves the `/Font` level (itself either a dictionary or a reference) and
+/// classifies each entry, without resolving the entries themselves — a caller
+/// holding a font cache keyed by object id can then skip the fetch entirely on
+/// a hit.
+///
+/// Every text extractor used to read only the entries that were indirect
+/// references, so a page with inline fonts decoded against an empty cache: no
+/// `/ToUnicode`, no `/Encoding`, and the byte-wise fallback turned glyph codes
+/// into whatever those bytes mean in WinAnsi.
+///
+/// Dereferences a single level, the convention throughout the parser: a `/Font`
+/// (or an entry) written as a reference *to another reference* dereferences to a
+/// `Reference`, falls through, and drops the font. That shape does not occur in
+/// the measured corpus and no producer is known to emit it; a double-indirect
+/// font resource would need its own handling.
+pub(crate) fn resolve_font_entries<R: Read + Seek>(
+    resources: &PdfDictionary,
+    document: &PdfDocument<R>,
+) -> Vec<(String, FontEntry)> {
+    let font_dict = match resources.get("Font") {
+        Some(PdfObject::Dictionary(dict)) => Some(dict.clone()),
+        Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+            Ok(PdfObject::Dictionary(dict)) => Some(dict),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    let Some(font_dict) = font_dict else {
+        return Vec::new();
+    };
+
+    font_dict
+        .0
+        .iter()
+        .filter_map(|(name, obj)| match obj {
+            PdfObject::Reference(num, gen) => {
+                Some((name.0.clone(), FontEntry::Indirect(*num, *gen)))
+            }
+            PdfObject::Dictionary(dict) => Some((name.0.clone(), FontEntry::Inline(dict.clone()))),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Decode text using font information — free function (no allocations).
@@ -773,7 +781,6 @@ fn decode_with_encoding(text_bytes: &[u8], font_info: &FontInfo) -> ParseResult<
 }
 
 /// Convert glyph name to Unicode character
-#[allow(dead_code)]
 fn glyph_name_to_unicode(name: &str) -> Option<char> {
     // Adobe Glyph List mapping (simplified subset)
     match name {
@@ -819,7 +826,6 @@ fn glyph_name_to_unicode(name: &str) -> Option<char> {
 }
 
 /// Decode WinAnsiEncoding
-#[allow(dead_code)]
 fn decode_winansi(byte: u8) -> char {
     // WinAnsiEncoding is mostly Latin-1 with some differences in 0x80-0x9F range
     match byte {
@@ -855,7 +861,6 @@ fn decode_winansi(byte: u8) -> char {
 }
 
 /// Decode MacRomanEncoding
-#[allow(dead_code)]
 fn decode_macroman(byte: u8) -> char {
     // MacRomanEncoding differs from Latin-1 in the 0x80-0xFF range
     match byte {
@@ -897,7 +902,6 @@ fn decode_macroman(byte: u8) -> char {
 }
 
 /// Decode StandardEncoding
-#[allow(dead_code)]
 fn decode_standard(byte: u8) -> char {
     // StandardEncoding is similar to Latin-1 with some differences
     // For simplicity, using Latin-1 as approximation
@@ -941,7 +945,6 @@ mod tests {
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics::default(),
             cid_encoding: None,
@@ -981,7 +984,6 @@ endcmap
             to_unicode: Some(cmap),
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics::default(),
             cid_encoding: None,
@@ -1018,7 +1020,6 @@ endcmap
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: Some("GB1".into()),
             metrics: FontMetrics::default(),
             cid_encoding: None,
@@ -1030,7 +1031,6 @@ endcmap
             to_unicode: None,
             differences: None,
             descendant_font: Some(Box::new(descendant)),
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics::default(),
             cid_encoding: Some(CidEncoding::Cmap(enc)),
@@ -1050,7 +1050,6 @@ endcmap
             to_unicode: None,
             differences: None,
             descendant_font: None,
-            cid_to_gid_map: None,
             cid_ordering: Some("GB1".into()),
             metrics: FontMetrics::default(),
             cid_encoding: None,
@@ -1062,7 +1061,6 @@ endcmap
             to_unicode: None,
             differences: None,
             descendant_font: Some(Box::new(descendant)),
-            cid_to_gid_map: None,
             cid_ordering: None,
             metrics: FontMetrics::default(),
             cid_encoding: Some(CidEncoding::Utf16Be),
@@ -1094,28 +1092,4 @@ endcmap
             "explicit mapping must override the CID-table fallback"
         );
     }
-}
-
-// =========================================================================
-// PUBLIC TEST HELPERS FOR KERNING (Issue #87 - Quality Agent Required)
-// =========================================================================
-
-/// Extract kerning pairs from raw TrueType font data (public wrapper for tests)
-///
-/// This is a convenience function for testing kerning extraction without
-/// needing a full PdfDocument context.
-#[allow(dead_code)]
-pub fn extract_truetype_kerning(font_data: &[u8]) -> ParseResult<HashMap<(u32, u32), f64>> {
-    let extractor: CMapTextExtractor<std::fs::File> = CMapTextExtractor::new();
-    extractor.parse_truetype_kern_table(font_data)
-}
-
-/// Parse TrueType kern table from raw kern table data (public wrapper for tests)
-///
-/// This function parses the kern table data directly, useful for unit testing
-/// the kern table parser without needing a full TrueType font file.
-#[allow(dead_code)]
-pub fn parse_truetype_kern_table(kern_data: &[u8]) -> ParseResult<HashMap<(u32, u32), f64>> {
-    let extractor: CMapTextExtractor<std::fs::File> = CMapTextExtractor::new();
-    extractor.parse_truetype_kern_table(kern_data)
 }

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -489,23 +489,26 @@ impl PlainTextExtractor {
 
         // Get page resources
         if let Some(resources) = page.get_resources() {
-            if let Some(PdfObject::Dictionary(font_dict)) = resources.get("Font") {
-                // Extract each font
-                for (font_name, font_obj) in font_dict.0.iter() {
-                    if let Some(font_ref) = font_obj.as_reference() {
-                        if let Ok(PdfObject::Dictionary(font_dict)) =
-                            document.get_object(font_ref.0, font_ref.1)
-                        {
-                            // Create a CMap extractor to use its font extraction logic
-                            let mut cmap_extractor: CMapTextExtractor<R> = CMapTextExtractor::new();
-
-                            if let Ok(font_info) =
-                                cmap_extractor.extract_font_info(&font_dict, document)
-                            {
-                                self.font_cache.insert(font_name.0.clone(), font_info);
-                            }
+            // `/Font` and each of its entries may be a reference or a direct
+            // dictionary; reading only the references left the cache empty on
+            // pages with inline fonts, losing `/ToUnicode`.
+            for (font_name, entry) in
+                crate::text::extraction_cmap::resolve_font_entries(resources, document)
+            {
+                let font_dict = match entry {
+                    crate::text::extraction_cmap::FontEntry::Indirect(num, gen) => {
+                        match document.get_object(num, gen) {
+                            Ok(PdfObject::Dictionary(dict)) => dict,
+                            _ => continue,
                         }
                     }
+                    crate::text::extraction_cmap::FontEntry::Inline(dict) => dict,
+                };
+
+                // Create a CMap extractor to use its font extraction logic
+                let mut cmap_extractor: CMapTextExtractor<R> = CMapTextExtractor::new();
+                if let Ok(font_info) = cmap_extractor.extract_font_info(&font_dict, document) {
+                    self.font_cache.insert(font_name, font_info);
                 }
             }
         }

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -3016,12 +3016,25 @@ impl<W: Write> PdfWriter<W> {
                 for (xobj_name, xobj_obj) in xobjects.iter() {
                     match xobj_obj {
                         Object::Stream(dict, data) => {
+                            // #465: an image XObject's dictionary can carry
+                            // nested streams (a soft mask `/SMask`, a `/Mask`,
+                            // an ICCBased colour space) that `from_parsed_with_content`
+                            // inlined. Per ISO 32000-1 §7.3.8 a stream MUST be an
+                            // indirect object, so a nested inline stream would
+                            // produce invalid PDF; externalize each before
+                            // writing the image itself.
+                            let dict = self.externalize_nested_streams_in_dict(dict)?;
                             let obj_id = self.allocate_object_id();
-                            self.write_object(obj_id, Object::Stream(dict.clone(), data.clone()))?;
+                            self.write_object(obj_id, Object::Stream(dict, data.clone()))?;
                             xobjects_with_refs.set(xobj_name, Object::Reference(obj_id));
                         }
                         Object::Dictionary(dict) => {
-                            // Dictionary XObjects may contain nested streams (e.g., SMask)
+                            // A bare-dictionary XObject is already invalid per
+                            // ISO 32000-1 §8.10 (XObjects must be streams), so it
+                            // cannot legitimately carry the array-/sub-dict-nested
+                            // stream shapes the Stream arm above must handle.
+                            // Top-level externalization is deliberately enough
+                            // here; do not "fix" this into the recursive walk.
                             let externalized = self.externalize_streams_in_dict(dict)?;
                             xobjects_with_refs.set(xobj_name, Object::Dictionary(externalized));
                         }
@@ -3251,6 +3264,50 @@ impl<W: Write> PdfWriter<W> {
         dict: &crate::objects::Dictionary,
     ) -> Result<crate::objects::Dictionary> {
         self.externalize_streams_in_dict_with_font_refs(dict, &HashMap::new())
+    }
+
+    /// Recursively rewrites every inline `Object::Stream` reachable through a
+    /// dictionary — including streams nested inside sub-dictionaries and arrays
+    /// — into an indirect reference, writing each as its own object (#465).
+    ///
+    /// Unlike [`externalize_streams_in_dict`], which only externalizes streams
+    /// at the top level of the dictionary, this walks arrays and nested
+    /// dictionaries too. It is applied to a preserved image XObject's
+    /// dictionary, where `from_parsed_with_content` may have inlined a soft
+    /// mask (`/SMask`), a `/Mask`, or an ICCBased colour-space stream (which
+    /// lives inside a `/ColorSpace` array). Per ISO 32000-1 §7.3.8 a stream
+    /// must be an indirect object, so none may remain inline.
+    fn externalize_nested_streams_in_dict(
+        &mut self,
+        dict: &crate::objects::Dictionary,
+    ) -> Result<crate::objects::Dictionary> {
+        let mut result = crate::objects::Dictionary::new();
+        for (key, value) in dict.iter() {
+            result.set(key, self.externalize_nested_streams_value(value)?);
+        }
+        Ok(result)
+    }
+
+    fn externalize_nested_streams_value(&mut self, value: &Object) -> Result<Object> {
+        match value {
+            Object::Stream(d, data) => {
+                let d = self.externalize_nested_streams_in_dict(d)?;
+                let obj_id = self.allocate_object_id();
+                self.write_object(obj_id, Object::Stream(d, data.clone()))?;
+                Ok(Object::Reference(obj_id))
+            }
+            Object::Dictionary(d) => Ok(Object::Dictionary(
+                self.externalize_nested_streams_in_dict(d)?,
+            )),
+            Object::Array(items) => {
+                let mut out = Vec::with_capacity(items.len());
+                for item in items {
+                    out.push(self.externalize_nested_streams_value(item)?);
+                }
+                Ok(Object::Array(out))
+            }
+            other => Ok(other.clone()),
+        }
     }
 
     /// Same as [`externalize_streams_in_dict`] but also rewrites any

--- a/oxidize-pdf-core/tests/inline_font_resources_test.rs
+++ b/oxidize-pdf-core/tests/inline_font_resources_test.rs
@@ -1,0 +1,203 @@
+//! A `/Font` entry may legally be a direct dictionary, not only an indirect
+//! reference (ISO 32000-1 §7.3.7: any dictionary value may be direct, and §9.5
+//! puts no reference requirement on the font subdictionary's entries). Every
+//! text extractor cached only the entries that were indirect references, so a
+//! page whose fonts are inline decoded with an empty font cache: no `/ToUnicode`
+//! CMap, no `/Encoding`, byte-wise fallback — the glyph codes came out as
+//! whatever the raw bytes happen to mean in WinAnsi.
+//!
+//! This is not a synthetic concern: our own writer emits page resources with
+//! inline font dictionaries, so any document round-tripped through this library
+//! (`merge`, and every page operation) came back unreadable to our own
+//! extractors while other readers read it fine.
+//!
+//! The oracle is falsifiable by construction: `/ToUnicode` maps `A` to `Ω` and
+//! `B` to `Δ`. A decode that consults the font yields `ΩΔ`; the byte-wise
+//! fallback yields `AB`. The two answers cannot be confused.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::operations::{merge_pdfs, MergeInput, MergeOptions};
+use oxidize_pdf::parser::{ParseOptions, PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, PlainTextExtractor, TextExtractor};
+use std::io::Cursor;
+
+/// `/ToUnicode` CMap mapping the single-byte codes 0x41/0x42 to Ω/Δ.
+fn tounicode_cmap() -> Vec<u8> {
+    b"/CIDInit /ProcSet findresource begin\n\
+      12 dict begin\n\
+      begincmap\n\
+      /CMapName /Test-UCS2 def\n\
+      /CMapType 2 def\n\
+      1 begincodespacerange\n\
+      <00> <FF>\n\
+      endcodespacerange\n\
+      2 beginbfchar\n\
+      <41> <03A9>\n\
+      <42> <0394>\n\
+      endbfchar\n\
+      endcmap\n\
+      CMapName currentdict /CMap defineresource pop\n\
+      end\n\
+      end"
+    .to_vec()
+}
+
+/// Page draws `(AB)` with `/F1`, whose font dictionary carries the `/ToUnicode`
+/// above. `font_dict_indirect` selects whether the `/Font` **subdictionary**
+/// itself is written inline or behind a reference; in both shapes the `/F1`
+/// entry inside it is a direct dictionary, which is what this pins.
+fn pdf_with_inline_font(font_dict_indirect: bool) -> Vec<u8> {
+    let font_entry = "/F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica /ToUnicode 5 0 R >>";
+    let content = b"BT /F1 12 Tf 20 100 Td (AB) Tj ET".to_vec();
+
+    let (resources, extra) = if font_dict_indirect {
+        ("/Font 6 0 R".to_string(), true)
+    } else {
+        (format!("/Font << {font_entry} >>"), false)
+    };
+
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << {resources} >> /Contents 4 0 R >>"
+        )
+        .into_bytes(),
+        stream_obj("", &content),
+        stream_obj("", &tounicode_cmap()),
+    ];
+    if extra {
+        objects.push(format!("<< {font_entry} >>").into_bytes());
+    }
+    assemble_pdf(&objects)
+}
+
+fn doc_of(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
+    let reader =
+        PdfReader::new_with_options(Cursor::new(bytes), ParseOptions::default()).expect("parses");
+    PdfDocument::new(reader)
+}
+
+#[test]
+fn text_extractor_reads_tounicode_from_an_inline_font_dictionary() {
+    let doc = doc_of(pdf_with_inline_font(false));
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    let text = extractor.extract_from_page(&doc, 0).expect("extracts").text;
+
+    assert!(
+        text.contains('\u{03A9}') && text.contains('\u{0394}'),
+        "inline font dictionary ignored: /ToUnicode never consulted, got {text:?}"
+    );
+    assert!(
+        !text.contains("AB"),
+        "raw glyph codes leaked through the byte-wise fallback: {text:?}"
+    );
+}
+
+#[test]
+fn text_extractor_reads_inline_font_behind_an_indirect_font_subdictionary() {
+    let doc = doc_of(pdf_with_inline_font(true));
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    let text = extractor.extract_from_page(&doc, 0).expect("extracts").text;
+
+    assert!(
+        text.contains('\u{03A9}') && text.contains('\u{0394}'),
+        "inline font behind an indirect /Font dictionary ignored, got {text:?}"
+    );
+}
+
+#[test]
+fn plain_text_extractor_reads_tounicode_from_an_inline_font_dictionary() {
+    let doc = doc_of(pdf_with_inline_font(false));
+    let mut extractor = PlainTextExtractor::new();
+    let text = extractor.extract(&doc, 0).expect("extracts").text;
+
+    assert!(
+        text.contains('\u{03A9}') && text.contains('\u{0394}'),
+        "PlainTextExtractor ignored the inline font dictionary, got {text:?}"
+    );
+    assert!(
+        !text.contains("AB"),
+        "raw glyph codes leaked through the byte-wise fallback: {text:?}"
+    );
+}
+
+#[test]
+fn plain_text_extractor_resolves_an_indirect_font_subdictionary() {
+    let doc = doc_of(pdf_with_inline_font(true));
+    let mut extractor = PlainTextExtractor::new();
+    let text = extractor.extract(&doc, 0).expect("extracts").text;
+
+    assert!(
+        text.contains('\u{03A9}') && text.contains('\u{0394}'),
+        "PlainTextExtractor did not resolve /Font as an indirect reference, got {text:?}"
+    );
+}
+
+/// Extract every page of a document as one string.
+fn whole_document_text(path: &str) -> String {
+    let reader = PdfReader::open_with_options(path, ParseOptions::default()).expect("opens");
+    let doc = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    let mut out = String::new();
+    for page in 0..doc.page_count().expect("page count") {
+        if let Ok(extracted) = extractor.extract_from_page(&doc, page) {
+            out.push_str(&extracted.text);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// The end-to-end consequence, on a real 44-page document with subsetted
+/// `Identity-H` CID fonts: a document written by this library must stay
+/// readable to this library. Before the fix `merge` wrote a file other readers
+/// (poppler) read perfectly while our own extractors returned the raw glyph
+/// codes — `Cold` came back as `& R O G`.
+///
+/// The assertion is on whole words rather than on character counts on purpose:
+/// the mojibake preserved length, so any size- or coverage-based check passed
+/// straight through it.
+#[test]
+fn a_document_written_by_this_library_stays_readable_to_this_library() {
+    let input = "tests/fixtures/Cold_Email_Hacks.pdf";
+    let output = std::env::temp_dir().join("inline_font_round_trip.pdf");
+    merge_pdfs(
+        vec![MergeInput::new(input)],
+        &output,
+        MergeOptions::default(),
+    )
+    .expect("merge writes the document");
+
+    let before = whole_document_text(input);
+    let after = whole_document_text(output.to_str().expect("utf-8 path"));
+
+    let after_words: std::collections::HashSet<&str> = after.split_whitespace().collect();
+    let before_words: Vec<&str> = before
+        .split_whitespace()
+        .filter(|w| w.chars().filter(|c| c.is_alphabetic()).count() >= 4)
+        .collect();
+
+    assert!(
+        before_words.len() > 1000,
+        "fixture no longer carries enough text to make this test meaningful: {} words",
+        before_words.len()
+    );
+
+    let kept = before_words
+        .iter()
+        .filter(|w| after_words.contains(*w))
+        .count();
+    let retention = kept as f64 / before_words.len() as f64;
+
+    assert!(
+        retention > 0.99,
+        "round trip lost the text: {kept}/{} words survived ({retention:.4}); \
+         output begins {:?}",
+        before_words.len(),
+        after.chars().take(80).collect::<String>()
+    );
+}

--- a/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
@@ -1,0 +1,269 @@
+//! #453: the page operations (rotate, split, reorder, page extraction) must
+//! preserve page content, not reconstruct it.
+//!
+//! Each operation used to walk the content stream with its own operator `match`
+//! and re-emit text through the high-level page API — mapping every font to one
+//! of the standard 14, decoding bytes with `from_utf8`, and dropping every
+//! operator it did not recognize (images, XObjects, curves, and any positioning
+//! operator beyond `Td`). The produced PDF was therefore wrong: text at the
+//! wrong place or gone, images gone. The correct behavior is to copy the
+//! original content streams and resources verbatim, exactly as `merge` does.
+//!
+//! The oracle is poppler (`pdftotext` / `pdfimages`), independent of this
+//! crate's own extractor: it reads the *bytes we wrote*, so a passing test means
+//! the written PDF is correct for any reader, not just ours.
+
+use oxidize_pdf::operations::PageRange;
+use oxidize_pdf::operations::{
+    extract_page_to_file, reorder_pdf_pages, rotate_pdf_pages, split_into_pages, RotateOptions,
+    RotationAngle,
+};
+use std::path::Path;
+use std::process::Command;
+
+const FIXTURE: &str = "tests/fixtures/Cold_Email_Hacks.pdf";
+
+/// The fixture's title page (index 0) is image-only; page 16 (1-based) is the
+/// first that carries both substantial prose and images, so it exercises text
+/// and raster preservation together. Verified against poppler: 100 words, 2
+/// images, `/Rotate` absent.
+const RICH_PAGE_1BASED: u32 = 16;
+const RICH_PAGE_0BASED: usize = 15;
+const PAGE_COUNT: usize = 44;
+
+/// Words of 4+ letters that poppler extracts from a 1-based page range of a file.
+fn poppler_words(path: &Path, first: u32, last: u32) -> Option<Vec<String>> {
+    let out = Command::new("pdftotext")
+        .args([
+            "-f",
+            &first.to_string(),
+            "-l",
+            &last.to_string(),
+            path.to_str()?,
+            "-",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    Some(
+        text.split_whitespace()
+            .filter(|w| w.chars().filter(|c| c.is_alphabetic()).count() >= 4)
+            .map(|w| w.to_string())
+            .collect(),
+    )
+}
+
+/// Number of raster images (type `image`) poppler finds in a 1-based page
+/// range. Soft masks (type `smask`) are excluded on purpose: preserving an
+/// image XObject's nested `/SMask` stream is a separate resource-embedding gap
+/// in the verbatim-copy path (it affects `merge` too), not part of the
+/// operator-dispatch defect #453 fixes.
+fn poppler_image_count(path: &Path, first: u32, last: u32) -> Option<usize> {
+    let out = Command::new("pdfimages")
+        .args([
+            "-list",
+            "-f",
+            &first.to_string(),
+            "-l",
+            &last.to_string(),
+            path.to_str()?,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // Header is two lines; the `type` column (index 2) is `image` for a raster.
+    Some(
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .skip(2)
+            .filter(|l| l.split_whitespace().nth(2) == Some("image"))
+            .count(),
+    )
+}
+
+/// `/Rotate` value poppler reports for a 1-based page (0 when absent).
+fn poppler_rotation(path: &Path, page: u32) -> Option<i32> {
+    let out = Command::new("pdfinfo")
+        .args([
+            "-f",
+            &page.to_string(),
+            "-l",
+            &page.to_string(),
+            path.to_str()?,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    // `Page N rot: 90`
+    for line in text.lines() {
+        if let Some(rest) = line.split("rot:").nth(1) {
+            return rest.trim().parse().ok();
+        }
+    }
+    Some(0)
+}
+
+fn poppler_available() -> bool {
+    Command::new("pdftotext").arg("-v").output().is_ok()
+        && Command::new("pdfimages").arg("-v").output().is_ok()
+        && Command::new("pdfinfo").arg("-v").output().is_ok()
+}
+
+/// Fraction of `want` present in `got`.
+fn retention(want: &[String], got: &[String]) -> f64 {
+    if want.is_empty() {
+        return 1.0;
+    }
+    let set: std::collections::HashSet<&String> = got.iter().collect();
+    want.iter().filter(|w| set.contains(w)).count() as f64 / want.len() as f64
+}
+
+#[test]
+fn extract_page_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+    assert!(
+        want_words.len() > 20 && want_images >= 1,
+        "fixture rich page must have prose and an image to make this test meaningful: \
+         {} words, {} images",
+        want_words.len(),
+        want_images
+    );
+
+    let out = std::env::temp_dir().join("issue453_extract.pdf");
+    extract_page_to_file(src, RICH_PAGE_0BASED, &out).expect("extract");
+
+    let got_words = poppler_words(&out, 1, 1).expect("output words");
+    let got_images = poppler_image_count(&out, 1, 1).expect("output images");
+
+    let r = retention(&want_words, &got_words);
+    assert!(
+        r > 0.99,
+        "extracted page lost text: retention {r:.4} ({}/{} words)",
+        (r * want_words.len() as f64) as usize,
+        want_words.len()
+    );
+    assert_eq!(
+        got_images, want_images,
+        "extracted page lost the image(s): {got_images} vs {want_images}"
+    );
+}
+
+#[test]
+fn split_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+
+    let dir = std::env::temp_dir().join("issue453_split");
+    std::fs::create_dir_all(&dir).unwrap();
+    let pattern = dir.join("page_{}.pdf");
+    let paths = split_into_pages(src, pattern.to_str().unwrap()).expect("split");
+    let rich = &paths[RICH_PAGE_0BASED];
+
+    let got_words = poppler_words(rich, 1, 1).expect("output words");
+    let got_images = poppler_image_count(rich, 1, 1).expect("output images");
+
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "split rich page lost text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+    assert_eq!(
+        got_images, want_images,
+        "split rich page lost the image(s): {got_images} vs {want_images}"
+    );
+}
+
+#[test]
+fn reorder_preserves_text_and_images() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+
+    let out = std::env::temp_dir().join("issue453_reorder.pdf");
+    // Reorder needs a full permutation; reverse the whole document.
+    let order: Vec<usize> = (0..PAGE_COUNT).rev().collect();
+    reorder_pdf_pages(src, &out, order).expect("reorder");
+
+    // After reversal the rich source page (0-based RICH_PAGE_0BASED) lands at
+    // output 0-based PAGE_COUNT-1-RICH_PAGE_0BASED.
+    let dest_1based = (PAGE_COUNT - 1 - RICH_PAGE_0BASED + 1) as u32;
+    let got_words = poppler_words(&out, dest_1based, dest_1based).expect("output words");
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "reorder mislaid the rich page's text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+}
+
+#[test]
+fn rotate_sets_native_rotate_and_preserves_content() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want_words = poppler_words(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source words");
+    let want_images =
+        poppler_image_count(src, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("source images");
+    assert_eq!(
+        poppler_rotation(src, RICH_PAGE_1BASED),
+        Some(0),
+        "fixture rich page is expected unrotated"
+    );
+
+    let out = std::env::temp_dir().join("issue453_rotate.pdf");
+    rotate_pdf_pages(
+        src,
+        &out,
+        RotateOptions {
+            angle: RotationAngle::Clockwise90,
+            pages: PageRange::All,
+            preserve_page_size: false,
+        },
+    )
+    .expect("rotate");
+
+    // Native /Rotate, not a baked-in content transform.
+    assert_eq!(
+        poppler_rotation(&out, RICH_PAGE_1BASED),
+        Some(90),
+        "rotate did not set the native /Rotate entry"
+    );
+    // Content is untouched by a /Rotate rotation: same text, same image.
+    let got_words = poppler_words(&out, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("output words");
+    let got_images =
+        poppler_image_count(&out, RICH_PAGE_1BASED, RICH_PAGE_1BASED).expect("output images");
+    assert!(
+        retention(&want_words, &got_words) > 0.99,
+        "rotate lost text: retention {:.4}",
+        retention(&want_words, &got_words)
+    );
+    assert_eq!(
+        got_images, want_images,
+        "rotate lost the image(s): {got_images} vs {want_images}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
@@ -57,10 +57,11 @@ fn poppler_words(path: &Path, first: u32, last: u32) -> Option<Vec<String>> {
 }
 
 /// Number of raster images (type `image`) poppler finds in a 1-based page
-/// range. Soft masks (type `smask`) are excluded on purpose: preserving an
-/// image XObject's nested `/SMask` stream is a separate resource-embedding gap
-/// in the verbatim-copy path (it affects `merge` too), not part of the
-/// operator-dispatch defect #453 fixes.
+/// range. Soft masks (type `smask`) are counted separately here because they
+/// were a distinct resource-embedding gap in the verbatim-copy path — the
+/// operator-dispatch defect #453 fixes is orthogonal to it. That gap is now
+/// closed by #465; its own regression coverage lives in
+/// `issue_465_smask_preservation_test.rs`.
 fn poppler_image_count(path: &Path, first: u32, last: u32) -> Option<usize> {
     let out = Command::new("pdfimages")
         .args([

--- a/oxidize-pdf-core/tests/issue_453_text_streamer_positioning_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_text_streamer_positioning_test.rs
@@ -1,0 +1,86 @@
+//! #453: `TextStreamer`, a public extraction path, tracked only `Td`. It
+//! ignored `TD`, `T*`, `Tm`, and the `'`/`"` show-and-move operators, so every
+//! line placed with one of them landed at the previous line's coordinates —
+//! lines fused, positions wrong. This mirrors the `PlainTextExtractor` defect of
+//! #451, on the third extractor.
+//!
+//! The oracle is the y-coordinate of each emitted chunk: a content stream that
+//! places four lines with four different positioning operators must yield four
+//! chunks at four descending y values.
+
+use oxidize_pdf::streaming::{TextStreamOptions, TextStreamer};
+
+/// A content stream that draws one word per line, each line reached by a
+/// different positioning operator:
+///   line 1: `Td` (absolute-ish move from the BT origin)
+///   line 2: `T*` (uses the leading set by `TL`)
+///   line 3: `TD` (moves and sets a new leading in one operator)
+///   line 4: `Tm` (absolute text matrix)
+const STREAM: &[u8] = b"BT\n\
+/F1 12 Tf\n\
+14 TL\n\
+100 700 Td\n\
+(Alpha) Tj\n\
+T*\n\
+(Bravo) Tj\n\
+0 -20 TD\n\
+(Charlie) Tj\n\
+1 0 0 1 200 500 Tm\n\
+(Delta) Tj\n\
+ET\n";
+
+fn chunk_ys(stream: &[u8]) -> Vec<(String, f64)> {
+    let mut s = TextStreamer::new(TextStreamOptions::default());
+    let chunks = s.process_chunk(stream).expect("parses");
+    chunks.into_iter().map(|c| (c.text, c.y)).collect()
+}
+
+#[test]
+fn text_streamer_honors_td_tstar_tm_positioning() {
+    let got = chunk_ys(STREAM);
+    let texts: Vec<&str> = got.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["Alpha", "Bravo", "Charlie", "Delta"],
+        "every line must be emitted as its own chunk"
+    );
+
+    let y = |name: &str| got.iter().find(|(t, _)| t == name).unwrap().1;
+
+    // Td placed line 1 at y = 700.
+    assert!((y("Alpha") - 700.0).abs() < 0.01, "Td y = {}", y("Alpha"));
+    // T* dropped one leading (14) → 686. Before the fix T* was ignored and this
+    // stayed at 700, fused onto line 1.
+    assert!((y("Bravo") - 686.0).abs() < 0.01, "T* y = {}", y("Bravo"));
+    // TD set leading 20 and moved down 20 from 686 → 666.
+    assert!(
+        (y("Charlie") - 666.0).abs() < 0.01,
+        "TD y = {}",
+        y("Charlie")
+    );
+    // Tm placed line 4 absolutely at y = 500.
+    assert!((y("Delta") - 500.0).abs() < 0.01, "Tm y = {}", y("Delta"));
+
+    // Distinct y for every line: the defect collapsed them.
+    let mut ys: Vec<f64> = got.iter().map(|(_, y)| *y).collect();
+    ys.sort_by(|a, b| a.total_cmp(b));
+    ys.dedup_by(|a, b| (*a - *b).abs() < 0.01);
+    assert_eq!(
+        ys.len(),
+        4,
+        "lines collapsed onto shared y coordinates: {got:?}"
+    );
+}
+
+#[test]
+fn text_streamer_apostrophe_operator_moves_to_next_line() {
+    // `'` is "T* then show": it must both emit the text and advance one leading.
+    let stream = b"BT\n/F1 12 Tf\n10 TL\n50 400 Td\n(First) Tj\n(Second) '\n(Third) '\nET\n";
+    let got = chunk_ys(stream);
+    let texts: Vec<&str> = got.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(texts, vec!["First", "Second", "Third"]);
+    let y = |name: &str| got.iter().find(|(t, _)| t == name).unwrap().1;
+    assert!((y("First") - 400.0).abs() < 0.01);
+    assert!((y("Second") - 390.0).abs() < 0.01, "' y = {}", y("Second"));
+    assert!((y("Third") - 380.0).abs() < 0.01, "' y = {}", y("Third"));
+}

--- a/oxidize-pdf-core/tests/issue_465_smask_preservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_465_smask_preservation_test.rs
@@ -1,0 +1,133 @@
+//! #465: verbatim page copy drops an image's nested `/SMask` (and other nested
+//! XObject references), so transparency is lost through `merge` and the page
+//! operations.
+//!
+//! Root cause: `Page::from_parsed_with_content` resolves only the *top-level*
+//! XObject reference (`/XObject/<name> N 0 R` → stream); it does not walk into
+//! the resolved image stream, so a `/SMask N 0 R` inside it stays a reference
+//! into the *source* document's object table. The writer then emits that image
+//! verbatim with a dangling `/SMask`, and the referenced soft-mask stream is
+//! never written to the output.
+//!
+//! The oracle is poppler (`pdfimages -list`), independent of this crate's own
+//! reader: a soft mask shows up as a row of `type` = `smask`. It reads the bytes
+//! we wrote, so a passing test means the output is correct for any reader.
+//!
+//! Fixture: `Cold_Email_Hacks.pdf` page 16 (1-based) carries one image with a
+//! soft mask (poppler: one `smask` row, object 31). The other pages are plain.
+
+use oxidize_pdf::operations::{
+    extract_page_to_file, merge_pdfs, split_into_pages, MergeInput, MergeOptions, PageRange,
+};
+use std::path::Path;
+use std::process::Command;
+
+const FIXTURE: &str = "tests/fixtures/Cold_Email_Hacks.pdf";
+
+/// The 1-based page whose image carries a `/SMask`.
+const SMASK_PAGE_1BASED: u32 = 16;
+const SMASK_PAGE_0BASED: usize = 15;
+
+fn poppler_available() -> bool {
+    Command::new("pdfimages").arg("-v").output().is_ok()
+}
+
+/// Number of soft-mask rows (`type` = `smask`) poppler finds in a 1-based page
+/// range. This is the transparency signal #465 is about.
+fn poppler_smask_count(path: &Path, first: u32, last: u32) -> Option<usize> {
+    let out = Command::new("pdfimages")
+        .args([
+            "-list",
+            "-f",
+            &first.to_string(),
+            "-l",
+            &last.to_string(),
+            path.to_str()?,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // Header is two lines; the `type` column (index 2) is `smask` for a soft mask.
+    Some(
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .skip(2)
+            .filter(|l| l.split_whitespace().nth(2) == Some("smask"))
+            .count(),
+    )
+}
+
+#[test]
+fn extract_page_preserves_smask() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want =
+        poppler_smask_count(src, SMASK_PAGE_1BASED, SMASK_PAGE_1BASED).expect("source smask");
+    assert!(
+        want >= 1,
+        "fixture page {SMASK_PAGE_1BASED} must have a soft mask for this test to be meaningful (got {want})"
+    );
+
+    let out = std::env::temp_dir().join("issue465_extract.pdf");
+    extract_page_to_file(src, SMASK_PAGE_0BASED, &out).expect("extract");
+
+    let got = poppler_smask_count(&out, 1, 1).expect("output smask");
+    assert_eq!(
+        got, want,
+        "extracted page lost the image soft mask (transparency): {got} vs {want}"
+    );
+}
+
+#[test]
+fn merge_preserves_smask() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want =
+        poppler_smask_count(src, SMASK_PAGE_1BASED, SMASK_PAGE_1BASED).expect("source smask");
+
+    // Merge the soft-mask page after one plain page from the same file, so the
+    // smask page lands at index 1 (1-based page 2) of the output.
+    let inputs = vec![
+        MergeInput::with_pages(src, PageRange::Single(0)),
+        MergeInput::with_pages(src, PageRange::Single(SMASK_PAGE_0BASED)),
+    ];
+    let out = std::env::temp_dir().join("issue465_merge.pdf");
+    merge_pdfs(inputs, &out, MergeOptions::default()).expect("merge");
+
+    let got = poppler_smask_count(&out, 2, 2).expect("output smask");
+    assert_eq!(
+        got, want,
+        "merged page lost the image soft mask (transparency): {got} vs {want}"
+    );
+}
+
+#[test]
+fn split_preserves_smask() {
+    if !poppler_available() {
+        eprintln!("skipping: poppler not on PATH");
+        return;
+    }
+    let src = Path::new(FIXTURE);
+    let want =
+        poppler_smask_count(src, SMASK_PAGE_1BASED, SMASK_PAGE_1BASED).expect("source smask");
+
+    let dir = std::env::temp_dir().join("issue465_split");
+    std::fs::create_dir_all(&dir).unwrap();
+    let pattern = dir.join("page_{}.pdf");
+    let paths = split_into_pages(src, pattern.to_str().unwrap()).expect("split");
+    let rich = &paths[SMASK_PAGE_0BASED];
+
+    let got = poppler_smask_count(rich, 1, 1).expect("output smask");
+    assert_eq!(
+        got, want,
+        "split page lost the image soft mask (transparency): {got} vs {want}"
+    );
+}


### PR DESCRIPTION
Patch release bundling three non-breaking bug fixes on `develop` since 4.2.2, all in the page-copy / text-extraction paths.

## Contenido

| # | Fix |
|---|-----|
| #465 | Copia verbatim de página perdía el `/SMask` anidado de una imagen (transparencia perdida en merge/split/extract/rotate) |
| #453 | Ops de página reconstruían la página redibujando en vez de copiar verbatim (perdía imágenes/XObjects/curvas) |
| #463 | Entradas `/Font` inline ignoradas → mojibake en cualquier documento round-tripeado por la librería |

SemVer: todo camino de lectura/escritura, sin cambio de API → **PATCH**.

## Validación pre-release (local; las PRs solo corren T0/T1)

- **Corpus T2–T6: 119/0** (T2 23 · T3 22 · T4 25 · T5 26 · T6 23).
- **Gates diferenciales**: fusión 33/0 (fusions=680, sin cambio), orden 37/0 (rate 0.287179, marginalmente bajo baseline = ruido).
- **Kripteia 100/100** sobre los tests nuevos.
- Suite lib completa **6680/0**; build `--locked` a 4.2.3.

## CHANGELOG

#453 y #463 se mergearon (vía #466/#464) sin entrada; añadidas junto a #465 bajo `[4.2.3]`.

Tras merge: tag `v4.2.3` en `main` → `release.yml` publica a crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)