### PR TITLE
fix(text): preserve structural regions during layout sorting (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   annotation's appearance text) happened to sit at a Y-coordinate between the
   two halves of a hyphen-wrapped word elsewhere on the page, the sort spliced
   it in between them, and the hyphen got joined to the wrong fragment —
-  corrupting both the wrapped word and the unrelated text at once. This case is
-  mitigated by
-  fusing a hyphen-ended fragment with its wrap continuation while fragments
-  are still in emission (content-stream) order, before the Y-sort runs, so
-  the wrapped token becomes a single atomic fragment nothing can be spliced
-  into afterward. Structural region-aware ordering remains follow-up work.
+  corrupting both the wrapped word and the unrelated text at once. The initial
+  mitigation fused hyphen-wrapped continuations before sorting. Positional
+  sorting is now also scoped to structural emission regions: geometric flow
+  restarts separate untagged regions, while MCID ownership separates tagged
+  regions. Independent body, overlay, annotation, and appearance flows can no
+  longer be interleaved merely because their Y ranges overlap.
 
 - **`merge_hyphenated` had no effect on the flat (default) extraction path**
   (#486). It was only wired into `reconstruct_text_from_fragments`

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2208,11 +2208,26 @@ impl TextExtractor {
         // font size, not the paragraph-break `newline_threshold`), and order each
         // line left-to-right by X. Ties broken by original index keep it stable.
         let n = fragments.len();
+        // Preserve independent emission regions before applying positional
+        // ordering. A Y-up-jump means the producer finished one top-to-bottom
+        // flow and started another (a new column, overlay, annotation
+        // appearance, etc.). Sorting the whole page by Y discarded that
+        // boundary and could splice the second flow into the first (#482).
+        // `assign_row_ids` already provides this segmentation for paragraph
+        // reconstruction; use the same source-order signal here so every
+        // fragment reconstruction path agrees on region boundaries.
+        let region_ids = assign_layout_region_ids(fragments);
         let mut order: Vec<usize> = (0..n).collect();
-        order.sort_by(|&i, &j| fragments[j].y.total_cmp(&fragments[i].y).then(i.cmp(&j)));
+        order.sort_by(|&i, &j| {
+            region_ids[i]
+                .cmp(&region_ids[j])
+                .then(fragments[j].y.total_cmp(&fragments[i].y))
+                .then(i.cmp(&j))
+        });
 
         let mut line_start = 0usize;
         while line_start < n {
+            let head_region = region_ids[order[line_start]];
             let head_y = fragments[order[line_start]].y;
             let head_h = fragments[order[line_start]].height;
             let mut line_end = line_start + 1;
@@ -2222,7 +2237,7 @@ impl TextExtractor {
                 // Negated `< tol` (not `>= tol`) so a non-finite Y from a
                 // degenerate text matrix forces a line break instead of a
                 // NaN comparison silently swallowing every remaining fragment.
-                if !((head_y - frag.y).abs() < tol) {
+                if region_ids[order[line_end]] != head_region || !((head_y - frag.y).abs() < tol) {
                     break;
                 }
                 line_end += 1;
@@ -3657,6 +3672,31 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
         "assign_row_ids: output length must equal input length"
     );
     result
+}
+
+/// Assign stable layout-region ids in content-stream emission order.
+///
+/// A region ends when the geometric flow restarts (`assign_row_ids`) or when
+/// marked-content ownership changes. The former covers untagged columns and
+/// overlays; the latter preserves author-supplied logical structure even when
+/// two regions occupy overlapping Y ranges (#482).
+fn assign_layout_region_ids(fragments: &[TextFragment]) -> Vec<u32> {
+    let row_ids = assign_row_ids(fragments);
+    let mut regions = Vec::with_capacity(fragments.len());
+    let mut region = 0u32;
+
+    for i in 0..fragments.len() {
+        if i > 0 {
+            let row_changed = row_ids[i] != row_ids[i - 1];
+            let mcid_changed = fragments[i].mcid != fragments[i - 1].mcid
+                && (fragments[i].mcid.is_some() || fragments[i - 1].mcid.is_some());
+            if row_changed || mcid_changed {
+                region = region.saturating_add(1);
+            }
+        }
+        regions.push(region);
+    }
+    regions
 }
 
 /// Decide whether a single visual line should be read in emission order.
@@ -5428,5 +5468,50 @@ mod tests {
             "NaN-Y fragment must stay its own line; the finite lines keep \
              top-to-bottom reading order instead of collapsing to X order"
         );
+    }
+
+    #[test]
+    fn sort_and_merge_fragments_keeps_emission_regions_atomic() {
+        let extractor = TextExtractor::with_options(ExtractionOptions::default());
+
+        // Region 0 is a normal top-to-bottom footer. Region 1 is an overlay
+        // emitted later: its first line jumps back up the page, while its
+        // second line falls numerically between the footer's two lines. A
+        // page-wide Y-sort would produce body-1, overlay-1, overlay-2, body-2.
+        let mut fragments = vec![
+            tf("body-1", 50.0, 45.0, 40.0, 10.0),
+            tf("body-2", 50.0, 30.0, 40.0, 10.0),
+            tf("overlay-1", 250.0, 50.0, 60.0, 10.0),
+            tf("overlay-2", 250.0, 35.0, 60.0, 10.0),
+        ];
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["body-1", "body-2", "overlay-1", "overlay-2"],
+            "positional sorting must not interleave independent emission regions"
+        );
+    }
+
+    #[test]
+    fn sort_and_merge_fragments_uses_mcid_as_a_region_boundary() {
+        let extractor = TextExtractor::with_options(ExtractionOptions::default());
+        let mut fragments = vec![
+            tf("body-1", 50.0, 45.0, 40.0, 10.0),
+            tf("body-2", 50.0, 30.0, 40.0, 10.0),
+            // The small Y increase is below assign_row_ids' reset threshold;
+            // MCID ownership must still keep this overlay independent.
+            tf("overlay", 250.0, 33.0, 60.0, 10.0),
+        ];
+        fragments[0].mcid = Some(7);
+        fragments[1].mcid = Some(7);
+        fragments[2].mcid = Some(8);
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(order, vec!["body-1", "body-2", "overlay"]);
     }
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1085,7 +1085,7 @@ impl TextExtractor {
             // this way for `reconstruct_paragraphs`), so it is safe to run here
             // on unsorted emission order.
             if !fragments.is_empty() {
-                fragments = self.merge_close_fragments(&fragments);
+                fragments = self.merge_close_fragments_in_layout_regions(&fragments);
                 fragments = self.merge_hyphenated_line_wraps_in_emission_order(fragments);
             }
 
@@ -2256,19 +2256,21 @@ impl TextExtractor {
             return fragments;
         }
 
-        let mut result: Vec<TextFragment> = Vec::with_capacity(fragments.len());
-        for fragment in fragments {
+        let region_ids = assign_layout_region_ids(&fragments);
+        let mut result: Vec<(u32, TextFragment)> = Vec::with_capacity(fragments.len());
+        for (region_id, fragment) in region_ids.into_iter().zip(fragments) {
             let should_merge = result
                 .last()
-                .map(|prev: &TextFragment| {
-                    prev.text.ends_with('-')
+                .map(|(prev_region, prev)| {
+                    *prev_region == region_id
+                        && prev.text.ends_with('-')
                         && is_line_wrap_geometry(prev, &fragment, self.options.newline_threshold)
                 })
                 .unwrap_or(false);
 
             if should_merge {
                 // Safe: just checked `result.last()` is `Some` above.
-                let prev = result.last_mut().expect("checked non-empty above");
+                let (_, prev) = result.last_mut().expect("checked non-empty above");
                 prev.text.pop(); // drop the trailing hyphen
                 prev.text.push_str(&fragment.text);
                 // Extend the fused fragment's box to cover both lines so
@@ -2284,10 +2286,33 @@ impl TextExtractor {
                 prev.y = y_min;
                 prev.height = y_max - y_min;
             } else {
-                result.push(fragment);
+                result.push((region_id, fragment));
             }
         }
-        result
+        result.into_iter().map(|(_, fragment)| fragment).collect()
+    }
+
+    /// Apply the kerning merge independently inside each layout region.
+    /// Keeping this pre-sort pass region-scoped prevents two adjacent emission
+    /// runs from different marked-content/overlay flows being fused before the
+    /// ordering stage gets a chance to preserve their boundary (#482).
+    fn merge_close_fragments_in_layout_regions(
+        &self,
+        fragments: &[TextFragment],
+    ) -> Vec<TextFragment> {
+        let region_ids = assign_layout_region_ids(fragments);
+        let mut merged = Vec::with_capacity(fragments.len());
+        let mut start = 0usize;
+        while start < fragments.len() {
+            let region = region_ids[start];
+            let mut end = start + 1;
+            while end < fragments.len() && region_ids[end] == region {
+                end += 1;
+            }
+            merged.extend(self.merge_close_fragments(&fragments[start..end]));
+            start = end;
+        }
+        merged
     }
 
     /// Sort text fragments by position and merge them appropriately
@@ -2363,12 +2388,13 @@ impl TextExtractor {
         if self.options.detect_columns
             || (self.options.reorder_columns && !self.options.preserve_layout)
         {
-            self.detect_and_sort_columns(fragments);
+            let sorted_region_ids: Vec<u32> = order.iter().map(|&i| region_ids[i]).collect();
+            self.detect_and_sort_columns(fragments, &sorted_region_ids);
         }
     }
 
     /// Detect columns and re-sort fragments accordingly
-    fn detect_and_sort_columns(&self, fragments: &mut [TextFragment]) {
+    fn detect_and_sort_columns(&self, fragments: &mut [TextFragment], region_ids: &[u32]) {
         // `fragments` arrives pre-sorted by `sort_and_merge_fragments` in reading
         // order: top-to-bottom by Y band, left-to-right by X within a band.
         //
@@ -2401,7 +2427,9 @@ impl TextExtractor {
                 // Negated `< tol` (not `>= tol`) so a non-finite Y from a
                 // degenerate text matrix forces a line break rather than swallowing
                 // the whole page into one line.
-                if !((head_y - fragment.y).abs() < tol) {
+                if region_ids[i] != region_ids[current_line[0]]
+                    || !((head_y - fragment.y).abs() < tol)
+                {
                     lines.push(std::mem::take(&mut current_line));
                 }
             }
@@ -2490,7 +2518,8 @@ impl TextExtractor {
                 .copied()
                 .filter(|&p| boundaries.iter().any(|&c| (p - c).abs() < COLUMN_ALIGN_TOL))
                 .collect();
-            if li > 0 && columnar && prev_columnar && row_spaced && !shared.is_empty() {
+            let same_region = li > 0 && region_ids[line[0]] == region_ids[lines[li - 1][0]];
+            if same_region && columnar && prev_columnar && row_spaced && !shared.is_empty() {
                 // Line joins the current block; tighten the anchor to the
                 // corridors that persist, so a boundary must recur consistently
                 // across the whole block to survive.
@@ -3785,16 +3814,24 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
 /// overlays; the latter preserves author-supplied logical structure even when
 /// two regions occupy overlapping Y ranges (#482).
 fn assign_layout_region_ids(fragments: &[TextFragment]) -> Vec<u32> {
-    let row_ids = assign_row_ids(fragments);
     let mut regions = Vec::with_capacity(fragments.len());
     let mut region = 0u32;
 
     for i in 0..fragments.len() {
         if i > 0 {
-            let row_changed = row_ids[i] != row_ids[i - 1];
+            let prev = &fragments[i - 1];
+            let current = &fragments[i];
+            // A new flow may restart only a few points above the preceding
+            // baseline (the real #482 footer/annotation gap is ~2pt), well
+            // below assign_row_ids' superscript-friendly 0.5em threshold.
+            // For layout ordering the relevant boundary is the same visual-line
+            // tolerance used by sorting: an upward move beyond 0.2 line height
+            // starts a new monotonic emission region.
+            let line_tol = prev.height.min(current.height) * 0.2;
+            let flow_restarted = current.y - prev.y > line_tol;
             let mcid_changed = fragments[i].mcid != fragments[i - 1].mcid
                 && (fragments[i].mcid.is_some() || fragments[i - 1].mcid.is_some());
-            if row_changed || mcid_changed {
+            if flow_restarted || mcid_changed {
                 region = region.saturating_add(1);
             }
         }
@@ -5617,5 +5654,31 @@ mod tests {
 
         let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
         assert_eq!(order, vec!["body-1", "body-2", "overlay"]);
+    }
+
+    #[test]
+    fn column_detection_does_not_join_independent_layout_regions() {
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            detect_columns: true,
+            ..Default::default()
+        });
+        let mut fragments = vec![
+            tf("a1", 0.0, 100.0, 10.0, 10.0),
+            tf("b1", 100.0, 100.0, 10.0, 10.0),
+            tf("a2", 0.0, 80.0, 10.0, 10.0),
+            tf("b2", 100.0, 80.0, 10.0, 10.0),
+            // A later overlay repeats the same column corridor and overlaps
+            // the first region's Y span. Column detection must not combine
+            // both into one column-major block.
+            tf("c1", 0.0, 103.0, 10.0, 10.0),
+            tf("d1", 100.0, 103.0, 10.0, 10.0),
+            tf("c2", 0.0, 83.0, 10.0, 10.0),
+            tf("d2", 100.0, 83.0, 10.0, 10.0),
+        ];
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(order, vec!["a1", "a2", "b1", "b2", "c1", "c2", "d1", "d2"]);
     }
 }

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -73,6 +73,26 @@ fn extract_preserve_layout(content: &str) -> String {
         .text
 }
 
+fn extract_preserve_layout_fragment_texts(content: &str) -> Vec<String> {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .fragments
+        .into_iter()
+        .map(|fragment| fragment.text)
+        .collect()
+}
+
 #[test]
 fn hyphenated_wrap_survives_an_unrelated_fragment_sorted_between_its_two_lines() {
     // Mirrors the real-world document that motivated #482: a phone-number-like
@@ -140,5 +160,47 @@ fn same_line_hyphen_is_not_treated_as_a_wrap() {
     assert!(
         text.contains("well-known") || text.contains("well- known"),
         "a same-line hyphen must not be silently dropped or merged incorrectly, got: {text:?}"
+    );
+}
+
+#[test]
+fn non_hyphenated_overlay_does_not_interleave_with_an_earlier_flow() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        // First emission region: two body/footer lines.
+        "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
+        "1 0 0 1 100 30 Tm\n(Body second) Tj\n",
+        // Second region restarts above the first and overlaps its Y range.
+        "1 0 0 1 300 50 Tm\n(Overlay first) Tj\n",
+        "1 0 0 1 300 35 Tm\n(Overlay second) Tj\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec![
+            "Body first",
+            "Body second",
+            "Overlay first",
+            "Overlay second"
+        ]
+    );
+}
+
+#[test]
+fn marked_content_regions_do_not_interleave_when_y_ranges_overlap() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "/P <</MCID 7>> BDC\n",
+        "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
+        "1 0 0 1 100 30 Tm\n(Body second) Tj\nEMC\n",
+        // The 3pt upward move is deliberately below the geometric reset
+        // threshold; the MCID transition is the structural boundary.
+        "/Span <</MCID 8>> BDC\n",
+        "1 0 0 1 300 33 Tm\n(Tagged overlay) Tj\nEMC\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec!["Body first", "Body second", "Tagged overlay"]
     );
 }

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -170,9 +170,10 @@ fn non_hyphenated_overlay_does_not_interleave_with_an_earlier_flow() {
         // First emission region: two body/footer lines.
         "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
         "1 0 0 1 100 30 Tm\n(Body second) Tj\n",
-        // Second region restarts above the first and overlaps its Y range.
-        "1 0 0 1 300 50 Tm\n(Overlay first) Tj\n",
-        "1 0 0 1 300 35 Tm\n(Overlay second) Tj\nET"
+        // Second region restarts only 3pt above the preceding baseline: below
+        // the old 0.5em reset threshold, but outside the visual-line tolerance.
+        "1 0 0 1 300 33 Tm\n(Overlay first) Tj\n",
+        "1 0 0 1 300 18 Tm\n(Overlay second) Tj\nET"
     );
 
     assert_eq!(
@@ -202,5 +203,22 @@ fn marked_content_regions_do_not_interleave_when_y_ranges_overlap() {
     assert_eq!(
         extract_preserve_layout_fragment_texts(content),
         vec!["Body first", "Body second", "Tagged overlay"]
+    );
+}
+
+#[test]
+fn hyphen_prefusion_does_not_cross_an_mcid_region_boundary() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "/P <</MCID 7>> BDC\n",
+        "1 0 0 1 100 45 Tm\n(Body-) Tj\nEMC\n",
+        "/Span <</MCID 8>> BDC\n",
+        "1 0 0 1 300 30 Tm\n(Unrelated overlay) Tj\nEMC\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec!["Body-", "Unrelated overlay"],
+        "the pre-sort hyphen mitigation must not fuse distinct MCID regions"
     );
 }


### PR DESCRIPTION
Closes #482.

## Summary

#485 mitigated the hyphen-specific corruption, but the layout path still needed to prevent unrelated content flows with overlapping Y ranges from being interleaved.

This PR makes layout ordering region-aware across the complete reconstruction pipeline:

- Assigns stable emission regions before positional sorting.
- Uses MCID transitions as explicit structural boundaries.
- Uses visual-line-scale Y restarts for untagged PDFs, including the ~2–3pt class from the real #482 report.
- Applies close-fragment and hyphen pre-merges independently inside each region.
- Sorts Y/X only within a region and prevents same-line grouping across boundaries.
- Carries the region boundary into column detection so aligned corridors from independent flows cannot be combined.
- Keeps the public TextFragment and ExtractionOptions APIs unchanged.

## Regression coverage

The #482 suite now covers six end-to-end cases:

- original hyphen corruption;
- ordinary hyphenated wrapping;
- same-line hyphens;
- non-hyphenated untagged overlay with a small Y restart;
- overlapping MCID regions;
- a hyphen immediately before an MCID boundary.

Unit coverage also verifies that column detection cannot recombine two independent regions with aligned column corridors.

## Validation

- cargo fmt -p oxidize-pdf -- --check
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- cargo test -p oxidize-pdf --lib: 6,693 passed, 3 ignored
- issue_482_preserve_layout_interleave_test: 6 passed
- issue #389/#403/#408/#417/#422 column suites plus paragraph reconstruction: 25 passed
- Quality Review completed
- Kripteia focused test-quality score: 93/100
- Kripteia security: no issues found