### PR TITLE
feat(text): isolated flat-path reading-order primitive (#448)

### DIFF
--- a/oxidize-pdf-core/src/text/flat_reading_order.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order.rs
@@ -1,0 +1,219 @@
+//! Flat-path reading order (issue #448).
+//!
+//! The default `.text` flat path emits fragments in content-stream order,
+//! which transposes multi-column and out-of-order layouts. This module is the
+//! isolated ordering primitive: a pure function from line-group boxes to a
+//! permutation of their indices. It is deliberately decoupled from
+//! `extraction.rs` — the wiring into the show-text arms is a separate, later
+//! step (design doc §5.8) that rebases onto #456.
+//!
+//! Two properties set it apart from the pre-existing
+//! [`crate::pipeline::reading_order::XYCutReadingOrder`], which serves the
+//! partition/Element pipeline and is unsuitable here:
+//!
+//! - **Scale-relative significance** (§5.4). A gap counts as a column gutter or
+//!   a section break only when it exceeds a multiple of the region's median
+//!   glyph size, never an absolute point threshold. The absolute `min_gap` of
+//!   the existing cut is the exact bug family that motivated #448.
+//! - **Stream-order leaf** (§5.4). A region the cut cannot split comes back in
+//!   input (content-stream) order, not re-sorted geometrically. The probe
+//!   measured this as the larger share of the gain (stream leaf −17% vs a
+//!   geometric leaf −13%), and it is what makes the identity permutation
+//!   byte-preserving for the caller (§5.2).
+
+// Staged ahead of its call site: the show-text wiring (§5.8) is a later step
+// that rebases onto #456, so in a non-test build nothing references this module
+// yet. Remove this attribute when the wiring lands and the module is live.
+#![allow(dead_code)]
+
+/// A box the flat-path orderer permutes: one per line group (§5.1).
+///
+/// Coordinates are page space with `/Rotate` already applied by the caller
+/// (§5.3), so the orderer never looks at rotation itself. PDF convention: `y`
+/// grows upward, `min_y` is the bottom edge and `max_y` the top edge.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OrderBox {
+    /// Left edge.
+    pub min_x: f64,
+    /// Right edge.
+    pub max_x: f64,
+    /// Bottom edge (PDF space: smaller y is lower on the page).
+    pub min_y: f64,
+    /// Top edge.
+    pub max_y: f64,
+    /// Representative glyph size of the group; the unit for the gutter and the
+    /// line-break scale in [`CutConfig`].
+    pub font_size: f64,
+}
+
+/// Scale-relative cut thresholds (§5.4). A gap must exceed `k ×` the region's
+/// median [`OrderBox::font_size`] to be taken as a significant cut. One
+/// constant per axis, calibrated against the order gate — the calibration is
+/// deferred until #456/#458 land, so these stay parameters, not constants.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CutConfig {
+    /// Horizontal gutter significance, in multiples of the median glyph size.
+    pub horizontal_k: f64,
+    /// Vertical section-break significance, in multiples of the median glyph
+    /// size.
+    pub vertical_k: f64,
+}
+
+/// Order line-group boxes and return a permutation of `0..boxes.len()`.
+///
+/// The recursion cuts on whichever axis carries the widest scale-relative gap;
+/// a region with no significant gap is a leaf and is returned in input order,
+/// so `reading_order` is the identity permutation whenever the stream order is
+/// already the reading order.
+pub(crate) fn reading_order(boxes: &[OrderBox], cfg: &CutConfig) -> Vec<usize> {
+    let mut order = Vec::with_capacity(boxes.len());
+    let indices: Vec<usize> = (0..boxes.len()).collect();
+    cut_recursive(boxes, &indices, cfg, &mut order);
+    order
+}
+
+/// The scale unit for a region: the median glyph size of its boxes. Returns
+/// `None` for an empty region or a non-positive median (degenerate input),
+/// which forces the region to be treated as a leaf rather than dividing by a
+/// meaningless scale (§5.5 guard 6).
+fn median_font_size(boxes: &[OrderBox], indices: &[usize]) -> Option<f64> {
+    if indices.is_empty() {
+        return None;
+    }
+    let mut sizes: Vec<f64> = indices.iter().map(|&i| boxes[i].font_size).collect();
+    sizes.sort_by(|a, b| a.total_cmp(b));
+    let median = sizes[sizes.len() / 2];
+    (median.is_finite() && median > 0.0).then_some(median)
+}
+
+/// Recursively cut `indices` and append the resulting reading order to `order`.
+fn cut_recursive(boxes: &[OrderBox], indices: &[usize], cfg: &CutConfig, order: &mut Vec<usize>) {
+    if indices.len() <= 1 {
+        order.extend_from_slice(indices);
+        return;
+    }
+    let Some(scale) = median_font_size(boxes, indices) else {
+        emit_leaf(indices, order);
+        return;
+    };
+
+    // A column gutter (gap along X) is judged against `horizontal_k`; a section
+    // break (gap along Y) against `vertical_k`. Take whichever significant cut
+    // carries the wider scale-relative gap (§5.4, "hueco más ancho").
+    let column = find_column_gap(boxes, indices).filter(|c| c.ratio(scale) >= cfg.horizontal_k);
+    let section = find_section_gap(boxes, indices).filter(|c| c.ratio(scale) >= cfg.vertical_k);
+
+    let choose_column = match (&column, &section) {
+        (Some(c), Some(s)) => c.ratio(scale) >= s.ratio(scale),
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => {
+            emit_leaf(indices, order);
+            return;
+        }
+    };
+
+    if choose_column {
+        let (left, right) = partition_x(boxes, indices, column.unwrap().split);
+        // Left column before right column.
+        cut_recursive(boxes, &left, cfg, order);
+        cut_recursive(boxes, &right, cfg, order);
+    } else {
+        let (top, bottom) = partition_y(boxes, indices, section.unwrap().split);
+        // Higher-on-the-page section before lower.
+        cut_recursive(boxes, &top, cfg, order);
+        cut_recursive(boxes, &bottom, cfg, order);
+    }
+}
+
+/// A leaf region: no significant cut, so preserve content-stream order (§5.4).
+/// The original indices ascending are the stream order.
+fn emit_leaf(indices: &[usize], order: &mut Vec<usize>) {
+    let mut leaf = indices.to_vec();
+    leaf.sort_unstable();
+    order.extend(leaf);
+}
+
+/// A candidate cut: the absolute gap width and the coordinate to split at.
+struct Gap {
+    width: f64,
+    split: f64,
+}
+
+impl Gap {
+    fn ratio(&self, scale: f64) -> f64 {
+        self.width / scale
+    }
+}
+
+/// Largest whitespace gap along X (a column gutter). Sweeps left to right
+/// tracking the running maximum right edge, so a short box nested inside a tall
+/// column does not open a spurious gap.
+fn find_column_gap(boxes: &[OrderBox], indices: &[usize]) -> Option<Gap> {
+    let mut edges: Vec<(f64, f64)> = indices
+        .iter()
+        .map(|&i| (boxes[i].min_x, boxes[i].max_x))
+        .collect();
+    edges.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut max_gap = 0.0f64;
+    let mut split = 0.0f64;
+    let mut max_right = edges[0].1;
+    for window in edges.windows(2) {
+        let next_left = window[1].0;
+        let gap = next_left - max_right;
+        if gap > max_gap {
+            max_gap = gap;
+            split = max_right + gap / 2.0;
+        }
+        max_right = max_right.max(window[1].1);
+    }
+    (max_gap > 0.0).then_some(Gap {
+        width: max_gap,
+        split,
+    })
+}
+
+/// Largest whitespace gap along Y (a section break). PDF space is y-up, so the
+/// sweep runs top (large y) to bottom, tracking the running minimum bottom edge.
+fn find_section_gap(boxes: &[OrderBox], indices: &[usize]) -> Option<Gap> {
+    let mut edges: Vec<(f64, f64)> = indices
+        .iter()
+        .map(|&i| (boxes[i].min_y, boxes[i].max_y))
+        .collect();
+    // Sort by top edge descending (topmost first).
+    edges.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+    let mut max_gap = 0.0f64;
+    let mut split = 0.0f64;
+    let mut min_bottom = edges[0].0;
+    for window in edges.windows(2) {
+        let next_top = window[1].1;
+        let gap = min_bottom - next_top;
+        if gap > max_gap {
+            max_gap = gap;
+            split = next_top + gap / 2.0;
+        }
+        min_bottom = min_bottom.min(window[1].0);
+    }
+    (max_gap > 0.0).then_some(Gap {
+        width: max_gap,
+        split,
+    })
+}
+
+/// Split a region into (left, right) by box-center X against `split`. Both
+/// partitions preserve the input order of `indices`.
+fn partition_x(boxes: &[OrderBox], indices: &[usize], split: f64) -> (Vec<usize>, Vec<usize>) {
+    indices
+        .iter()
+        .partition(|&&i| (boxes[i].min_x + boxes[i].max_x) / 2.0 < split)
+}
+
+/// Split a region into (top, bottom) by box-center Y against `split`. Top is the
+/// higher-on-the-page half (larger y). Both partitions preserve input order.
+fn partition_y(boxes: &[OrderBox], indices: &[usize], split: f64) -> (Vec<usize>, Vec<usize>) {
+    indices
+        .iter()
+        .partition(|&&i| (boxes[i].min_y + boxes[i].max_y) / 2.0 >= split)
+}

--- a/oxidize-pdf-core/src/text/flat_reading_order.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order.rs
@@ -31,6 +31,11 @@
 /// Coordinates are page space with `/Rotate` already applied by the caller
 /// (§5.3), so the orderer never looks at rotation itself. PDF convention: `y`
 /// grows upward, `min_y` is the bottom edge and `max_y` the top edge.
+///
+/// A well-formed box has `min_x <= max_x` and `min_y <= max_y`. An inverted box
+/// (e.g. from a negative-scale CTM upstream) is not rejected: the orderer
+/// degrades any region it cannot actually divide to stream order, so inverted
+/// input yields a valid permutation rather than a panic or a hang.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OrderBox {
     /// Left edge.
@@ -115,11 +120,25 @@ fn cut_recursive(boxes: &[OrderBox], indices: &[usize], cfg: &CutConfig, order: 
 
     if choose_column {
         let (left, right) = partition_x(boxes, indices, column.unwrap().split);
+        // A gap can exist yet fail to divide the region when a box center lands
+        // on the far side of the split — an inverted box (min > max, from a
+        // negative-scale CTM upstream) puts its center outside [min, max]. Then
+        // one half equals `indices` and the recursion never shrinks, so degrade
+        // to a leaf. This makes termination unconditional, independent of any
+        // geometric precondition on untrusted input.
+        if left.is_empty() || right.is_empty() {
+            emit_leaf(indices, order);
+            return;
+        }
         // Left column before right column.
         cut_recursive(boxes, &left, cfg, order);
         cut_recursive(boxes, &right, cfg, order);
     } else {
         let (top, bottom) = partition_y(boxes, indices, section.unwrap().split);
+        if top.is_empty() || bottom.is_empty() {
+            emit_leaf(indices, order);
+            return;
+        }
         // Higher-on-the-page section before lower.
         cut_recursive(boxes, &top, cfg, order);
         cut_recursive(boxes, &bottom, cfg, order);

--- a/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
@@ -1,0 +1,193 @@
+//! Guards for the flat-path reading-order primitive (issue #448, design §5.5).
+//! Every test constructs synthetic line-group boxes so the expected permutation
+//! is unambiguous and the orderer is exercised as the pure function it is.
+
+use super::flat_reading_order::{reading_order, CutConfig, OrderBox};
+
+/// A single-line box `font_size` tall at the given left/bottom corner.
+fn line(min_x: f64, bottom_y: f64, width: f64, font_size: f64) -> OrderBox {
+    OrderBox {
+        min_x,
+        max_x: min_x + width,
+        min_y: bottom_y,
+        max_y: bottom_y + font_size,
+        font_size,
+    }
+}
+
+fn cfg() -> CutConfig {
+    CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    }
+}
+
+/// §5.5 guard 4: two columns whose lines are drawn right-column-first must come
+/// out left-column-first. Ablation teeth: with the stub identity permutation
+/// this fails, proving the ordering is what fixes it.
+#[test]
+fn two_columns_drawn_right_first_come_out_left_first() {
+    // font 10, gutter = 350 - 150 = 200 pt = 20x the glyph size.
+    let boxes = vec![
+        line(350.0, 700.0, 100.0, 10.0), // right col, top    (stream 0)
+        line(350.0, 680.0, 100.0, 10.0), // right col, bottom (stream 1)
+        line(50.0, 700.0, 100.0, 10.0),  // left col,  top    (stream 2)
+        line(50.0, 680.0, 100.0, 10.0),  // left col,  bottom (stream 3)
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![2, 3, 0, 1]);
+}
+
+/// A section break (gap along Y) drawn bottom-block-first must come out
+/// top-block-first. Drives the horizontal cut; without it this stays [0,1,2,3].
+#[test]
+fn stacked_sections_drawn_bottom_first_come_out_top_first() {
+    // Two single-column blocks. Bottom block near y=100, top block near y=700;
+    // the 570 pt gap is 57x the glyph size. Stream lists the bottom one first.
+    let boxes = vec![
+        line(50.0, 100.0, 200.0, 10.0), // bottom block, upper line (stream 0)
+        line(50.0, 80.0, 200.0, 10.0),  // bottom block, lower line (stream 1)
+        line(50.0, 700.0, 200.0, 10.0), // top block, upper line    (stream 2)
+        line(50.0, 680.0, 200.0, 10.0), // top block, lower line    (stream 3)
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![2, 3, 0, 1]);
+}
+
+/// §5.5 guard 1: the output is always a permutation of the input indices — no
+/// box created, dropped or duplicated — whatever the layout.
+#[test]
+fn output_is_always_a_permutation() {
+    // A two-column page with a section break inside each column: exercises both
+    // axes and the recursion.
+    let boxes = vec![
+        line(350.0, 700.0, 100.0, 10.0),
+        line(350.0, 300.0, 100.0, 10.0),
+        line(50.0, 700.0, 100.0, 10.0),
+        line(50.0, 300.0, 100.0, 10.0),
+        line(50.0, 690.0, 100.0, 10.0),
+    ];
+    let order = reading_order(&boxes, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, (0..boxes.len()).collect::<Vec<_>>());
+}
+
+/// §5.2 precondition: a single column already in top-to-bottom stream order is
+/// returned unchanged (identity), which is what lets the caller emit verbatim.
+#[test]
+fn single_column_in_reading_order_is_the_identity_permutation() {
+    let boxes = vec![
+        line(50.0, 700.0, 200.0, 10.0),
+        line(50.0, 686.0, 200.0, 10.0),
+        line(50.0, 672.0, 200.0, 10.0),
+        line(50.0, 658.0, 200.0, 10.0),
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![0, 1, 2, 3]);
+}
+
+/// §5.5 guard 5: the gutter threshold has teeth on both sides. The same
+/// reversed two-column input splits when `horizontal_k` is small and does NOT
+/// split (stays in stream order) when it is large enough that the gutter no
+/// longer clears the bar.
+#[test]
+fn horizontal_threshold_degrades_on_both_sides() {
+    // Gutter (right edge of left box to left edge of right box) = 190 - 170
+    // = 20 pt = 2x the glyph size.
+    let boxes = vec![
+        line(190.0, 700.0, 20.0, 10.0), // right col, x in [190,210] (stream 0)
+        line(150.0, 700.0, 20.0, 10.0), // left col,  x in [150,170] (stream 1)
+    ];
+    let split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    };
+    let no_split = CutConfig {
+        horizontal_k: 3.0,
+        vertical_k: 1.5,
+    };
+    assert_eq!(reading_order(&boxes, &split), vec![1, 0]); // gutter 2x >= 1x
+    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1]); // gutter 2x < 3x
+}
+
+/// §5.5 guard 5, vertical axis: the section threshold has teeth on both sides
+/// too. The same input splits into two sections when `vertical_k` is small and
+/// stays in stream order when it is large.
+#[test]
+fn vertical_threshold_degrades_on_both_sides() {
+    // Vertical gap between the two blocks = 700 - 660 = 40 pt = 4x glyph size.
+    // Stream order lists the lower block first.
+    let boxes = vec![
+        line(50.0, 640.0, 200.0, 10.0), // lower block, upper line (stream 0)
+        line(50.0, 620.0, 200.0, 10.0), // lower block, lower line (stream 1)
+        line(50.0, 700.0, 200.0, 10.0), // upper block            (stream 2)
+    ];
+    let split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    };
+    let no_split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 6.0,
+    };
+    assert_eq!(reading_order(&boxes, &split), vec![2, 0, 1]); // 4x >= 1.5x
+    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1, 2]); // 4x < 6x
+}
+
+/// §5.5 guard 6 (adversarial): degenerate inputs must not panic and must still
+/// return a valid permutation.
+#[test]
+fn adversarial_inputs_do_not_panic() {
+    // Empty.
+    assert_eq!(reading_order(&[], &cfg()), Vec::<usize>::new());
+    // Single box.
+    assert_eq!(
+        reading_order(&[line(0.0, 0.0, 10.0, 10.0)], &cfg()),
+        vec![0]
+    );
+    // All boxes at the same position (no gap on either axis) -> stream order.
+    let coincident = vec![
+        line(10.0, 10.0, 5.0, 10.0),
+        line(10.0, 10.0, 5.0, 10.0),
+        line(10.0, 10.0, 5.0, 10.0),
+    ];
+    assert_eq!(reading_order(&coincident, &cfg()), vec![0, 1, 2]);
+    // Non-positive font size (degenerate scale) -> leaf, no division by it.
+    let zero_font = vec![
+        OrderBox {
+            min_x: 300.0,
+            max_x: 400.0,
+            min_y: 0.0,
+            max_y: 0.0,
+            font_size: 0.0,
+        },
+        OrderBox {
+            min_x: 0.0,
+            max_x: 100.0,
+            min_y: 0.0,
+            max_y: 0.0,
+            font_size: 0.0,
+        },
+    ];
+    assert_eq!(reading_order(&zero_font, &cfg()), vec![0, 1]);
+    // Overlapping boxes.
+    let overlap = vec![line(0.0, 100.0, 300.0, 10.0), line(50.0, 98.0, 300.0, 10.0)];
+    let order = reading_order(&overlap, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+    // NaN coordinates (a degenerate CTM upstream) must not panic; total_cmp
+    // orders NaN deterministically, so the result is still a permutation.
+    let nan = vec![
+        OrderBox {
+            min_x: f64::NAN,
+            max_x: f64::NAN,
+            min_y: 0.0,
+            max_y: 10.0,
+            font_size: 10.0,
+        },
+        line(0.0, 0.0, 10.0, 10.0),
+    ];
+    let order = reading_order(&nan, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+}

--- a/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
@@ -104,8 +104,16 @@ fn horizontal_threshold_degrades_on_both_sides() {
         horizontal_k: 3.0,
         vertical_k: 1.5,
     };
-    assert_eq!(reading_order(&boxes, &split), vec![1, 0]); // gutter 2x >= 1x
-    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1]); // gutter 2x < 3x
+    assert_eq!(
+        reading_order(&boxes, &split),
+        vec![1, 0],
+        "gutter 2x median glyph clears horizontal_k=1.0, so the columns split"
+    );
+    assert_eq!(
+        reading_order(&boxes, &no_split),
+        vec![0, 1],
+        "gutter 2x median glyph is below horizontal_k=3.0, so stream order stands"
+    );
 }
 
 /// §5.5 guard 5, vertical axis: the section threshold has teeth on both sides
@@ -128,8 +136,16 @@ fn vertical_threshold_degrades_on_both_sides() {
         horizontal_k: 1.0,
         vertical_k: 6.0,
     };
-    assert_eq!(reading_order(&boxes, &split), vec![2, 0, 1]); // 4x >= 1.5x
-    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1, 2]); // 4x < 6x
+    assert_eq!(
+        reading_order(&boxes, &split),
+        vec![2, 0, 1],
+        "section gap 4x median glyph clears vertical_k=1.5, so the blocks split"
+    );
+    assert_eq!(
+        reading_order(&boxes, &no_split),
+        vec![0, 1, 2],
+        "section gap 4x median glyph is below vertical_k=6.0, so stream order stands"
+    );
 }
 
 /// §5.5 guard 6 (adversarial): degenerate inputs must not panic and must still
@@ -188,6 +204,43 @@ fn adversarial_inputs_do_not_panic() {
     ];
     let order = reading_order(&nan, &cfg());
     let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+}
+
+/// §5.5 guard 6: a box with `min > max` (a negative-scale CTM upstream) must not
+/// send the recursion into an infinite loop. The gap/split are computed from
+/// `min`/`max` separately but the partition uses the box center, which for an
+/// inverted box falls outside `[min, max]` — so a naive cut can put every box on
+/// one side and recurse on the same set forever. The orderer must degrade such a
+/// region to a leaf and terminate with a valid permutation.
+#[test]
+fn inverted_boxes_do_not_recurse_forever() {
+    let inverted_x = vec![
+        line(0.0, 0.0, 10.0, 10.0),
+        OrderBox {
+            min_x: 1000.0,
+            max_x: -1000.0,
+            min_y: 0.0,
+            max_y: 10.0,
+            font_size: 10.0,
+        },
+    ];
+    let mut sorted = reading_order(&inverted_x, &cfg());
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+
+    let inverted_y = vec![
+        line(0.0, 0.0, 10.0, 10.0),
+        OrderBox {
+            min_x: 0.0,
+            max_x: 10.0,
+            min_y: 1000.0,
+            max_y: -1000.0,
+            font_size: 10.0,
+        },
+    ];
+    let mut sorted = reading_order(&inverted_y, &cfg());
     sorted.sort_unstable();
     assert_eq!(sorted, vec![0, 1]);
 }

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod encoding;
 pub(crate) mod encoding_cmap;
 pub mod extraction;
 mod extraction_cmap;
+pub(crate) mod flat_reading_order;
 mod flow;
 mod font;
 pub mod font_manager;
@@ -24,6 +25,9 @@ pub mod validation;
 
 #[cfg(test)]
 mod cmap_tests;
+
+#[cfg(test)]
+mod flat_reading_order_tests;
 
 #[cfg(feature = "ocr-tesseract")]
 pub mod tesseract_provider;


### PR DESCRIPTION
## Summary

Addresses #448. Adds the **isolated ordering primitive** for the flat `.text`
path: a pure function from line-group boxes to a permutation of their indices.
This is groundwork — it does **not** touch `extraction.rs`. Wiring into the
show-text arms and calibrating the cut constants are later steps (design §5.8)
that rebase onto #456/#458, so this lands inert behind a module-level
`allow(dead_code)` that is removed when the wiring goes in.

## Why a new module instead of the existing `XYCutReadingOrder`

`pipeline::reading_order::XYCutReadingOrder` serves the partition/Element
pipeline and is unsuitable for the flat path:

- **Scale-relative significance** (§5.4): a gap counts as a column gutter or a
  section break only when it exceeds `k ×` the region's median glyph size, never
  an absolute point threshold. The absolute `min_gap` of the existing cut is the
  exact bug family that motivated #448.
- **Stream-order leaf** (§5.4): a region the cut cannot split returns in input
  (content-stream) order, not re-sorted geometrically. The probe measured this
  as the larger share of the gain, and it is what makes the identity permutation
  byte-preserving for the caller (§5.2).

## Changes

- `oxidize-pdf-core/src/text/flat_reading_order.rs`: `reading_order(&[OrderBox],
  &CutConfig) -> Vec<usize>` — recursive XY-cut, relative threshold, stream-order
  leaf, returns a permutation.
- `oxidize-pdf-core/src/text/flat_reading_order_tests.rs`: guard suite (§5.5).
- `oxidize-pdf-core/src/text/mod.rs`: register the module + its test module.

## Guards (all on synthetic boxes, TDD red→green)

- Output is always a permutation of the input (§5.5 guard 1).
- Two columns drawn right-first come out left-first (guard 4); sections drawn
  bottom-first come out top-first.
- A single column already in reading order is the identity permutation (§5.2).
- Both thresholds have teeth on each side: splits below the bar, no split above
  (guard 5, horizontal and vertical).
- Adversarial (guard 6): empty, single, coincident, zero/NaN, overlapping, and
  **inverted boxes** (`min > max`) never panic and never recurse forever.

## Quality gate

QR (quality-rust) review found and this PR fixes a **critical defect**: an
inverted box (`min > max`, from a negative-scale CTM upstream) put its center
outside `[min, max]`, so a cut could partition a region into `(all, empty)` and
`cut_recursive` recursed on the same set forever → stack overflow on adversarial
input. Fixed by degrading any region a cut fails to divide to a leaf;
termination is now unconditional. Regression test reproduces the overflow on
both axes before the fix. Kripteia test-quality: 91/100, 8 tests, no
blocking findings.

## Testing

- `cargo test -p oxidize-pdf --lib text::flat_reading_order_tests` — 8/8.
- Full lib suite — 6685/0. `cargo clippy -p oxidize-pdf --lib` — clean.

## Notes

- No breaking change: internal `pub(crate)` module, no public API added.
- Inert until wired; the `allow(dead_code)` marks the staging and is removed at
  wiring time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
