### PR TITLE
fix(text): read /DescendantFonts in all four legal spellings (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+
+### Fixed
+
+- **Three of the four legal `/DescendantFonts` spellings decoded CID text to
+  mojibake** (#469). `extract_font_info` read the entry only when it was a
+  direct array whose element is an indirect reference. ISO 32000-1 puts no
+  reference requirement on either the array or its element (Table 121, §7.3.6,
+  §7.3.7 — where the spec wants a reference it says so, as Table 117 does for
+  the CIDFont's FontDescriptor), and producers write the element inline:
+  ReportLab's `UnicodeCIDFont` does. For those files `descendant_font` stayed
+  empty, `decode_text_with_font` skipped its Type0 branch, and the already
+  correct `cid_encoding` (e.g. `UniJIS-UCS2-H` → UTF-16BE) went unused — the
+  text fell through to byte-wise decoding. The same defect class as #463, fixed
+  here for `/DescendantFonts`: the value may now be a direct array or a
+  reference to one, and the CIDFont element a dictionary or a reference.
+
 ## [4.2.3] - 2026-08-09
 
 ### Fixed

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -177,15 +177,44 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
 
         // Handle Type0 (composite) fonts
         if font_type.as_str() == "Type0" {
-            if let Some(PdfObject::Array(descendant_array)) = font_dict.get("DescendantFonts") {
-                if let Some(desc_ref) = descendant_array.0.first().and_then(|o| o.as_reference()) {
-                    if let Ok(PdfObject::Dictionary(desc_dict)) =
-                        document.get_object(desc_ref.0, desc_ref.1)
-                    {
-                        let descendant = self.extract_font_info(&desc_dict, document)?;
-                        font_info.descendant_font = Some(Box::new(descendant));
+            // The DescendantFonts value and the CIDFont element inside it may
+            // each be written inline or as an indirect reference: ISO 32000-1
+            // Table 121 types the entry as "array" with no reference
+            // requirement, §7.3.6 lets array elements be dictionaries, and
+            // §7.3.7 lets a dictionary value be any kind of object — where
+            // the spec wants a reference it says so (Table 117 marks the
+            // CIDFont's FontDescriptor "shall be an indirect reference"), and
+            // the DescendantFonts row carries no such words. The same argument
+            // as #463, which fixed this for /Font resource entries. Producers
+            // do use the inline form (ReportLab's UnicodeCIDFont writes the
+            // CIDFont as a direct dictionary). Reading only the
+            // reference-inside-direct-array combination left `descendant_font`
+            // empty, which silently skipped the `cid_encoding` branch in
+            // `decode_text_with_font` and fell back to byte-wise decoding.
+            let resolved_array;
+            let descendant_fonts = match font_dict.get("DescendantFonts") {
+                Some(PdfObject::Array(array)) => Some(array),
+                Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                    Ok(PdfObject::Array(array)) => {
+                        resolved_array = array;
+                        Some(&resolved_array)
                     }
-                }
+                    _ => None,
+                },
+                _ => None,
+            };
+            let descendant = match descendant_fonts.and_then(|array| array.0.first()) {
+                Some(PdfObject::Dictionary(dict)) => Some(self.extract_font_info(dict, document)?),
+                Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                    Ok(PdfObject::Dictionary(dict)) => {
+                        Some(self.extract_font_info(&dict, document)?)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(descendant) = descendant {
+                font_info.descendant_font = Some(Box::new(descendant));
             }
         }
 

--- a/oxidize-pdf-core/tests/descendant_fonts_spellings_test.rs
+++ b/oxidize-pdf-core/tests/descendant_fonts_spellings_test.rs
@@ -1,0 +1,134 @@
+//! `/DescendantFonts` may legally be written in four combinations: the value
+//! is a direct array or an indirect reference to one, and the CIDFont element
+//! inside is a direct dictionary or an indirect reference. ISO 32000-1
+//! Table 121 types the entry as `array` with no reference requirement, §7.3.6
+//! lets array elements be "dictionaries, or any other objects", and §7.3.7
+//! lets a dictionary value "be any kind of object" — where the spec wants an
+//! indirect reference it says so (Table 117 marks the CIDFont's
+//! FontDescriptor "shall be an indirect reference"), and the DescendantFonts
+//! row carries no such words. The same argument as #463 for inline `/Font`
+//! resource entries. Producers use the inline form: ReportLab's
+//! `UnicodeCIDFont` writes the CIDFont as a direct dictionary.
+//!
+//! The extractor read only the reference-inside-direct-array combination. For
+//! the other three, `descendant_font` stayed empty, which silently skipped the
+//! `cid_encoding` branch in `decode_text_with_font` and fell back to byte-wise
+//! decoding.
+//!
+//! The oracle is falsifiable by construction: the page shows 第1章 概要
+//! GRIMWALD through `/Encoding /UniJIS-UCS2-H` (the character codes ARE the
+//! UTF-16BE values) with no `/ToUnicode`, so a decode that reaches the
+//! descendant yields the Japanese text, while the byte-wise fallback renders
+//! the UTF-16BE code units one byte at a time (`第` = U+7B2C comes out as
+//! `{,`). The two answers cannot be confused.
+
+mod common;
+
+use common::pdf_assembler::assemble_pdf_with_version;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+const EXPECTED: &str = "第1章 概要 GRIMWALD";
+
+/// ISO 32000-1 Table 117: the CIDFont's FontDescriptor is
+/// "(Required; shall be an indirect reference)" — object 7 here.
+const FONT_DESCRIPTOR: &str = "<< /Type /FontDescriptor /FontName /HeiseiKakuGo-W5 /Flags 4 \
+     /FontBBox [ -92 -250 1010 922 ] /ItalicAngle 0 /Ascent 752 /Descent -221 \
+     /CapHeight 737 /StemV 114 >>";
+
+const CID_FONT: &str = "<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HeiseiKakuGo-W5 \
+     /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> \
+     /FontDescriptor 7 0 R /DW 1000 >>";
+
+#[derive(Clone, Copy)]
+enum Spelling {
+    /// `/DescendantFonts [ 6 0 R ]` — the only combination read before the fix
+    IndirectFont,
+    /// `/DescendantFonts [ << ...CIDFont... >> ]` — what ReportLab emits
+    DirectDict,
+    /// `/DescendantFonts 8 0 R` where `8 0 obj` is `[ 6 0 R ]`
+    IndirectArray,
+    /// `/DescendantFonts 8 0 R` where `8 0 obj` is `[ << ...CIDFont... >> ]`
+    IndirectArrayDirectDict,
+}
+
+/// One page drawing `EXPECTED` in a Type0 font. Objects 1..=7 are identical
+/// across spellings (object 6 is written whether or not anything references
+/// it); only object 5's `/DescendantFonts` value differs, so the three
+/// documents differ in exactly that respect.
+fn build(spelling: Spelling) -> Vec<u8> {
+    let hex: String = EXPECTED
+        .encode_utf16()
+        .flat_map(|unit| unit.to_be_bytes())
+        .map(|byte| format!("{byte:02X}"))
+        .collect();
+    let content = format!("BT /F2 18 Tf 60 700 Td <{hex}> Tj ET");
+
+    let descendant_fonts = match spelling {
+        Spelling::DirectDict => format!("[ {CID_FONT} ]"),
+        Spelling::IndirectFont => "[ 6 0 R ]".to_string(),
+        Spelling::IndirectArray | Spelling::IndirectArrayDirectDict => "8 0 R".to_string(),
+    };
+
+    let mut objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 595 842 ] \
+           /Resources << /Font << /F2 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        format!(
+            "<< /Length {} >>\nstream\n{content}\nendstream",
+            content.len()
+        )
+        .into_bytes(),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /HeiseiKakuGo-W5 \
+             /Encoding /UniJIS-UCS2-H /DescendantFonts {descendant_fonts} >>"
+        )
+        .into_bytes(),
+        CID_FONT.as_bytes().to_vec(),
+        FONT_DESCRIPTOR.as_bytes().to_vec(),
+    ];
+    match spelling {
+        Spelling::IndirectArray => objects.push(b"[ 6 0 R ]".to_vec()),
+        Spelling::IndirectArrayDirectDict => objects.push(format!("[ {CID_FONT} ]").into_bytes()),
+        _ => {}
+    }
+
+    assemble_pdf_with_version("1.7", &objects)
+}
+
+fn extract_page_text(bytes: Vec<u8>) -> String {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(bytes)).expect("open PDF"));
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+/// The spelling that already worked — pins the existing behavior so the fix
+/// cannot regress it.
+#[test]
+fn descendant_written_as_an_indirect_reference_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::IndirectFont)), EXPECTED);
+}
+
+#[test]
+fn descendant_written_as_a_direct_dictionary_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::DirectDict)), EXPECTED);
+}
+
+#[test]
+fn descendant_array_written_as_an_indirect_value_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::IndirectArray)), EXPECTED);
+}
+
+#[test]
+fn indirect_array_holding_a_direct_dictionary_decodes() {
+    assert_eq!(
+        extract_page_text(build(Spelling::IndirectArrayDirectDict)),
+        EXPECTED
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #469.

`extract_font_info` read `/DescendantFonts` only when the value is a direct
array whose first element is an indirect reference. ISO 32000-1 puts no
reference requirement on either the array or its element (Table 121, §7.3.6,
§7.3.7 — where the spec wants a reference it says so, as Table 117 does for
the CIDFont's FontDescriptor), and producers write the element inline:
ReportLab's `UnicodeCIDFont` does. For those files `descendant_font` stayed
empty, `decode_text_with_font` skipped its Type0 branch, and the already
correct `cid_encoding` (`UniJIS-UCS2-H` → UTF-16BE) went unused — CID text
fell through to byte-wise decoding and came out as mojibake. Same defect class
as #463, which #464 fixed for `/Font` resource entries.

Two deliberate behavior points, so they are a decision rather than an accident:

- A malformed **direct** descendant (e.g. missing `/Subtype`) now propagates
  its parse error out of `extract_font_info`, matching what a malformed
  resolved **indirect** descendant already did (that arm already used `?`).
  Before, a direct dictionary was skipped without ever being parsed.
- The direct-dictionary arm recurses no deeper than the raw object parser
  already recursed to build the nested literal, so it adds no exposure that
  did not exist at parse time. (A *cyclic indirect* `DescendantFonts` chain
  could already recurse unboundedly before this change — `stack_safe.rs` is
  not wired into `extraction_cmap.rs` — this PR neither worsens nor fixes
  that; flagged in #469 in case you want a follow-up.)

## Changes

- `oxidize-pdf-core/src/text/extraction_cmap.rs`: resolve the
  `/DescendantFonts` value when it is itself an indirect reference, and accept
  the CIDFont element as either a direct dictionary or a reference — all four
  combinations of direct/indirect array × direct/indirect element now reach
  the descendant.
- `oxidize-pdf-core/tests/descendant_fonts_spellings_test.rs`: regression test
  covering all four combinations, built with the `tests/common/pdf_assembler`
  helpers from #464. The oracle is falsifiable by construction: the page shows
  Japanese through `/Encoding /UniJIS-UCS2-H` with no `/ToUnicode`, so a
  decode that reaches the descendant yields `第1章 概要 GRIMWALD` while the
  byte-wise fallback yields `{, 1zà …` — the two cannot be confused.
- `CHANGELOG.md`: entry under `<!-- next-header -->`.

## Testing

Red → green on this branch's parent (`develop` @ 534ba74):

```
# unpatched (fix stashed):
test descendant_written_as_an_indirect_reference_decodes ... ok
test descendant_array_written_as_an_indirect_value_decodes ... FAILED
test descendant_written_as_a_direct_dictionary_decodes ... FAILED
test indirect_array_holding_a_direct_dictionary_decodes ... FAILED
test result: FAILED. 1 passed; 3 failed

# patched:
test result: ok. 4 passed; 0 failed
```

- `cargo test -p oxidize-pdf --lib text::` — 809 passed / 0 failed
- `cargo test -p oxidize-pdf --test inline_font_resources_test` (#464's suite) — 5 passed / 0 failed
- `cargo test --workspace` — exit 0, no failing binary (cargo aborts non-zero on any failure)
- `rustfmt --check` clean on both changed `.rs` files (the `cargo fmt` wrapper
  hits the Windows path-length limit in my checkout; CI will confirm the full
  sweep)
- Also reproduced the bug on crates.io 4.1.1, 4.2.0, 4.2.1, 4.2.2 and 4.2.3 —
  all four combinations behave identically on all five releases (matrix in
  #469).

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all -- -D warnings` clean — exit 0
- [x] `cargo fmt --all --check` clean (changed files verified locally; see note above)
- [x] New behavior is covered by tests that assert real content (no smoke tests)

## Checklist

- [x] Branch follows gitflow (targets `develop`)
- [x] CHANGELOG.md updated for user-facing changes
- [x] No breaking change to existing public APIs (`extract_font_info`'s
  signature and `FontInfo` are unchanged; previously-working documents decode
  identically — the reference-inside-array test pins that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
