### PR TITLE
fix(text): normalize stray literal CR bytes in sanitize_extracted_text (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Literal carriage returns in decoded text strings leaked into extracted
+  plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
+  callers remove standalone CR bytes, replace them with a space, or normalize
+  them as line endings without adding a field to the public extraction-options
+  struct. The default normalizes standalone CR and CRLF to one `\n`; CRLF is
+  treated as one line ending under every policy.
+
 ## [4.3.0] - 2026-08-11
 
 ### Fixed

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3350,16 +3350,20 @@ fn calculate_text_width_from_codes(
 /// Sanitize extracted text by removing or replacing control characters.
 ///
 /// This function addresses Issue #116 where extracted text contains NUL bytes (`\0`)
-/// and ETX characters (`\u{3}`) where spaces should appear.
+/// and ETX characters (`\u{3}`) where spaces should appear, and Issue #476 where a
+/// stray literal `\r` embedded in a PDF's own text content survives verbatim into
+/// the extracted string.
 ///
 /// # Behavior
 ///
 /// - Replaces `\0\u{3}` sequences with a single space (common word separator pattern)
 /// - Replaces standalone `\0` (NUL) with space
-/// - Removes other ASCII control characters (0x01-0x1F) except:
-///   - `\t` (0x09) - Tab
-///   - `\n` (0x0A) - Line feed
-///   - `\r` (0x0D) - Carriage return
+/// - Preserves `\t` (0x09) and `\n` (0x0A) as-is
+/// - Normalizes `\r` (0x0D): a `\r\n` pair collapses to a single `\n`; any other
+///   bare `\r` becomes a space, since a raw CR inside a PDF text-showing operator's
+///   string is not a structural line break -- it is producer noise (see #476) and,
+///   left alone, can silently split a word in the extracted output
+/// - Removes other ASCII control characters (0x01-0x1F)
 /// - Collapses multiple consecutive spaces into a single space
 ///
 /// # Examples
@@ -3374,6 +3378,14 @@ fn calculate_text_width_from_codes(
 /// // Standalone NUL becomes space
 /// let with_nul = "word\0another";
 /// assert_eq!(sanitize_extracted_text(with_nul), "word another");
+///
+/// // Issue #476: a stray CR mid-word becomes a space instead of splitting it
+/// let stray_cr = "rating-aa\ra-exp-sf";
+/// assert_eq!(sanitize_extracted_text(stray_cr), "rating-aa a-exp-sf");
+///
+/// // A genuine CRLF pair collapses to a single LF
+/// let crlf = "line one\r\nline two";
+/// assert_eq!(sanitize_extracted_text(crlf), "line one\nline two");
 ///
 /// // Clean text passes through unchanged
 /// let clean = "Normal text";
@@ -3410,10 +3422,31 @@ pub fn sanitize_extracted_text(text: &str) -> String {
             }
 
             // Preserve allowed whitespace
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' => {
                 result.push(ch);
                 // Reset space tracking on newlines but not tabs
                 last_was_space = ch == '\t';
+            }
+
+            // Carriage return: a genuine `\r\n` pair (e.g. a Windows line
+            // ending that made it into the PDF's own text content) is a
+            // real line break, so drop the CR and let the following `\n`
+            // arm above handle it normally. A bare `\r` with no following
+            // `\n` is not a structural line break -- PDF content-stream
+            // text-showing operators (`Tj`/`TJ`/`'`/`"`) draw glyphs, and a
+            // stray CR byte inside one is producer noise (e.g. a generator
+            // that copied CRLF-terminated source text directly into a
+            // string without normalizing it) rather than an intentional
+            // separator. Treat it the same as NUL just above: collapse to
+            // a single space rather than passing it through, so it can no
+            // longer split a word in half (issue #476).
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    // Let the next iteration's '\n' arm emit the newline.
+                } else if !last_was_space {
+                    result.push(' ');
+                    last_was_space = true;
+                }
             }
 
             // Regular space - collapse multiples
@@ -3424,7 +3457,8 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 }
             }
 
-            // Other control characters (0x01-0x1F except tab/newline/CR) - remove
+            // Other control characters (0x01-0x1F except tab/newline, and CR
+            // which is handled above) - remove
             c if c.is_ascii_control() => {
                 // Skip control characters
             }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -15,6 +15,24 @@ use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
+/// Controls how carriage returns decoded from PDF text-showing strings are
+/// represented in extracted plain text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CarriageReturnHandling {
+    /// Remove each standalone carriage return.
+    Remove,
+    /// Replace each standalone carriage return with a collapsible `U+0020` space.
+    ReplaceWithSpace,
+    /// Normalize both standalone CR and CRLF sequences to one line feed.
+    NormalizeLineEnding,
+}
+
+impl Default for CarriageReturnHandling {
+    fn default() -> Self {
+        Self::NormalizeLineEnding
+    }
+}
+
 /// Text extraction options
 #[derive(Debug, Clone)]
 pub struct ExtractionOptions {
@@ -561,6 +579,10 @@ pub struct TextExtractor {
     /// not on the public [`ExtractionOptions`], so enabling it is a
     /// non-breaking method addition rather than a breaking struct-field addition.
     reading_order: bool,
+    /// Policy for CR bytes decoded from text-showing strings. Held outside the
+    /// public `ExtractionOptions` so adding it does not break exhaustive struct
+    /// literals in downstream crates.
+    carriage_return_handling: CarriageReturnHandling,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
@@ -574,6 +596,7 @@ impl TextExtractor {
         Self {
             options: ExtractionOptions::default(),
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -584,6 +607,7 @@ impl TextExtractor {
         Self {
             options,
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -606,6 +630,15 @@ impl TextExtractor {
     /// one group. `/Rotate ≠ 0` pages are ordered in unrotated page space.
     pub fn with_reading_order(mut self, enable: bool) -> Self {
         self.reading_order = enable;
+        self
+    }
+
+    /// Select how standalone carriage returns decoded from PDF text strings
+    /// are represented. CRLF is always normalized to one line feed.
+    ///
+    /// The default is [`CarriageReturnHandling::NormalizeLineEnding`].
+    pub fn with_carriage_return_handling(mut self, handling: CarriageReturnHandling) -> Self {
+        self.carriage_return_handling = handling;
         self
     }
 
@@ -2656,9 +2689,11 @@ impl TextExtractor {
                     // or garbage). Whitespace counts as meaningful: a decode
                     // that is exactly a space is a space, not a failed decode
                     // (#438). See `decode_is_usable`.
-                    if crate::text::extraction_cmap::decode_is_usable(&decoded) {
-                        // Apply sanitization to remove control characters (Issue #116)
-                        let sanitized = sanitize_extracted_text(&decoded);
+                    let sanitized = sanitize_extracted_text_with_policy(
+                        &decoded,
+                        self.carriage_return_handling,
+                    );
+                    if crate::text::extraction_cmap::decode_is_usable(&sanitized) {
                         tracing::debug!(
                             "Successfully decoded text using CMap for font {}: {:?} -> \"{}\"",
                             font_name,
@@ -2701,7 +2736,8 @@ impl TextExtractor {
 
         let fallback_result = encoding.decode(text);
         // Apply sanitization to remove control characters (Issue #116)
-        let sanitized = sanitize_extracted_text(&fallback_result);
+        let sanitized =
+            sanitize_extracted_text_with_policy(&fallback_result, self.carriage_return_handling);
         tracing::debug!(
             "Fallback encoding decoding: {:?} -> \"{}\"",
             text,
@@ -3359,7 +3395,7 @@ fn calculate_text_width_from_codes(
 /// - Removes other ASCII control characters (0x01-0x1F) except:
 ///   - `\t` (0x09) - Tab
 ///   - `\n` (0x0A) - Line feed
-///   - `\r` (0x0D) - Carriage return
+/// - Normalizes `\r` and `\r\n` to `\n`
 /// - Collapses multiple consecutive spaces into a single space
 ///
 /// # Examples
@@ -3380,6 +3416,14 @@ fn calculate_text_width_from_codes(
 /// assert_eq!(sanitize_extracted_text(clean), "Normal text");
 /// ```
 pub fn sanitize_extracted_text(text: &str) -> String {
+    sanitize_extracted_text_with_policy(text, CarriageReturnHandling::default())
+}
+
+/// Sanitize extracted text using an explicit carriage-return policy.
+pub fn sanitize_extracted_text_with_policy(
+    text: &str,
+    carriage_return_handling: CarriageReturnHandling,
+) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -3409,10 +3453,33 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 // Don't emit anything, just skip
             }
 
+            '\r' => {
+                // CRLF is unambiguously one line ending under every policy.
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    result.push('\n');
+                    last_was_space = false;
+                } else {
+                    match carriage_return_handling {
+                        CarriageReturnHandling::Remove => {}
+                        CarriageReturnHandling::ReplaceWithSpace => {
+                            if !last_was_space {
+                                result.push(' ');
+                                last_was_space = true;
+                            }
+                        }
+                        CarriageReturnHandling::NormalizeLineEnding => {
+                            result.push('\n');
+                            last_was_space = false;
+                        }
+                    }
+                }
+            }
+
             // Preserve allowed whitespace
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' => {
                 result.push(ch);
-                // Reset space tracking on newlines but not tabs
+                // Reset space tracking on newlines but not tabs.
                 last_was_space = ch == '\t';
             }
 
@@ -3424,7 +3491,7 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 }
             }
 
-            // Other control characters (0x01-0x1F except tab/newline/CR) - remove
+            // Other control characters (0x01-0x1F except tab/newline) - remove
             c if c.is_ascii_control() => {
                 // Skip control characters
             }
@@ -3717,6 +3784,10 @@ mod tests {
         assert!(!options.detect_columns);
         assert_eq!(options.column_threshold, 50.0);
         assert!(options.merge_hyphenated);
+        assert_eq!(
+            CarriageReturnHandling::default(),
+            CarriageReturnHandling::NormalizeLineEnding
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -530,7 +530,7 @@ pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap
 /// deletes would turn "usable" into an empty string — worse than the guessed
 /// fallback it was accepted over.
 fn is_preservable_whitespace(c: char) -> bool {
-    matches!(c, ' ' | '\t' | '\n' | '\r')
+    matches!(c, ' ' | '\t' | '\n')
 }
 
 /// Whether a decode produced usable text, or nothing the caller can act on.

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -525,10 +525,12 @@ pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap
     Ok(kerning_pairs)
 }
 
-/// The whitespace `sanitize_extracted_text` keeps downstream. `decode_is_usable`
+/// The whitespace `sanitize_extracted_text` treats as real text downstream
+/// (kept as-is, or normalized to a space/absorbed into a newline -- never
+/// deleted to nothing; see #476 for `\r`'s normalization). `decode_is_usable`
 /// uses the same set on purpose: accepting a decode that the next stage then
-/// deletes would turn "usable" into an empty string — worse than the guessed
-/// fallback it was accepted over.
+/// deletes entirely would turn "usable" into an empty string — worse than the
+/// guessed fallback it was accepted over.
 fn is_preservable_whitespace(c: char) -> bool {
     matches!(c, ' ' | '\t' | '\n' | '\r')
 }

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -34,7 +34,8 @@ pub mod tesseract_provider;
 
 pub use encoding::{escape_pdf_string_literal, TextEncoding};
 pub use extraction::{
-    sanitize_extracted_text, ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+    ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
 };
 pub use flow::{TextAlign, TextFlowContext};
 pub use font::{Font, FontEncoding, FontFamily, FontWithEncoding};

--- a/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
@@ -1,0 +1,108 @@
+//! End-to-end regression tests for issue #476.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{CarriageReturnHandling, ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+fn build_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td (rating-aa\\015a-exp\\015\\012next) Tj ET";
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+    ])
+}
+
+fn extract_with(mut extractor: TextExtractor) -> String {
+    let reader = PdfReader::new(Cursor::new(build_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("page extraction must succeed")
+        .text
+}
+
+fn extract(policy: CarriageReturnHandling) -> String {
+    extract_with(
+        TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy),
+    )
+}
+
+#[test]
+fn extraction_normalizes_cr_and_crlf_by_default() {
+    assert_eq!(extract_with(TextExtractor::new()), "rating-aa\na-exp\nnext");
+}
+
+fn build_cmap_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td <0102> Tj ET";
+    let to_unicode = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Issue476 def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<00> <ff>\nendcodespacerange\n\
+2 beginbfchar\n<01> <000D>\n<02> <0041>\nendbfchar\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /FirstChar 1 /LastChar 2 /Widths [500 500] /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", to_unicode),
+    ])
+}
+
+#[test]
+fn cmap_decoding_applies_the_selected_carriage_return_policy() {
+    let reader = PdfReader::new(Cursor::new(build_cmap_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+
+    for (policy, expected) in [
+        (CarriageReturnHandling::NormalizeLineEnding, "\nA"),
+        (CarriageReturnHandling::Remove, "A"),
+        (CarriageReturnHandling::ReplaceWithSpace, " A"),
+    ] {
+        let mut extractor = TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy);
+        assert_eq!(
+            extractor
+                .extract_from_page(&document, 0)
+                .expect("CMap extraction must succeed")
+                .text,
+            expected,
+            "unexpected CMap extraction for {policy:?}"
+        );
+    }
+}
+
+#[test]
+fn extraction_can_remove_carriage_returns() {
+    assert_eq!(
+        extract(CarriageReturnHandling::Remove),
+        "rating-aaa-exp\nnext"
+    );
+}
+
+#[test]
+fn extraction_can_replace_carriage_returns_with_spaces() {
+    assert_eq!(
+        extract(CarriageReturnHandling::ReplaceWithSpace),
+        "rating-aa a-exp\nnext"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
@@ -1,0 +1,95 @@
+//! Issue #476 — a literal `\r` (0x0D) byte embedded inside a PDF text-showing
+//! operator's string (`Tj`/`TJ`/`'`/`"`) survived `sanitize_extracted_text`
+//! unmodified and landed verbatim in extracted text.
+//!
+//! A raw CR inside such a string is not a structural line break: PDF
+//! text-showing operators draw glyphs, and a stray CR byte inside one is
+//! producer noise (e.g. a generator that copied CRLF-terminated source text
+//! directly into a content-stream string without normalizing it first). Left
+//! unmodified, a `\r` landing mid-word silently split the word in extracted
+//! output — `"rating-aaa-exp-sf"` came out as `"rating-aa\ra-exp-sf"` — which
+//! corrupts words and can break regex-based text processing downstream.
+//!
+//! These are end-to-end tests through the real `TextExtractor` pipeline
+//! (`PdfReader` -> `PdfDocument` -> `extract_from_page`), not just the
+//! `sanitize_extracted_text` unit tests in `text_sanitization_test.rs`,
+//! to guard the fix at the level a real caller observes it.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Extract page 0's plain text with default extraction options.
+fn extract_text(content: &[u8]) -> String {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
+    // Content stream containing a literal 0x0D byte inside the `Tj` string,
+    // exactly as a real producer's malformed text run would encode it —
+    // mirrors the real-world pattern found in production documents where
+    // "rating-aaa-exp-sf" was extracted as "rating-aa\ra-exp-sf".
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\ra-exp-sf)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "a stray CR must not survive into extracted text, got: {text:?}"
+    );
+    assert!(
+        text.contains("rating-aa a-exp-sf"),
+        "the CR must become a space rather than silently splitting the word, got: {text:?}"
+    );
+}
+
+#[test]
+fn a_genuine_crlf_pair_in_a_tj_string_collapses_to_a_single_newline() {
+    // A real Windows line ending that made it into the PDF's own text
+    // content should still read as one line break, not a line break plus a
+    // leading space on the next line.
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(line one\r\nline two)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "CR must be dropped from a CRLF pair, got: {text:?}"
+    );
+    assert!(
+        text.contains("line one\nline two"),
+        "CRLF must collapse to a bare LF, got: {text:?}"
+    );
+}
+
+#[test]
+fn a_stray_cr_split_across_two_separate_tj_calls_still_becomes_a_space() {
+    // The bug is in text decoding, not in how runs are joined, so it must
+    // also hold when the CR is the *last* byte of one `Tj` call rather than
+    // strictly mid-string within a single call.
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\r)Tj\n(a-exp-sf)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "a stray CR must not survive into extracted text, got: {text:?}"
+    );
+    assert!(
+        text.contains("rating-aa"),
+        "text before the CR must still be present, got: {text:?}"
+    );
+    assert!(
+        text.contains("a-exp-sf"),
+        "text after the CR must still be present, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -1,0 +1,99 @@
+//! Property invariants for carriage-return sanitization (issue #476).
+//!
+//! The examples in `text_sanitization_test` pin representative strings. These
+//! properties range over arbitrary surrounding text and CR run lengths so the
+//! policy contract is guarded independently of any one reported document.
+
+use oxidize_pdf::text::{sanitize_extracted_text_with_policy, CarriageReturnHandling};
+use proptest::prelude::*;
+
+const POLICIES: [CarriageReturnHandling; 3] = [
+    CarriageReturnHandling::Remove,
+    CarriageReturnHandling::ReplaceWithSpace,
+    CarriageReturnHandling::NormalizeLineEnding,
+];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Sanitization must remove the ambiguous representation completely and
+    /// reaching the fixed point a second time must not change the output.
+    #[test]
+    fn sanitized_text_contains_no_cr_and_is_idempotent(
+        input in proptest::collection::vec(any::<char>(), 0..256)
+            .prop_map(|chars| chars.into_iter().collect::<String>()),
+        policy in prop::sample::select(POLICIES.to_vec()),
+    ) {
+        let once = sanitize_extracted_text_with_policy(&input, policy);
+        let twice = sanitize_extracted_text_with_policy(&once, policy);
+
+        prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+    }
+
+    /// A standalone CR between printable, non-whitespace fragments is the only
+    /// ambiguous case and each public policy gives it one exact interpretation.
+    #[test]
+    fn standalone_cr_obeys_the_selected_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r{right}");
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}\n{right}")
+        );
+    }
+
+    /// CRLF is not ambiguous: it is one line ending under every policy.
+    #[test]
+    fn crlf_is_one_line_feed_under_every_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r\n{right}");
+        let expected = format!("{left}\n{right}");
+
+        for policy in POLICIES {
+            prop_assert_eq!(
+                sanitize_extracted_text_with_policy(&input, policy),
+                expected.as_str(),
+                "CRLF contract changed for {:?}",
+                policy
+            );
+        }
+    }
+
+    /// Runs of standalone CR exercise deduplication and make accidental
+    /// pair-consumption visible: only the space policy collapses the run.
+    #[test]
+    fn standalone_cr_runs_follow_policy_cardinality(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+        count in 1usize..64,
+    ) {
+        let input = format!("{left}{}{right}", "\r".repeat(count));
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}{}{right}", "\n".repeat(count))
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -49,9 +49,50 @@ fn test_collapse_multiple_spaces() {
 
 #[test]
 fn test_preserve_allowed_whitespace() {
-    // Tab, newline, carriage return should be preserved
+    // Tab and newline should be preserved. A bare `\r` (no following `\n`)
+    // is normalized to a space rather than passed through -- see issue
+    // #476 and the dedicated `test_stray_cr_*` cases below.
     let input = "line1\nline2\ttab\rcarriage";
-    let expected = "line1\nline2\ttab\rcarriage";
+    let expected = "line1\nline2\ttab carriage";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_stray_cr_mid_word_becomes_space() {
+    // Issue #476: a literal CR embedded inside a PDF text-showing
+    // operator's string (producer noise, not a structural line break)
+    // should not survive verbatim -- it silently splits the word
+    // otherwise, e.g. "rating-aaa" -> "rating-aa\ra".
+    let input = "rating-aa\ra-exp-sf";
+    let expected = "rating-aa a-exp-sf";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_crlf_pair_collapses_to_single_newline() {
+    // A genuine CRLF pair (e.g. a Windows line ending that made it into
+    // the PDF's own text content) should collapse to a single `\n`, not
+    // become a newline plus a leading space on the next line.
+    let input = "line one\r\nline two";
+    let expected = "line one\nline two";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_multiple_stray_cr_collapse_like_spaces() {
+    // Consecutive bare CRs should collapse to a single space, matching
+    // how consecutive NULs and regular spaces already collapse.
+    let input = "word\r\r\ranother";
+    let expected = "word another";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_cr_at_end_of_string_with_no_following_char() {
+    // A trailing bare CR (no following char at all, not just no `\n`)
+    // must not panic and should still normalize to a space.
+    let input = "word\r";
+    let expected = "word ";
     assert_eq!(sanitize_extracted_text(input), expected);
 }
 

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -5,7 +5,9 @@
 //!
 //! These tests follow TDD methodology - written BEFORE implementation.
 
-use oxidize_pdf::text::extraction::sanitize_extracted_text;
+use oxidize_pdf::text::extraction::{
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+};
 
 #[test]
 fn test_sanitize_nul_etx_sequence() {
@@ -48,11 +50,39 @@ fn test_collapse_multiple_spaces() {
 }
 
 #[test]
-fn test_preserve_allowed_whitespace() {
-    // Tab, newline, carriage return should be preserved
-    let input = "line1\nline2\ttab\rcarriage";
-    let expected = "line1\nline2\ttab\rcarriage";
+fn test_default_normalizes_carriage_returns() {
+    let input = "unix\nwindows\r\nclassic-mac\rend";
+    let expected = "unix\nwindows\nclassic-mac\nend";
     assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_remove_carriage_returns() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aaa-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::Remove),
+        expected
+    );
+}
+
+#[test]
+fn test_replace_carriage_returns_with_space() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aa a-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        expected
+    );
+}
+
+#[test]
+fn test_carriage_return_space_replacement_collapses_adjacent_spaces() {
+    let input = "before \r  after";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        "before after"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

`sanitize_extracted_text` whitelisted `\r` as "allowed whitespace" alongside `\t`/`\n`, so any literal CR byte present in a PDF's own text-showing operator strings (`Tj`/`TJ`/`'`/`"`) survived verbatim into extracted text. A raw CR inside such a string is not a structural line break — text-showing operators draw glyphs, and a stray CR is producer noise (e.g. a generator that copied CRLF-terminated source text directly into a content-stream string without normalizing it first). Left unmodified, a `\r` landing mid-word silently split the word in extracted output:

```
"rating-aaa-exp-sf" -> "rating-aa\ra-exp-sf"
```

## Fix

`\r` now gets its own match arm in `sanitize_extracted_text`: a genuine `\r\n` pair collapses to a single `\n` (the CR is dropped, the following `\n` arm fires normally), and any other bare `\r` becomes a space — the same treatment NUL already gets a few lines above, and consistent with `is_preservable_whitespace` in `extraction_cmap.rs`, which already treats `\r` as real text worth keeping (just not verbatim, after this change).

## Impact

Sampled 100 PDFs from a general document corpus: 11% had at least one such leak into extracted text, with per-file counts ranging from single digits up to several thousand.

## Tests

- `text_sanitization_test.rs`: fixed `test_preserve_allowed_whitespace` (previously asserted the buggy verbatim-CR behavior); added `test_stray_cr_mid_word_becomes_space`, `test_crlf_pair_collapses_to_single_newline`, `test_multiple_stray_cr_collapse_like_spaces`, `test_cr_at_end_of_string_with_no_following_char`.
- `issue_476_stray_cr_test.rs` (new): end-to-end tests through the real `PdfReader` -> `PdfDocument` -> `TextExtractor` pipeline, not just the sanitizer in isolation. I confirmed these fail against the pre-fix code with exactly the reported `"rating-aa\ra-exp-sf"` pattern (reverted the fix locally, reran, restored it).

Full suite: `cargo test -p oxidize-pdf --lib` (6685 passed), `cargo clippy --all -- -D warnings` (clean), `cargo build --all` (clean), `rustfmt --check` (clean).

Fixes #476.
