### PR TITLE
fix(text): normalize CRLF across removed controls (#481)

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3455,8 +3455,21 @@ pub fn sanitize_extracted_text_with_policy(
 
             '\r' => {
                 // CRLF is unambiguously one line ending under every policy.
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
+                // Ignore controls that sanitization would remove between the
+                // pair, otherwise a first pass could create CRLF and a second
+                // pass would change it again (for example `"\r\u{1}\n"`).
+                let removed_controls_before_lf = chars
+                    .clone()
+                    .take_while(|next| {
+                        next.is_ascii_control() && !matches!(next, '\0' | '\t' | '\n' | '\r')
+                    })
+                    .count();
+                let followed_by_lf = chars.clone().nth(removed_controls_before_lf) == Some('\n');
+
+                if followed_by_lf {
+                    for _ in 0..=removed_controls_before_lf {
+                        chars.next();
+                    }
                     result.push('\n');
                     last_was_space = false;
                 } else {

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -16,8 +16,10 @@ const POLICIES: [CarriageReturnHandling; 3] = [
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
-    /// Every policy must reach a fixed point. Policies that rewrite standalone
-    /// CR must also remove that representation completely.
+    /// Policies that rewrite standalone CR must remove that representation
+    /// completely and reach a fixed point. `NormalizeLineEnding` deliberately
+    /// preserves standalone CR, so overlapping input such as CR+CRLF cannot be
+    /// globally idempotent: the first pass correctly yields CRLF.
     #[test]
     fn sanitized_text_contains_no_cr_and_is_idempotent(
         input in proptest::collection::vec(any::<char>(), 0..256)
@@ -30,7 +32,9 @@ proptest! {
         if policy != CarriageReturnHandling::NormalizeLineEnding {
             prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
         }
-        prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+        if policy != CarriageReturnHandling::NormalizeLineEnding {
+            prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+        }
     }
 
     /// A standalone CR between printable, non-whitespace fragments is the only

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -67,6 +67,18 @@ fn test_normalize_line_ending_preserves_standalone_carriage_returns() {
 }
 
 #[test]
+fn test_crlf_normalization_is_idempotent_across_removed_controls() {
+    let input = "\r\u{1}\n";
+    let once =
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::NormalizeLineEnding);
+    let twice =
+        sanitize_extracted_text_with_policy(&once, CarriageReturnHandling::NormalizeLineEnding);
+
+    assert_eq!(once, "\n");
+    assert_eq!(twice, once);
+}
+
+#[test]
 fn test_remove_carriage_returns() {
     let input = "rating-aa\ra-exp\r\nnext";
     let expected = "rating-aaa-exp\nnext";


### PR DESCRIPTION
## Summary

- normalize CRLF even when removable ASCII controls occur between CR and LF
- add a deterministic regression for the macOS CI counterexample
- scope the idempotence property to policies that rewrite standalone CR, since preserving standalone CR and normalizing overlapping CR+CRLF cannot be globally idempotent

Follow-up to #483 and #481.

## Validation

- repository pre-commit hook passed
- 6,685 library tests passed, 0 failed, 3 ignored
- targeted sanitization, property, CMap, and end-to-end tests passed
- Clippy passed with warnings denied