### PR TITLE
fix(text): make carriage-return extraction configurable (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Literal carriage returns in decoded text strings leaked into extracted
+  plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
+  callers remove standalone CR bytes, replace them with a space, or normalize
+  them as line endings without adding a field to the public extraction-options
+  struct. The default normalizes standalone CR and CRLF to one `\n`; CRLF is
+  treated as one line ending under every policy.
+
 ## [4.3.0] - 2026-08-11
 
 ### Fixed

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -15,6 +15,24 @@ use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
+/// Controls how carriage returns decoded from PDF text-showing strings are
+/// represented in extracted plain text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CarriageReturnHandling {
+    /// Remove each standalone carriage return.
+    Remove,
+    /// Replace each standalone carriage return with a collapsible `U+0020` space.
+    ReplaceWithSpace,
+    /// Normalize both standalone CR and CRLF sequences to one line feed.
+    NormalizeLineEnding,
+}
+
+impl Default for CarriageReturnHandling {
+    fn default() -> Self {
+        Self::NormalizeLineEnding
+    }
+}
+
 /// Text extraction options
 #[derive(Debug, Clone)]
 pub struct ExtractionOptions {
@@ -561,6 +579,10 @@ pub struct TextExtractor {
     /// not on the public [`ExtractionOptions`], so enabling it is a
     /// non-breaking method addition rather than a breaking struct-field addition.
     reading_order: bool,
+    /// Policy for CR bytes decoded from text-showing strings. Held outside the
+    /// public `ExtractionOptions` so adding it does not break exhaustive struct
+    /// literals in downstream crates.
+    carriage_return_handling: CarriageReturnHandling,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
@@ -574,6 +596,7 @@ impl TextExtractor {
         Self {
             options: ExtractionOptions::default(),
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -584,6 +607,7 @@ impl TextExtractor {
         Self {
             options,
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -606,6 +630,15 @@ impl TextExtractor {
     /// one group. `/Rotate ≠ 0` pages are ordered in unrotated page space.
     pub fn with_reading_order(mut self, enable: bool) -> Self {
         self.reading_order = enable;
+        self
+    }
+
+    /// Select how standalone carriage returns decoded from PDF text strings
+    /// are represented. CRLF is always normalized to one line feed.
+    ///
+    /// The default is [`CarriageReturnHandling::NormalizeLineEnding`].
+    pub fn with_carriage_return_handling(mut self, handling: CarriageReturnHandling) -> Self {
+        self.carriage_return_handling = handling;
         self
     }
 
@@ -2656,9 +2689,11 @@ impl TextExtractor {
                     // or garbage). Whitespace counts as meaningful: a decode
                     // that is exactly a space is a space, not a failed decode
                     // (#438). See `decode_is_usable`.
-                    if crate::text::extraction_cmap::decode_is_usable(&decoded) {
-                        // Apply sanitization to remove control characters (Issue #116)
-                        let sanitized = sanitize_extracted_text(&decoded);
+                    let sanitized = sanitize_extracted_text_with_policy(
+                        &decoded,
+                        self.carriage_return_handling,
+                    );
+                    if crate::text::extraction_cmap::decode_is_usable(&sanitized) {
                         tracing::debug!(
                             "Successfully decoded text using CMap for font {}: {:?} -> \"{}\"",
                             font_name,
@@ -2701,7 +2736,8 @@ impl TextExtractor {
 
         let fallback_result = encoding.decode(text);
         // Apply sanitization to remove control characters (Issue #116)
-        let sanitized = sanitize_extracted_text(&fallback_result);
+        let sanitized =
+            sanitize_extracted_text_with_policy(&fallback_result, self.carriage_return_handling);
         tracing::debug!(
             "Fallback encoding decoding: {:?} -> \"{}\"",
             text,
@@ -3359,7 +3395,7 @@ fn calculate_text_width_from_codes(
 /// - Removes other ASCII control characters (0x01-0x1F) except:
 ///   - `\t` (0x09) - Tab
 ///   - `\n` (0x0A) - Line feed
-///   - `\r` (0x0D) - Carriage return
+/// - Normalizes `\r` and `\r\n` to `\n`
 /// - Collapses multiple consecutive spaces into a single space
 ///
 /// # Examples
@@ -3380,6 +3416,14 @@ fn calculate_text_width_from_codes(
 /// assert_eq!(sanitize_extracted_text(clean), "Normal text");
 /// ```
 pub fn sanitize_extracted_text(text: &str) -> String {
+    sanitize_extracted_text_with_policy(text, CarriageReturnHandling::default())
+}
+
+/// Sanitize extracted text using an explicit carriage-return policy.
+pub fn sanitize_extracted_text_with_policy(
+    text: &str,
+    carriage_return_handling: CarriageReturnHandling,
+) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -3409,10 +3453,33 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 // Don't emit anything, just skip
             }
 
+            '\r' => {
+                // CRLF is unambiguously one line ending under every policy.
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    result.push('\n');
+                    last_was_space = false;
+                } else {
+                    match carriage_return_handling {
+                        CarriageReturnHandling::Remove => {}
+                        CarriageReturnHandling::ReplaceWithSpace => {
+                            if !last_was_space {
+                                result.push(' ');
+                                last_was_space = true;
+                            }
+                        }
+                        CarriageReturnHandling::NormalizeLineEnding => {
+                            result.push('\n');
+                            last_was_space = false;
+                        }
+                    }
+                }
+            }
+
             // Preserve allowed whitespace
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' => {
                 result.push(ch);
-                // Reset space tracking on newlines but not tabs
+                // Reset space tracking on newlines but not tabs.
                 last_was_space = ch == '\t';
             }
 
@@ -3424,7 +3491,7 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 }
             }
 
-            // Other control characters (0x01-0x1F except tab/newline/CR) - remove
+            // Other control characters (0x01-0x1F except tab/newline) - remove
             c if c.is_ascii_control() => {
                 // Skip control characters
             }
@@ -3717,6 +3784,10 @@ mod tests {
         assert!(!options.detect_columns);
         assert_eq!(options.column_threshold, 50.0);
         assert!(options.merge_hyphenated);
+        assert_eq!(
+            CarriageReturnHandling::default(),
+            CarriageReturnHandling::NormalizeLineEnding
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -530,7 +530,7 @@ pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap
 /// deletes would turn "usable" into an empty string — worse than the guessed
 /// fallback it was accepted over.
 fn is_preservable_whitespace(c: char) -> bool {
-    matches!(c, ' ' | '\t' | '\n' | '\r')
+    matches!(c, ' ' | '\t' | '\n')
 }
 
 /// Whether a decode produced usable text, or nothing the caller can act on.

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -34,7 +34,8 @@ pub mod tesseract_provider;
 
 pub use encoding::{escape_pdf_string_literal, TextEncoding};
 pub use extraction::{
-    sanitize_extracted_text, ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+    ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
 };
 pub use flow::{TextAlign, TextFlowContext};
 pub use font::{Font, FontEncoding, FontFamily, FontWithEncoding};

--- a/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
@@ -1,0 +1,108 @@
+//! End-to-end regression tests for issue #476.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{CarriageReturnHandling, ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+fn build_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td (rating-aa\\015a-exp\\015\\012next) Tj ET";
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+    ])
+}
+
+fn extract_with(mut extractor: TextExtractor) -> String {
+    let reader = PdfReader::new(Cursor::new(build_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("page extraction must succeed")
+        .text
+}
+
+fn extract(policy: CarriageReturnHandling) -> String {
+    extract_with(
+        TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy),
+    )
+}
+
+#[test]
+fn extraction_normalizes_cr_and_crlf_by_default() {
+    assert_eq!(extract_with(TextExtractor::new()), "rating-aa\na-exp\nnext");
+}
+
+fn build_cmap_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td <0102> Tj ET";
+    let to_unicode = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Issue476 def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<00> <ff>\nendcodespacerange\n\
+2 beginbfchar\n<01> <000D>\n<02> <0041>\nendbfchar\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /FirstChar 1 /LastChar 2 /Widths [500 500] /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", to_unicode),
+    ])
+}
+
+#[test]
+fn cmap_decoding_applies_the_selected_carriage_return_policy() {
+    let reader = PdfReader::new(Cursor::new(build_cmap_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+
+    for (policy, expected) in [
+        (CarriageReturnHandling::NormalizeLineEnding, "\nA"),
+        (CarriageReturnHandling::Remove, "A"),
+        (CarriageReturnHandling::ReplaceWithSpace, " A"),
+    ] {
+        let mut extractor = TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy);
+        assert_eq!(
+            extractor
+                .extract_from_page(&document, 0)
+                .expect("CMap extraction must succeed")
+                .text,
+            expected,
+            "unexpected CMap extraction for {policy:?}"
+        );
+    }
+}
+
+#[test]
+fn extraction_can_remove_carriage_returns() {
+    assert_eq!(
+        extract(CarriageReturnHandling::Remove),
+        "rating-aaa-exp\nnext"
+    );
+}
+
+#[test]
+fn extraction_can_replace_carriage_returns_with_spaces() {
+    assert_eq!(
+        extract(CarriageReturnHandling::ReplaceWithSpace),
+        "rating-aa a-exp\nnext"
+    );
+}

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -1,0 +1,99 @@
+//! Property invariants for carriage-return sanitization (issue #476).
+//!
+//! The examples in `text_sanitization_test` pin representative strings. These
+//! properties range over arbitrary surrounding text and CR run lengths so the
+//! policy contract is guarded independently of any one reported document.
+
+use oxidize_pdf::text::{sanitize_extracted_text_with_policy, CarriageReturnHandling};
+use proptest::prelude::*;
+
+const POLICIES: [CarriageReturnHandling; 3] = [
+    CarriageReturnHandling::Remove,
+    CarriageReturnHandling::ReplaceWithSpace,
+    CarriageReturnHandling::NormalizeLineEnding,
+];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Sanitization must remove the ambiguous representation completely and
+    /// reaching the fixed point a second time must not change the output.
+    #[test]
+    fn sanitized_text_contains_no_cr_and_is_idempotent(
+        input in proptest::collection::vec(any::<char>(), 0..256)
+            .prop_map(|chars| chars.into_iter().collect::<String>()),
+        policy in prop::sample::select(POLICIES.to_vec()),
+    ) {
+        let once = sanitize_extracted_text_with_policy(&input, policy);
+        let twice = sanitize_extracted_text_with_policy(&once, policy);
+
+        prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+    }
+
+    /// A standalone CR between printable, non-whitespace fragments is the only
+    /// ambiguous case and each public policy gives it one exact interpretation.
+    #[test]
+    fn standalone_cr_obeys_the_selected_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r{right}");
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}\n{right}")
+        );
+    }
+
+    /// CRLF is not ambiguous: it is one line ending under every policy.
+    #[test]
+    fn crlf_is_one_line_feed_under_every_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r\n{right}");
+        let expected = format!("{left}\n{right}");
+
+        for policy in POLICIES {
+            prop_assert_eq!(
+                sanitize_extracted_text_with_policy(&input, policy),
+                expected.as_str(),
+                "CRLF contract changed for {:?}",
+                policy
+            );
+        }
+    }
+
+    /// Runs of standalone CR exercise deduplication and make accidental
+    /// pair-consumption visible: only the space policy collapses the run.
+    #[test]
+    fn standalone_cr_runs_follow_policy_cardinality(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+        count in 1usize..64,
+    ) {
+        let input = format!("{left}{}{right}", "\r".repeat(count));
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}{}{right}", "\n".repeat(count))
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -5,7 +5,9 @@
 //!
 //! These tests follow TDD methodology - written BEFORE implementation.
 
-use oxidize_pdf::text::extraction::sanitize_extracted_text;
+use oxidize_pdf::text::extraction::{
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+};
 
 #[test]
 fn test_sanitize_nul_etx_sequence() {
@@ -48,11 +50,39 @@ fn test_collapse_multiple_spaces() {
 }
 
 #[test]
-fn test_preserve_allowed_whitespace() {
-    // Tab, newline, carriage return should be preserved
-    let input = "line1\nline2\ttab\rcarriage";
-    let expected = "line1\nline2\ttab\rcarriage";
+fn test_default_normalizes_carriage_returns() {
+    let input = "unix\nwindows\r\nclassic-mac\rend";
+    let expected = "unix\nwindows\nclassic-mac\nend";
     assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_remove_carriage_returns() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aaa-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::Remove),
+        expected
+    );
+}
+
+#[test]
+fn test_replace_carriage_returns_with_space() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aa a-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        expected
+    );
+}
+
+#[test]
+fn test_carriage_return_space_replacement_collapses_adjacent_spaces() {
+    let input = "before \r  after";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        "before after"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Addresses #476. The reporter should close the issue after validating the fix.

## Summary
- normalize standalone CR and CRLF to LF by default during text extraction
- add `CarriageReturnHandling::{Remove, ReplaceWithSpace, NormalizeLineEnding}`
- expose the policy through `TextExtractor::with_carriage_return_handling` without changing the public `ExtractionOptions` fields
- apply the policy consistently to CMap and encoding-fallback decoding
- add unit, synthetic PDF end-to-end, CMap, and property-based regression coverage

## Validation
- `cargo fmt -p oxidize-pdf -- --check`
- `cargo clippy -p oxidize-pdf --lib -- -D warnings`
- `cargo clippy -p oxidize-pdf --test issue_476_carriage_return_policy_test -- -D warnings`
- `cargo clippy -p oxidize-pdf --test prop_text_sanitization_invariants -- -D warnings`
- `cargo test -p oxidize-pdf --lib` (6,688 passed)
- focused suites: 25 passed