### PR TITLE
release: 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+
+### Fixed
+
+- **Three of the four legal `/DescendantFonts` spellings decoded CID text to
+  mojibake** (#469). `extract_font_info` read the entry only when it was a
+  direct array whose element is an indirect reference. ISO 32000-1 puts no
+  reference requirement on either the array or its element (Table 121, §7.3.6,
+  §7.3.7 — where the spec wants a reference it says so, as Table 117 does for
+  the CIDFont's FontDescriptor), and producers write the element inline:
+  ReportLab's `UnicodeCIDFont` does. For those files `descendant_font` stayed
+  empty, `decode_text_with_font` skipped its Type0 branch, and the already
+  correct `cid_encoding` (e.g. `UniJIS-UCS2-H` → UTF-16BE) went unused — the
+  text fell through to byte-wise decoding. The same defect class as #463, fixed
+  here for `/DescendantFonts`: the value may now be a direct array or a
+  reference to one, and the CIDFont element a dictionary or a reference.
+
 ## [4.2.3] - 2026-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.3.0] - 2026-08-11
+
 ### Fixed
 
 - **Three of the four legal `/DescendantFonts` spellings decoded CID text to
@@ -33,6 +35,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both before showing a line, now takes effect. `Tr` (render mode, including the
   invisible `Tr 3` OCR-layer case) is unchanged — exposing it on the public
   `TextFragment` is a breaking change deferred to the next major.
+
+- **Two `TJ` operators drawn side by side on one line were glued together**
+  (#458). The `Tj` arm turns a forward pen jump wider than the threshold into a
+  space, but the `TJ` arm used the same delta only to decide newlines, so
+  adjacent multi-column table cells extracted as `CellOneCellTwo` and a list
+  bullet welded onto its item text as `vlarge`. A boundary space now fires on
+  the first glyph of a `TJ` array when the pen jumped forward past
+  `0.7 em` (calibrated on the Tc/Tw-corrected advance from #456; a leading kern
+  no longer masks the jump). On the `t3-stress` corpus this cut word fusions
+  0.0032 → 0.0014 and reading-order misplacement 0.2766 → 0.2486. An external
+  corpus of 421 real-world PDFs (contributor @oshtivi) measured regressed
+  detections dropping 177 → 125 with this fix, the largest single-fix drop of
+  the cycle.
+
+### Added
+
+- **Opt-in reading-order reorder for the flat text path** (#448), via
+  `TextExtractor::with_reading_order(true)`. Off by default (the flat path stays
+  byte-identical); when on, the flat `.text` line groups are permuted into
+  reading order — left column before right, top block before bottom — using a
+  scale-relative XY-cut whose gap thresholds are multiples of the region's
+  median glyph size, so column detection is font-size-relative rather than an
+  absolute point gap. The text inside each group is untouched. On the
+  `t3-stress` corpus this cut reading-order misplacement 0.2486 → 0.2255 at
+  identical coverage. It reorders only groups the newline heuristic already
+  separated (columns drawn row-interleaved fall in one group), and orders
+  `/Rotate ≠ 0` pages in unrotated page space.
 
 ## [4.2.3] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+## [Unreleased]
 
 ### Fixed
 
@@ -21,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text fell through to byte-wise decoding. The same defect class as #463, fixed
   here for `/DescendantFonts`: the value may now be a direct array or a
   reference to one, and the CIDFont element a dictionary or a reference.
+
+- **`Tc`, `Tw` and `Ts` were parsed and stored but never applied to extraction**
+  (#456). The character-spacing (`Tc`) and word-spacing (`Tw`) parameters are
+  now folded into the pen advance and `Ts` (text rise) into the glyph baseline
+  (ISO 32000-1 §9.4.4): `Tc` is added once per glyph, `Tw` once per single-byte
+  space (code 32, §9.3.3), and `Ts` offsets the fragment's y-origin. Because the
+  advance feeds the flat path's space/newline heuristics, documents that set a
+  non-zero `Tc`/`Tw` now get correct separators; the `"` operator, which sets
+  both before showing a line, now takes effect. `Tr` (render mode, including the
+  invisible `Tr 3` OCR-layer case) is unchanged — exposing it on the public
+  `TextFragment` is a breaking change deferred to the next major.
 
 ## [4.2.3] - 2026-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.2.3"
+version = "4.3.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.2.3"
+version = "4.3.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -10,6 +10,7 @@ use crate::parser::objects::{PdfDictionary, PdfObject};
 use crate::parser::page_tree::ParsedPage;
 use crate::parser::ParseResult;
 use crate::text::extraction_cmap::{CMapTextExtractor, FontInfo};
+use crate::text::flat_reading_order;
 use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
@@ -432,6 +433,32 @@ struct OpRunState {
     /// accumulation short. Propagates through Form XObject recursion and into
     /// [`ExtractedText::truncated`] (issue #382).
     truncated: bool,
+    /// Closed line groups for the reading-order option (issue #448). Empty and
+    /// untouched unless `ExtractionOptions::reading_order` is on. Each group
+    /// records the byte range of its text in `extracted_text` plus its page-space
+    /// box, so the finalizer can permute groups without rebuilding their text —
+    /// the identity permutation is byte-identical (design §5.2).
+    line_groups: Vec<LineGroupGeom>,
+    /// The group currently being accumulated (opens on the first glyph after a
+    /// newline separator). Flushed into `line_groups` at page end.
+    cur_group: Option<LineGroupGeom>,
+}
+
+/// One flat-path line group for the reading-order option (issue #448): the byte
+/// range of its text within `extracted_text`, and the page-space box the
+/// ordering primitive sees. Byte offsets (not owned text) keep the identity
+/// permutation provably byte-identical — the finalizer joins the recorded
+/// slices with `'\n'`, which is exactly the separator the flat path put between
+/// groups in the first place.
+#[derive(Debug, Clone, Copy)]
+struct LineGroupGeom {
+    start: usize,
+    end: usize,
+    min_x: f64,
+    max_x: f64,
+    min_y: f64,
+    max_y: f64,
+    font_size: f64,
 }
 
 impl Default for TextState {
@@ -529,6 +556,11 @@ fn same_paragraph_style(a: &TextFragment, b: &TextFragment) -> bool {
 /// Text extractor for PDF pages with CMap support
 pub struct TextExtractor {
     options: ExtractionOptions,
+    /// Reorder the flat `.text` line groups into reading order (issue #448).
+    /// Off by default; set via [`TextExtractor::with_reading_order`]. Held here,
+    /// not on the public [`ExtractionOptions`], so enabling it is a
+    /// non-breaking method addition rather than a breaking struct-field addition.
+    reading_order: bool,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
@@ -541,6 +573,7 @@ impl TextExtractor {
     pub fn new() -> Self {
         Self {
             options: ExtractionOptions::default(),
+            reading_order: false,
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -550,9 +583,30 @@ impl TextExtractor {
     pub fn with_options(options: ExtractionOptions) -> Self {
         Self {
             options,
+            reading_order: false,
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
+    }
+
+    /// Enable (or disable) flat-path reading-order reordering (issue #448).
+    ///
+    /// Off by default. When on, the flat `.text` path permutes its line groups
+    /// into reading order (left column before right, top block before bottom)
+    /// using the scale-relative XY-cut primitive; the text inside each group is
+    /// untouched, and the result is byte-identical whenever the stream order is
+    /// already the reading order. Only affects the flat path
+    /// (`ExtractionOptions::preserve_layout = false`, no `reorder_columns`).
+    ///
+    /// Consuming builder, so it chains after the constructors:
+    /// `TextExtractor::with_options(opts).with_reading_order(true)`.
+    ///
+    /// Known ceiling (issue #448 design §5.1): only reorders groups the newline
+    /// heuristic already separated — two columns drawn row-interleaved fall into
+    /// one group. `/Rotate ≠ 0` pages are ordered in unrotated page space.
+    pub fn with_reading_order(mut self, enable: bool) -> Self {
+        self.reading_order = enable;
+        self
     }
 
     /// Run the full fragment-merge chain used by the partition pipeline:
@@ -902,6 +956,8 @@ impl TextExtractor {
             extracted_text,
             fragments,
             truncated: false,
+            line_groups: Vec::new(),
+            cur_group: None,
         };
 
         // Process each content stream
@@ -956,6 +1012,8 @@ impl TextExtractor {
             mut extracted_text,
             mut fragments,
             mut truncated,
+            mut line_groups,
+            cur_group,
             ..
         } = run;
         {
@@ -1008,6 +1066,40 @@ impl TextExtractor {
                 fragments.clear();
             }
 
+            // Flat-path reading order (issue #448): permute the line groups into
+            // reading order with the scale-relative XY-cut primitive. Only the
+            // pure flat path — `preserve_layout` and `reorder_columns` rebuild
+            // `.text` from fragments and own their ordering. Rejoining the
+            // recorded group slices with `'\n'` (the flat path's own inter-group
+            // separator) makes an identity permutation byte-identical (§5.2).
+            if self.reading_order && !self.options.preserve_layout && !self.options.reorder_columns
+            {
+                if let Some(g) = cur_group {
+                    line_groups.push(g);
+                }
+                if line_groups.len() > 1 {
+                    let boxes: Vec<flat_reading_order::OrderBox> = line_groups
+                        .iter()
+                        .map(|g| flat_reading_order::OrderBox {
+                            min_x: g.min_x,
+                            max_x: g.max_x,
+                            min_y: g.min_y,
+                            max_y: g.max_y,
+                            font_size: g.font_size,
+                        })
+                        .collect();
+                    let order = flat_reading_order::reading_order(&boxes, &READING_ORDER_CFG);
+                    let mut rebuilt = String::with_capacity(extracted_text.len());
+                    for (n, &i) in order.iter().enumerate() {
+                        if n > 0 {
+                            rebuilt.push('\n');
+                        }
+                        rebuilt.push_str(&extracted_text[line_groups[i].start..line_groups[i].end]);
+                    }
+                    extracted_text = rebuilt;
+                }
+            }
+
             // Final safety net (issue #382): the layout/reorder reconstruction
             // above rebuilds `.text` with its own separators, so guarantee the
             // `text.len() <= max_extracted_bytes` invariant for every path here.
@@ -1046,6 +1138,8 @@ impl TextExtractor {
             mut extracted_text,
             mut fragments,
             mut truncated,
+            mut line_groups,
+            mut cur_group,
         } = run;
 
         let page_properties: Option<&crate::parser::objects::PdfDictionary> =
@@ -1132,6 +1226,10 @@ impl TextExtractor {
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
 
                         // Add spacing based on position change
+                        // Separator of the run that was actually appended, for the
+                        // reading-order line grouping (issue #448); `None` when the
+                        // run was skipped.
+                        let mut emitted_sep: Option<Option<char>> = None;
                         if !skip_text {
                             let separator = if !extracted_text.is_empty() {
                                 // Baseline-frame deltas (issue #443): identical
@@ -1181,6 +1279,7 @@ impl TextExtractor {
                             ) {
                                 break;
                             }
+                            emitted_sep = Some(separator);
                         }
 
                         // Get font info for accurate width calculation.
@@ -1212,6 +1311,24 @@ impl TextExtractor {
                                 &mut state,
                                 self.options.include_artifacts,
                             );
+                        }
+
+                        // Record the run into the reading-order line groups
+                        // (issue #448) once its width is known.
+                        if self.reading_order {
+                            if let Some(sep) = emitted_sep {
+                                record_line_group(
+                                    &mut line_groups,
+                                    &mut cur_group,
+                                    extracted_text.len(),
+                                    decoded.len(),
+                                    sep,
+                                    x,
+                                    y,
+                                    text_width,
+                                    &state,
+                                );
+                            }
                         }
 
                         // Advance the text matrix and track the true post-advance
@@ -1274,6 +1391,9 @@ impl TextExtractor {
                                         dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
                                     let line_wrap = dx < -(self.options.newline_threshold * 2.0)
                                         && (dy > SAME_LINE_EPS || same_y_wrap);
+                                    // Separator of the run actually appended, for the
+                                    // reading-order line grouping (issue #448).
+                                    let mut emitted_sep: Option<Option<char>> = None;
                                     if !skip_text {
                                         // Word spacing at the operator boundary.
                                         // The `Tj` arm turns a forward jump wider
@@ -1322,6 +1442,7 @@ impl TextExtractor {
                                         ) {
                                             break;
                                         }
+                                        emitted_sep = Some(separator);
                                     }
 
                                     let text_width = {
@@ -1350,6 +1471,24 @@ impl TextExtractor {
                                             &mut state,
                                             self.options.include_artifacts,
                                         );
+                                    }
+
+                                    // Record the run into the reading-order line
+                                    // groups (issue #448) once its width is known.
+                                    if self.reading_order {
+                                        if let Some(sep) = emitted_sep {
+                                            record_line_group(
+                                                &mut line_groups,
+                                                &mut cur_group,
+                                                extracted_text.len(),
+                                                decoded.len(),
+                                                sep,
+                                                x,
+                                                y,
+                                                text_width,
+                                                &state,
+                                            );
+                                        }
                                     }
 
                                     // Keep the pen position in sync so a following
@@ -1401,6 +1540,14 @@ impl TextExtractor {
                                             &mut truncated,
                                         ) {
                                             break;
+                                        }
+                                        // The synthesised space is intra-group
+                                        // (issue #448): keep it inside the current
+                                        // group's byte range, no new group.
+                                        if self.reading_order {
+                                            if let Some(g) = cur_group.as_mut() {
+                                                g.end = extracted_text.len();
+                                            }
                                         }
 
                                         // Skip the fragment-level emission while an
@@ -1460,6 +1607,7 @@ impl TextExtractor {
 
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
+                        let mut emitted_sep: Option<Option<char>> = None;
                         if !skip_text {
                             let separator = if extracted_text.is_empty() {
                                 None
@@ -1476,6 +1624,7 @@ impl TextExtractor {
                             ) {
                                 break;
                             }
+                            emitted_sep = Some(separator);
                         }
 
                         let text_width = {
@@ -1503,6 +1652,23 @@ impl TextExtractor {
                                 &mut state,
                                 self.options.include_artifacts,
                             );
+                        }
+
+                        // Record into the reading-order line groups (issue #448).
+                        if self.reading_order {
+                            if let Some(sep) = emitted_sep {
+                                record_line_group(
+                                    &mut line_groups,
+                                    &mut cur_group,
+                                    extracted_text.len(),
+                                    decoded.len(),
+                                    sep,
+                                    x,
+                                    y,
+                                    text_width,
+                                    &state,
+                                );
+                            }
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
@@ -1529,6 +1695,7 @@ impl TextExtractor {
 
                         // Mirror the artifact gate (issue #330).
                         let skip_text = skip_artifact_text(&state, self.options.include_artifacts);
+                        let mut emitted_sep: Option<Option<char>> = None;
                         if !skip_text {
                             let separator = if extracted_text.is_empty() {
                                 None
@@ -1545,6 +1712,7 @@ impl TextExtractor {
                             ) {
                                 break;
                             }
+                            emitted_sep = Some(separator);
                         }
 
                         let text_width = {
@@ -1572,6 +1740,23 @@ impl TextExtractor {
                                 &mut state,
                                 self.options.include_artifacts,
                             );
+                        }
+
+                        // Record into the reading-order line groups (issue #448).
+                        if self.reading_order {
+                            if let Some(sep) = emitted_sep {
+                                record_line_group(
+                                    &mut line_groups,
+                                    &mut cur_group,
+                                    extracted_text.len(),
+                                    decoded.len(),
+                                    sep,
+                                    x,
+                                    y,
+                                    text_width,
+                                    &state,
+                                );
+                            }
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
@@ -1815,6 +2000,8 @@ impl TextExtractor {
                                 extracted_text,
                                 fragments,
                                 truncated,
+                                line_groups,
+                                cur_group,
                             };
                             let mut out = self.process_operations(
                                 xobj_ops,
@@ -1835,6 +2022,8 @@ impl TextExtractor {
                             extracted_text = out.extracted_text;
                             fragments = out.fragments;
                             truncated = out.truncated;
+                            line_groups = out.line_groups;
+                            cur_group = out.cur_group;
                         }
                     }
                 }
@@ -1852,6 +2041,8 @@ impl TextExtractor {
             extracted_text,
             fragments,
             truncated,
+            line_groups,
+            cur_group,
         })
     }
 
@@ -2559,6 +2750,73 @@ fn skip_artifact_text(state: &TextState, include_artifacts: bool) -> bool {
     !include_artifacts && state.mc_stack.iter().any(|e| e.is_artifact)
 }
 
+/// Page-space scale factors `(x_scale, y_scale)` of the current text/CTM
+/// combination (issue #262). Converts a text-space width/size into page space,
+/// mirroring the scaling [`emit_text_fragment`] applies, so the reading-order
+/// boxes and the median-font unit that judges their gaps share the page-space
+/// scale of the `x`/`y` origins.
+fn combined_text_scale(state: &TextState) -> (f64, f64) {
+    let combined = multiply_matrix(&state.text_matrix, &state.ctm);
+    let x_scale = (combined[0] * combined[0] + combined[1] * combined[1]).sqrt();
+    let y_scale = (combined[2] * combined[2] + combined[3] * combined[3]).sqrt();
+    (x_scale, y_scale)
+}
+
+/// Record a just-emitted glyph run into the flat-path line groups (issue #448).
+///
+/// Called only when `ExtractionOptions::reading_order` is on, right after a
+/// successful [`append_bounded`], with `text_len` = `extracted_text.len()` after
+/// the append. `width` and `font_size` must already be page-space (scaled via
+/// [`combined_text_scale`]) so the box matches the page-space `x`/`y` origin. A
+/// run whose separator is a newline opens a new group; anything else extends the
+/// current one. The group's byte range excludes the leading newline (a group's
+/// text starts at `text_len - decoded_len`, which is past the separator), so
+/// rejoining slices with `'\n'` reproduces the original exactly.
+#[allow(clippy::too_many_arguments)]
+fn record_line_group(
+    line_groups: &mut Vec<LineGroupGeom>,
+    cur_group: &mut Option<LineGroupGeom>,
+    text_len: usize,
+    decoded_len: usize,
+    separator: Option<char>,
+    x: f64,
+    y: f64,
+    text_width: f64,
+    state: &TextState,
+) {
+    // Convert the text-space advance and font size to page space so the box
+    // matches the page-space `x`/`y` and the median-font unit is on the same
+    // scale as the gaps it judges (issue #262).
+    let (x_scale, y_scale) = combined_text_scale(state);
+    let width = text_width * x_scale;
+    let font_size = state.font_size * y_scale;
+    let run_start = text_len.saturating_sub(decoded_len);
+    let (rx0, rx1) = (x.min(x + width), x.max(x + width));
+    let (ry0, ry1) = (y.min(y + font_size), y.max(y + font_size));
+    let opens = matches!(separator, Some('\n')) || cur_group.is_none();
+    if opens {
+        if let Some(g) = cur_group.take() {
+            line_groups.push(g);
+        }
+        *cur_group = Some(LineGroupGeom {
+            start: run_start,
+            end: text_len,
+            min_x: rx0,
+            max_x: rx1,
+            min_y: ry0,
+            max_y: ry1,
+            font_size,
+        });
+    } else if let Some(g) = cur_group.as_mut() {
+        g.end = text_len;
+        g.min_x = g.min_x.min(rx0);
+        g.max_x = g.max_x.max(rx1);
+        g.min_y = g.min_y.min(ry0);
+        g.max_y = g.max_y.max(ry1);
+        g.font_size = g.font_size.max(font_size);
+    }
+}
+
 /// Append an optional `separator` plus `decoded` to `acc`, honouring the
 /// per-page byte budget `limit` (issue #382).
 ///
@@ -2732,6 +2990,25 @@ fn advance_pen(state: &mut TextState, text_width: f64) -> (f64, f64) {
 /// below this epsilon is "the same baseline". The smallest meaningful
 /// leading in real documents is orders of magnitude above it.
 const SAME_LINE_EPS: f64 = 1e-6;
+
+/// Scale-relative cut thresholds for the flat-path reading-order option
+/// (issue #448), in multiples of a region's median glyph size: a horizontal gap
+/// is a column gutter past `horizontal_k`, a vertical gap a section break past
+/// `vertical_k`.
+///
+/// Validated against the opt-in differential order gate on the full `t3-stress`
+/// corpus (`t3-stress-reading-order` baseline): with the option on, the
+/// misplaced-word rate drops 0.2486 → 0.2255 (−9.3%) versus the default flat
+/// path, at identical alignment coverage — the gain is reordering, not dropped
+/// text. That clears the design probe's ceiling estimate (~0.2375), so these
+/// values are kept rather than sweeping for a marginal further gain. (An
+/// earlier, geometrically wrong build that fed the cut un-CTM-scaled boxes
+/// scored a hair better here, 0.2226, purely because the corpus is
+/// identity-CTM-dominated; the correct page-space geometry is kept.)
+const READING_ORDER_CFG: flat_reading_order::CutConfig = flat_reading_order::CutConfig {
+    horizontal_k: 1.0,
+    vertical_k: 1.5,
+};
 
 /// Minimum forward pen jump, in em, that reads as a word break at the boundary
 /// between two show-text operators — the first element of a `TJ` array whose

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1223,6 +1223,15 @@ impl TextExtractor {
 
                 ContentOperation::ShowTextArray(array) => {
                     if in_text_object {
+                        // True until this `TJ` array draws its first glyph. Only
+                        // on that first text element can a forward pen jump come
+                        // from the operator boundary (a `Tm`, or the previous
+                        // operator's advance); once a glyph is drawn, a later
+                        // forward jump is the array's own kerning, which
+                        // `TextElement::Spacing` already turns into a space. A
+                        // leading kern does NOT clear this (see the Spacing arm).
+                        // See the boundary gate below.
+                        let mut at_array_start = true;
                         for item in array {
                             match item {
                                 TextElement::Text(text_bytes) => {
@@ -1266,10 +1275,39 @@ impl TextExtractor {
                                     let line_wrap = dx < -(self.options.newline_threshold * 2.0)
                                         && (dy > SAME_LINE_EPS || same_y_wrap);
                                     if !skip_text {
-                                        let separator = if !extracted_text.is_empty()
-                                            && (dy > self.options.newline_threshold || line_wrap)
-                                        {
+                                        // Word spacing at the operator boundary.
+                                        // The `Tj` arm turns a forward jump wider
+                                        // than `space_threshold` into a space;
+                                        // this arm used to decide newlines only,
+                                        // so two `TJ` operators drawn side by side
+                                        // on the same line came out glued: a
+                                        // multi-column table cell read as
+                                        // `CellOneCellTwo` (issue #458), and a list
+                                        // bullet 0.75 em from its item text read as
+                                        // `vlarge` (found on preserve_027613.pdf,
+                                        // an IBM manual whose every bullet is a
+                                        // separate `TJ`).
+                                        //
+                                        // Restricted to the array's first element
+                                        // because that is the only jump the
+                                        // boundary owns. Inside the array the jump
+                                        // IS the kern, and `TextElement::Spacing`
+                                        // below already synthesises its space —
+                                        // firing here too would double it. A short
+                                        // forward gap (below the threshold) is left
+                                        // alone: the pen advance is only as
+                                        // accurate as the font widths, so a
+                                        // producer that draws one word as several
+                                        // positioned runs must not be split.
+                                        let boundary_space = at_array_start
+                                            && dx > TJ_BOUNDARY_SPACE_EM * state.font_size
+                                            && !extracted_text.ends_with(' ');
+                                        let separator = if extracted_text.is_empty() {
+                                            None
+                                        } else if dy > self.options.newline_threshold || line_wrap {
                                             Some('\n')
+                                        } else if boundary_space {
+                                            Some(' ')
                                         } else {
                                             None
                                         };
@@ -1319,8 +1357,24 @@ impl TextExtractor {
                                     // (issue #381: a stale `last_y` dropped newlines;
                                     // issue #386: the pen must fold in Tz/CTM scale).
                                     (last_x, last_y) = advance_pen(&mut state, text_width);
+                                    at_array_start = false;
                                 }
                                 TextElement::Spacing(adjustment) => {
+                                    // `at_array_start` is deliberately NOT cleared
+                                    // here. It marks "no glyph drawn yet", not "no
+                                    // item seen yet": a `TJ` array may open with a
+                                    // small intra-word kern while the real
+                                    // operator-boundary jump (a `Tm` to a new
+                                    // column) still lands on the first *text*
+                                    // element. Clearing the flag on the leading
+                                    // kern would suppress the boundary space and
+                                    // re-glue separate columns (issue #458). The
+                                    // kern's own space synthesis below works off
+                                    // `tx` (the kern delta), not `dx` (the full pen
+                                    // jump), so the two checks measure different
+                                    // quantities; the `!ends_with(' ')` guard on
+                                    // each keeps a leading kern that IS wide from
+                                    // producing a double space.
                                     // Text position adjustment (negative = move left,
                                     // i.e. shifts the pen forward). When the synthesised
                                     // forward advance exceeds `tj_space_threshold * font_size`
@@ -2678,6 +2732,39 @@ fn advance_pen(state: &mut TextState, text_width: f64) -> (f64, f64) {
 /// below this epsilon is "the same baseline". The smallest meaningful
 /// leading in real documents is orders of magnitude above it.
 const SAME_LINE_EPS: f64 = 1e-6;
+
+/// Minimum forward pen jump, in em, that reads as a word break at the boundary
+/// between two show-text operators — the first element of a `TJ` array whose
+/// pen jumped forward from the previous operator (a `Tm` reposition, or the
+/// prior operator's advance). Without it, two `TJ` operators drawn side by side
+/// on the same line come out glued: a multi-column table cell reads as
+/// `CellOneCellTwo` (issue #458), and a list bullet 0.75 em from its item text
+/// reads as `vlarge` (found on preserve_027613.pdf, an IBM manual whose every
+/// bullet is a separate `TJ`).
+///
+/// Calibrated on the full `t3-stress` corpus against poppler, with the
+/// reading-order (misplaced) rate as the objective and alignment coverage as
+/// the guard. Recalibrated on the Tc/Tw-corrected pen advance (#456), which
+/// feeds the `dx` this threshold judges:
+///
+/// | em | 0.0 | 0.3 | 0.7 | 1.0 | 2.0 | 3.0 | 6.0 | off |
+/// |---|---|---|---|---|---|---|---|---|
+/// | misplaced rate | .2806 | .2485 | **.2486** | .2486 | .2486 | .2512 | .2702 | .2766 |
+///
+/// Below ~0.3 em the rule splits words a producer draws as several positioned
+/// runs — the pen advance is only as accurate as the font widths, so a short
+/// run inflates the apparent gap, and em=0.0 lands *worse* than not firing at
+/// all. From 0.3 to 2.0 the corpus cannot discriminate (a flat plateau within
+/// 1e-4 of the minimum); above 3 em the rule stops firing on genuine column
+/// gaps and converges back on the un-fixed number.
+///
+/// 0.7 sits inside that plateau with margin on both sides: comfortably above
+/// the word-splitting floor, and below 0.748 em — the narrowest real word gap
+/// verified by hand (the bullet above), which the threshold must stay under to
+/// keep separating. On the corrected advance the fix moves the rate .2766 →
+/// .2486 (vs .2874 → .2714 before #456: an accurate advance lets the boundary
+/// fire more cleanly).
+const TJ_BOUNDARY_SPACE_EM: f64 = 0.7;
 
 /// Backward-jump magnitude, in multiples of the font size, above which a
 /// same-baseline (`dy == 0`) backward pen jump is a line wrap rather than a

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1197,6 +1197,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -1294,6 +1296,8 @@ impl TextExtractor {
                                             &decoded,
                                             state.font_size,
                                             font_info,
+                                            state.char_space,
+                                            state.word_space,
                                         )
                                     };
 
@@ -1430,6 +1434,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -1497,6 +1503,8 @@ impl TextExtractor {
                                 &decoded,
                                 state.font_size,
                                 font_info,
+                                state.char_space,
+                                state.word_space,
                             )
                         };
 
@@ -2643,7 +2651,10 @@ fn emit_text_fragment(
 /// or pure-translation matrix; non-uniform CTM scaling produced wrong origins.
 fn text_origin(state: &TextState) -> (f64, f64) {
     let combined = multiply_matrix(&state.text_matrix, &state.ctm);
-    transform_point(0.0, 0.0, &combined)
+    // Text rise (`Ts`) shifts the glyph origin up the text-space y-axis before
+    // the text/CTM transform (ISO 32000-1 §9.4.4). For an axis-aligned matrix
+    // this moves the user-space y by exactly `Ts`.
+    transform_point(0.0, state.text_rise, &combined)
 }
 
 /// Advance the text matrix by one shown glyph run of unscaled width
@@ -2901,20 +2912,38 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `decoded` is the already-decoded text for this run; it is only consulted for
 /// composite (Type0) fonts, whose multi-byte codes cannot be indexed byte-wise
 /// and whose width path is unchanged here to avoid regressing CJK extraction.
+/// Unscaled text-space advance of a run (before `Th`), including the text-state
+/// spacing parameters (ISO 32000-1 §9.4.4): the glyph displacement is
+/// `w0/1000 * Tfs + Tc + Tw`, so `char_space` (`Tc`) is added once per glyph and
+/// `word_space` (`Tw`) once per *single-byte* space (code 32, §9.3.3). Both are
+/// unscaled text-space units, added directly (not multiplied by the font size);
+/// the caller's `advance_pen` applies `Th`.
 fn calculate_text_width_from_codes(
     codes: &[u8],
     decoded: &str,
     font_size: f64,
     font_info: Option<&FontInfo>,
+    char_space: f64,
+    word_space: f64,
 ) -> f64 {
     // Composite (Type0) fonts use multi-byte codes; a single byte is not a code,
     // so byte-indexed width lookup is invalid. Preserve the existing decoded-based
-    // behavior for them.
+    // behavior for them, adding `Tc` per glyph. `Tw` applies only to the
+    // single-byte code 32 (§9.3.3), which a multi-byte code can never be, so it
+    // does not apply here.
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
-        return calculate_text_width(decoded, font_size, font_info);
+        let glyphs = decoded.chars().count() as f64;
+        return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
+
+    // `Tc` on every byte-code, `Tw` on every space byte. Shared by the metric
+    // and no-metric branches below.
+    let spacing = |codes: &[u8]| -> f64 {
+        char_space * codes.len() as f64
+            + word_space * codes.iter().filter(|&&b| b == b' ').count() as f64
+    };
 
     if let Some(font) = font_info {
         if let Some(ref widths) = font.metrics.widths {
@@ -2946,12 +2975,12 @@ fn calculate_text_width_from_codes(
                 }
             }
 
-            return total_width;
+            return total_width + spacing(codes);
         }
     }
 
     // No metrics: one fallback width per code (byte), the simple-font glyph count.
-    codes.len() as f64 * font_size * 0.5
+    codes.len() as f64 * font_size * 0.5 + spacing(codes)
 }
 
 /// Sanitize extracted text by removing or replacing control characters.
@@ -3697,7 +3726,8 @@ mod tests {
 
         let codes = [1u8, 2u8];
         let decoded = "mi"; // what decode_text produced for these codes
-        let width = calculate_text_width_from_codes(&codes, decoded, 10.0, Some(&font_info));
+        let width =
+            calculate_text_width_from_codes(&codes, decoded, 10.0, Some(&font_info), 0.0, 0.0);
         let expected = (1000.0 + 100.0) / 1000.0 * 10.0; // 11.0
         assert!(
             (width - expected).abs() < 1e-6,

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -177,15 +177,44 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
 
         // Handle Type0 (composite) fonts
         if font_type.as_str() == "Type0" {
-            if let Some(PdfObject::Array(descendant_array)) = font_dict.get("DescendantFonts") {
-                if let Some(desc_ref) = descendant_array.0.first().and_then(|o| o.as_reference()) {
-                    if let Ok(PdfObject::Dictionary(desc_dict)) =
-                        document.get_object(desc_ref.0, desc_ref.1)
-                    {
-                        let descendant = self.extract_font_info(&desc_dict, document)?;
-                        font_info.descendant_font = Some(Box::new(descendant));
+            // The DescendantFonts value and the CIDFont element inside it may
+            // each be written inline or as an indirect reference: ISO 32000-1
+            // Table 121 types the entry as "array" with no reference
+            // requirement, §7.3.6 lets array elements be dictionaries, and
+            // §7.3.7 lets a dictionary value be any kind of object — where
+            // the spec wants a reference it says so (Table 117 marks the
+            // CIDFont's FontDescriptor "shall be an indirect reference"), and
+            // the DescendantFonts row carries no such words. The same argument
+            // as #463, which fixed this for /Font resource entries. Producers
+            // do use the inline form (ReportLab's UnicodeCIDFont writes the
+            // CIDFont as a direct dictionary). Reading only the
+            // reference-inside-direct-array combination left `descendant_font`
+            // empty, which silently skipped the `cid_encoding` branch in
+            // `decode_text_with_font` and fell back to byte-wise decoding.
+            let resolved_array;
+            let descendant_fonts = match font_dict.get("DescendantFonts") {
+                Some(PdfObject::Array(array)) => Some(array),
+                Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                    Ok(PdfObject::Array(array)) => {
+                        resolved_array = array;
+                        Some(&resolved_array)
                     }
-                }
+                    _ => None,
+                },
+                _ => None,
+            };
+            let descendant = match descendant_fonts.and_then(|array| array.0.first()) {
+                Some(PdfObject::Dictionary(dict)) => Some(self.extract_font_info(dict, document)?),
+                Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                    Ok(PdfObject::Dictionary(dict)) => {
+                        Some(self.extract_font_info(&dict, document)?)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(descendant) = descendant {
+                font_info.descendant_font = Some(Box::new(descendant));
             }
         }
 

--- a/oxidize-pdf-core/src/text/flat_reading_order.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order.rs
@@ -1,0 +1,219 @@
+//! Flat-path reading order (issue #448).
+//!
+//! The default `.text` flat path emits fragments in content-stream order,
+//! which transposes multi-column and out-of-order layouts. This module is the
+//! isolated ordering primitive: a pure function from line-group boxes to a
+//! permutation of their indices. It is deliberately decoupled from
+//! `extraction.rs` — the wiring into the show-text arms is a separate, later
+//! step (design doc §5.8) that rebases onto #456.
+//!
+//! Two properties set it apart from the pre-existing
+//! [`crate::pipeline::reading_order::XYCutReadingOrder`], which serves the
+//! partition/Element pipeline and is unsuitable here:
+//!
+//! - **Scale-relative significance** (§5.4). A gap counts as a column gutter or
+//!   a section break only when it exceeds a multiple of the region's median
+//!   glyph size, never an absolute point threshold. The absolute `min_gap` of
+//!   the existing cut is the exact bug family that motivated #448.
+//! - **Stream-order leaf** (§5.4). A region the cut cannot split comes back in
+//!   input (content-stream) order, not re-sorted geometrically. The probe
+//!   measured this as the larger share of the gain (stream leaf −17% vs a
+//!   geometric leaf −13%), and it is what makes the identity permutation
+//!   byte-preserving for the caller (§5.2).
+
+// Staged ahead of its call site: the show-text wiring (§5.8) is a later step
+// that rebases onto #456, so in a non-test build nothing references this module
+// yet. Remove this attribute when the wiring lands and the module is live.
+#![allow(dead_code)]
+
+/// A box the flat-path orderer permutes: one per line group (§5.1).
+///
+/// Coordinates are page space with `/Rotate` already applied by the caller
+/// (§5.3), so the orderer never looks at rotation itself. PDF convention: `y`
+/// grows upward, `min_y` is the bottom edge and `max_y` the top edge.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OrderBox {
+    /// Left edge.
+    pub min_x: f64,
+    /// Right edge.
+    pub max_x: f64,
+    /// Bottom edge (PDF space: smaller y is lower on the page).
+    pub min_y: f64,
+    /// Top edge.
+    pub max_y: f64,
+    /// Representative glyph size of the group; the unit for the gutter and the
+    /// line-break scale in [`CutConfig`].
+    pub font_size: f64,
+}
+
+/// Scale-relative cut thresholds (§5.4). A gap must exceed `k ×` the region's
+/// median [`OrderBox::font_size`] to be taken as a significant cut. One
+/// constant per axis, calibrated against the order gate — the calibration is
+/// deferred until #456/#458 land, so these stay parameters, not constants.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CutConfig {
+    /// Horizontal gutter significance, in multiples of the median glyph size.
+    pub horizontal_k: f64,
+    /// Vertical section-break significance, in multiples of the median glyph
+    /// size.
+    pub vertical_k: f64,
+}
+
+/// Order line-group boxes and return a permutation of `0..boxes.len()`.
+///
+/// The recursion cuts on whichever axis carries the widest scale-relative gap;
+/// a region with no significant gap is a leaf and is returned in input order,
+/// so `reading_order` is the identity permutation whenever the stream order is
+/// already the reading order.
+pub(crate) fn reading_order(boxes: &[OrderBox], cfg: &CutConfig) -> Vec<usize> {
+    let mut order = Vec::with_capacity(boxes.len());
+    let indices: Vec<usize> = (0..boxes.len()).collect();
+    cut_recursive(boxes, &indices, cfg, &mut order);
+    order
+}
+
+/// The scale unit for a region: the median glyph size of its boxes. Returns
+/// `None` for an empty region or a non-positive median (degenerate input),
+/// which forces the region to be treated as a leaf rather than dividing by a
+/// meaningless scale (§5.5 guard 6).
+fn median_font_size(boxes: &[OrderBox], indices: &[usize]) -> Option<f64> {
+    if indices.is_empty() {
+        return None;
+    }
+    let mut sizes: Vec<f64> = indices.iter().map(|&i| boxes[i].font_size).collect();
+    sizes.sort_by(|a, b| a.total_cmp(b));
+    let median = sizes[sizes.len() / 2];
+    (median.is_finite() && median > 0.0).then_some(median)
+}
+
+/// Recursively cut `indices` and append the resulting reading order to `order`.
+fn cut_recursive(boxes: &[OrderBox], indices: &[usize], cfg: &CutConfig, order: &mut Vec<usize>) {
+    if indices.len() <= 1 {
+        order.extend_from_slice(indices);
+        return;
+    }
+    let Some(scale) = median_font_size(boxes, indices) else {
+        emit_leaf(indices, order);
+        return;
+    };
+
+    // A column gutter (gap along X) is judged against `horizontal_k`; a section
+    // break (gap along Y) against `vertical_k`. Take whichever significant cut
+    // carries the wider scale-relative gap (§5.4, "hueco más ancho").
+    let column = find_column_gap(boxes, indices).filter(|c| c.ratio(scale) >= cfg.horizontal_k);
+    let section = find_section_gap(boxes, indices).filter(|c| c.ratio(scale) >= cfg.vertical_k);
+
+    let choose_column = match (&column, &section) {
+        (Some(c), Some(s)) => c.ratio(scale) >= s.ratio(scale),
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => {
+            emit_leaf(indices, order);
+            return;
+        }
+    };
+
+    if choose_column {
+        let (left, right) = partition_x(boxes, indices, column.unwrap().split);
+        // Left column before right column.
+        cut_recursive(boxes, &left, cfg, order);
+        cut_recursive(boxes, &right, cfg, order);
+    } else {
+        let (top, bottom) = partition_y(boxes, indices, section.unwrap().split);
+        // Higher-on-the-page section before lower.
+        cut_recursive(boxes, &top, cfg, order);
+        cut_recursive(boxes, &bottom, cfg, order);
+    }
+}
+
+/// A leaf region: no significant cut, so preserve content-stream order (§5.4).
+/// The original indices ascending are the stream order.
+fn emit_leaf(indices: &[usize], order: &mut Vec<usize>) {
+    let mut leaf = indices.to_vec();
+    leaf.sort_unstable();
+    order.extend(leaf);
+}
+
+/// A candidate cut: the absolute gap width and the coordinate to split at.
+struct Gap {
+    width: f64,
+    split: f64,
+}
+
+impl Gap {
+    fn ratio(&self, scale: f64) -> f64 {
+        self.width / scale
+    }
+}
+
+/// Largest whitespace gap along X (a column gutter). Sweeps left to right
+/// tracking the running maximum right edge, so a short box nested inside a tall
+/// column does not open a spurious gap.
+fn find_column_gap(boxes: &[OrderBox], indices: &[usize]) -> Option<Gap> {
+    let mut edges: Vec<(f64, f64)> = indices
+        .iter()
+        .map(|&i| (boxes[i].min_x, boxes[i].max_x))
+        .collect();
+    edges.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut max_gap = 0.0f64;
+    let mut split = 0.0f64;
+    let mut max_right = edges[0].1;
+    for window in edges.windows(2) {
+        let next_left = window[1].0;
+        let gap = next_left - max_right;
+        if gap > max_gap {
+            max_gap = gap;
+            split = max_right + gap / 2.0;
+        }
+        max_right = max_right.max(window[1].1);
+    }
+    (max_gap > 0.0).then_some(Gap {
+        width: max_gap,
+        split,
+    })
+}
+
+/// Largest whitespace gap along Y (a section break). PDF space is y-up, so the
+/// sweep runs top (large y) to bottom, tracking the running minimum bottom edge.
+fn find_section_gap(boxes: &[OrderBox], indices: &[usize]) -> Option<Gap> {
+    let mut edges: Vec<(f64, f64)> = indices
+        .iter()
+        .map(|&i| (boxes[i].min_y, boxes[i].max_y))
+        .collect();
+    // Sort by top edge descending (topmost first).
+    edges.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+    let mut max_gap = 0.0f64;
+    let mut split = 0.0f64;
+    let mut min_bottom = edges[0].0;
+    for window in edges.windows(2) {
+        let next_top = window[1].1;
+        let gap = min_bottom - next_top;
+        if gap > max_gap {
+            max_gap = gap;
+            split = next_top + gap / 2.0;
+        }
+        min_bottom = min_bottom.min(window[1].0);
+    }
+    (max_gap > 0.0).then_some(Gap {
+        width: max_gap,
+        split,
+    })
+}
+
+/// Split a region into (left, right) by box-center X against `split`. Both
+/// partitions preserve the input order of `indices`.
+fn partition_x(boxes: &[OrderBox], indices: &[usize], split: f64) -> (Vec<usize>, Vec<usize>) {
+    indices
+        .iter()
+        .partition(|&&i| (boxes[i].min_x + boxes[i].max_x) / 2.0 < split)
+}
+
+/// Split a region into (top, bottom) by box-center Y against `split`. Top is the
+/// higher-on-the-page half (larger y). Both partitions preserve input order.
+fn partition_y(boxes: &[OrderBox], indices: &[usize], split: f64) -> (Vec<usize>, Vec<usize>) {
+    indices
+        .iter()
+        .partition(|&&i| (boxes[i].min_y + boxes[i].max_y) / 2.0 >= split)
+}

--- a/oxidize-pdf-core/src/text/flat_reading_order.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order.rs
@@ -21,11 +21,6 @@
 //!   geometric leaf −13%), and it is what makes the identity permutation
 //!   byte-preserving for the caller (§5.2).
 
-// Staged ahead of its call site: the show-text wiring (§5.8) is a later step
-// that rebases onto #456, so in a non-test build nothing references this module
-// yet. Remove this attribute when the wiring lands and the module is live.
-#![allow(dead_code)]
-
 /// A box the flat-path orderer permutes: one per line group (§5.1).
 ///
 /// Coordinates are page space with `/Rotate` already applied by the caller

--- a/oxidize-pdf-core/src/text/flat_reading_order.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order.rs
@@ -31,6 +31,11 @@
 /// Coordinates are page space with `/Rotate` already applied by the caller
 /// (§5.3), so the orderer never looks at rotation itself. PDF convention: `y`
 /// grows upward, `min_y` is the bottom edge and `max_y` the top edge.
+///
+/// A well-formed box has `min_x <= max_x` and `min_y <= max_y`. An inverted box
+/// (e.g. from a negative-scale CTM upstream) is not rejected: the orderer
+/// degrades any region it cannot actually divide to stream order, so inverted
+/// input yields a valid permutation rather than a panic or a hang.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OrderBox {
     /// Left edge.
@@ -115,11 +120,25 @@ fn cut_recursive(boxes: &[OrderBox], indices: &[usize], cfg: &CutConfig, order: 
 
     if choose_column {
         let (left, right) = partition_x(boxes, indices, column.unwrap().split);
+        // A gap can exist yet fail to divide the region when a box center lands
+        // on the far side of the split — an inverted box (min > max, from a
+        // negative-scale CTM upstream) puts its center outside [min, max]. Then
+        // one half equals `indices` and the recursion never shrinks, so degrade
+        // to a leaf. This makes termination unconditional, independent of any
+        // geometric precondition on untrusted input.
+        if left.is_empty() || right.is_empty() {
+            emit_leaf(indices, order);
+            return;
+        }
         // Left column before right column.
         cut_recursive(boxes, &left, cfg, order);
         cut_recursive(boxes, &right, cfg, order);
     } else {
         let (top, bottom) = partition_y(boxes, indices, section.unwrap().split);
+        if top.is_empty() || bottom.is_empty() {
+            emit_leaf(indices, order);
+            return;
+        }
         // Higher-on-the-page section before lower.
         cut_recursive(boxes, &top, cfg, order);
         cut_recursive(boxes, &bottom, cfg, order);

--- a/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
@@ -1,0 +1,193 @@
+//! Guards for the flat-path reading-order primitive (issue #448, design §5.5).
+//! Every test constructs synthetic line-group boxes so the expected permutation
+//! is unambiguous and the orderer is exercised as the pure function it is.
+
+use super::flat_reading_order::{reading_order, CutConfig, OrderBox};
+
+/// A single-line box `font_size` tall at the given left/bottom corner.
+fn line(min_x: f64, bottom_y: f64, width: f64, font_size: f64) -> OrderBox {
+    OrderBox {
+        min_x,
+        max_x: min_x + width,
+        min_y: bottom_y,
+        max_y: bottom_y + font_size,
+        font_size,
+    }
+}
+
+fn cfg() -> CutConfig {
+    CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    }
+}
+
+/// §5.5 guard 4: two columns whose lines are drawn right-column-first must come
+/// out left-column-first. Ablation teeth: with the stub identity permutation
+/// this fails, proving the ordering is what fixes it.
+#[test]
+fn two_columns_drawn_right_first_come_out_left_first() {
+    // font 10, gutter = 350 - 150 = 200 pt = 20x the glyph size.
+    let boxes = vec![
+        line(350.0, 700.0, 100.0, 10.0), // right col, top    (stream 0)
+        line(350.0, 680.0, 100.0, 10.0), // right col, bottom (stream 1)
+        line(50.0, 700.0, 100.0, 10.0),  // left col,  top    (stream 2)
+        line(50.0, 680.0, 100.0, 10.0),  // left col,  bottom (stream 3)
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![2, 3, 0, 1]);
+}
+
+/// A section break (gap along Y) drawn bottom-block-first must come out
+/// top-block-first. Drives the horizontal cut; without it this stays [0,1,2,3].
+#[test]
+fn stacked_sections_drawn_bottom_first_come_out_top_first() {
+    // Two single-column blocks. Bottom block near y=100, top block near y=700;
+    // the 570 pt gap is 57x the glyph size. Stream lists the bottom one first.
+    let boxes = vec![
+        line(50.0, 100.0, 200.0, 10.0), // bottom block, upper line (stream 0)
+        line(50.0, 80.0, 200.0, 10.0),  // bottom block, lower line (stream 1)
+        line(50.0, 700.0, 200.0, 10.0), // top block, upper line    (stream 2)
+        line(50.0, 680.0, 200.0, 10.0), // top block, lower line    (stream 3)
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![2, 3, 0, 1]);
+}
+
+/// §5.5 guard 1: the output is always a permutation of the input indices — no
+/// box created, dropped or duplicated — whatever the layout.
+#[test]
+fn output_is_always_a_permutation() {
+    // A two-column page with a section break inside each column: exercises both
+    // axes and the recursion.
+    let boxes = vec![
+        line(350.0, 700.0, 100.0, 10.0),
+        line(350.0, 300.0, 100.0, 10.0),
+        line(50.0, 700.0, 100.0, 10.0),
+        line(50.0, 300.0, 100.0, 10.0),
+        line(50.0, 690.0, 100.0, 10.0),
+    ];
+    let order = reading_order(&boxes, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, (0..boxes.len()).collect::<Vec<_>>());
+}
+
+/// §5.2 precondition: a single column already in top-to-bottom stream order is
+/// returned unchanged (identity), which is what lets the caller emit verbatim.
+#[test]
+fn single_column_in_reading_order_is_the_identity_permutation() {
+    let boxes = vec![
+        line(50.0, 700.0, 200.0, 10.0),
+        line(50.0, 686.0, 200.0, 10.0),
+        line(50.0, 672.0, 200.0, 10.0),
+        line(50.0, 658.0, 200.0, 10.0),
+    ];
+    assert_eq!(reading_order(&boxes, &cfg()), vec![0, 1, 2, 3]);
+}
+
+/// §5.5 guard 5: the gutter threshold has teeth on both sides. The same
+/// reversed two-column input splits when `horizontal_k` is small and does NOT
+/// split (stays in stream order) when it is large enough that the gutter no
+/// longer clears the bar.
+#[test]
+fn horizontal_threshold_degrades_on_both_sides() {
+    // Gutter (right edge of left box to left edge of right box) = 190 - 170
+    // = 20 pt = 2x the glyph size.
+    let boxes = vec![
+        line(190.0, 700.0, 20.0, 10.0), // right col, x in [190,210] (stream 0)
+        line(150.0, 700.0, 20.0, 10.0), // left col,  x in [150,170] (stream 1)
+    ];
+    let split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    };
+    let no_split = CutConfig {
+        horizontal_k: 3.0,
+        vertical_k: 1.5,
+    };
+    assert_eq!(reading_order(&boxes, &split), vec![1, 0]); // gutter 2x >= 1x
+    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1]); // gutter 2x < 3x
+}
+
+/// §5.5 guard 5, vertical axis: the section threshold has teeth on both sides
+/// too. The same input splits into two sections when `vertical_k` is small and
+/// stays in stream order when it is large.
+#[test]
+fn vertical_threshold_degrades_on_both_sides() {
+    // Vertical gap between the two blocks = 700 - 660 = 40 pt = 4x glyph size.
+    // Stream order lists the lower block first.
+    let boxes = vec![
+        line(50.0, 640.0, 200.0, 10.0), // lower block, upper line (stream 0)
+        line(50.0, 620.0, 200.0, 10.0), // lower block, lower line (stream 1)
+        line(50.0, 700.0, 200.0, 10.0), // upper block            (stream 2)
+    ];
+    let split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 1.5,
+    };
+    let no_split = CutConfig {
+        horizontal_k: 1.0,
+        vertical_k: 6.0,
+    };
+    assert_eq!(reading_order(&boxes, &split), vec![2, 0, 1]); // 4x >= 1.5x
+    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1, 2]); // 4x < 6x
+}
+
+/// §5.5 guard 6 (adversarial): degenerate inputs must not panic and must still
+/// return a valid permutation.
+#[test]
+fn adversarial_inputs_do_not_panic() {
+    // Empty.
+    assert_eq!(reading_order(&[], &cfg()), Vec::<usize>::new());
+    // Single box.
+    assert_eq!(
+        reading_order(&[line(0.0, 0.0, 10.0, 10.0)], &cfg()),
+        vec![0]
+    );
+    // All boxes at the same position (no gap on either axis) -> stream order.
+    let coincident = vec![
+        line(10.0, 10.0, 5.0, 10.0),
+        line(10.0, 10.0, 5.0, 10.0),
+        line(10.0, 10.0, 5.0, 10.0),
+    ];
+    assert_eq!(reading_order(&coincident, &cfg()), vec![0, 1, 2]);
+    // Non-positive font size (degenerate scale) -> leaf, no division by it.
+    let zero_font = vec![
+        OrderBox {
+            min_x: 300.0,
+            max_x: 400.0,
+            min_y: 0.0,
+            max_y: 0.0,
+            font_size: 0.0,
+        },
+        OrderBox {
+            min_x: 0.0,
+            max_x: 100.0,
+            min_y: 0.0,
+            max_y: 0.0,
+            font_size: 0.0,
+        },
+    ];
+    assert_eq!(reading_order(&zero_font, &cfg()), vec![0, 1]);
+    // Overlapping boxes.
+    let overlap = vec![line(0.0, 100.0, 300.0, 10.0), line(50.0, 98.0, 300.0, 10.0)];
+    let order = reading_order(&overlap, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+    // NaN coordinates (a degenerate CTM upstream) must not panic; total_cmp
+    // orders NaN deterministically, so the result is still a permutation.
+    let nan = vec![
+        OrderBox {
+            min_x: f64::NAN,
+            max_x: f64::NAN,
+            min_y: 0.0,
+            max_y: 10.0,
+            font_size: 10.0,
+        },
+        line(0.0, 0.0, 10.0, 10.0),
+    ];
+    let order = reading_order(&nan, &cfg());
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+}

--- a/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
+++ b/oxidize-pdf-core/src/text/flat_reading_order_tests.rs
@@ -104,8 +104,16 @@ fn horizontal_threshold_degrades_on_both_sides() {
         horizontal_k: 3.0,
         vertical_k: 1.5,
     };
-    assert_eq!(reading_order(&boxes, &split), vec![1, 0]); // gutter 2x >= 1x
-    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1]); // gutter 2x < 3x
+    assert_eq!(
+        reading_order(&boxes, &split),
+        vec![1, 0],
+        "gutter 2x median glyph clears horizontal_k=1.0, so the columns split"
+    );
+    assert_eq!(
+        reading_order(&boxes, &no_split),
+        vec![0, 1],
+        "gutter 2x median glyph is below horizontal_k=3.0, so stream order stands"
+    );
 }
 
 /// §5.5 guard 5, vertical axis: the section threshold has teeth on both sides
@@ -128,8 +136,16 @@ fn vertical_threshold_degrades_on_both_sides() {
         horizontal_k: 1.0,
         vertical_k: 6.0,
     };
-    assert_eq!(reading_order(&boxes, &split), vec![2, 0, 1]); // 4x >= 1.5x
-    assert_eq!(reading_order(&boxes, &no_split), vec![0, 1, 2]); // 4x < 6x
+    assert_eq!(
+        reading_order(&boxes, &split),
+        vec![2, 0, 1],
+        "section gap 4x median glyph clears vertical_k=1.5, so the blocks split"
+    );
+    assert_eq!(
+        reading_order(&boxes, &no_split),
+        vec![0, 1, 2],
+        "section gap 4x median glyph is below vertical_k=6.0, so stream order stands"
+    );
 }
 
 /// §5.5 guard 6 (adversarial): degenerate inputs must not panic and must still
@@ -188,6 +204,43 @@ fn adversarial_inputs_do_not_panic() {
     ];
     let order = reading_order(&nan, &cfg());
     let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+}
+
+/// §5.5 guard 6: a box with `min > max` (a negative-scale CTM upstream) must not
+/// send the recursion into an infinite loop. The gap/split are computed from
+/// `min`/`max` separately but the partition uses the box center, which for an
+/// inverted box falls outside `[min, max]` — so a naive cut can put every box on
+/// one side and recurse on the same set forever. The orderer must degrade such a
+/// region to a leaf and terminate with a valid permutation.
+#[test]
+fn inverted_boxes_do_not_recurse_forever() {
+    let inverted_x = vec![
+        line(0.0, 0.0, 10.0, 10.0),
+        OrderBox {
+            min_x: 1000.0,
+            max_x: -1000.0,
+            min_y: 0.0,
+            max_y: 10.0,
+            font_size: 10.0,
+        },
+    ];
+    let mut sorted = reading_order(&inverted_x, &cfg());
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1]);
+
+    let inverted_y = vec![
+        line(0.0, 0.0, 10.0, 10.0),
+        OrderBox {
+            min_x: 0.0,
+            max_x: 10.0,
+            min_y: 1000.0,
+            max_y: -1000.0,
+            font_size: 10.0,
+        },
+    ];
+    let mut sorted = reading_order(&inverted_y, &cfg());
     sorted.sort_unstable();
     assert_eq!(sorted, vec![0, 1]);
 }

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod encoding;
 pub(crate) mod encoding_cmap;
 pub mod extraction;
 mod extraction_cmap;
+pub(crate) mod flat_reading_order;
 mod flow;
 mod font;
 pub mod font_manager;
@@ -24,6 +25,9 @@ pub mod validation;
 
 #[cfg(test)]
 mod cmap_tests;
+
+#[cfg(test)]
+mod flat_reading_order_tests;
 
 #[cfg(feature = "ocr-tesseract")]
 pub mod tesseract_provider;

--- a/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
@@ -1,11 +1,11 @@
 {
   "t3-stress": {
     "compared": 1695,
-    "content_coverage": 0.9859671643695178,
+    "content_coverage": 0.9859646628613168,
     "denominator": 211815,
-    "numerator": 676,
-    "our_alpha_chars": 4729789,
+    "numerator": 299,
+    "our_alpha_chars": 4729777,
     "pop_alpha_chars": 4797106,
-    "rate": 0.0031914642494629748
+    "rate": 0.0014116091872624695
   }
 }

--- a/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_fusion_baseline.json
@@ -1,11 +1,11 @@
 {
   "t3-stress": {
     "compared": 1695,
-    "content_coverage": 0.9854051588603628,
+    "content_coverage": 0.9859671643695178,
     "denominator": 211815,
-    "numerator": 680,
-    "our_alpha_chars": 4727093,
+    "numerator": 676,
+    "our_alpha_chars": 4729789,
     "pop_alpha_chars": 4797106,
-    "rate": 0.003210348653305951
+    "rate": 0.0031914642494629748
   }
 }

--- a/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
@@ -7,5 +7,14 @@
     "our_alpha_chars": 4719072,
     "pop_alpha_chars": 4748581,
     "rate": 0.2485839619325709
+  },
+  "t3-stress-reading-order": {
+    "compared": 1053,
+    "content_coverage": 0.9937857225137362,
+    "denominator": 591792,
+    "numerator": 133452,
+    "our_alpha_chars": 4719072,
+    "pop_alpha_chars": 4748581,
+    "rate": 0.225504907129532
   }
 }

--- a/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
@@ -1,11 +1,11 @@
 {
   "t3-stress": {
-    "compared": 1037,
-    "content_coverage": 0.9937813547683058,
-    "denominator": 591428,
-    "numerator": 169957,
-    "our_alpha_chars": 4716376,
-    "pop_alpha_chars": 4745889,
-    "rate": 0.2873671858620153
+    "compared": 1053,
+    "content_coverage": 0.9937857225137362,
+    "denominator": 591792,
+    "numerator": 163717,
+    "our_alpha_chars": 4719072,
+    "pop_alpha_chars": 4748581,
+    "rate": 0.27664618649795875
   }
 }

--- a/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
+++ b/oxidize-pdf-core/tests/baselines/differential_order_baseline.json
@@ -3,9 +3,9 @@
     "compared": 1053,
     "content_coverage": 0.9937857225137362,
     "denominator": 591792,
-    "numerator": 163717,
+    "numerator": 147110,
     "our_alpha_chars": 4719072,
     "pop_alpha_chars": 4748581,
-    "rate": 0.27664618649795875
+    "rate": 0.2485839619325709
   }
 }

--- a/oxidize-pdf-core/tests/descendant_fonts_spellings_test.rs
+++ b/oxidize-pdf-core/tests/descendant_fonts_spellings_test.rs
@@ -1,0 +1,134 @@
+//! `/DescendantFonts` may legally be written in four combinations: the value
+//! is a direct array or an indirect reference to one, and the CIDFont element
+//! inside is a direct dictionary or an indirect reference. ISO 32000-1
+//! Table 121 types the entry as `array` with no reference requirement, §7.3.6
+//! lets array elements be "dictionaries, or any other objects", and §7.3.7
+//! lets a dictionary value "be any kind of object" — where the spec wants an
+//! indirect reference it says so (Table 117 marks the CIDFont's
+//! FontDescriptor "shall be an indirect reference"), and the DescendantFonts
+//! row carries no such words. The same argument as #463 for inline `/Font`
+//! resource entries. Producers use the inline form: ReportLab's
+//! `UnicodeCIDFont` writes the CIDFont as a direct dictionary.
+//!
+//! The extractor read only the reference-inside-direct-array combination. For
+//! the other three, `descendant_font` stayed empty, which silently skipped the
+//! `cid_encoding` branch in `decode_text_with_font` and fell back to byte-wise
+//! decoding.
+//!
+//! The oracle is falsifiable by construction: the page shows 第1章 概要
+//! GRIMWALD through `/Encoding /UniJIS-UCS2-H` (the character codes ARE the
+//! UTF-16BE values) with no `/ToUnicode`, so a decode that reaches the
+//! descendant yields the Japanese text, while the byte-wise fallback renders
+//! the UTF-16BE code units one byte at a time (`第` = U+7B2C comes out as
+//! `{,`). The two answers cannot be confused.
+
+mod common;
+
+use common::pdf_assembler::assemble_pdf_with_version;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+const EXPECTED: &str = "第1章 概要 GRIMWALD";
+
+/// ISO 32000-1 Table 117: the CIDFont's FontDescriptor is
+/// "(Required; shall be an indirect reference)" — object 7 here.
+const FONT_DESCRIPTOR: &str = "<< /Type /FontDescriptor /FontName /HeiseiKakuGo-W5 /Flags 4 \
+     /FontBBox [ -92 -250 1010 922 ] /ItalicAngle 0 /Ascent 752 /Descent -221 \
+     /CapHeight 737 /StemV 114 >>";
+
+const CID_FONT: &str = "<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HeiseiKakuGo-W5 \
+     /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> \
+     /FontDescriptor 7 0 R /DW 1000 >>";
+
+#[derive(Clone, Copy)]
+enum Spelling {
+    /// `/DescendantFonts [ 6 0 R ]` — the only combination read before the fix
+    IndirectFont,
+    /// `/DescendantFonts [ << ...CIDFont... >> ]` — what ReportLab emits
+    DirectDict,
+    /// `/DescendantFonts 8 0 R` where `8 0 obj` is `[ 6 0 R ]`
+    IndirectArray,
+    /// `/DescendantFonts 8 0 R` where `8 0 obj` is `[ << ...CIDFont... >> ]`
+    IndirectArrayDirectDict,
+}
+
+/// One page drawing `EXPECTED` in a Type0 font. Objects 1..=7 are identical
+/// across spellings (object 6 is written whether or not anything references
+/// it); only object 5's `/DescendantFonts` value differs, so the three
+/// documents differ in exactly that respect.
+fn build(spelling: Spelling) -> Vec<u8> {
+    let hex: String = EXPECTED
+        .encode_utf16()
+        .flat_map(|unit| unit.to_be_bytes())
+        .map(|byte| format!("{byte:02X}"))
+        .collect();
+    let content = format!("BT /F2 18 Tf 60 700 Td <{hex}> Tj ET");
+
+    let descendant_fonts = match spelling {
+        Spelling::DirectDict => format!("[ {CID_FONT} ]"),
+        Spelling::IndirectFont => "[ 6 0 R ]".to_string(),
+        Spelling::IndirectArray | Spelling::IndirectArrayDirectDict => "8 0 R".to_string(),
+    };
+
+    let mut objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 595 842 ] \
+           /Resources << /Font << /F2 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        format!(
+            "<< /Length {} >>\nstream\n{content}\nendstream",
+            content.len()
+        )
+        .into_bytes(),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /HeiseiKakuGo-W5 \
+             /Encoding /UniJIS-UCS2-H /DescendantFonts {descendant_fonts} >>"
+        )
+        .into_bytes(),
+        CID_FONT.as_bytes().to_vec(),
+        FONT_DESCRIPTOR.as_bytes().to_vec(),
+    ];
+    match spelling {
+        Spelling::IndirectArray => objects.push(b"[ 6 0 R ]".to_vec()),
+        Spelling::IndirectArrayDirectDict => objects.push(format!("[ {CID_FONT} ]").into_bytes()),
+        _ => {}
+    }
+
+    assemble_pdf_with_version("1.7", &objects)
+}
+
+fn extract_page_text(bytes: Vec<u8>) -> String {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(bytes)).expect("open PDF"));
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+/// The spelling that already worked — pins the existing behavior so the fix
+/// cannot regress it.
+#[test]
+fn descendant_written_as_an_indirect_reference_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::IndirectFont)), EXPECTED);
+}
+
+#[test]
+fn descendant_written_as_a_direct_dictionary_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::DirectDict)), EXPECTED);
+}
+
+#[test]
+fn descendant_array_written_as_an_indirect_value_decodes() {
+    assert_eq!(extract_page_text(build(Spelling::IndirectArray)), EXPECTED);
+}
+
+#[test]
+fn indirect_array_holding_a_direct_dictionary_decodes() {
+    assert_eq!(
+        extract_page_text(build(Spelling::IndirectArrayDirectDict)),
+        EXPECTED
+    );
+}

--- a/oxidize-pdf-core/tests/differential_order_test.rs
+++ b/oxidize-pdf-core/tests/differential_order_test.rs
@@ -43,16 +43,17 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use oxidize_pdf::parser::{ParseOptions, PdfReader};
-use oxidize_pdf::text::TextExtractor;
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
 
 const PER_FILE_TIMEOUT_SECS: u64 = 15;
 
-fn ours(path: &Path) -> Option<String> {
+fn ours(path: &Path, reading_order: bool) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;
     let doc = PdfReader::new_with_options(std::io::Cursor::new(bytes), ParseOptions::lenient())
         .ok()?
         .into_document();
-    let mut ex = TextExtractor::new();
+    let mut ex =
+        TextExtractor::with_options(ExtractionOptions::default()).with_reading_order(reading_order);
     let mut out = String::new();
     for i in 0..doc.page_count().unwrap_or(0) {
         if let Ok(p) = ex.extract_from_page(&doc, i) {
@@ -227,14 +228,14 @@ type FileSample = (OrderMetrics, u64, u64);
 
 /// Per-file metrics on a worker thread with a hard timeout, so a slow parse is
 /// excluded rather than fatal. `None` means excluded, never counted as zero.
-fn metrics_for_file(path: &Path) -> Option<FileSample> {
+fn metrics_for_file(path: &Path, reading_order: bool) -> Option<FileSample> {
     let p = path.to_path_buf();
     let (tx, rx) = mpsc::channel();
     let handle = std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024)
         .spawn(move || {
             let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                match (ours(&p), poppler(&p)) {
+                match (ours(&p, reading_order), poppler(&p)) {
                     (Some(o), Some(pop)) => {
                         let m = order_metrics(&o, &pop);
                         // Nothing alignable in this pair (a scanned page, a
@@ -290,8 +291,26 @@ fn the_committed_baseline_is_loadable() {
     }
 }
 
+/// The flat path in stream order (`reading_order = false`): the DEFAULT
+/// extraction. Ratchets against the `t3-stress` baseline.
 #[test]
 fn flat_extraction_does_not_transpose_more_words_than_poppler() {
+    run_order_gate(false, "t3-stress");
+}
+
+/// The opt-in reading-order path (`reading_order = true`, issue #448): the same
+/// corpus and oracle, extracted with the flat-path XY-cut reorder on. Its own
+/// baseline key (`t3-stress-reading-order`), so a regression on the reordered
+/// path is caught independently of the default path — and the two baselines'
+/// rates are directly comparable, since only the option differs.
+#[test]
+fn reading_order_option_does_not_transpose_more_words_than_poppler() {
+    run_order_gate(true, "t3-stress-reading-order");
+}
+
+/// Shared corpus run for both gates. `reading_order` toggles the opt-in reorder;
+/// `key` selects the baseline entry so the two measurements ratchet separately.
+fn run_order_gate(reading_order: bool, key: &str) {
     // Skip cleanly when the independent oracle is unavailable — unless the
     // job declared the measurement mandatory (see ratchet::corpus_required).
     if Command::new("pdftotext").arg("-v").output().is_err() {
@@ -320,7 +339,7 @@ fn flat_extraction_does_not_transpose_more_words_than_poppler() {
     let mut pop_chars = 0u64;
 
     for pdf in &pdfs {
-        match metrics_for_file(pdf) {
+        match metrics_for_file(pdf, reading_order) {
             Some((m, ours_len, pop_len)) => {
                 compared += 1;
                 pop_words_total += m.pop_words;
@@ -363,7 +382,6 @@ fn flat_extraction_does_not_transpose_more_words_than_poppler() {
     let p10 = per_doc.get(per_doc.len() / 10).copied().unwrap_or(0.0);
     let below = per_doc.iter().filter(|f| **f < 0.95).count();
 
-    let key = dir.file_name().and_then(|s| s.to_str()).unwrap_or("corpus");
     let current = ratchet::GateSample {
         compared,
         numerator: misplaced,

--- a/oxidize-pdf-core/tests/issue_448_reading_order_wiring_test.rs
+++ b/oxidize-pdf-core/tests/issue_448_reading_order_wiring_test.rs
@@ -1,0 +1,94 @@
+//! Issue #448 — the flat-path reading-order option reorders line groups.
+//!
+//! The isolated ordering primitive (`text::flat_reading_order`) is wired into
+//! the flat `.text` path behind an opt-in flag. With the flag OFF the output is
+//! byte-identical to before (stream order). With it ON, line groups are permuted
+//! into reading order: left column before right, top block before bottom.
+//!
+//! These tests pin both directions on a fully synthetic PDF whose content
+//! stream deliberately draws blocks in the WRONG order, so a passing assertion
+//! can only come from the reorder actually running (not from the stream already
+//! being correct).
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+#[path = "common/synthetic_pdf.rs"]
+mod synthetic_pdf;
+
+fn extract_with(content: &str, reading_order: bool) -> String {
+    let bytes = synthetic_pdf::build_pdf_with_content_stream(content.as_bytes());
+    let doc = PdfReader::new_with_options(std::io::Cursor::new(bytes), ParseOptions::lenient())
+        .expect("synthetic PDF must parse")
+        .into_document();
+    TextExtractor::with_options(ExtractionOptions::default())
+        .with_reading_order(reading_order)
+        .extract_from_page(&doc, 0)
+        .expect("extraction must succeed")
+        .text
+}
+
+/// Two columns, drawn right-column-first, each line its own `TJ` at its own Y.
+const TWO_COLUMNS_RIGHT_FIRST: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 350 700 Tm\n[(Right top)] TJ\n",
+    "1 0 0 1 350 680 Tm\n[(Right bottom)] TJ\n",
+    "1 0 0 1 50 700 Tm\n[(Left top)] TJ\n",
+    "1 0 0 1 50 680 Tm\n[(Left bottom)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn flag_off_leaves_stream_order_untouched() {
+    let text = extract_with(TWO_COLUMNS_RIGHT_FIRST, false);
+    assert_eq!(
+        text, "Right top\nRight bottom\nLeft top\nLeft bottom",
+        "with the flag off, output must be exactly stream order: {text:?}"
+    );
+}
+
+#[test]
+fn flag_on_reorders_columns_left_before_right() {
+    let text = extract_with(TWO_COLUMNS_RIGHT_FIRST, true);
+    assert_eq!(
+        text, "Left top\nLeft bottom\nRight top\nRight bottom",
+        "with the flag on, the left column must come out before the right: {text:?}"
+    );
+}
+
+/// Two stacked single-column sections, drawn bottom-section-first.
+const STACKED_SECTIONS_BOTTOM_FIRST: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 50 120 Tm\n[(Bottom one)] TJ\n",
+    "1 0 0 1 50 100 Tm\n[(Bottom two)] TJ\n",
+    "1 0 0 1 50 700 Tm\n[(Top one)] TJ\n",
+    "1 0 0 1 50 680 Tm\n[(Top two)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn flag_on_reorders_sections_top_before_bottom() {
+    let text = extract_with(STACKED_SECTIONS_BOTTOM_FIRST, true);
+    assert_eq!(
+        text, "Top one\nTop two\nBottom one\nBottom two",
+        "with the flag on, the top section must come out before the bottom: {text:?}"
+    );
+}
+
+/// A single column already in reading order: the permutation is the identity,
+/// so the flag must not change a single byte (the §5.2 invariant).
+const SINGLE_COLUMN_IN_ORDER: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 50 700 Tm\n[(First line)] TJ\n",
+    "1 0 0 1 50 680 Tm\n[(Second line)] TJ\n",
+    "1 0 0 1 50 660 Tm\n[(Third line)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn identity_permutation_is_byte_identical() {
+    let on = extract_with(SINGLE_COLUMN_IN_ORDER, true);
+    let off = extract_with(SINGLE_COLUMN_IN_ORDER, false);
+    assert_eq!(on, off, "identity permutation must be byte-identical");
+    assert_eq!(on, "First line\nSecond line\nThird line");
+}

--- a/oxidize-pdf-core/tests/issue_456_text_state_params_test.rs
+++ b/oxidize-pdf-core/tests/issue_456_text_state_params_test.rs
@@ -1,0 +1,139 @@
+//! Issue #456 — `Tc` (char spacing), `Tw` (word spacing) and `Ts` (text rise)
+//! were parsed and stored but never read, so they had no effect on extraction
+//! (ISO 32000-1 §9.3.2, §9.3.3, §9.4.4).
+//!
+//! The glyph-displacement formula is, per §9.4.4:
+//!
+//! ```text
+//! tx = ((w0/1000 - Tj/1000) * Tfs + Tc + Tw) * Th
+//! ```
+//!
+//! `Tc` is added once per glyph shown, `Tw` once per *single-byte* space
+//! (code 32, §9.3.3), both in unscaled text-space units and both then scaled by
+//! `Th`. `Ts` shifts the glyph origin up the y-axis by an unscaled text-space
+//! amount before the text/CTM transform.
+//!
+//! Oracle: fragment coordinates under `preserve_layout` — the only extraction
+//! mode that exposes the pen position, and therefore the only place the pen
+//! advance and the baseline offset are observable. Each test measures the shift
+//! of a *following* run between spacing = 0 and spacing = k, which cancels the
+//! (font-dependent) base glyph widths and isolates the parameter under test.
+//!
+//! Scope note: these apply to `TextExtractor` only. `PlainTextExtractor` decides
+//! separators from the explicit pen positions the producer writes (Td/TD/TJ),
+//! never from accumulated glyph advances (see its `_char_space`/`_word_space`
+//! fields), so `Tc`/`Tw` are correctly unobservable there.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Extract every fragment under `preserve_layout`.
+fn fragments(content: &[u8]) -> Vec<oxidize_pdf::text::TextFragment> {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let options = ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    };
+    let mut extractor = TextExtractor::with_options(options);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .fragments
+}
+
+/// `(x, y)` of the first fragment whose trimmed text equals `needle`.
+fn frag_xy(content: &[u8], needle: &str) -> (f64, f64) {
+    fragments(content)
+        .into_iter()
+        .find(|f| f.text.trim() == needle)
+        .map(|f| (f.x, f.y))
+        .unwrap_or_else(|| panic!("no fragment with text {needle:?}"))
+}
+
+/// Width of the first fragment whose trimmed text equals `needle`. The fragment
+/// width is the run's pen advance (`text_width`, scaled by the CTM x-scale,
+/// which is 1 here), the same quantity that drives the flat path's separator
+/// deltas — so it is the faithful oracle for `Tc`/`Tw` in the advance.
+fn frag_width(content: &[u8], needle: &str) -> f64 {
+    fragments(content)
+        .into_iter()
+        .find(|f| f.text.trim() == needle)
+        .map(|f| f.width)
+        .unwrap_or_else(|| panic!("no fragment with text {needle:?}"))
+}
+
+const EPS: f64 = 1e-6;
+
+/// `Tc` advances the pen once per glyph shown. "ABCD" is four glyphs, so `Tc = 5`
+/// must widen its advance by `4 * 5 = 20` relative to `Tc = 0`. The base glyph
+/// widths cancel between the two runs.
+#[test]
+fn char_spacing_advances_pen_once_per_glyph() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(ABCD)Tj\nET\n";
+    let with_tc = b"BT\n/F1 12 Tf\n5 Tc\n100 700 Td\n(ABCD)Tj\nET\n";
+    let delta = frag_width(with_tc, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        (delta - 20.0).abs() < EPS,
+        "Tc=5 over 4 glyphs must add 20.0 of advance; got {delta}"
+    );
+}
+
+/// `Tw` advances the pen once per single-byte space. The run "A A A" holds two
+/// spaces, so `Tw = 7` must widen its advance by `2 * 7 = 14`.
+#[test]
+fn word_spacing_advances_pen_once_per_space() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(A A A)Tj\nET\n";
+    let with_tw = b"BT\n/F1 12 Tf\n7 Tw\n100 700 Td\n(A A A)Tj\nET\n";
+    let delta = frag_width(with_tw, "A A A") - frag_width(base, "A A A");
+    assert!(
+        (delta - 14.0).abs() < EPS,
+        "Tw=7 over 2 spaces must add 14.0 of advance; got {delta}"
+    );
+}
+
+/// `Tw` applies to spaces only. A run with no spaces must be unaffected by it —
+/// this is what separates `Tw` from `Tc` (§9.3.3).
+#[test]
+fn word_spacing_does_not_advance_on_non_space_glyphs() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(ABCD)Tj\nET\n";
+    let with_tw = b"BT\n/F1 12 Tf\n50 Tw\n100 700 Td\n(ABCD)Tj\nET\n";
+    let delta = frag_width(with_tw, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        delta.abs() < EPS,
+        "Tw must not change the advance of a run without spaces; got {delta}"
+    );
+}
+
+/// `Tc` must also fold into the `TJ` (`ShowTextArray`) advance, not just `Tj` —
+/// real documents draw almost everything through `TJ`.
+#[test]
+fn char_spacing_advances_pen_in_show_text_array() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n[(ABCD)]TJ\nET\n";
+    let with_tc = b"BT\n/F1 12 Tf\n5 Tc\n100 700 Td\n[(ABCD)]TJ\nET\n";
+    let delta = frag_width(with_tc, "ABCD") - frag_width(base, "ABCD");
+    assert!(
+        (delta - 20.0).abs() < EPS,
+        "Tc=5 over 4 glyphs must add 20.0 of advance through TJ; got {delta}"
+    );
+}
+
+/// `Ts` (text rise) offsets the glyph baseline up the y-axis by an unscaled
+/// text-space amount. With an axis-aligned matrix the user-space y shifts by
+/// exactly `Ts`.
+#[test]
+fn text_rise_offsets_the_baseline_y() {
+    let base = b"BT\n/F1 12 Tf\n100 700 Td\n(A)Tj\nET\n";
+    let with_ts = b"BT\n/F1 12 Tf\n5 Ts\n100 700 Td\n(A)Tj\nET\n";
+    let delta = frag_xy(with_ts, "A").1 - frag_xy(base, "A").1;
+    assert!(
+        (delta - 5.0).abs() < EPS,
+        "Ts=5 must raise the baseline by 5.0; got {delta}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_458_tj_boundary_space_test.rs
+++ b/oxidize-pdf-core/tests/issue_458_tj_boundary_space_test.rs
@@ -1,0 +1,258 @@
+//! Issue #458 — a horizontal jump between two `TJ` operators on the same line
+//! must produce a space in the extracted text.
+//!
+//! The `Tj` arm of the extractor turns a forward pen jump wider than
+//! `space_threshold × font size` into a `U+0020`. The `TJ` arm computes the
+//! same delta and used it only to decide newlines, so two `TJ` operators drawn
+//! side by side on one line came out glued together.
+//!
+//! Two independent reports hit the same mechanism:
+//!
+//! - Issue #458: a multi-column contact-info table (three `"Tel: …"` phone
+//!   numbers on one row, each drawn as its own `TJ` at a distinct X, identical
+//!   Y) extracted as `Tel: …Tel: …Tel: …`, destroying every phone-number match
+//!   past the first cell.
+//! - The #448 reading-order probe on `preserve_027613.pdf` (an IBM manual, 429
+//!   pages): every bulleted item is drawn as one `TJ` for the bullet glyph and
+//!   another for the item text, 7.48pt apart at 10pt type (0.75 em, well past
+//!   the 0.3 em threshold). The extractor emitted `vlarge`, `vquery`,
+//!   `vmaintain` — the bullet welded onto the first word. Poppler splits them.
+//!
+//! The tests below pin both directions: the boundary between two `TJ`
+//! operators must break, and kerning INSIDE one `TJ` array must not, because
+//! that is how a single word is drawn as several positioned pieces.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+#[path = "common/synthetic_pdf.rs"]
+mod synthetic_pdf;
+
+fn extract(content: &str) -> String {
+    let bytes = synthetic_pdf::build_pdf_with_content_stream(content.as_bytes());
+    let doc = PdfReader::new_with_options(std::io::Cursor::new(bytes), ParseOptions::lenient())
+        .expect("synthetic PDF must parse")
+        .into_document();
+    TextExtractor::with_options(ExtractionOptions::default())
+        .extract_from_page(&doc, 0)
+        .expect("extraction must succeed")
+        .text
+}
+
+/// The issue #458 case: three table cells on one row, each a separate `TJ` at
+/// its own X and the same Y (a wide, unambiguous forward gap). Placeholder text
+/// stands in for the confidential phone numbers of the original report; the
+/// mechanism — separate `TJ` calls, same Y, forward X gap, no separator — is
+/// identical.
+const MULTI_COLUMN_TABLE_ROW: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 218.27 554.25 Tm\n[(CellOne)] TJ\n",
+    "1 0 0 1 286.65 554.25 Tm\n[(CellTwo)] TJ\n",
+    "1 0 0 1 352.10 554.25 Tm\n[(CellThree)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn issue_458_multi_column_table_cells_are_not_fused() {
+    let text = extract(MULTI_COLUMN_TABLE_ROW);
+    assert!(
+        !text.contains("CellOneCellTwo"),
+        "adjacent table cells were welded together: {text:?}"
+    );
+    assert!(
+        text.contains("CellOne CellTwo CellThree"),
+        "three cells drawn as three TJ calls on one row must read as three \
+         separate words: {text:?}"
+    );
+}
+
+/// The #448 bullet case, in pen-gap terms.
+///
+/// There the bullet is a 3.31pt glyph of a symbol font at x=113.75 and the item
+/// text starts at x=124.54, both at 10pt: a pen gap of 7.48pt, 0.748 em. The
+/// fixture cannot reuse those absolute coordinates, because its `/F1` is
+/// Helvetica, whose `v` advances further and would leave a smaller gap than the
+/// document has. What matters to the rule is the GAP, so the second run is
+/// placed to reproduce it — and it lands just above `TJ_BOUNDARY_SPACE_EM`,
+/// which is the narrowest verified word gap the constant is chosen to cover.
+fn bullet_then_text(pen_gap_pt: f64) -> String {
+    let bullet_advance = 5.0; // `v` in Helvetica: 500/1000 em at 10pt
+    let x = 113.75;
+    let text_x = x + bullet_advance + pen_gap_pt;
+    format!(
+        "BT\n/F1 10 Tf\n1 0 0 1 {x} 593.37 Tm\n[(v)] TJ\n\
+         1 0 0 1 {text_x} 593.37 Tm\n[(large scale retrieval)] TJ\nET"
+    )
+}
+
+#[test]
+fn a_gap_between_two_tj_operators_on_one_line_becomes_a_space() {
+    let text = extract(&bullet_then_text(7.48));
+    assert!(
+        !text.contains("vlarge"),
+        "the bullet was welded onto the first word of the item: {text:?}"
+    );
+    assert!(
+        text.contains("v large scale retrieval"),
+        "a 0.75 em gap between two TJ operators must read as a word break: {text:?}"
+    );
+}
+
+/// The same page draws body text as several `TJ` operators separated by
+/// hairline gaps — `(Cr)` then `(eate new or select)` — because the producer
+/// repositions mid-word. Those must NOT break, or the fix would split every
+/// word it touches.
+const WORD_SPLIT_ACROSS_TJ_OPERATORS: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 124.54 593.37 Tm\n[(Cr)] TJ\n",
+    "1 0 0 1 135.38 593.37 Tm\n[(eate new forms)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn a_hairline_gap_between_two_tj_operators_does_not_break_the_word() {
+    let text = extract(WORD_SPLIT_ACROSS_TJ_OPERATORS);
+    assert!(
+        text.contains("Create new forms"),
+        "a sub-threshold reposition inside a word must stay welded: {text:?}"
+    );
+}
+
+/// Kerning inside ONE `TJ` array is governed by the `Spacing` elements, which
+/// synthesise their own space past `tj_space_threshold`. The boundary rule must
+/// not fire there as well, or a kerned word gains a space it never had.
+const KERNED_WORD_IN_ONE_ARRAY: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 100 700 Tm\n[(Cr) -40 (eate) -40 (test) -300 (data)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn kerning_inside_one_tj_array_is_left_to_the_spacing_rule() {
+    let text = extract(KERNED_WORD_IN_ONE_ARRAY);
+    assert!(
+        text.contains("Createtest data") || text.contains("Create test data"),
+        "tight kerns must not become spaces and the wide one must: {text:?}"
+    );
+    assert!(
+        !text.contains("Cr eate"),
+        "a 40/1000 em kern is not a word break: {text:?}"
+    );
+    assert!(
+        !text.contains("test  data"),
+        "the wide kern must produce exactly one space, not two: {text:?}"
+    );
+}
+
+/// A `TJ` array whose FIRST element is a kern: the pen jump the boundary rule
+/// would see is that kern, which the `Spacing` rule already owns. Applying both
+/// would double the space.
+const ARRAY_STARTING_WITH_A_KERN: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 100 700 Tm\n[(alpha)] TJ\n",
+    "[-400 (beta)] TJ\n",
+    "ET"
+);
+
+/// Both sides of the calibrated threshold, pinned at the unit level so a change
+/// to the constant cannot pass unnoticed. The corpus sweep behind the value is
+/// in the doc comment of `TJ_BOUNDARY_SPACE_EM`; what these two tests add is
+/// that the rule has teeth in both directions rather than firing everywhere or
+/// nowhere.
+fn two_runs_with_gap(gap_em: f64) -> String {
+    let size = 10.0;
+    // `alpha` in 10pt Helvetica advances 24.45pt (widths 556+278+556+278+500 of
+    // 1000/em). The second run starts that far along, plus the requested gap.
+    let start = 100.0;
+    let advance = 24.45;
+    let second = start + advance + gap_em * size;
+    format!(
+        "BT\n/F1 {size} Tf\n1 0 0 1 {start} 700 Tm\n[(alpha)] TJ\n\
+         1 0 0 1 {second} 700 Tm\n[(beta)] TJ\nET"
+    )
+}
+
+#[test]
+fn a_gap_below_the_threshold_leaves_the_runs_welded() {
+    let text = extract(&two_runs_with_gap(0.5));
+    assert!(
+        text.contains("alphabeta"),
+        "half an em is inside the range where a producer just repositions \
+         mid-word, so it must not split: {text:?}"
+    );
+}
+
+#[test]
+fn a_gap_above_the_threshold_splits_the_runs() {
+    let text = extract(&two_runs_with_gap(0.9));
+    assert!(
+        text.contains("alpha beta"),
+        "nine tenths of an em between two separately positioned runs is a word \
+         break: {text:?}"
+    );
+}
+
+/// The mirror case: an array that ENDS with a kern, followed by another `TJ`
+/// that does not reposition. The kern already produced the space and the pen
+/// jump the boundary rule sees is that same kern.
+const TRAILING_KERN_THEN_NEW_ARRAY: &str = concat!(
+    "BT\n/F1 10 Tf\n",
+    "1 0 0 1 100 700 Tm\n[(alpha) -400] TJ\n",
+    "[(beta)] TJ\n",
+    "ET"
+);
+
+#[test]
+fn a_trailing_kern_followed_by_another_array_produces_one_space_not_two() {
+    let text = extract(TRAILING_KERN_THEN_NEW_ARRAY);
+    assert!(
+        text.contains("alpha beta"),
+        "the trailing kern must read as one word break: {text:?}"
+    );
+    assert!(
+        !text.contains("alpha  beta"),
+        "the boundary rule counted the kern the spacing rule had already counted: {text:?}"
+    );
+}
+
+#[test]
+fn a_leading_kern_produces_one_space_not_two() {
+    let text = extract(ARRAY_STARTING_WITH_A_KERN);
+    assert!(
+        text.contains("alpha beta"),
+        "the leading kern must read as one word break: {text:?}"
+    );
+    assert!(
+        !text.contains("alpha  beta"),
+        "the boundary rule and the kern rule both fired: {text:?}"
+    );
+}
+
+/// A `TJ` that opens with a SMALL intra-word kern (below `tj_space_threshold`,
+/// so the kern itself synthesises nothing) while a real `Tm`-driven column gap
+/// sits on its first text element. The boundary space must still fire — the
+/// leading kern must not consume `at_array_start` and mask the jump, or issue
+/// #458 recurs for arrays shaped `Tm … [-N (word)…] TJ`.
+fn column_gap_then_array_with_small_leading_kern(gap_em: f64) -> String {
+    let size = 10.0;
+    let start = 100.0;
+    let advance = 24.45; // `alpha` in 10pt Helvetica
+    let second = start + advance + gap_em * size;
+    format!(
+        "BT\n/F1 {size} Tf\n1 0 0 1 {start} 700 Tm\n[(alpha)] TJ\n\
+         1 0 0 1 {second} 700 Tm\n[-20 (beta)] TJ\nET"
+    )
+}
+
+#[test]
+fn a_small_leading_kern_does_not_mask_a_real_boundary_gap() {
+    let text = extract(&column_gap_then_array_with_small_leading_kern(0.9));
+    assert!(
+        text.contains("alpha beta"),
+        "a 0.2/1000 em leading kern must not suppress the 0.9 em column boundary: {text:?}"
+    );
+    assert!(
+        !text.contains("alpha  beta"),
+        "a sub-threshold leading kern must not add a second space: {text:?}"
+    );
+}


### PR DESCRIPTION
## 4.3.0 — text-extraction quality release

All changes non-breaking (`cargo-semver-checks`: minor; confirmed locally and in CI).

### Included
- **#469 fix** — `/DescendantFonts` decoded CID text to mojibake in three of the four legal spellings.
- **#456 fix** — `Tc`/`Tw`/`Ts` were parsed but never applied to extraction; now folded into the pen advance and baseline.
- **#458 fix** — two `TJ` operators drawn side by side on one line were glued (`CellOneCellTwo`); a calibrated boundary space now separates them.
- **#448 feat** — opt-in reading-order reorder for the flat path via `TextExtractor::with_reading_order(true)`; off by default, byte-identical when off.

### Validation
- Full corpus T0–T6 + both differential gates (fusion, order) green on final `develop`.
- Kripteia test-quality gate: 90–100 on the cycle's new tests.
- **External confirmation** (contributor @oshtivi, 421 real-world PDFs vs KeyView baseline): regressed detections **196 (4.2.3) → 125**, with the worst multi-column IFU documents now at zero regressions.

### Release mechanics
Tag `v4.3.0` on `main` after merge triggers `release.yml` → crates.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)