### PR TITLE
feat(tagging): support ActualText marked content

### DIFF
--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -2029,6 +2029,39 @@ impl Page {
         Ok(mcid)
     }
 
+    /// Begins a marked content sequence with an `/ActualText` replacement.
+    ///
+    /// `/ActualText` supplies the logical text used by copy/paste, search,
+    /// accessibility tools, and text extraction while the enclosed drawing
+    /// operators retain their visual representation. The value is serialized
+    /// as UTF-16BE with a byte-order mark so every Unicode scalar is preserved.
+    ///
+    /// The returned MCID can be attached to a structure element in the same way
+    /// as the value returned by [`Page::begin_marked_content`]. This makes the
+    /// method useful both for lightweight semantic spans and for fully tagged
+    /// documents.
+    pub fn begin_marked_content_with_actual_text(
+        &mut self,
+        tag: &str,
+        actual_text: &str,
+    ) -> Result<u32> {
+        let mcid = self.next_mcid;
+        self.next_mcid += 1;
+
+        let utf16be_hex: String = actual_text
+            .encode_utf16()
+            .map(|unit| format!("{unit:04X}"))
+            .collect();
+        let bdc_op = format!(
+            "/{} <</MCID {} /ActualText <FEFF{}>>> BDC\n",
+            tag, mcid, utf16be_hex
+        );
+        self.text_context.append_raw_operation(&bdc_op);
+        self.marked_content_stack.push(tag.to_string());
+
+        Ok(mcid)
+    }
+
     /// Ends the current marked content sequence
     ///
     /// This adds an EMC (End Marked Content) operator to close the most recently

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1991,7 +1991,8 @@ impl TextExtractor {
 
                 ContentOperation::EndMarkedContent => {
                     let popped_depth = state.mc_stack.len();
-                    if state.mc_stack.pop().is_none() {
+                    let closed_entry = state.mc_stack.pop();
+                    if closed_entry.is_none() {
                         // Unbalanced EMC — log and ignore. Real PDFs occasionally emit
                         // dangling EMC (e.g. from incremental updates). We must not panic.
                         tracing::debug!(
@@ -2005,8 +2006,14 @@ impl TextExtractor {
                             if run.populated
                                 && (self.options.preserve_layout || self.options.reorder_columns)
                             {
-                                let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
-                                let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
+                                // The ActualText owner has just been popped, so
+                                // retain its structural identity explicitly
+                                // instead of accidentally inheriting the parent.
+                                let closed_entry = closed_entry.as_ref().unwrap();
+                                let mcid = closed_entry.mcid;
+                                let struct_tag = Some(closed_entry.tag.clone());
+                                let in_artifact = closed_entry.is_artifact
+                                    || state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
                                     // Per-page byte budget (issue #382): the
                                     // `/ActualText` override is this scope's

--- a/oxidize-pdf-core/tests/marked_content_roundtrip_test.rs
+++ b/oxidize-pdf-core/tests/marked_content_roundtrip_test.rs
@@ -119,3 +119,43 @@ fn writer_to_extractor_keeps_overlaid_mcid_blocks_distinct() {
         "World must carry struct_tag 'P'"
     );
 }
+
+#[test]
+fn writer_actual_text_roundtrips_unicode_and_replaces_visual_glyphs() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content_with_actual_text("Span", "^{40} € 😀")
+        .expect("begin ActualText span");
+    page.text()
+        .set_font(Font::Helvetica, 9.0)
+        .at(100.0, 705.0)
+        .write("40")
+        .expect("write visual superscript glyphs");
+    page.end_marked_content().expect("end ActualText span");
+
+    let mut doc = Document::new();
+    doc.add_page(page);
+    let bytes = doc.to_bytes().expect("serialize PDF");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("read generated PDF");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    let page = extractor
+        .extract_from_page(&document, 0)
+        .expect("extract generated page");
+
+    assert_eq!(mcid, 0);
+    assert!(
+        page.fragments
+            .iter()
+            .any(|fragment| fragment.text == "^{40} € 😀" && fragment.mcid == Some(mcid)),
+        "ActualText must replace the visual glyphs and retain its MCID: {:?}",
+        page.fragments
+    );
+    assert!(
+        page.fragments.iter().all(|fragment| fragment.text != "40"),
+        "visual glyphs must not leak into logical extraction"
+    );
+}


### PR DESCRIPTION
## Summary

- add a writer API for marked-content spans with Unicode `/ActualText`
- preserve the owning MCID and structure tag when extracting `/ActualText`
- add writer-to-extractor Unicode roundtrip coverage

## Validation

- pre-commit checks passed
- 6,690 library tests passed; 3 ignored; 0 failed
- focused marked-content and extraction tests passed
- Kripteia quality score: 94

## Follow-up review notes

- share/strengthen marked-content tag validation
- optimize UTF-16 hex serialization to avoid per-unit allocations
- cover the flat extraction path explicitly

Required by bzsanti/oxidize-cloud#63.