### PR TITLE
fix(text): preserve standalone CR during line normalization (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
-  callers remove standalone CR bytes, replace them with a space, or normalize
-  them as line endings without adding a field to the public extraction-options
-  struct. The default normalizes standalone CR and CRLF to one `\n`; CRLF is
-  treated as one line ending under every policy.
+  callers remove standalone CR bytes, replace them with a space, or preserve
+  them while normalizing CRLF without adding a field to the public
+  extraction-options struct. The default removes standalone CR so producer
+  noise does not split words or URLs; CRLF is treated as one line ending under
+  every policy. `NormalizeLineEnding` preserves a standalone CR because it is
+  not equivalent to LF (#481).
 
 ## [4.3.0] - 2026-08-11
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -23,13 +23,13 @@ pub enum CarriageReturnHandling {
     Remove,
     /// Replace each standalone carriage return with a collapsible `U+0020` space.
     ReplaceWithSpace,
-    /// Normalize both standalone CR and CRLF sequences to one line feed.
+    /// Preserve standalone carriage returns and normalize CRLF to one line feed.
     NormalizeLineEnding,
 }
 
 impl Default for CarriageReturnHandling {
     fn default() -> Self {
-        Self::NormalizeLineEnding
+        Self::Remove
     }
 }
 
@@ -636,7 +636,7 @@ impl TextExtractor {
     /// Select how standalone carriage returns decoded from PDF text strings
     /// are represented. CRLF is always normalized to one line feed.
     ///
-    /// The default is [`CarriageReturnHandling::NormalizeLineEnding`].
+    /// The default is [`CarriageReturnHandling::Remove`].
     pub fn with_carriage_return_handling(mut self, handling: CarriageReturnHandling) -> Self {
         self.carriage_return_handling = handling;
         self
@@ -3469,7 +3469,10 @@ pub fn sanitize_extracted_text_with_policy(
                             }
                         }
                         CarriageReturnHandling::NormalizeLineEnding => {
-                            result.push('\n');
+                            // A standalone CR is valid input and is not
+                            // equivalent to LF. Only the CRLF sequence above
+                            // is normalized as a line ending.
+                            result.push('\r');
                             last_was_space = false;
                         }
                     }
@@ -3786,7 +3789,7 @@ mod tests {
         assert!(options.merge_hyphenated);
         assert_eq!(
             CarriageReturnHandling::default(),
-            CarriageReturnHandling::NormalizeLineEnding
+            CarriageReturnHandling::Remove
         );
     }
 

--- a/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
@@ -39,8 +39,8 @@ fn extract(policy: CarriageReturnHandling) -> String {
 }
 
 #[test]
-fn extraction_normalizes_cr_and_crlf_by_default() {
-    assert_eq!(extract_with(TextExtractor::new()), "rating-aa\na-exp\nnext");
+fn extraction_removes_standalone_cr_and_normalizes_crlf_by_default() {
+    assert_eq!(extract_with(TextExtractor::new()), "rating-aaa-exp\nnext");
 }
 
 fn build_cmap_pdf() -> Vec<u8> {
@@ -74,7 +74,7 @@ fn cmap_decoding_applies_the_selected_carriage_return_policy() {
     let document = PdfDocument::new(reader);
 
     for (policy, expected) in [
-        (CarriageReturnHandling::NormalizeLineEnding, "\nA"),
+        (CarriageReturnHandling::NormalizeLineEnding, "\rA"),
         (CarriageReturnHandling::Remove, "A"),
         (CarriageReturnHandling::ReplaceWithSpace, " A"),
     ] {

--- a/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
@@ -34,6 +34,18 @@ fn extract_text(content: &[u8], handling: CarriageReturnHandling) -> String {
         .text
 }
 
+/// Extract page 0's plain text using the default carriage-return policy.
+fn extract_text_with_default(content: &[u8]) -> String {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
 #[test]
 fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
     // Content stream containing a literal 0x0D byte inside the `Tj` string,
@@ -41,15 +53,15 @@ fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
     // mirrors the real-world pattern found in production documents where
     // "rating-aaa-exp-sf" was extracted as "rating-aa\ra-exp-sf".
     let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\ra-exp-sf)Tj\nET\n";
-    let text = extract_text(content, CarriageReturnHandling::ReplaceWithSpace);
+    let text = extract_text_with_default(content);
 
     assert!(
         !text.contains('\r'),
         "a stray CR must not survive into extracted text, got: {text:?}"
     );
     assert!(
-        text.contains("rating-aa a-exp-sf"),
-        "the CR must become a space rather than silently splitting the word, got: {text:?}"
+        text.contains("rating-aaa-exp-sf"),
+        "the default policy must remove the stray CR without splitting the word, got: {text:?}"
     );
 }
 

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -16,8 +16,8 @@ const POLICIES: [CarriageReturnHandling; 3] = [
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
-    /// Sanitization must remove the ambiguous representation completely and
-    /// reaching the fixed point a second time must not change the output.
+    /// Every policy must reach a fixed point. Policies that rewrite standalone
+    /// CR must also remove that representation completely.
     #[test]
     fn sanitized_text_contains_no_cr_and_is_idempotent(
         input in proptest::collection::vec(any::<char>(), 0..256)
@@ -27,7 +27,9 @@ proptest! {
         let once = sanitize_extracted_text_with_policy(&input, policy);
         let twice = sanitize_extracted_text_with_policy(&once, policy);
 
-        prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        if policy != CarriageReturnHandling::NormalizeLineEnding {
+            prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        }
         prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
     }
 
@@ -50,7 +52,7 @@ proptest! {
         );
         prop_assert_eq!(
             sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
-            format!("{left}\n{right}")
+            input
         );
     }
 
@@ -93,7 +95,7 @@ proptest! {
         );
         prop_assert_eq!(
             sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
-            format!("{left}{}{right}", "\n".repeat(count))
+            input
         );
     }
 }

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -50,10 +50,20 @@ fn test_collapse_multiple_spaces() {
 }
 
 #[test]
-fn test_default_normalizes_carriage_returns() {
+fn test_default_removes_standalone_carriage_returns() {
     let input = "unix\nwindows\r\nclassic-mac\rend";
-    let expected = "unix\nwindows\nclassic-mac\nend";
+    let expected = "unix\nwindows\nclassic-macend";
     assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_normalize_line_ending_preserves_standalone_carriage_returns() {
+    let input = "unix\nwindows\r\nclassic-mac\rend";
+    let expected = "unix\nwindows\nclassic-mac\rend";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::NormalizeLineEnding),
+        expected
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make `Remove` the default carriage-return policy so stray producer noise does not split words or URLs
- preserve a standalone CR under `NormalizeLineEnding`; only CRLF is normalized to LF
- update end-to-end, unit, CMap, and property coverage for the distinct semantics
- document the corrected behavior in the changelog

Closes #481.

## Validation

- repository pre-commit hook
- formatting and Clippy passed
- library build passed
- 6,685 library tests passed, 0 failed, 3 ignored
- 29 targeted carriage-return tests passed