### PR TITLE
fix(text): fuse hyphen-wrapped fragments in emission order before Y-sort (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`preserve_layout`'s global Y-sort could interleave unrelated content
+  regions, corrupting hyphen-wrapped words** (#482). `sort_and_merge_fragments`
+  sorts every fragment on a page by Y-coordinate with no notion of separate
+  content regions; when an unrelated fragment (e.g. a digital-signature
+  annotation's appearance text) happened to sit at a Y-coordinate between the
+  two halves of a hyphen-wrapped word elsewhere on the page, the sort spliced
+  it in between them, and the hyphen got joined to the wrong fragment —
+  corrupting both the wrapped word and the unrelated text at once. Fixed by
+  fusing a hyphen-ended fragment with its wrap continuation while fragments
+  are still in emission (content-stream) order, before the Y-sort runs, so
+  the wrapped token becomes a single atomic fragment nothing can be spliced
+  into afterward.
+
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
   callers remove standalone CR bytes, replace them with a space, or normalize

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -571,6 +571,19 @@ fn same_paragraph_style(a: &TextFragment, b: &TextFragment) -> bool {
     (a.font_size - b.font_size).abs() / scale <= PARAGRAPH_STYLE_SIZE_TOLERANCE
 }
 
+/// Whether `next` is plausibly the wrapped continuation of `prev` on a new
+/// line, using the exact same Y-gap test `reconstruct_text_from_fragments`
+/// already uses to decide "new line vs. same line" (`|Δy| > newline_threshold`).
+///
+/// Deliberately mirrors that threshold rather than inventing a stricter one:
+/// this function's only job is to protect an already-correct merge decision
+/// from being corrupted by an unrelated fragment sorting in between the two
+/// halves (issue #482) — not to second-guess which pairs `merge_hyphenated`
+/// would otherwise join. Used by `merge_hyphenated_line_wraps_in_emission_order`.
+fn is_line_wrap_geometry(prev: &TextFragment, next: &TextFragment, newline_threshold: f64) -> bool {
+    (prev.y - next.y).abs() > newline_threshold
+}
+
 /// Text extractor for PDF pages with CMap support
 pub struct TextExtractor {
     options: ExtractionOptions,
@@ -1051,6 +1064,30 @@ impl TextExtractor {
         } = run;
         {
             let _span = tracing::info_span!("layout_finalize").entered();
+
+            // Fuse hyphen-wrapped tokens while fragments are still in emission
+            // order (issue #482), *before* any Y-sort below can interleave an
+            // unrelated fragment between a wrapped line's two halves. Fragments
+            // only exist here for the `preserve_layout`/`reorder_columns` paths
+            // (see the `emit_text_fragment` call sites), both of which feed
+            // `reconstruct_text_from_fragments` further down, so this always
+            // runs ahead of the merge it's protecting.
+            //
+            // `merge_close_fragments` must run first: a word's trailing hyphen
+            // is frequently its own separate glyph-run fragment (e.g. a style
+            // or kerning boundary right at "3016" | "-"), so the hyphen check
+            // below would otherwise fire against that lone "-" fragment (whose
+            // own predecessor is the stranded "6") instead of against the real
+            // "...3016-" line. Coalescing same-line adjacent runs first makes
+            // the trailing-hyphen text end up on one fragment, as the check
+            // assumes. `merge_close_fragments` is a local, order-preserving
+            // pass over adjacent pairs (see its own doc comment on being used
+            // this way for `reconstruct_paragraphs`), so it is safe to run here
+            // on unsorted emission order.
+            if !fragments.is_empty() {
+                fragments = self.merge_close_fragments(&fragments);
+                fragments = self.merge_hyphenated_line_wraps_in_emission_order(fragments);
+            }
 
             // Sort and process fragments if requested — but ONLY when we're not
             // going to run merge_into_lines later. merge_into_lines does its
@@ -2141,6 +2178,73 @@ impl TextExtractor {
                 }
             });
         Some((ops, xobj_res, matrix))
+    }
+
+    /// Fuse a hyphen-ended fragment with its line-wrap continuation while
+    /// fragments are still in emission (content-stream) order, before any
+    /// Y-coordinate sort runs.
+    ///
+    /// `sort_and_merge_fragments`'s global Y-sort has no concept of separate
+    /// content regions (issue #482): an unrelated fragment (an annotation's
+    /// appearance stream, a watermark, …) whose Y-coordinate happens to fall
+    /// between two wrapped lines of unrelated body text gets sorted in
+    /// between them, and the hyphen-merge check in `reconstruct_text_from_fragments`
+    /// — which only ever looks at the *immediately preceding* fragment in
+    /// the already-sorted list — then joins the hyphen to the wrong
+    /// fragment, corrupting both regions at once.
+    ///
+    /// Emission order does not have this problem: two fragments that are
+    /// genuinely adjacent lines of the same wrapped text are (barring a
+    /// pathological content stream) emitted consecutively, regardless of
+    /// where an unrelated annotation's text happens to sit on the Y axis.
+    /// Fusing the pair here, before the sort, makes the wrapped token a
+    /// single atomic fragment that nothing can be spliced into afterward.
+    ///
+    /// Uses `is_line_wrap_geometry` (the same Y-gap test
+    /// `reconstruct_text_from_fragments` already applies) to confirm the
+    /// pair actually looks like consecutive lines before merging, so an
+    /// unrelated same-line hyphen (e.g. "well-known" on one line) is not
+    /// fused with whatever fragment happens to follow it in emission order.
+    fn merge_hyphenated_line_wraps_in_emission_order(
+        &self,
+        fragments: Vec<TextFragment>,
+    ) -> Vec<TextFragment> {
+        if !self.options.merge_hyphenated || fragments.len() < 2 {
+            return fragments;
+        }
+
+        let mut result: Vec<TextFragment> = Vec::with_capacity(fragments.len());
+        for fragment in fragments {
+            let should_merge = result
+                .last()
+                .map(|prev: &TextFragment| {
+                    prev.text.ends_with('-')
+                        && is_line_wrap_geometry(prev, &fragment, self.options.newline_threshold)
+                })
+                .unwrap_or(false);
+
+            if should_merge {
+                // Safe: just checked `result.last()` is `Some` above.
+                let prev = result.last_mut().expect("checked non-empty above");
+                prev.text.pop(); // drop the trailing hyphen
+                prev.text.push_str(&fragment.text);
+                // Extend the fused fragment's box to cover both lines so
+                // downstream geometry (space/newline decisions keyed on
+                // `x + width`, `y`) still reasons about real coverage
+                // rather than only the first line's box.
+                let x_min = prev.x.min(fragment.x);
+                let x_max = (prev.x + prev.width).max(fragment.x + fragment.width);
+                let y_min = prev.y.min(fragment.y);
+                let y_max = (prev.y + prev.height).max(fragment.y + fragment.height);
+                prev.x = x_min;
+                prev.width = x_max - x_min;
+                prev.y = y_min;
+                prev.height = y_max - y_min;
+            } else {
+                result.push(fragment);
+            }
+        }
+        result
     }
 
     /// Sort text fragments by position and merge them appropriately

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -1,0 +1,144 @@
+//! Regression tests for issue #482.
+//!
+//! `preserve_layout = true` (and `reorder_columns = true`, which shares the
+//! same `sort_and_merge_fragments` call) sorts *every* fragment on a page by
+//! Y-coordinate with no notion of separate content regions. When a hyphenated
+//! word wraps across two lines, and an unrelated fragment drawn elsewhere in
+//! the content stream (e.g. a digital-signature annotation's appearance
+//! text) happens to sit at a Y-coordinate between those two lines, the sort
+//! splices the unrelated fragment in between them. `reconstruct_text_from_fragments`
+//! then walks the sorted list linearly and joins the hyphen to the wrong
+//! fragment, corrupting both the wrapped word and the unrelated text at once.
+//!
+//! Fix: fuse a hyphen-ended fragment with its wrap continuation while
+//! fragments are still in emission (content-stream) order — before the
+//! Y-sort runs — so the wrapped token becomes a single atomic fragment that
+//! nothing can be spliced into afterward.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_preserve_layout(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn hyphenated_wrap_survives_an_unrelated_fragment_sorted_between_its_two_lines() {
+    // Mirrors the real-world document that motivated #482: a phone-number-like
+    // token wraps hyphenated across two lines at y=45.72 and y=33.48. An
+    // unrelated fragment (standing in for a digital-signature annotation's
+    // appearance text) is drawn *later* in the content stream, but at
+    // y=35.62 -- a Y-coordinate that falls strictly between the two wrapped
+    // lines. Before the fix, `sort_and_merge_fragments`'s global Y-sort
+    // placed the unrelated fragment between them, and the hyphen got joined
+    // to it instead of to "0900".
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        // Line 1: ends with a hyphen, wrapping to the next line.
+        "1 0 0 1 100 45.72 Tm\n(Tel.: 3016-) Tj\n",
+        // Line 2: the wrap continuation. Y is far enough below line 1 to be a
+        // real line wrap (> newline_threshold).
+        "1 0 0 1 100 33.48 Tm\n(0900) Tj\n",
+        // An unrelated fragment, drawn *after* both lines above in emission
+        // order, but at a Y-coordinate strictly between them.
+        "1 0 0 1 300 35.62 Tm\n(Unrelated annotation text) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+
+    assert!(
+        text.contains("3016-0900") || text.contains("30160900"),
+        "the hyphen-wrapped number must survive intact, got: {text:?}"
+    );
+    assert!(
+        !text.contains("3016Unrelated") && !text.contains("3016-Unrelated"),
+        "the unrelated fragment must not be spliced into the wrapped number: {text:?}"
+    );
+    assert!(
+        text.contains("Unrelated annotation text"),
+        "the unrelated fragment's own text must still be present somewhere: {text:?}"
+    );
+}
+
+#[test]
+fn hyphenated_wrap_without_interleaving_fragment_still_merges_normally() {
+    // Baseline sanity check: with no unrelated fragment in the way, a simple
+    // hyphenated wrap must still merge exactly as before.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(hyphen-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(ated) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+    assert!(
+        text.contains("hyphenated"),
+        "plain hyphenated wrap (no interleaving fragment) must still merge, got: {text:?}"
+    );
+}
+
+#[test]
+fn same_line_hyphen_is_not_treated_as_a_wrap() {
+    // A hyphen that is part of the SAME line (e.g. "well-known") must not be
+    // merged with whatever fragment happens to be next in emission order --
+    // only a genuine line-wrap gap should trigger the merge.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(well-) Tj\n",
+        "1 0 0 1 140 700 Tm\n(known fact) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+    assert!(
+        text.contains("well-known") || text.contains("well- known"),
+        "a same-line hyphen must not be silently dropped or merged incorrectly, got: {text:?}"
+    );
+}


### PR DESCRIPTION
Addresses #482.

## Summary

`sort_and_merge_fragments` (used by `preserve_layout` and `reorder_columns`) sorts every fragment on a page by Y-coordinate with no notion of separate content regions. When a hyphenated word wraps across two lines, and an unrelated fragment (e.g. a digital-signature annotation's appearance text) happens to sit at a Y-coordinate between those two lines, the sort splices the unrelated fragment in between them. `reconstruct_text_from_fragments` then joins the hyphen to the wrong fragment, corrupting both the wrapped word and the unrelated text at once — see #482 for the full real-world repro.

- Fuse a hyphen-ended fragment with its wrap continuation while fragments are still in emission (content-stream) order, *before* any Y-sort runs, via a new `merge_hyphenated_line_wraps_in_emission_order`. The wrapped token becomes a single atomic fragment that nothing can be spliced into afterward.
- Run `merge_close_fragments` immediately before that pass (also pre-sort): a word's trailing hyphen is frequently its own separate glyph-run fragment (a style/kerning boundary right at the hyphen), so without this the hyphen check would fire against the lone `"-"` fragment instead of the real `"...word-"` fragment.
- New `is_line_wrap_geometry` helper mirrors the exact Y-gap test `reconstruct_text_from_fragments` already uses (`|Δy| > newline_threshold`), so this doesn't second-guess which pairs `merge_hyphenated` would otherwise join — it only protects an already-correct decision from being corrupted by sort interleaving.

## Validation

- `cargo fmt -p oxidize-pdf -- --check`
- `cargo clippy -p oxidize-pdf --lib -- -D warnings`
- `cargo test -p oxidize-pdf --lib` (6,685 passed)
- New regression test (`issue_482_preserve_layout_interleave_test.rs`, 3 tests) — confirmed it fails without the fix (reproduces `"Tel.: 3016Unrelated annotation text0900"`) and passes with it
- All existing extraction/hyphenation/fragment-related integration test files (30 files, paragraph reconstruction, line-wrap, column-reorder, etc.) re-run clean
- Verified against the real-world document from #482: the phone number split across a hyphenated wrap now extracts as one intact token instead of being spliced with an interleaved signature annotation's text
