### PR TITLE
fix(text): honor merge_hyphenated on the flat text-extraction path (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`merge_hyphenated` had no effect on the flat (default) extraction path**
+  (#486). It was only wired into `reconstruct_text_from_fragments`
+  (`preserve_layout: true`) and `merge_into_paragraphs`
+  (`reconstruct_paragraphs: true`); every text-showing operator on the flat
+  path (`Tj`, `TJ`, `'`, `"`) independently decided a `'\n'` separator via
+  the shared `append_bounded` helper without ever checking for a trailing
+  hyphen, so a hyphenated word or number wrapping across two lines extracted
+  with a raw newline in place of the hyphen — e.g. a phone number split as
+  `"...3016-"` / `"0900"` came out `"...3016-\n0900"` instead of
+  `"...30160900"`. `append_bounded` now pops the trailing `-` and fuses the
+  next run with no separator when the caller requested `'\n'` and
+  `merge_hyphenated` is enabled (the default); the actual separator applied
+  is threaded back to callers so reading-order line grouping (#448) treats a
+  fused run as a continuation rather than opening a new line.
+
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
   callers remove standalone CR bytes, replace them with a space, or normalize

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1302,17 +1302,24 @@ impl TextExtractor {
 
                             // Per-page byte budget (issue #382): stop before the
                             // run that would overshoot; the outer loop guard ends
-                            // extraction on the next iteration.
-                            if !append_bounded(
+                            // extraction on the next iteration. Hyphen-wrap fusion
+                            // (issue #486) may replace the requested `\n` with no
+                            // separator at all — `emitted_sep` must reflect what
+                            // was actually applied, not what was requested, so
+                            // reading-order line grouping below sees the run as a
+                            // continuation rather than a new line.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         // Get font info for accurate width calculation.
@@ -1466,16 +1473,23 @@ impl TextExtractor {
                                         };
 
                                         // Per-page byte budget (issue #382).
-                                        if !append_bounded(
+                                        // Hyphen-wrap fusion (issue #486) may
+                                        // replace the requested `\n` with no
+                                        // separator; `emitted_sep` reflects what
+                                        // was actually applied (see the `Tj` arm
+                                        // above for the full rationale).
+                                        let outcome = append_bounded(
                                             &mut extracted_text,
                                             separator,
                                             &decoded,
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
-                                        ) {
+                                            self.options.merge_hyphenated,
+                                        );
+                                        if !outcome.appended {
                                             break;
                                         }
-                                        emitted_sep = Some(separator);
+                                        emitted_sep = Some(outcome.applied_separator);
                                     }
 
                                     let text_width = {
@@ -1565,13 +1579,18 @@ impl TextExtractor {
                                         // Per-page byte budget (issue #382): even
                                         // the synthesised space counts, so the
                                         // `text.len() <= limit` invariant holds.
+                                        // Always a space, never `\n` — hyphen-wrap
+                                        // fusion (issue #486) does not apply here.
                                         if !append_bounded(
                                             &mut extracted_text,
                                             Some(' '),
                                             "",
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
-                                        ) {
+                                            self.options.merge_hyphenated,
+                                        )
+                                        .appended
+                                        {
                                             break;
                                         }
                                         // The synthesised space is intra-group
@@ -1647,17 +1666,26 @@ impl TextExtractor {
                             } else {
                                 Some('\n')
                             };
-                            // Per-page byte budget (issue #382).
-                            if !append_bounded(
+                            // Per-page byte budget (issue #382). Hyphen-wrap
+                            // fusion (issue #486) may replace the requested `\n`
+                            // with no separator; `emitted_sep` reflects what was
+                            // actually applied (see the `Tj` arm for the full
+                            // rationale). `'` (this operator) always requests a
+                            // new line by definition (ISO 32000-1 §9.4.3's
+                            // `T* Tj`), so this is where a hyphen at the end of
+                            // one `'`-delimited line meets the start of the next.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         let text_width = {
@@ -1735,17 +1763,24 @@ impl TextExtractor {
                             } else {
                                 Some('\n')
                             };
-                            // Per-page byte budget (issue #382).
-                            if !append_bounded(
+                            // Per-page byte budget (issue #382). Hyphen-wrap
+                            // fusion (issue #486) may replace the requested `\n`
+                            // with no separator; `emitted_sep` reflects what was
+                            // actually applied (see the `Tj` arm for the full
+                            // rationale). `"` (this operator) always requests a
+                            // new line by definition, same as `'` above.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         let text_width = {
@@ -1946,13 +1981,21 @@ impl TextExtractor {
                                     // If it would overshoot, drop the fragment and
                                     // stop — a huge override must not escape the
                                     // cap while reporting `truncated = false`.
+                                    // Always `None` separator, never `\n` —
+                                    // hyphen-wrap fusion (issue #486) does not
+                                    // apply here. This site is also only reached
+                                    // under `preserve_layout`/`reorder_columns`
+                                    // (see the gate above), not the flat path.
                                     if !append_bounded(
                                         &mut extracted_text,
                                         None,
                                         &run.text,
                                         self.options.max_extracted_bytes,
                                         &mut truncated,
-                                    ) {
+                                        self.options.merge_hyphenated,
+                                    )
+                                    .appended
+                                    {
                                         break;
                                     }
                                     fragments.push(TextFragment {
@@ -2853,40 +2896,95 @@ fn record_line_group(
     }
 }
 
+/// Outcome of [`append_bounded`]: whether the run was appended, and — when it
+/// was — the separator actually applied. The applied separator can differ
+/// from the one the caller requested when hyphen-wrap fusion (issue #486)
+/// consumes a trailing `-` instead of inserting the requested `\n`; callers
+/// that feed the separator into reading-order line grouping (`record_line_group`)
+/// must use `applied_separator`, not the separator they originally computed,
+/// so a fused run correctly extends its line group instead of opening a new one.
+struct AppendOutcome {
+    appended: bool,
+    applied_separator: Option<char>,
+}
+
 /// Append an optional `separator` plus `decoded` to `acc`, honouring the
-/// per-page byte budget `limit` (issue #382).
+/// per-page byte budget `limit` (issue #382), with optional hyphen-wrap
+/// fusion (issue #486).
 ///
-/// Returns `true` when the run was appended. Returns `false` — appending
-/// nothing and setting `*truncated` — when the combined bytes would exceed
-/// `limit`. The separator is counted against the budget so the invariant
-/// `acc.len() <= limit` holds *exactly*, and because whole runs are the unit of
-/// truncation a multi-byte UTF-8 character is never split (undershoot
-/// semantics). A `None` limit always appends and never truncates, keeping the
-/// no-limit path byte-identical to before. Once `*truncated` is set the helper
-/// is a no-op, so a caller that keeps calling it after the budget is reached
-/// simply accumulates nothing further.
+/// Returns [`AppendOutcome`] with `appended: true` when the run was appended.
+/// Returns `appended: false` — appending nothing and setting `*truncated` —
+/// when the combined bytes would exceed `limit`. The separator is counted
+/// against the budget so the invariant `acc.len() <= limit` holds *exactly*,
+/// and because whole runs are the unit of truncation a multi-byte UTF-8
+/// character is never split (undershoot semantics). A `None` limit always
+/// appends and never truncates, keeping the no-limit path byte-identical to
+/// before. Once `*truncated` is set the helper is a no-op, so a caller that
+/// keeps calling it after the budget is reached simply accumulates nothing
+/// further.
+///
+/// When `merge_hyphenated` is set and the caller requests a `'\n'` separator
+/// (a genuine line wrap) while `acc` already ends with `-`, the hyphen is
+/// producer noise from a hyphenated word/number wrapping across two lines,
+/// not a real word boundary (issue #486: `merge_hyphenated` had no effect on
+/// this flat/default extraction path, unlike `preserve_layout`'s
+/// `reconstruct_text_from_fragments` and `reconstruct_paragraphs`'s
+/// `merge_into_paragraphs`, both of which already apply this same rule). The
+/// trailing hyphen is popped and `decoded` is appended directly with no
+/// separator, fusing the wrapped token into one word instead of splitting it
+/// on a newline — e.g. `"...3016-"` + `"0900"` becomes `"...30160900"`
+/// instead of `"...3016-\n0900"`. `separator` is only ever `'\n'` here when
+/// `acc` is already non-empty (every call site gates on that), so the pop is
+/// always into at least one existing byte.
 fn append_bounded(
     acc: &mut String,
     separator: Option<char>,
     decoded: &str,
     limit: Option<usize>,
     truncated: &mut bool,
-) -> bool {
+    merge_hyphenated: bool,
+) -> AppendOutcome {
     if *truncated {
-        return false;
+        return AppendOutcome {
+            appended: false,
+            applied_separator: None,
+        };
     }
+
+    let hyphen_fusion = merge_hyphenated && separator == Some('\n') && acc.ends_with('-');
+    let separator = if hyphen_fusion { None } else { separator };
+
     if let Some(max) = limit {
+        // Popping the hyphen frees one byte before the new run is added, so
+        // account against the post-pop length — otherwise a run that fits
+        // once the hyphen is dropped could be wrongly rejected as
+        // over-budget by one byte.
+        let base_len = if hyphen_fusion {
+            acc.len() - 1
+        } else {
+            acc.len()
+        };
         let add = separator.map_or(0, char::len_utf8) + decoded.len();
-        if acc.len() + add > max {
+        if base_len + add > max {
             *truncated = true;
-            return false;
+            return AppendOutcome {
+                appended: false,
+                applied_separator: None,
+            };
         }
+    }
+
+    if hyphen_fusion {
+        acc.pop();
     }
     if let Some(sep) = separator {
         acc.push(sep);
     }
     acc.push_str(decoded);
-    true
+    AppendOutcome {
+        appended: true,
+        applied_separator: separator,
+    }
 }
 
 /// Defensive final clamp of a page's text to the byte budget (issue #382).
@@ -3667,8 +3765,8 @@ mod tests {
     fn test_append_bounded_no_limit_always_appends() {
         let mut s = String::new();
         let mut trunc = false;
-        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc));
-        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc));
+        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc, true).appended);
+        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc, true).appended);
         assert_eq!(s, "hello world");
         assert!(!trunc, "no limit never truncates");
     }
@@ -3678,19 +3776,13 @@ mod tests {
         // "abcd" (4) is at budget 5; a Some('\n') + "x" would need 2 more → over.
         let mut s = String::from("abcd");
         let mut trunc = false;
-        assert!(!append_bounded(
-            &mut s,
-            Some('\n'),
-            "x",
-            Some(5),
-            &mut trunc
-        ));
+        assert!(!append_bounded(&mut s, Some('\n'), "x", Some(5), &mut trunc, true).appended);
         assert_eq!(s, "abcd", "nothing appended when it would overshoot");
         assert!(trunc, "budget hit sets truncated");
         // Exactly-fits case: "e" alone (1 byte, no separator) reaches 5.
         let mut s2 = String::from("abcd");
         let mut t2 = false;
-        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2));
+        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2, true).appended);
         assert_eq!(s2, "abcde");
         assert!(!t2);
         assert!(s2.len() <= 5, "invariant: len <= limit exactly");
@@ -3700,7 +3792,7 @@ mod tests {
     fn test_append_bounded_zero_limit_truncates_immediately() {
         let mut s = String::new();
         let mut trunc = false;
-        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc));
+        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc, true).appended);
         assert!(s.is_empty());
         assert!(trunc);
     }
@@ -3709,14 +3801,82 @@ mod tests {
     fn test_append_bounded_is_noop_once_truncated() {
         let mut s = String::from("kept");
         let mut trunc = true; // already truncated
-        assert!(!append_bounded(
-            &mut s,
-            None,
-            "more",
-            Some(1_000),
-            &mut trunc
-        ));
+        assert!(!append_bounded(&mut s, None, "more", Some(1_000), &mut trunc, true).appended);
         assert_eq!(s, "kept", "no further accumulation after truncation");
+    }
+
+    // ── issue #486: flat-path hyphen-wrap fusion ─────────────────────────────
+
+    #[test]
+    fn test_append_bounded_fuses_hyphen_wrap_when_enabled() {
+        // Real-world shape: a hyphen-wrapped phone number split across two
+        // lines, e.g. "...3016-" / "0900" must reconstruct as "...30160900".
+        let mut s = String::from("+55 11 3016-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "0900", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(
+            outcome.applied_separator, None,
+            "hyphen fusion applies no separator, not the requested '\\n'"
+        );
+        assert_eq!(s, "+55 11 30160900", "hyphen popped, halves fused");
+    }
+
+    #[test]
+    fn test_append_bounded_no_fusion_without_a_trailing_hyphen() {
+        let mut s = String::from("hello world");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "next line", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(
+            outcome.applied_separator,
+            Some('\n'),
+            "no trailing hyphen: requested separator applies unchanged"
+        );
+        assert_eq!(s, "hello world\nnext line");
+    }
+
+    #[test]
+    fn test_append_bounded_does_not_fuse_when_merge_hyphenated_disabled() {
+        let mut s = String::from("rating-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "aa-exp-sf", None, &mut trunc, false);
+        assert!(outcome.appended);
+        assert_eq!(outcome.applied_separator, Some('\n'));
+        assert_eq!(s, "rating-\naa-exp-sf", "no fusion: split as requested");
+    }
+
+    #[test]
+    fn test_append_bounded_does_not_fuse_a_space_separator() {
+        // Only a requested '\n' is a wrap candidate; a same-line space must
+        // never trigger hyphen fusion even if the accumulator ends in '-'.
+        let mut s = String::from("well-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some(' '), "known", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(outcome.applied_separator, Some(' '));
+        assert_eq!(s, "well- known");
+    }
+
+    #[test]
+    fn test_append_bounded_hyphen_fusion_respects_budget() {
+        // "rating-" (7 bytes, trailing hyphen) minus the popped hyphen (6)
+        // plus fused "aa-exp" (6 bytes, no separator) = 12.
+        // Budget 12 must fit; budget 11 must not (would need to drop the
+        // hyphen-adjusted run, not silently truncate mid-word).
+        let mut s = String::from("rating-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "aa-exp", Some(12), &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(s, "ratingaa-exp");
+        assert!(!trunc);
+
+        let mut s2 = String::from("rating-");
+        let mut trunc2 = false;
+        let outcome2 = append_bounded(&mut s2, Some('\n'), "aa-exp", Some(11), &mut trunc2, true);
+        assert!(!outcome2.appended);
+        assert_eq!(s2, "rating-", "nothing appended when over budget");
+        assert!(trunc2);
     }
 
     #[test]

--- a/oxidize-pdf-core/tests/issue_486_flat_hyphen_merge_test.rs
+++ b/oxidize-pdf-core/tests/issue_486_flat_hyphen_merge_test.rs
@@ -1,0 +1,202 @@
+//! Regression tests for issue #486.
+//!
+//! `merge_hyphenated` (default `true` on `ExtractionOptions`) is documented
+//! as "merge hyphenated words at line ends," but it was only wired into
+//! `reconstruct_text_from_fragments` (`preserve_layout: true`) and
+//! `merge_into_paragraphs` (`reconstruct_paragraphs: true`). The flat
+//! (default) path -- every text-showing operator (`Tj`, `TJ`, `'`, `"`)
+//! independently deciding a `'\n'` separator via the shared `append_bounded`
+//! helper -- had no such logic: a hyphen-wrapped word or number split across
+//! two lines extracted with a raw `\n` in place of the hyphen instead of
+//! being joined.
+//!
+//! Fix: `append_bounded` now pops a trailing `-` and fuses the next run with
+//! no separator when the caller requested `'\n'` (a genuine line wrap) and
+//! `merge_hyphenated` is enabled.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false, merge_hyphenated = true
+    // (the flat path, previously unaffected by merge_hyphenated).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+fn extract_flat_with_options(content: &str, options: ExtractionOptions) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(options);
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_hyphenated_line_wrap_merges_on_the_flat_path() {
+    // Real-world shape: a phone number's "3016-" wraps to "0900" on the next
+    // line, drawn as two separate Tj (ShowText) calls.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(+55 11 3016-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(0900) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("+55 11 30160900"),
+        "hyphen-wrapped number must fuse into one token on the flat path, got: {text:?}"
+    );
+    assert!(
+        !text.contains("3016-\n0900") && !text.contains("3016-0900"),
+        "the hyphen must be dropped, not kept alongside a newline or as-is: {text:?}"
+    );
+}
+
+#[test]
+fn tj_array_hyphenated_line_wrap_merges_on_the_flat_path() {
+    // Same wrap, drawn with the TJ (ShowTextArray) operator instead of Tj.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n[(+55 11 3016-)] TJ\n",
+        "1 0 0 1 100 688 Tm\n[(0900)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("+55 11 30160900"),
+        "TJ path must also fuse the hyphen-wrapped number, got: {text:?}"
+    );
+}
+
+#[test]
+fn quote_operator_hyphenated_line_wrap_merges() {
+    // The `'` operator (T* then Tj) always starts a new line by definition;
+    // a hyphen at the end of one `'`-drawn line must still merge with the
+    // next `'`-drawn line's text.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n10 TL\n",
+        "1 0 0 1 100 700 Tm\n(docu-) '\n",
+        "(ment) '\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("document"),
+        "the `'` operator's hyphenated wrap must merge, got: {text:?}"
+    );
+    assert!(!text.contains("docu-\nment"), "got: {text:?}");
+}
+
+#[test]
+fn double_quote_operator_hyphenated_line_wrap_merges() {
+    // The `"` operator (set spacing, then ' semantics) must behave the same
+    // way as plain `'`.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n10 TL\n",
+        "1 0 0 1 100 700 Tm\n(docu-) '\n",
+        "0 0 (ment) \"\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("document"),
+        "the `\"` operator's hyphenated wrap must merge, got: {text:?}"
+    );
+}
+
+#[test]
+fn same_line_hyphen_is_not_merged_across_an_unrelated_boundary() {
+    // "well-" and "known" are two Tj calls on the SAME line (small forward
+    // dx, well under the newline threshold) -- this is a real same-line
+    // hyphenated word, not a line wrap, and must be left as ordinary text
+    // (either glued as-is by the small-gap rule or space-separated), never
+    // treated as a wrap-merge candidate. This only actually exercises the
+    // fusion gate at all if a '\n' separator is produced, which it should
+    // not be here.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(well-) Tj\n",
+        "1 0 0 1 140 700 Tm\n(known fact) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "same-line pieces must not gain a newline at all: {text:?}"
+    );
+    assert!(
+        text.contains("well-known") || text.contains("well- known"),
+        "same-line hyphen must be preserved as ordinary text: {text:?}"
+    );
+}
+
+#[test]
+fn merge_hyphenated_false_disables_flat_path_fusion() {
+    // Opting out of merge_hyphenated must restore the pre-#486 behavior: the
+    // hyphen and the newline both survive, split across two lines.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(+55 11 3016-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(0900) Tj\nET"
+    );
+    let text = extract_flat_with_options(
+        content,
+        ExtractionOptions {
+            merge_hyphenated: false,
+            ..Default::default()
+        },
+    );
+    assert!(
+        text.contains("3016-\n0900"),
+        "merge_hyphenated: false must keep the pre-fix split behavior, got: {text:?}"
+    );
+}


### PR DESCRIPTION
Addresses #486.

## Summary

`merge_hyphenated` (default `true`) was only wired into `reconstruct_text_from_fragments` (`preserve_layout: true`) and `merge_into_paragraphs` (`reconstruct_paragraphs: true`). The flat (default) path never attempted the merge at all: every text-showing operator handler (`Tj`, `TJ`, `'`, `"`) independently decided a `'\n'` separator and passed it to the shared `append_bounded` helper, which appended it unconditionally with no hyphen check.

This implements the approach proposed in #486:

- `append_bounded` now returns an `AppendOutcome { appended, applied_separator }` instead of a bare `bool`, and takes a new `merge_hyphenated: bool` parameter. When the caller requests `Some('\n')`, `merge_hyphenated` is enabled, and the accumulator currently ends with `-`, it pops the hyphen and appends the next run with **no** separator instead of `\n` (with the freed byte accounted for in the length budget).
- All six call sites (`Tj`/`ShowText`, `TJ`-array line-boundary, `TJ`-array kerning-space, `'` `NextLineShowText`, `"` `SetSpacingNextLineShowText`, `ActualText`-scope flush) now use `outcome.applied_separator` — the separator actually applied, not the one originally requested — when feeding `emitted_sep`/`record_line_group`. This matters because a hyphen-merged run must extend its existing reading-order line group (#448) rather than opening a new one.

## Example

```rust
let mut extractor = TextExtractor::new(); // preserve_layout: false, merge_hyphenated: true (default)
let text = extractor.extract_from_page(&document, 0)?.text;
// Content stream draws "3016-" via one Tj, wraps to "0900" via the next Tj.
assert_eq\!(text, "30160900"); // now correct; was "3016-\n0900"
```

## Validation

- `cargo fmt -p oxidize-pdf -- --check`
- `cargo clippy -p oxidize-pdf --lib -- -D warnings`
- `cargo test -p oxidize-pdf --lib` (6,690 passed)
- New regression test (`issue_486_flat_hyphen_merge_test.rs`, 6 tests): `Tj` wrap-merge, `TJ` wrap-merge, `'` operator wrap-merge, `"` operator wrap-merge, same-line-hyphen negative case (must not merge), and `merge_hyphenated: false` opt-out
- Updated/added unit tests directly on `append_bounded` (10 tests covering the new return type and fusion logic)
- 39 related integration test files re-run clean, including all reading-order/line-grouping tests (#265, #448, #417, #403, #422, #458) most likely to interact with the `emitted_sep` change
- Verified against a real-world document referenced in #486: a phone number split across a hyphenated line wrap now extracts as one intact token instead of being split by a stray `\n`

## Note on scope vs. #485

This branch is based on `develop` and does not include #485 (the #482 fix for `preserve_layout`'s Y-sort interleaving). The two are independent — #485 only affects `preserve_layout`/`reorder_columns`, this only affects the flat path — but let me know if you'd like them combined before merging either.
