### PR TITLE
fix(text): apply Tc, Tw and Ts to text extraction (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
 
 ### Fixed
 
@@ -21,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text fell through to byte-wise decoding. The same defect class as #463, fixed
   here for `/DescendantFonts`: the value may now be a direct array or a
   reference to one, and the CIDFont element a dictionary or a reference.
+
+- **`Tc`, `Tw` and `Ts` were parsed and stored but never applied to extraction**
+  (#456). The character-spacing (`Tc`) and word-spacing (`Tw`) parameters are
+  now folded into the pen advance and `Ts` (text rise) into the glyph baseline
+  (ISO 32000-1 §9.4.4): `Tc` is added once per glyph, `Tw` once per single-byte
+  space (code 32, §9.3.3), and `Ts` offsets the fragment's y-origin. Because the
+  advance feeds the flat path's space/newline heuristics, documents that set a
+  non-zero `Tc`/`Tw` now get correct separators; the `"` operator, which sets
+  both before showing a line, now takes effect. `Tr` (render mode, including the
+  invisible `Tr 3` OCR-layer case) is unchanged — exposing it on the public
+  `TextFragment` is a breaking change deferred to the next major.
 
 ## [4.2.3] - 2026-08-09
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1197,6 +1197,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -1294,6 +1296,8 @@ impl TextExtractor {
                                             &decoded,
                                             state.font_size,
                                             font_info,
+                                            state.char_space,
+                                            state.word_space,
                                         )
                                     };
 
@@ -1430,6 +1434,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -1497,6 +1503,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -2643,7 +2651,10 @@ fn emit_text_fragment(
 /// or pure-translation matrix; non-uniform CTM scaling produced wrong origins.
 fn text_origin(state: &TextState) -> (f64, f64) {
     let combined = multiply_matrix(&state.text_matrix, &state.ctm);
-    transform_point(0.0, 0.0, &combined)
+    // Text rise (`Ts`) shifts the glyph origin up the text-space y-axis before
+    // the text/CTM transform (ISO 32000-1 §9.4.4). For an axis-aligned matrix
+    // this moves the user-space y by exactly `Ts`.
+    transform_point(0.0, state.text_rise, &combined)
 }
 
 /// Advance the text matrix by one shown glyph run of unscaled width
@@ -2901,20 +2912,38 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `decoded` is the already-decoded text for this run; it is only consulted for
 /// composite (Type0) fonts, whose multi-byte codes cannot be indexed byte-wise
 /// and whose width path is unchanged here to avoid regressing CJK extraction.
+/// Unscaled text-space advance of a run (before `Th`), including the text-state
+/// spacing parameters (ISO 32000-1 §9.4.4): the glyph displacement is
+/// `w0/1000 * Tfs + Tc + Tw`, so `char_space` (`Tc`) is added once per glyph and
+/// `word_space` (`Tw`) once per *single-byte* space (code 32, §9.3.3). Both are
+/// unscaled text-space units, added directly (not multiplied by the font size);
+/// the caller's `advance_pen` applies `Th`.
 fn calculate_text_width_from_codes(
     codes: &[u8],
     decoded: &str,
     font_size: f64,
     font_info: Option<&FontInfo>,
+    char_space: f64,
+    word_space: f64,
 ) -> f64 {
     // Composite (Type0) fonts use multi-byte codes; a single byte is not a code,
     // so byte-indexed width lookup is invalid. Preserve the existing decoded-based
-    // behavior for them.
+    // behavior for them, adding `Tc` per glyph. `Tw` applies only to the
+    // single-byte code 32 (§9.3.3), which a multi-byte code can never be, so it
+    // does not apply here.
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
-        return calculate_text_width(decoded, font_size, font_info);
+        let glyphs = decoded.chars().count() as f64;
+        return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
+
+    // `Tc` on every byte-code, `Tw` on every space byte. Shared by the metric
+    // and no-metric branches below.
+    let spacing = |codes: &[u8]| -> f64 {
+        char_space * codes.len() as f64
+            + word_space * codes.iter().filter(|&&b| b == b' ').count() as f64
+    };
 
     if let Some(font) = font_info {
         if let Some(ref widths) = font.metrics.widths {
@@ -2946,12 +2975,12 @@ fn calculate_text_width_from_codes(
                 }
             }
 
-            return total_width;
+            return total_width + spacing(codes);
         }
     }
 
     // No metrics: one fallback width per code (byte), the simple-font glyph count.
-    codes.len() as f64 * font_size * 0.5
+    codes.len() as f64 * font_size * 0.5 + spacing(codes)
 }
 
 /// Sanitize extracted text by removing or replacing control characters.
@@ -3697,7 +3726,8 @@ mod tests {
 
         let codes = [1u8, 2u8];
         let decoded = "mi"; // what decode_text produced for these codes
-        let width = calculate_text_width_from_codes(&codes, decoded, 10.0, Some(&font_info));
+        let width =
+            calculate_text_width_from_codes(&codes, decoded, 10.0, Some(&font_info), 0.0, 0.0);
         let expected = (1000.0 + 100.0) / 1000.0 * 10.0; // 11.0
         assert!(
             (width - expected).abs() < 1e-6,

--- a/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
@@ -1,11 +1,11 @@
 {
   "t3-stress": {
     "compared": 1695,
-    "content_coverage": 0.9854051588603628,
+    "content_coverage": 0.9859671643695178,
     "denominator": 211815,
-    "numerator": 680,
-    "our_alpha_chars": 4727093,
+    "numerator": 676,
+    "our_alpha_chars": 4729789,
     "pop_alpha_chars": 4797106,
-    "rate": 0.003210348653305951
+    "rate": 0.0031914642494629748
   }
 }

--- a/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
@@ -1,11 +1,11 @@
 {
   "t3-stress": {
-    "compared": 1037,
-    "content_coverage": 0.9937813547683058,
-    "denominator": 591428,
-    "numerator": 169957,
-    "our_alpha_chars": 4716376,
-    "pop_alpha_chars": 4745889,
-    "rate": 0.2873671858620153
+    "compared": 1053,
+    "content_coverage": 0.9937857225137362,
+    "denominator": 591792,
+    "numerator": 163717,
+    "our_alpha_chars": 4719072,
+    "pop_alpha_chars": 4748581,
+    "rate": 0.27664618649795875
   }
 }

--- a/oxidize-pdf-core/tests/issue_456_text_state_params_test.rs
+++ b/oxidize-pdf-core/tests/issue_456_text_state_params_test.rs
@@ -1,0 +1,139 @@
+//! Issue #456 — `Tc` (char spacing), `Tw` (word spacing) and `Ts` (text rise)
+//! were parsed and stored but never read, so they had no effect on extraction
+//! (ISO 32000-1 §9.3.2, §9.3.3, §9.4.4).
+//!
+//! The glyph-displacement formula is, per §9.4.4:
+//!
+//! ```text
+//! tx = ((w0/1000 - Tj/1000) * Tfs + Tc + Tw) * Th
+//! ```
+//!
+//! `Tc` is added once per glyph shown, `Tw` once per *single-byte* space
+//! (code 32, §9.3.3), both in unscaled text-space units and both then scaled by
+//! `Th`. `Ts` shifts the glyph origin up the y-axis by an unscaled text-space
+//! amount before the text/CTM transform.
+//!
+//! Oracle: fragment coordinates under `preserve_layout` — the only extraction
+//! mode that exposes the pen position, and therefore the only place the pen
+//! advance and the baseline offset are observable. Each test measures the shift
+//! of a *following* run between spacing = 0 and spacing = k, which cancels the
+//! (font-dependent) base glyph widths and isolates the parameter under test.
+//!
+//! Scope note: these apply to `TextExtractor` only. `PlainTextExtractor` decides
+//! separators from the explicit pen positions the producer writes (Td/TD/TJ),
+//! never from accumulated glyph advances (see its `_char_space`/`_word_space`
+//! fields), so `Tc`/`Tw` are correctly unobservable there.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Extract every fragment under `preserve_layout`.
+fn fragments(content: &[u8]) -> Vec<oxidize_pdf::text::TextFragment> {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .fragments
+}
+
+/// `(x, y)` of the first fragment whose trimmed text equals `needle`.
+fn frag_xy(content: &[u8], needle: &str) -> (f64, f64) {
+    fragments(content)
+        .into_iter()
+        .find(|f| f.text.trim() == needle)
+        .map(|f| (f.x, f.y))
+        .unwrap_or_else(|| panic!("no fragment with text {needle:?}"))
+}
+
+/// Width of the first fragment whose trimmed text equals `needle`. The fragment
+/// width is the run's pen advance (`text_width`, scaled by the CTM x-scale,
+/// which is 1 here), the same quantity that drives the flat path's separator
+/// deltas — so it is the faithful oracle for `Tc`/`Tw` in the advance.
+fn frag_width(content: &[u8], needle: &str) -> f64 {
+    fragments(content)
+        .into_iter()
+        .find(|f| f.text.trim() == needle)
+        .map(|f| f.width)
+        .unwrap_or_else(|| panic!("no fragment with text {needle:?}"))
+}
+
+const EPS: f64 = 1e-6;
+
+/// `Tc` advances the pen once per glyph shown. "ABCD" is four glyphs, so `Tc = 5`
+/// must widen its advance by `4 * 5 = 20` relative to `Tc = 0`. The base glyph
+/// widths cancel between the two runs.
+#[test]
+fn char_spacing_advances_pen_once_per_glyph() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(ABCD)Tj\nET\n";
+    let with_tc = b"BT\n/F1 12 Tf\n5 Tc\n100 700 Td\n(ABCD)Tj\nET\n";
+    let delta = frag_width(with_tc, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        (delta - 20.0).abs() < EPS,
+        "Tc=5 over 4 glyphs must add 20.0 of advance; got {delta}"
+    );
+}
+
+/// `Tw` advances the pen once per single-byte space. The run "A A A" holds two
+/// spaces, so `Tw = 7` must widen its advance by `2 * 7 = 14`.
+#[test]
+fn word_spacing_advances_pen_once_per_space() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(A A A)Tj\nET\n";
+    let with_tw = b"BT\n/F1 12 Tf\n7 Tw\n100 700 Td\n(A A A)Tj\nET\n";
+    let delta = frag_width(with_tw, "A A A") - frag_width(base, "A A A");
+    assert!(
+        (delta - 14.0).abs() < EPS,
+        "Tw=7 over 2 spaces must add 14.0 of advance; got {delta}"
+    );
+}
+
+/// `Tw` applies to spaces only. A run with no spaces must be unaffected by it —
+/// this is what separates `Tw` from `Tc` (§9.3.3).
+#[test]
+fn word_spacing_does_not_advance_on_non_space_glyphs() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(ABCD)Tj\nET\n";
+    let with_tw = b"BT\n/F1 12 Tf\n50 Tw\n100 700 Td\n(ABCD)Tj\nET\n";
+    let delta = frag_width(with_tw, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        delta.abs() < EPS,
+        "Tw must not change the advance of a run without spaces; got {delta}"
+    );
+}
+
+/// `Tc` must also fold into the `TJ` (`ShowTextArray`) advance, not just `Tj` —
+/// real documents draw almost everything through `TJ`.
+#[test]
+fn char_spacing_advances_pen_in_show_text_array() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n[(ABCD)]TJ\nET\n";
+    let with_tc = b"BT\n/F1 12 Tf\n5 Tc\n100 700 Td\n[(ABCD)]TJ\nET\n";
+    let delta = frag_width(with_tc, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        (delta - 20.0).abs() < EPS,
+        "Tc=5 over 4 glyphs must add 20.0 of advance through TJ; got {delta}"
+    );
+}
+
+/// `Ts` (text rise) offsets the glyph baseline up the y-axis by an unscaled
+/// text-space amount. With an axis-aligned matrix the user-space y shifts by
+/// exactly `Ts`.
+#[test]
+fn text_rise_offsets_the_baseline_y() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(A)Tj\nET\n";
+    let with_ts = b"BT\n/F1 12 Tf\n5 Ts\n100 700 Td\n(A)Tj\nET\n";
+    let delta = frag_xy(with_ts, "A").1 - frag_xy(base, "A").1;
+    assert!(
+        (delta - 5.0).abs() < EPS,
+        "Ts=5 must raise the baseline by 5.0; got {delta}"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses #456.

`Tc` (character spacing), `Tw` (word spacing) and `Ts` (text rise) were parsed
into the graphics state but never applied to text extraction. The three
parameters are now used:

- `Tc` is folded into the pen advance, once per glyph.
- `Tw` is folded into the pen advance, once per **single-byte** space (code 32
  only, ISO 32000-1 §9.3.3).
- `Ts` offsets the fragment's y-origin (ISO 32000-1 §9.4.4).

Because the pen advance feeds the flat path's space/newline heuristics,
documents that set a non-zero `Tc`/`Tw` now get correct word/line separators.
All four show-text arms (`Tj`, `TJ`, `'`, `"`) apply the spacing; the `"`
operator, which sets `aw`/`ac` before showing a line, now takes effect.

`Tr` (render mode, including the invisible `Tr 3` OCR-layer case) is left
unchanged on purpose: exposing render mode on the public `TextFragment` is a
breaking change, deferred to the next major.

`PlainTextExtractor` is deliberately **not** touched: it decides separators by
explicit pen position, never by accumulated glyph advance, so `Tc`/`Tw` only
affect `TextExtractor`.

## Changes

- `oxidize-pdf-core/src/text/extraction.rs`: apply `Tc`/`Tw` in
  `calculate_text_width_from_codes` (all four show-text arms) and `Ts` in
  `text_origin`.
- `oxidize-pdf-core/tests/issue_456_text_state_params_test.rs`: 5 tests, oracle =
  fragment `width`/`y` under preserve-layout. RED on develop, GREEN here.
- `CHANGELOG.md`: entry under `<!-- next-header -->`.
- `tests/baselines/differential_{fusion,order}_baseline.json`: re-registered.

## Differential gates (improve)

- Fusion: 680 -> 676 pairs (0.003210 -> 0.003191).
- Order: misplaced 0.287367 -> 0.276646 (fidelity 0.7393 -> 0.7489,
  coverage 0.9640 -> 0.9659).
- Corpus T2-T6: 119/0.

## Testing

- `cargo test -p oxidize-pdf --test issue_456_text_state_params_test` — 5/5.

## Notes

- Rebased onto develop after #470 merged; CHANGELOG conflict resolved (both
  entries now coexist under `<!-- next-header -->`).
- No breaking change: `TextFragment` and public signatures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
