### PR TITLE
release: 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Literal carriage returns in decoded text strings leaked into extracted
+  plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
+  callers remove standalone CR bytes, replace them with a space, or normalize
+  them as line endings without adding a field to the public extraction-options
+  struct. The default normalizes standalone CR and CRLF to one `\n`; CRLF is
+  treated as one line ending under every policy.
+
 ## [4.3.0] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`preserve_layout`'s global Y-sort could interleave unrelated content
+  regions, corrupting hyphen-wrapped words** (#482). `sort_and_merge_fragments`
+  sorts every fragment on a page by Y-coordinate with no notion of separate
+  content regions; when an unrelated fragment (e.g. a digital-signature
+  annotation's appearance text) happened to sit at a Y-coordinate between the
+  two halves of a hyphen-wrapped word elsewhere on the page, the sort spliced
+  it in between them, and the hyphen got joined to the wrong fragment —
+  corrupting both the wrapped word and the unrelated text at once. Fixed by
+  fusing a hyphen-ended fragment with its wrap continuation while fragments
+  are still in emission (content-stream) order, before the Y-sort runs, so
+  the wrapped token becomes a single atomic fragment nothing can be spliced
+  into afterward.
+
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
   callers remove standalone CR bytes, replace them with a space, or normalize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   annotation's appearance text) happened to sit at a Y-coordinate between the
   two halves of a hyphen-wrapped word elsewhere on the page, the sort spliced
   it in between them, and the hyphen got joined to the wrong fragment —
-  corrupting both the wrapped word and the unrelated text at once. This case is
-  mitigated by
-  fusing a hyphen-ended fragment with its wrap continuation while fragments
-  are still in emission (content-stream) order, before the Y-sort runs, so
-  the wrapped token becomes a single atomic fragment nothing can be spliced
-  into afterward. Structural region-aware ordering remains follow-up work.
+  corrupting both the wrapped word and the unrelated text at once. The initial
+  mitigation fused hyphen-wrapped continuations before sorting. Positional
+  sorting is now also scoped to structural emission regions: geometric flow
+  restarts separate untagged regions, while MCID ownership separates tagged
+  regions. Independent body, overlay, annotation, and appearance flows can no
+  longer be interleaved merely because their Y ranges overlap.
 
 - **`merge_hyphenated` had no effect on the flat (default) extraction path**
   (#486). It was only wired into `reconstruct_text_from_fragments`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`merge_hyphenated` had no effect on the flat (default) extraction path**
+  (#486). It was only wired into `reconstruct_text_from_fragments`
+  (`preserve_layout: true`) and `merge_into_paragraphs`
+  (`reconstruct_paragraphs: true`); every text-showing operator on the flat
+  path (`Tj`, `TJ`, `'`, `"`) independently decided a `'\n'` separator via
+  the shared `append_bounded` helper without ever checking for a trailing
+  hyphen, so a hyphenated word or number wrapping across two lines extracted
+  with a raw newline in place of the hyphen — e.g. a phone number split as
+  `"...3016-"` / `"0900"` came out `"...3016-\n0900"` instead of
+  `"...30160900"`. `append_bounded` now pops the trailing `-` and fuses the
+  next run with no separator when the caller requested `'\n'` and
+  `merge_hyphenated` is enabled (the default); the actual separator applied
+  is threaded back to callers so reading-order line grouping (#448) treats a
+  fused run as a continuation rather than opening a new line.
+
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
   callers remove standalone CR bytes, replace them with a space, or normalize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.4.0] - 2026-08-16
+
+### Added
+
+- **`ActualText` marked-content support** (#63, #490). Page generation can now
+  attach replacement text to marked-content sequences, allowing assistive
+  technology and text extractors to consume an accessible textual alternative
+  for visually rendered content.
+
 ### Fixed
 
 - **`preserve_layout`'s global Y-sort could interleave unrelated content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Literal carriage returns in decoded text strings leaked into extracted
   plain text** (#476). `TextExtractor::with_carriage_return_handling` now lets
-  callers remove standalone CR bytes, replace them with a space, or normalize
-  them as line endings without adding a field to the public extraction-options
-  struct. The default normalizes standalone CR and CRLF to one `\n`; CRLF is
-  treated as one line ending under every policy.
+  callers remove standalone CR bytes, replace them with a space, or preserve
+  them while normalizing CRLF without adding a field to the public
+  extraction-options struct. The default removes standalone CR so producer
+  noise does not split words or URLs; CRLF is treated as one line ending under
+  every policy. `NormalizeLineEnding` preserves a standalone CR because it is
+  not equivalent to LF (#481).
 
 ## [4.3.0] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.3.0"
+version = "4.4.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -2029,6 +2029,39 @@ impl Page {
         Ok(mcid)
     }
 
+    /// Begins a marked content sequence with an `/ActualText` replacement.
+    ///
+    /// `/ActualText` supplies the logical text used by copy/paste, search,
+    /// accessibility tools, and text extraction while the enclosed drawing
+    /// operators retain their visual representation. The value is serialized
+    /// as UTF-16BE with a byte-order mark so every Unicode scalar is preserved.
+    ///
+    /// The returned MCID can be attached to a structure element in the same way
+    /// as the value returned by [`Page::begin_marked_content`]. This makes the
+    /// method useful both for lightweight semantic spans and for fully tagged
+    /// documents.
+    pub fn begin_marked_content_with_actual_text(
+        &mut self,
+        tag: &str,
+        actual_text: &str,
+    ) -> Result<u32> {
+        let mcid = self.next_mcid;
+        self.next_mcid += 1;
+
+        let utf16be_hex: String = actual_text
+            .encode_utf16()
+            .map(|unit| format!("{unit:04X}"))
+            .collect();
+        let bdc_op = format!(
+            "/{} <</MCID {} /ActualText <FEFF{}>>> BDC\n",
+            tag, mcid, utf16be_hex
+        );
+        self.text_context.append_raw_operation(&bdc_op);
+        self.marked_content_stack.push(tag.to_string());
+
+        Ok(mcid)
+    }
+
     /// Ends the current marked content sequence
     ///
     /// This adds an EMC (End Marked Content) operator to close the most recently

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3350,16 +3350,20 @@ fn calculate_text_width_from_codes(
 /// Sanitize extracted text by removing or replacing control characters.
 ///
 /// This function addresses Issue #116 where extracted text contains NUL bytes (`\0`)
-/// and ETX characters (`\u{3}`) where spaces should appear.
+/// and ETX characters (`\u{3}`) where spaces should appear, and Issue #476 where a
+/// stray literal `\r` embedded in a PDF's own text content survives verbatim into
+/// the extracted string.
 ///
 /// # Behavior
 ///
 /// - Replaces `\0\u{3}` sequences with a single space (common word separator pattern)
 /// - Replaces standalone `\0` (NUL) with space
-/// - Removes other ASCII control characters (0x01-0x1F) except:
-///   - `\t` (0x09) - Tab
-///   - `\n` (0x0A) - Line feed
-///   - `\r` (0x0D) - Carriage return
+/// - Preserves `\t` (0x09) and `\n` (0x0A) as-is
+/// - Normalizes `\r` (0x0D): a `\r\n` pair collapses to a single `\n`; any other
+///   bare `\r` becomes a space, since a raw CR inside a PDF text-showing operator's
+///   string is not a structural line break -- it is producer noise (see #476) and,
+///   left alone, can silently split a word in the extracted output
+/// - Removes other ASCII control characters (0x01-0x1F)
 /// - Collapses multiple consecutive spaces into a single space
 ///
 /// # Examples
@@ -3374,6 +3378,14 @@ fn calculate_text_width_from_codes(
 /// // Standalone NUL becomes space
 /// let with_nul = "word\0another";
 /// assert_eq!(sanitize_extracted_text(with_nul), "word another");
+///
+/// // Issue #476: a stray CR mid-word becomes a space instead of splitting it
+/// let stray_cr = "rating-aa\ra-exp-sf";
+/// assert_eq!(sanitize_extracted_text(stray_cr), "rating-aa a-exp-sf");
+///
+/// // A genuine CRLF pair collapses to a single LF
+/// let crlf = "line one\r\nline two";
+/// assert_eq!(sanitize_extracted_text(crlf), "line one\nline two");
 ///
 /// // Clean text passes through unchanged
 /// let clean = "Normal text";
@@ -3410,10 +3422,31 @@ pub fn sanitize_extracted_text(text: &str) -> String {
             }
 
             // Preserve allowed whitespace
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' => {
                 result.push(ch);
                 // Reset space tracking on newlines but not tabs
                 last_was_space = ch == '\t';
+            }
+
+            // Carriage return: a genuine `\r\n` pair (e.g. a Windows line
+            // ending that made it into the PDF's own text content) is a
+            // real line break, so drop the CR and let the following `\n`
+            // arm above handle it normally. A bare `\r` with no following
+            // `\n` is not a structural line break -- PDF content-stream
+            // text-showing operators (`Tj`/`TJ`/`'`/`"`) draw glyphs, and a
+            // stray CR byte inside one is producer noise (e.g. a generator
+            // that copied CRLF-terminated source text directly into a
+            // string without normalizing it) rather than an intentional
+            // separator. Treat it the same as NUL just above: collapse to
+            // a single space rather than passing it through, so it can no
+            // longer split a word in half (issue #476).
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    // Let the next iteration's '\n' arm emit the newline.
+                } else if !last_was_space {
+                    result.push(' ');
+                    last_was_space = true;
+                }
             }
 
             // Regular space - collapse multiples
@@ -3424,7 +3457,8 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 }
             }
 
-            // Other control characters (0x01-0x1F except tab/newline/CR) - remove
+            // Other control characters (0x01-0x1F except tab/newline, and CR
+            // which is handled above) - remove
             c if c.is_ascii_control() => {
                 // Skip control characters
             }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -2208,11 +2208,26 @@ impl TextExtractor {
         // font size, not the paragraph-break `newline_threshold`), and order each
         // line left-to-right by X. Ties broken by original index keep it stable.
         let n = fragments.len();
+        // Preserve independent emission regions before applying positional
+        // ordering. A Y-up-jump means the producer finished one top-to-bottom
+        // flow and started another (a new column, overlay, annotation
+        // appearance, etc.). Sorting the whole page by Y discarded that
+        // boundary and could splice the second flow into the first (#482).
+        // `assign_row_ids` already provides this segmentation for paragraph
+        // reconstruction; use the same source-order signal here so every
+        // fragment reconstruction path agrees on region boundaries.
+        let region_ids = assign_layout_region_ids(fragments);
         let mut order: Vec<usize> = (0..n).collect();
-        order.sort_by(|&i, &j| fragments[j].y.total_cmp(&fragments[i].y).then(i.cmp(&j)));
+        order.sort_by(|&i, &j| {
+            region_ids[i]
+                .cmp(&region_ids[j])
+                .then(fragments[j].y.total_cmp(&fragments[i].y))
+                .then(i.cmp(&j))
+        });
 
         let mut line_start = 0usize;
         while line_start < n {
+            let head_region = region_ids[order[line_start]];
             let head_y = fragments[order[line_start]].y;
             let head_h = fragments[order[line_start]].height;
             let mut line_end = line_start + 1;
@@ -2222,7 +2237,7 @@ impl TextExtractor {
                 // Negated `< tol` (not `>= tol`) so a non-finite Y from a
                 // degenerate text matrix forces a line break instead of a
                 // NaN comparison silently swallowing every remaining fragment.
-                if !((head_y - frag.y).abs() < tol) {
+                if region_ids[order[line_end]] != head_region || !((head_y - frag.y).abs() < tol) {
                     break;
                 }
                 line_end += 1;
@@ -3657,6 +3672,31 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
         "assign_row_ids: output length must equal input length"
     );
     result
+}
+
+/// Assign stable layout-region ids in content-stream emission order.
+///
+/// A region ends when the geometric flow restarts (`assign_row_ids`) or when
+/// marked-content ownership changes. The former covers untagged columns and
+/// overlays; the latter preserves author-supplied logical structure even when
+/// two regions occupy overlapping Y ranges (#482).
+fn assign_layout_region_ids(fragments: &[TextFragment]) -> Vec<u32> {
+    let row_ids = assign_row_ids(fragments);
+    let mut regions = Vec::with_capacity(fragments.len());
+    let mut region = 0u32;
+
+    for i in 0..fragments.len() {
+        if i > 0 {
+            let row_changed = row_ids[i] != row_ids[i - 1];
+            let mcid_changed = fragments[i].mcid != fragments[i - 1].mcid
+                && (fragments[i].mcid.is_some() || fragments[i - 1].mcid.is_some());
+            if row_changed || mcid_changed {
+                region = region.saturating_add(1);
+            }
+        }
+        regions.push(region);
+    }
+    regions
 }
 
 /// Decide whether a single visual line should be read in emission order.
@@ -5428,5 +5468,50 @@ mod tests {
             "NaN-Y fragment must stay its own line; the finite lines keep \
              top-to-bottom reading order instead of collapsing to X order"
         );
+    }
+
+    #[test]
+    fn sort_and_merge_fragments_keeps_emission_regions_atomic() {
+        let extractor = TextExtractor::with_options(ExtractionOptions::default());
+
+        // Region 0 is a normal top-to-bottom footer. Region 1 is an overlay
+        // emitted later: its first line jumps back up the page, while its
+        // second line falls numerically between the footer's two lines. A
+        // page-wide Y-sort would produce body-1, overlay-1, overlay-2, body-2.
+        let mut fragments = vec![
+            tf("body-1", 50.0, 45.0, 40.0, 10.0),
+            tf("body-2", 50.0, 30.0, 40.0, 10.0),
+            tf("overlay-1", 250.0, 50.0, 60.0, 10.0),
+            tf("overlay-2", 250.0, 35.0, 60.0, 10.0),
+        ];
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["body-1", "body-2", "overlay-1", "overlay-2"],
+            "positional sorting must not interleave independent emission regions"
+        );
+    }
+
+    #[test]
+    fn sort_and_merge_fragments_uses_mcid_as_a_region_boundary() {
+        let extractor = TextExtractor::with_options(ExtractionOptions::default());
+        let mut fragments = vec![
+            tf("body-1", 50.0, 45.0, 40.0, 10.0),
+            tf("body-2", 50.0, 30.0, 40.0, 10.0),
+            // The small Y increase is below assign_row_ids' reset threshold;
+            // MCID ownership must still keep this overlay independent.
+            tf("overlay", 250.0, 33.0, 60.0, 10.0),
+        ];
+        fragments[0].mcid = Some(7);
+        fragments[1].mcid = Some(7);
+        fragments[2].mcid = Some(8);
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(order, vec!["body-1", "body-2", "overlay"]);
     }
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3455,8 +3455,21 @@ pub fn sanitize_extracted_text_with_policy(
 
             '\r' => {
                 // CRLF is unambiguously one line ending under every policy.
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
+                // Ignore controls that sanitization would remove between the
+                // pair, otherwise a first pass could create CRLF and a second
+                // pass would change it again (for example `"\r\u{1}\n"`).
+                let removed_controls_before_lf = chars
+                    .clone()
+                    .take_while(|next| {
+                        next.is_ascii_control() && !matches!(next, '\0' | '\t' | '\n' | '\r')
+                    })
+                    .count();
+                let followed_by_lf = chars.clone().nth(removed_controls_before_lf) == Some('\n');
+
+                if followed_by_lf {
+                    for _ in 0..=removed_controls_before_lf {
+                        chars.next();
+                    }
                     result.push('\n');
                     last_was_space = false;
                 } else {

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1302,17 +1302,24 @@ impl TextExtractor {
 
                             // Per-page byte budget (issue #382): stop before the
                             // run that would overshoot; the outer loop guard ends
-                            // extraction on the next iteration.
-                            if !append_bounded(
+                            // extraction on the next iteration. Hyphen-wrap fusion
+                            // (issue #486) may replace the requested `\n` with no
+                            // separator at all — `emitted_sep` must reflect what
+                            // was actually applied, not what was requested, so
+                            // reading-order line grouping below sees the run as a
+                            // continuation rather than a new line.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         // Get font info for accurate width calculation.
@@ -1466,16 +1473,23 @@ impl TextExtractor {
                                         };
 
                                         // Per-page byte budget (issue #382).
-                                        if !append_bounded(
+                                        // Hyphen-wrap fusion (issue #486) may
+                                        // replace the requested `\n` with no
+                                        // separator; `emitted_sep` reflects what
+                                        // was actually applied (see the `Tj` arm
+                                        // above for the full rationale).
+                                        let outcome = append_bounded(
                                             &mut extracted_text,
                                             separator,
                                             &decoded,
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
-                                        ) {
+                                            self.options.merge_hyphenated,
+                                        );
+                                        if !outcome.appended {
                                             break;
                                         }
-                                        emitted_sep = Some(separator);
+                                        emitted_sep = Some(outcome.applied_separator);
                                     }
 
                                     let text_width = {
@@ -1565,13 +1579,18 @@ impl TextExtractor {
                                         // Per-page byte budget (issue #382): even
                                         // the synthesised space counts, so the
                                         // `text.len() <= limit` invariant holds.
+                                        // Always a space, never `\n` — hyphen-wrap
+                                        // fusion (issue #486) does not apply here.
                                         if !append_bounded(
                                             &mut extracted_text,
                                             Some(' '),
                                             "",
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
-                                        ) {
+                                            self.options.merge_hyphenated,
+                                        )
+                                        .appended
+                                        {
                                             break;
                                         }
                                         // The synthesised space is intra-group
@@ -1647,17 +1666,26 @@ impl TextExtractor {
                             } else {
                                 Some('\n')
                             };
-                            // Per-page byte budget (issue #382).
-                            if !append_bounded(
+                            // Per-page byte budget (issue #382). Hyphen-wrap
+                            // fusion (issue #486) may replace the requested `\n`
+                            // with no separator; `emitted_sep` reflects what was
+                            // actually applied (see the `Tj` arm for the full
+                            // rationale). `'` (this operator) always requests a
+                            // new line by definition (ISO 32000-1 §9.4.3's
+                            // `T* Tj`), so this is where a hyphen at the end of
+                            // one `'`-delimited line meets the start of the next.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         let text_width = {
@@ -1735,17 +1763,24 @@ impl TextExtractor {
                             } else {
                                 Some('\n')
                             };
-                            // Per-page byte budget (issue #382).
-                            if !append_bounded(
+                            // Per-page byte budget (issue #382). Hyphen-wrap
+                            // fusion (issue #486) may replace the requested `\n`
+                            // with no separator; `emitted_sep` reflects what was
+                            // actually applied (see the `Tj` arm for the full
+                            // rationale). `"` (this operator) always requests a
+                            // new line by definition, same as `'` above.
+                            let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
                                 &decoded,
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
-                            ) {
+                                self.options.merge_hyphenated,
+                            );
+                            if !outcome.appended {
                                 break;
                             }
-                            emitted_sep = Some(separator);
+                            emitted_sep = Some(outcome.applied_separator);
                         }
 
                         let text_width = {
@@ -1946,13 +1981,21 @@ impl TextExtractor {
                                     // If it would overshoot, drop the fragment and
                                     // stop — a huge override must not escape the
                                     // cap while reporting `truncated = false`.
+                                    // Always `None` separator, never `\n` —
+                                    // hyphen-wrap fusion (issue #486) does not
+                                    // apply here. This site is also only reached
+                                    // under `preserve_layout`/`reorder_columns`
+                                    // (see the gate above), not the flat path.
                                     if !append_bounded(
                                         &mut extracted_text,
                                         None,
                                         &run.text,
                                         self.options.max_extracted_bytes,
                                         &mut truncated,
-                                    ) {
+                                        self.options.merge_hyphenated,
+                                    )
+                                    .appended
+                                    {
                                         break;
                                     }
                                     fragments.push(TextFragment {
@@ -2853,40 +2896,95 @@ fn record_line_group(
     }
 }
 
+/// Outcome of [`append_bounded`]: whether the run was appended, and — when it
+/// was — the separator actually applied. The applied separator can differ
+/// from the one the caller requested when hyphen-wrap fusion (issue #486)
+/// consumes a trailing `-` instead of inserting the requested `\n`; callers
+/// that feed the separator into reading-order line grouping (`record_line_group`)
+/// must use `applied_separator`, not the separator they originally computed,
+/// so a fused run correctly extends its line group instead of opening a new one.
+struct AppendOutcome {
+    appended: bool,
+    applied_separator: Option<char>,
+}
+
 /// Append an optional `separator` plus `decoded` to `acc`, honouring the
-/// per-page byte budget `limit` (issue #382).
+/// per-page byte budget `limit` (issue #382), with optional hyphen-wrap
+/// fusion (issue #486).
 ///
-/// Returns `true` when the run was appended. Returns `false` — appending
-/// nothing and setting `*truncated` — when the combined bytes would exceed
-/// `limit`. The separator is counted against the budget so the invariant
-/// `acc.len() <= limit` holds *exactly*, and because whole runs are the unit of
-/// truncation a multi-byte UTF-8 character is never split (undershoot
-/// semantics). A `None` limit always appends and never truncates, keeping the
-/// no-limit path byte-identical to before. Once `*truncated` is set the helper
-/// is a no-op, so a caller that keeps calling it after the budget is reached
-/// simply accumulates nothing further.
+/// Returns [`AppendOutcome`] with `appended: true` when the run was appended.
+/// Returns `appended: false` — appending nothing and setting `*truncated` —
+/// when the combined bytes would exceed `limit`. The separator is counted
+/// against the budget so the invariant `acc.len() <= limit` holds *exactly*,
+/// and because whole runs are the unit of truncation a multi-byte UTF-8
+/// character is never split (undershoot semantics). A `None` limit always
+/// appends and never truncates, keeping the no-limit path byte-identical to
+/// before. Once `*truncated` is set the helper is a no-op, so a caller that
+/// keeps calling it after the budget is reached simply accumulates nothing
+/// further.
+///
+/// When `merge_hyphenated` is set and the caller requests a `'\n'` separator
+/// (a genuine line wrap) while `acc` already ends with `-`, the hyphen is
+/// producer noise from a hyphenated word/number wrapping across two lines,
+/// not a real word boundary (issue #486: `merge_hyphenated` had no effect on
+/// this flat/default extraction path, unlike `preserve_layout`'s
+/// `reconstruct_text_from_fragments` and `reconstruct_paragraphs`'s
+/// `merge_into_paragraphs`, both of which already apply this same rule). The
+/// trailing hyphen is popped and `decoded` is appended directly with no
+/// separator, fusing the wrapped token into one word instead of splitting it
+/// on a newline — e.g. `"...3016-"` + `"0900"` becomes `"...30160900"`
+/// instead of `"...3016-\n0900"`. `separator` is only ever `'\n'` here when
+/// `acc` is already non-empty (every call site gates on that), so the pop is
+/// always into at least one existing byte.
 fn append_bounded(
     acc: &mut String,
     separator: Option<char>,
     decoded: &str,
     limit: Option<usize>,
     truncated: &mut bool,
-) -> bool {
+    merge_hyphenated: bool,
+) -> AppendOutcome {
     if *truncated {
-        return false;
+        return AppendOutcome {
+            appended: false,
+            applied_separator: None,
+        };
     }
+
+    let hyphen_fusion = merge_hyphenated && separator == Some('\n') && acc.ends_with('-');
+    let separator = if hyphen_fusion { None } else { separator };
+
     if let Some(max) = limit {
+        // Popping the hyphen frees one byte before the new run is added, so
+        // account against the post-pop length — otherwise a run that fits
+        // once the hyphen is dropped could be wrongly rejected as
+        // over-budget by one byte.
+        let base_len = if hyphen_fusion {
+            acc.len() - 1
+        } else {
+            acc.len()
+        };
         let add = separator.map_or(0, char::len_utf8) + decoded.len();
-        if acc.len() + add > max {
+        if base_len + add > max {
             *truncated = true;
-            return false;
+            return AppendOutcome {
+                appended: false,
+                applied_separator: None,
+            };
         }
+    }
+
+    if hyphen_fusion {
+        acc.pop();
     }
     if let Some(sep) = separator {
         acc.push(sep);
     }
     acc.push_str(decoded);
-    true
+    AppendOutcome {
+        appended: true,
+        applied_separator: separator,
+    }
 }
 
 /// Defensive final clamp of a page's text to the byte budget (issue #382).
@@ -3667,8 +3765,8 @@ mod tests {
     fn test_append_bounded_no_limit_always_appends() {
         let mut s = String::new();
         let mut trunc = false;
-        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc));
-        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc));
+        assert!(append_bounded(&mut s, None, "hello", None, &mut trunc, true).appended);
+        assert!(append_bounded(&mut s, Some(' '), "world", None, &mut trunc, true).appended);
         assert_eq!(s, "hello world");
         assert!(!trunc, "no limit never truncates");
     }
@@ -3678,19 +3776,13 @@ mod tests {
         // "abcd" (4) is at budget 5; a Some('\n') + "x" would need 2 more → over.
         let mut s = String::from("abcd");
         let mut trunc = false;
-        assert!(!append_bounded(
-            &mut s,
-            Some('\n'),
-            "x",
-            Some(5),
-            &mut trunc
-        ));
+        assert!(!append_bounded(&mut s, Some('\n'), "x", Some(5), &mut trunc, true).appended);
         assert_eq!(s, "abcd", "nothing appended when it would overshoot");
         assert!(trunc, "budget hit sets truncated");
         // Exactly-fits case: "e" alone (1 byte, no separator) reaches 5.
         let mut s2 = String::from("abcd");
         let mut t2 = false;
-        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2));
+        assert!(append_bounded(&mut s2, None, "e", Some(5), &mut t2, true).appended);
         assert_eq!(s2, "abcde");
         assert!(!t2);
         assert!(s2.len() <= 5, "invariant: len <= limit exactly");
@@ -3700,7 +3792,7 @@ mod tests {
     fn test_append_bounded_zero_limit_truncates_immediately() {
         let mut s = String::new();
         let mut trunc = false;
-        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc));
+        assert!(!append_bounded(&mut s, None, "a", Some(0), &mut trunc, true).appended);
         assert!(s.is_empty());
         assert!(trunc);
     }
@@ -3709,14 +3801,82 @@ mod tests {
     fn test_append_bounded_is_noop_once_truncated() {
         let mut s = String::from("kept");
         let mut trunc = true; // already truncated
-        assert!(!append_bounded(
-            &mut s,
-            None,
-            "more",
-            Some(1_000),
-            &mut trunc
-        ));
+        assert!(!append_bounded(&mut s, None, "more", Some(1_000), &mut trunc, true).appended);
         assert_eq!(s, "kept", "no further accumulation after truncation");
+    }
+
+    // ── issue #486: flat-path hyphen-wrap fusion ─────────────────────────────
+
+    #[test]
+    fn test_append_bounded_fuses_hyphen_wrap_when_enabled() {
+        // Real-world shape: a hyphen-wrapped phone number split across two
+        // lines, e.g. "...3016-" / "0900" must reconstruct as "...30160900".
+        let mut s = String::from("+55 11 3016-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "0900", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(
+            outcome.applied_separator, None,
+            "hyphen fusion applies no separator, not the requested '\\n'"
+        );
+        assert_eq!(s, "+55 11 30160900", "hyphen popped, halves fused");
+    }
+
+    #[test]
+    fn test_append_bounded_no_fusion_without_a_trailing_hyphen() {
+        let mut s = String::from("hello world");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "next line", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(
+            outcome.applied_separator,
+            Some('\n'),
+            "no trailing hyphen: requested separator applies unchanged"
+        );
+        assert_eq!(s, "hello world\nnext line");
+    }
+
+    #[test]
+    fn test_append_bounded_does_not_fuse_when_merge_hyphenated_disabled() {
+        let mut s = String::from("rating-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "aa-exp-sf", None, &mut trunc, false);
+        assert!(outcome.appended);
+        assert_eq!(outcome.applied_separator, Some('\n'));
+        assert_eq!(s, "rating-\naa-exp-sf", "no fusion: split as requested");
+    }
+
+    #[test]
+    fn test_append_bounded_does_not_fuse_a_space_separator() {
+        // Only a requested '\n' is a wrap candidate; a same-line space must
+        // never trigger hyphen fusion even if the accumulator ends in '-'.
+        let mut s = String::from("well-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some(' '), "known", None, &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(outcome.applied_separator, Some(' '));
+        assert_eq!(s, "well- known");
+    }
+
+    #[test]
+    fn test_append_bounded_hyphen_fusion_respects_budget() {
+        // "rating-" (7 bytes, trailing hyphen) minus the popped hyphen (6)
+        // plus fused "aa-exp" (6 bytes, no separator) = 12.
+        // Budget 12 must fit; budget 11 must not (would need to drop the
+        // hyphen-adjusted run, not silently truncate mid-word).
+        let mut s = String::from("rating-");
+        let mut trunc = false;
+        let outcome = append_bounded(&mut s, Some('\n'), "aa-exp", Some(12), &mut trunc, true);
+        assert!(outcome.appended);
+        assert_eq!(s, "ratingaa-exp");
+        assert!(!trunc);
+
+        let mut s2 = String::from("rating-");
+        let mut trunc2 = false;
+        let outcome2 = append_bounded(&mut s2, Some('\n'), "aa-exp", Some(11), &mut trunc2, true);
+        assert!(!outcome2.appended);
+        assert_eq!(s2, "rating-", "nothing appended when over budget");
+        assert!(trunc2);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -23,13 +23,13 @@ pub enum CarriageReturnHandling {
     Remove,
     /// Replace each standalone carriage return with a collapsible `U+0020` space.
     ReplaceWithSpace,
-    /// Normalize both standalone CR and CRLF sequences to one line feed.
+    /// Preserve standalone carriage returns and normalize CRLF to one line feed.
     NormalizeLineEnding,
 }
 
 impl Default for CarriageReturnHandling {
     fn default() -> Self {
-        Self::NormalizeLineEnding
+        Self::Remove
     }
 }
 
@@ -636,7 +636,7 @@ impl TextExtractor {
     /// Select how standalone carriage returns decoded from PDF text strings
     /// are represented. CRLF is always normalized to one line feed.
     ///
-    /// The default is [`CarriageReturnHandling::NormalizeLineEnding`].
+    /// The default is [`CarriageReturnHandling::Remove`].
     pub fn with_carriage_return_handling(mut self, handling: CarriageReturnHandling) -> Self {
         self.carriage_return_handling = handling;
         self
@@ -3469,7 +3469,10 @@ pub fn sanitize_extracted_text_with_policy(
                             }
                         }
                         CarriageReturnHandling::NormalizeLineEnding => {
-                            result.push('\n');
+                            // A standalone CR is valid input and is not
+                            // equivalent to LF. Only the CRLF sequence above
+                            // is normalized as a line ending.
+                            result.push('\r');
                             last_was_space = false;
                         }
                     }
@@ -3786,7 +3789,7 @@ mod tests {
         assert!(options.merge_hyphenated);
         assert_eq!(
             CarriageReturnHandling::default(),
-            CarriageReturnHandling::NormalizeLineEnding
+            CarriageReturnHandling::Remove
         );
     }
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -15,6 +15,24 @@ use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
+/// Controls how carriage returns decoded from PDF text-showing strings are
+/// represented in extracted plain text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CarriageReturnHandling {
+    /// Remove each standalone carriage return.
+    Remove,
+    /// Replace each standalone carriage return with a collapsible `U+0020` space.
+    ReplaceWithSpace,
+    /// Normalize both standalone CR and CRLF sequences to one line feed.
+    NormalizeLineEnding,
+}
+
+impl Default for CarriageReturnHandling {
+    fn default() -> Self {
+        Self::NormalizeLineEnding
+    }
+}
+
 /// Text extraction options
 #[derive(Debug, Clone)]
 pub struct ExtractionOptions {
@@ -561,6 +579,10 @@ pub struct TextExtractor {
     /// not on the public [`ExtractionOptions`], so enabling it is a
     /// non-breaking method addition rather than a breaking struct-field addition.
     reading_order: bool,
+    /// Policy for CR bytes decoded from text-showing strings. Held outside the
+    /// public `ExtractionOptions` so adding it does not break exhaustive struct
+    /// literals in downstream crates.
+    carriage_return_handling: CarriageReturnHandling,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
@@ -574,6 +596,7 @@ impl TextExtractor {
         Self {
             options: ExtractionOptions::default(),
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -584,6 +607,7 @@ impl TextExtractor {
         Self {
             options,
             reading_order: false,
+            carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
@@ -606,6 +630,15 @@ impl TextExtractor {
     /// one group. `/Rotate ≠ 0` pages are ordered in unrotated page space.
     pub fn with_reading_order(mut self, enable: bool) -> Self {
         self.reading_order = enable;
+        self
+    }
+
+    /// Select how standalone carriage returns decoded from PDF text strings
+    /// are represented. CRLF is always normalized to one line feed.
+    ///
+    /// The default is [`CarriageReturnHandling::NormalizeLineEnding`].
+    pub fn with_carriage_return_handling(mut self, handling: CarriageReturnHandling) -> Self {
+        self.carriage_return_handling = handling;
         self
     }
 
@@ -2656,9 +2689,11 @@ impl TextExtractor {
                     // or garbage). Whitespace counts as meaningful: a decode
                     // that is exactly a space is a space, not a failed decode
                     // (#438). See `decode_is_usable`.
-                    if crate::text::extraction_cmap::decode_is_usable(&decoded) {
-                        // Apply sanitization to remove control characters (Issue #116)
-                        let sanitized = sanitize_extracted_text(&decoded);
+                    let sanitized = sanitize_extracted_text_with_policy(
+                        &decoded,
+                        self.carriage_return_handling,
+                    );
+                    if crate::text::extraction_cmap::decode_is_usable(&sanitized) {
                         tracing::debug!(
                             "Successfully decoded text using CMap for font {}: {:?} -> \"{}\"",
                             font_name,
@@ -2701,7 +2736,8 @@ impl TextExtractor {
 
         let fallback_result = encoding.decode(text);
         // Apply sanitization to remove control characters (Issue #116)
-        let sanitized = sanitize_extracted_text(&fallback_result);
+        let sanitized =
+            sanitize_extracted_text_with_policy(&fallback_result, self.carriage_return_handling);
         tracing::debug!(
             "Fallback encoding decoding: {:?} -> \"{}\"",
             text,
@@ -3359,7 +3395,7 @@ fn calculate_text_width_from_codes(
 /// - Removes other ASCII control characters (0x01-0x1F) except:
 ///   - `\t` (0x09) - Tab
 ///   - `\n` (0x0A) - Line feed
-///   - `\r` (0x0D) - Carriage return
+/// - Normalizes `\r` and `\r\n` to `\n`
 /// - Collapses multiple consecutive spaces into a single space
 ///
 /// # Examples
@@ -3380,6 +3416,14 @@ fn calculate_text_width_from_codes(
 /// assert_eq!(sanitize_extracted_text(clean), "Normal text");
 /// ```
 pub fn sanitize_extracted_text(text: &str) -> String {
+    sanitize_extracted_text_with_policy(text, CarriageReturnHandling::default())
+}
+
+/// Sanitize extracted text using an explicit carriage-return policy.
+pub fn sanitize_extracted_text_with_policy(
+    text: &str,
+    carriage_return_handling: CarriageReturnHandling,
+) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -3409,10 +3453,33 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 // Don't emit anything, just skip
             }
 
+            '\r' => {
+                // CRLF is unambiguously one line ending under every policy.
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    result.push('\n');
+                    last_was_space = false;
+                } else {
+                    match carriage_return_handling {
+                        CarriageReturnHandling::Remove => {}
+                        CarriageReturnHandling::ReplaceWithSpace => {
+                            if !last_was_space {
+                                result.push(' ');
+                                last_was_space = true;
+                            }
+                        }
+                        CarriageReturnHandling::NormalizeLineEnding => {
+                            result.push('\n');
+                            last_was_space = false;
+                        }
+                    }
+                }
+            }
+
             // Preserve allowed whitespace
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' => {
                 result.push(ch);
-                // Reset space tracking on newlines but not tabs
+                // Reset space tracking on newlines but not tabs.
                 last_was_space = ch == '\t';
             }
 
@@ -3424,7 +3491,7 @@ pub fn sanitize_extracted_text(text: &str) -> String {
                 }
             }
 
-            // Other control characters (0x01-0x1F except tab/newline/CR) - remove
+            // Other control characters (0x01-0x1F except tab/newline) - remove
             c if c.is_ascii_control() => {
                 // Skip control characters
             }
@@ -3717,6 +3784,10 @@ mod tests {
         assert!(!options.detect_columns);
         assert_eq!(options.column_threshold, 50.0);
         assert!(options.merge_hyphenated);
+        assert_eq!(
+            CarriageReturnHandling::default(),
+            CarriageReturnHandling::NormalizeLineEnding
+        );
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1085,7 +1085,7 @@ impl TextExtractor {
             // this way for `reconstruct_paragraphs`), so it is safe to run here
             // on unsorted emission order.
             if !fragments.is_empty() {
-                fragments = self.merge_close_fragments(&fragments);
+                fragments = self.merge_close_fragments_in_layout_regions(&fragments);
                 fragments = self.merge_hyphenated_line_wraps_in_emission_order(fragments);
             }
 
@@ -2256,19 +2256,21 @@ impl TextExtractor {
             return fragments;
         }
 
-        let mut result: Vec<TextFragment> = Vec::with_capacity(fragments.len());
-        for fragment in fragments {
+        let region_ids = assign_layout_region_ids(&fragments);
+        let mut result: Vec<(u32, TextFragment)> = Vec::with_capacity(fragments.len());
+        for (region_id, fragment) in region_ids.into_iter().zip(fragments) {
             let should_merge = result
                 .last()
-                .map(|prev: &TextFragment| {
-                    prev.text.ends_with('-')
+                .map(|(prev_region, prev)| {
+                    *prev_region == region_id
+                        && prev.text.ends_with('-')
                         && is_line_wrap_geometry(prev, &fragment, self.options.newline_threshold)
                 })
                 .unwrap_or(false);
 
             if should_merge {
                 // Safe: just checked `result.last()` is `Some` above.
-                let prev = result.last_mut().expect("checked non-empty above");
+                let (_, prev) = result.last_mut().expect("checked non-empty above");
                 prev.text.pop(); // drop the trailing hyphen
                 prev.text.push_str(&fragment.text);
                 // Extend the fused fragment's box to cover both lines so
@@ -2284,10 +2286,33 @@ impl TextExtractor {
                 prev.y = y_min;
                 prev.height = y_max - y_min;
             } else {
-                result.push(fragment);
+                result.push((region_id, fragment));
             }
         }
-        result
+        result.into_iter().map(|(_, fragment)| fragment).collect()
+    }
+
+    /// Apply the kerning merge independently inside each layout region.
+    /// Keeping this pre-sort pass region-scoped prevents two adjacent emission
+    /// runs from different marked-content/overlay flows being fused before the
+    /// ordering stage gets a chance to preserve their boundary (#482).
+    fn merge_close_fragments_in_layout_regions(
+        &self,
+        fragments: &[TextFragment],
+    ) -> Vec<TextFragment> {
+        let region_ids = assign_layout_region_ids(fragments);
+        let mut merged = Vec::with_capacity(fragments.len());
+        let mut start = 0usize;
+        while start < fragments.len() {
+            let region = region_ids[start];
+            let mut end = start + 1;
+            while end < fragments.len() && region_ids[end] == region {
+                end += 1;
+            }
+            merged.extend(self.merge_close_fragments(&fragments[start..end]));
+            start = end;
+        }
+        merged
     }
 
     /// Sort text fragments by position and merge them appropriately
@@ -2363,12 +2388,13 @@ impl TextExtractor {
         if self.options.detect_columns
             || (self.options.reorder_columns && !self.options.preserve_layout)
         {
-            self.detect_and_sort_columns(fragments);
+            let sorted_region_ids: Vec<u32> = order.iter().map(|&i| region_ids[i]).collect();
+            self.detect_and_sort_columns(fragments, &sorted_region_ids);
         }
     }
 
     /// Detect columns and re-sort fragments accordingly
-    fn detect_and_sort_columns(&self, fragments: &mut [TextFragment]) {
+    fn detect_and_sort_columns(&self, fragments: &mut [TextFragment], region_ids: &[u32]) {
         // `fragments` arrives pre-sorted by `sort_and_merge_fragments` in reading
         // order: top-to-bottom by Y band, left-to-right by X within a band.
         //
@@ -2401,7 +2427,9 @@ impl TextExtractor {
                 // Negated `< tol` (not `>= tol`) so a non-finite Y from a
                 // degenerate text matrix forces a line break rather than swallowing
                 // the whole page into one line.
-                if !((head_y - fragment.y).abs() < tol) {
+                if region_ids[i] != region_ids[current_line[0]]
+                    || !((head_y - fragment.y).abs() < tol)
+                {
                     lines.push(std::mem::take(&mut current_line));
                 }
             }
@@ -2490,7 +2518,8 @@ impl TextExtractor {
                 .copied()
                 .filter(|&p| boundaries.iter().any(|&c| (p - c).abs() < COLUMN_ALIGN_TOL))
                 .collect();
-            if li > 0 && columnar && prev_columnar && row_spaced && !shared.is_empty() {
+            let same_region = li > 0 && region_ids[line[0]] == region_ids[lines[li - 1][0]];
+            if same_region && columnar && prev_columnar && row_spaced && !shared.is_empty() {
                 // Line joins the current block; tighten the anchor to the
                 // corridors that persist, so a boundary must recur consistently
                 // across the whole block to survive.
@@ -3785,16 +3814,24 @@ fn assign_row_ids(fragments: &[TextFragment]) -> Vec<u32> {
 /// overlays; the latter preserves author-supplied logical structure even when
 /// two regions occupy overlapping Y ranges (#482).
 fn assign_layout_region_ids(fragments: &[TextFragment]) -> Vec<u32> {
-    let row_ids = assign_row_ids(fragments);
     let mut regions = Vec::with_capacity(fragments.len());
     let mut region = 0u32;
 
     for i in 0..fragments.len() {
         if i > 0 {
-            let row_changed = row_ids[i] != row_ids[i - 1];
+            let prev = &fragments[i - 1];
+            let current = &fragments[i];
+            // A new flow may restart only a few points above the preceding
+            // baseline (the real #482 footer/annotation gap is ~2pt), well
+            // below assign_row_ids' superscript-friendly 0.5em threshold.
+            // For layout ordering the relevant boundary is the same visual-line
+            // tolerance used by sorting: an upward move beyond 0.2 line height
+            // starts a new monotonic emission region.
+            let line_tol = prev.height.min(current.height) * 0.2;
+            let flow_restarted = current.y - prev.y > line_tol;
             let mcid_changed = fragments[i].mcid != fragments[i - 1].mcid
                 && (fragments[i].mcid.is_some() || fragments[i - 1].mcid.is_some());
-            if row_changed || mcid_changed {
+            if flow_restarted || mcid_changed {
                 region = region.saturating_add(1);
             }
         }
@@ -5617,5 +5654,31 @@ mod tests {
 
         let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
         assert_eq!(order, vec!["body-1", "body-2", "overlay"]);
+    }
+
+    #[test]
+    fn column_detection_does_not_join_independent_layout_regions() {
+        let extractor = TextExtractor::with_options(ExtractionOptions {
+            detect_columns: true,
+            ..Default::default()
+        });
+        let mut fragments = vec![
+            tf("a1", 0.0, 100.0, 10.0, 10.0),
+            tf("b1", 100.0, 100.0, 10.0, 10.0),
+            tf("a2", 0.0, 80.0, 10.0, 10.0),
+            tf("b2", 100.0, 80.0, 10.0, 10.0),
+            // A later overlay repeats the same column corridor and overlaps
+            // the first region's Y span. Column detection must not combine
+            // both into one column-major block.
+            tf("c1", 0.0, 103.0, 10.0, 10.0),
+            tf("d1", 100.0, 103.0, 10.0, 10.0),
+            tf("c2", 0.0, 83.0, 10.0, 10.0),
+            tf("d2", 100.0, 83.0, 10.0, 10.0),
+        ];
+
+        extractor.sort_and_merge_fragments(&mut fragments);
+
+        let order: Vec<&str> = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(order, vec!["a1", "a2", "b1", "b2", "c1", "c2", "d1", "d2"]);
     }
 }

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -571,6 +571,19 @@ fn same_paragraph_style(a: &TextFragment, b: &TextFragment) -> bool {
     (a.font_size - b.font_size).abs() / scale <= PARAGRAPH_STYLE_SIZE_TOLERANCE
 }
 
+/// Whether `next` is plausibly the wrapped continuation of `prev` on a new
+/// line, using the exact same Y-gap test `reconstruct_text_from_fragments`
+/// already uses to decide "new line vs. same line" (`|Δy| > newline_threshold`).
+///
+/// Deliberately mirrors that threshold rather than inventing a stricter one:
+/// this function's only job is to protect an already-correct merge decision
+/// from being corrupted by an unrelated fragment sorting in between the two
+/// halves (issue #482) — not to second-guess which pairs `merge_hyphenated`
+/// would otherwise join. Used by `merge_hyphenated_line_wraps_in_emission_order`.
+fn is_line_wrap_geometry(prev: &TextFragment, next: &TextFragment, newline_threshold: f64) -> bool {
+    (prev.y - next.y).abs() > newline_threshold
+}
+
 /// Text extractor for PDF pages with CMap support
 pub struct TextExtractor {
     options: ExtractionOptions,
@@ -1051,6 +1064,30 @@ impl TextExtractor {
         } = run;
         {
             let _span = tracing::info_span!("layout_finalize").entered();
+
+            // Fuse hyphen-wrapped tokens while fragments are still in emission
+            // order (issue #482), *before* any Y-sort below can interleave an
+            // unrelated fragment between a wrapped line's two halves. Fragments
+            // only exist here for the `preserve_layout`/`reorder_columns` paths
+            // (see the `emit_text_fragment` call sites), both of which feed
+            // `reconstruct_text_from_fragments` further down, so this always
+            // runs ahead of the merge it's protecting.
+            //
+            // `merge_close_fragments` must run first: a word's trailing hyphen
+            // is frequently its own separate glyph-run fragment (e.g. a style
+            // or kerning boundary right at "3016" | "-"), so the hyphen check
+            // below would otherwise fire against that lone "-" fragment (whose
+            // own predecessor is the stranded "6") instead of against the real
+            // "...3016-" line. Coalescing same-line adjacent runs first makes
+            // the trailing-hyphen text end up on one fragment, as the check
+            // assumes. `merge_close_fragments` is a local, order-preserving
+            // pass over adjacent pairs (see its own doc comment on being used
+            // this way for `reconstruct_paragraphs`), so it is safe to run here
+            // on unsorted emission order.
+            if !fragments.is_empty() {
+                fragments = self.merge_close_fragments(&fragments);
+                fragments = self.merge_hyphenated_line_wraps_in_emission_order(fragments);
+            }
 
             // Sort and process fragments if requested — but ONLY when we're not
             // going to run merge_into_lines later. merge_into_lines does its
@@ -2141,6 +2178,73 @@ impl TextExtractor {
                 }
             });
         Some((ops, xobj_res, matrix))
+    }
+
+    /// Fuse a hyphen-ended fragment with its line-wrap continuation while
+    /// fragments are still in emission (content-stream) order, before any
+    /// Y-coordinate sort runs.
+    ///
+    /// `sort_and_merge_fragments`'s global Y-sort has no concept of separate
+    /// content regions (issue #482): an unrelated fragment (an annotation's
+    /// appearance stream, a watermark, …) whose Y-coordinate happens to fall
+    /// between two wrapped lines of unrelated body text gets sorted in
+    /// between them, and the hyphen-merge check in `reconstruct_text_from_fragments`
+    /// — which only ever looks at the *immediately preceding* fragment in
+    /// the already-sorted list — then joins the hyphen to the wrong
+    /// fragment, corrupting both regions at once.
+    ///
+    /// Emission order does not have this problem: two fragments that are
+    /// genuinely adjacent lines of the same wrapped text are (barring a
+    /// pathological content stream) emitted consecutively, regardless of
+    /// where an unrelated annotation's text happens to sit on the Y axis.
+    /// Fusing the pair here, before the sort, makes the wrapped token a
+    /// single atomic fragment that nothing can be spliced into afterward.
+    ///
+    /// Uses `is_line_wrap_geometry` (the same Y-gap test
+    /// `reconstruct_text_from_fragments` already applies) to confirm the
+    /// pair actually looks like consecutive lines before merging, so an
+    /// unrelated same-line hyphen (e.g. "well-known" on one line) is not
+    /// fused with whatever fragment happens to follow it in emission order.
+    fn merge_hyphenated_line_wraps_in_emission_order(
+        &self,
+        fragments: Vec<TextFragment>,
+    ) -> Vec<TextFragment> {
+        if !self.options.merge_hyphenated || fragments.len() < 2 {
+            return fragments;
+        }
+
+        let mut result: Vec<TextFragment> = Vec::with_capacity(fragments.len());
+        for fragment in fragments {
+            let should_merge = result
+                .last()
+                .map(|prev: &TextFragment| {
+                    prev.text.ends_with('-')
+                        && is_line_wrap_geometry(prev, &fragment, self.options.newline_threshold)
+                })
+                .unwrap_or(false);
+
+            if should_merge {
+                // Safe: just checked `result.last()` is `Some` above.
+                let prev = result.last_mut().expect("checked non-empty above");
+                prev.text.pop(); // drop the trailing hyphen
+                prev.text.push_str(&fragment.text);
+                // Extend the fused fragment's box to cover both lines so
+                // downstream geometry (space/newline decisions keyed on
+                // `x + width`, `y`) still reasons about real coverage
+                // rather than only the first line's box.
+                let x_min = prev.x.min(fragment.x);
+                let x_max = (prev.x + prev.width).max(fragment.x + fragment.width);
+                let y_min = prev.y.min(fragment.y);
+                let y_max = (prev.y + prev.height).max(fragment.y + fragment.height);
+                prev.x = x_min;
+                prev.width = x_max - x_min;
+                prev.y = y_min;
+                prev.height = y_max - y_min;
+            } else {
+                result.push(fragment);
+            }
+        }
+        result
     }
 
     /// Sort text fragments by position and merge them appropriately

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1991,7 +1991,8 @@ impl TextExtractor {
 
                 ContentOperation::EndMarkedContent => {
                     let popped_depth = state.mc_stack.len();
-                    if state.mc_stack.pop().is_none() {
+                    let closed_entry = state.mc_stack.pop();
+                    if closed_entry.is_none() {
                         // Unbalanced EMC — log and ignore. Real PDFs occasionally emit
                         // dangling EMC (e.g. from incremental updates). We must not panic.
                         tracing::debug!(
@@ -2005,8 +2006,14 @@ impl TextExtractor {
                             if run.populated
                                 && (self.options.preserve_layout || self.options.reorder_columns)
                             {
-                                let (mcid, struct_tag) = innermost_mc_tag(&state.mc_stack);
-                                let in_artifact = state.mc_stack.iter().any(|e| e.is_artifact);
+                                // The ActualText owner has just been popped, so
+                                // retain its structural identity explicitly
+                                // instead of accidentally inheriting the parent.
+                                let closed_entry = closed_entry.as_ref().unwrap();
+                                let mcid = closed_entry.mcid;
+                                let struct_tag = Some(closed_entry.tag.clone());
+                                let in_artifact = closed_entry.is_artifact
+                                    || state.mc_stack.iter().any(|e| e.is_artifact);
                                 if !in_artifact || self.options.include_artifacts {
                                     // Per-page byte budget (issue #382): the
                                     // `/ActualText` override is this scope's

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -530,7 +530,7 @@ pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap
 /// deletes would turn "usable" into an empty string — worse than the guessed
 /// fallback it was accepted over.
 fn is_preservable_whitespace(c: char) -> bool {
-    matches!(c, ' ' | '\t' | '\n' | '\r')
+    matches!(c, ' ' | '\t' | '\n')
 }
 
 /// Whether a decode produced usable text, or nothing the caller can act on.

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -525,10 +525,12 @@ pub(crate) fn parse_truetype_kern_table(font_data: &[u8]) -> ParseResult<HashMap
     Ok(kerning_pairs)
 }
 
-/// The whitespace `sanitize_extracted_text` keeps downstream. `decode_is_usable`
+/// The whitespace `sanitize_extracted_text` treats as real text downstream
+/// (kept as-is, or normalized to a space/absorbed into a newline -- never
+/// deleted to nothing; see #476 for `\r`'s normalization). `decode_is_usable`
 /// uses the same set on purpose: accepting a decode that the next stage then
-/// deletes would turn "usable" into an empty string — worse than the guessed
-/// fallback it was accepted over.
+/// deletes entirely would turn "usable" into an empty string — worse than the
+/// guessed fallback it was accepted over.
 fn is_preservable_whitespace(c: char) -> bool {
     matches!(c, ' ' | '\t' | '\n' | '\r')
 }

--- a/oxidize-pdf-core/src/text/mod.rs
+++ b/oxidize-pdf-core/src/text/mod.rs
@@ -34,7 +34,8 @@ pub mod tesseract_provider;
 
 pub use encoding::{escape_pdf_string_literal, TextEncoding};
 pub use extraction::{
-    sanitize_extracted_text, ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+    ExtractedText, ExtractionOptions, TextExtractor, TextFragment,
 };
 pub use flow::{TextAlign, TextFlowContext};
 pub use font::{Font, FontEncoding, FontFamily, FontWithEncoding};

--- a/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
@@ -1,0 +1,108 @@
+//! End-to-end regression tests for issue #476.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{CarriageReturnHandling, ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+fn build_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td (rating-aa\\015a-exp\\015\\012next) Tj ET";
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /Encoding /WinAnsiEncoding >>"
+            .to_vec(),
+    ])
+}
+
+fn extract_with(mut extractor: TextExtractor) -> String {
+    let reader = PdfReader::new(Cursor::new(build_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("page extraction must succeed")
+        .text
+}
+
+fn extract(policy: CarriageReturnHandling) -> String {
+    extract_with(
+        TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy),
+    )
+}
+
+#[test]
+fn extraction_normalizes_cr_and_crlf_by_default() {
+    assert_eq!(extract_with(TextExtractor::new()), "rating-aa\na-exp\nnext");
+}
+
+fn build_cmap_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 100 700 Td <0102> Tj ET";
+    let to_unicode = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Issue476 def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<00> <ff>\nendcodespacerange\n\
+2 beginbfchar\n<01> <000D>\n<02> <0041>\nendbfchar\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+
+    assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+          /FirstChar 1 /LastChar 2 /Widths [500 500] /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", to_unicode),
+    ])
+}
+
+#[test]
+fn cmap_decoding_applies_the_selected_carriage_return_policy() {
+    let reader = PdfReader::new(Cursor::new(build_cmap_pdf())).expect("fixture must parse");
+    let document = PdfDocument::new(reader);
+
+    for (policy, expected) in [
+        (CarriageReturnHandling::NormalizeLineEnding, "\nA"),
+        (CarriageReturnHandling::Remove, "A"),
+        (CarriageReturnHandling::ReplaceWithSpace, " A"),
+    ] {
+        let mut extractor = TextExtractor::with_options(ExtractionOptions::default())
+            .with_carriage_return_handling(policy);
+        assert_eq!(
+            extractor
+                .extract_from_page(&document, 0)
+                .expect("CMap extraction must succeed")
+                .text,
+            expected,
+            "unexpected CMap extraction for {policy:?}"
+        );
+    }
+}
+
+#[test]
+fn extraction_can_remove_carriage_returns() {
+    assert_eq!(
+        extract(CarriageReturnHandling::Remove),
+        "rating-aaa-exp\nnext"
+    );
+}
+
+#[test]
+fn extraction_can_replace_carriage_returns_with_spaces() {
+    assert_eq!(
+        extract(CarriageReturnHandling::ReplaceWithSpace),
+        "rating-aa a-exp\nnext"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_carriage_return_policy_test.rs
@@ -39,8 +39,8 @@ fn extract(policy: CarriageReturnHandling) -> String {
 }
 
 #[test]
-fn extraction_normalizes_cr_and_crlf_by_default() {
-    assert_eq!(extract_with(TextExtractor::new()), "rating-aa\na-exp\nnext");
+fn extraction_removes_standalone_cr_and_normalizes_crlf_by_default() {
+    assert_eq!(extract_with(TextExtractor::new()), "rating-aaa-exp\nnext");
 }
 
 fn build_cmap_pdf() -> Vec<u8> {
@@ -74,7 +74,7 @@ fn cmap_decoding_applies_the_selected_carriage_return_policy() {
     let document = PdfDocument::new(reader);
 
     for (policy, expected) in [
-        (CarriageReturnHandling::NormalizeLineEnding, "\nA"),
+        (CarriageReturnHandling::NormalizeLineEnding, "\rA"),
         (CarriageReturnHandling::Remove, "A"),
         (CarriageReturnHandling::ReplaceWithSpace, " A"),
     ] {

--- a/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
@@ -34,6 +34,18 @@ fn extract_text(content: &[u8], handling: CarriageReturnHandling) -> String {
         .text
 }
 
+/// Extract page 0's plain text using the default carriage-return policy.
+fn extract_text_with_default(content: &[u8]) -> String {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
 #[test]
 fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
     // Content stream containing a literal 0x0D byte inside the `Tj` string,
@@ -41,15 +53,15 @@ fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
     // mirrors the real-world pattern found in production documents where
     // "rating-aaa-exp-sf" was extracted as "rating-aa\ra-exp-sf".
     let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\ra-exp-sf)Tj\nET\n";
-    let text = extract_text(content, CarriageReturnHandling::ReplaceWithSpace);
+    let text = extract_text_with_default(content);
 
     assert!(
         !text.contains('\r'),
         "a stray CR must not survive into extracted text, got: {text:?}"
     );
     assert!(
-        text.contains("rating-aa a-exp-sf"),
-        "the CR must become a space rather than silently splitting the word, got: {text:?}"
+        text.contains("rating-aaa-exp-sf"),
+        "the default policy must remove the stray CR without splitting the word, got: {text:?}"
     );
 }
 

--- a/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
+++ b/oxidize-pdf-core/tests/issue_476_stray_cr_test.rs
@@ -1,0 +1,95 @@
+//! Issue #476 — a literal `\r` (0x0D) byte embedded inside a PDF text-showing
+//! operator's string (`Tj`/`TJ`/`'`/`"`) survived `sanitize_extracted_text`
+//! unmodified and landed verbatim in extracted text.
+//!
+//! A raw CR inside such a string is not a structural line break: PDF
+//! text-showing operators draw glyphs, and a stray CR byte inside one is
+//! producer noise (e.g. a generator that copied CRLF-terminated source text
+//! directly into a content-stream string without normalizing it first). Left
+//! unmodified, a `\r` landing mid-word silently split the word in extracted
+//! output — `"rating-aaa-exp-sf"` came out as `"rating-aa\ra-exp-sf"` — which
+//! corrupts words and can break regex-based text processing downstream.
+//!
+//! These are end-to-end tests through the real `TextExtractor` pipeline
+//! (`PdfReader` -> `PdfDocument` -> `extract_from_page`), not just the
+//! `sanitize_extracted_text` unit tests in `text_sanitization_test.rs`,
+//! to guard the fix at the level a real caller observes it.
+
+#[path = "common/mod.rs"]
+mod common;
+use common::synthetic_pdf::build_pdf_with_content_stream;
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// Extract page 0's plain text with default extraction options.
+fn extract_text(content: &[u8]) -> String {
+    let pdf = build_pdf_with_content_stream(content);
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("synthetic PDF must parse");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions::default());
+    extractor
+        .extract_from_page(&document, 0)
+        .expect("extract page 0")
+        .text
+}
+
+#[test]
+fn a_stray_cr_mid_word_in_a_tj_string_does_not_split_the_word() {
+    // Content stream containing a literal 0x0D byte inside the `Tj` string,
+    // exactly as a real producer's malformed text run would encode it —
+    // mirrors the real-world pattern found in production documents where
+    // "rating-aaa-exp-sf" was extracted as "rating-aa\ra-exp-sf".
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\ra-exp-sf)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "a stray CR must not survive into extracted text, got: {text:?}"
+    );
+    assert!(
+        text.contains("rating-aa a-exp-sf"),
+        "the CR must become a space rather than silently splitting the word, got: {text:?}"
+    );
+}
+
+#[test]
+fn a_genuine_crlf_pair_in_a_tj_string_collapses_to_a_single_newline() {
+    // A real Windows line ending that made it into the PDF's own text
+    // content should still read as one line break, not a line break plus a
+    // leading space on the next line.
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(line one\r\nline two)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "CR must be dropped from a CRLF pair, got: {text:?}"
+    );
+    assert!(
+        text.contains("line one\nline two"),
+        "CRLF must collapse to a bare LF, got: {text:?}"
+    );
+}
+
+#[test]
+fn a_stray_cr_split_across_two_separate_tj_calls_still_becomes_a_space() {
+    // The bug is in text decoding, not in how runs are joined, so it must
+    // also hold when the CR is the *last* byte of one `Tj` call rather than
+    // strictly mid-string within a single call.
+    let content = b"BT\n/F1 12 Tf\n100 700 Td\n(rating-aa\r)Tj\n(a-exp-sf)Tj\nET\n";
+    let text = extract_text(content);
+
+    assert!(
+        !text.contains('\r'),
+        "a stray CR must not survive into extracted text, got: {text:?}"
+    );
+    assert!(
+        text.contains("rating-aa"),
+        "text before the CR must still be present, got: {text:?}"
+    );
+    assert!(
+        text.contains("a-exp-sf"),
+        "text after the CR must still be present, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -73,6 +73,26 @@ fn extract_preserve_layout(content: &str) -> String {
         .text
 }
 
+fn extract_preserve_layout_fragment_texts(content: &str) -> Vec<String> {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .fragments
+        .into_iter()
+        .map(|fragment| fragment.text)
+        .collect()
+}
+
 #[test]
 fn hyphenated_wrap_survives_an_unrelated_fragment_sorted_between_its_two_lines() {
     // Mirrors the real-world document that motivated #482: a phone-number-like
@@ -140,5 +160,47 @@ fn same_line_hyphen_is_not_treated_as_a_wrap() {
     assert!(
         text.contains("well-known") || text.contains("well- known"),
         "a same-line hyphen must not be silently dropped or merged incorrectly, got: {text:?}"
+    );
+}
+
+#[test]
+fn non_hyphenated_overlay_does_not_interleave_with_an_earlier_flow() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        // First emission region: two body/footer lines.
+        "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
+        "1 0 0 1 100 30 Tm\n(Body second) Tj\n",
+        // Second region restarts above the first and overlaps its Y range.
+        "1 0 0 1 300 50 Tm\n(Overlay first) Tj\n",
+        "1 0 0 1 300 35 Tm\n(Overlay second) Tj\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec![
+            "Body first",
+            "Body second",
+            "Overlay first",
+            "Overlay second"
+        ]
+    );
+}
+
+#[test]
+fn marked_content_regions_do_not_interleave_when_y_ranges_overlap() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "/P <</MCID 7>> BDC\n",
+        "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
+        "1 0 0 1 100 30 Tm\n(Body second) Tj\nEMC\n",
+        // The 3pt upward move is deliberately below the geometric reset
+        // threshold; the MCID transition is the structural boundary.
+        "/Span <</MCID 8>> BDC\n",
+        "1 0 0 1 300 33 Tm\n(Tagged overlay) Tj\nEMC\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec!["Body first", "Body second", "Tagged overlay"]
     );
 }

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -1,0 +1,144 @@
+//! Regression tests for issue #482.
+//!
+//! `preserve_layout = true` (and `reorder_columns = true`, which shares the
+//! same `sort_and_merge_fragments` call) sorts *every* fragment on a page by
+//! Y-coordinate with no notion of separate content regions. When a hyphenated
+//! word wraps across two lines, and an unrelated fragment drawn elsewhere in
+//! the content stream (e.g. a digital-signature annotation's appearance
+//! text) happens to sit at a Y-coordinate between those two lines, the sort
+//! splices the unrelated fragment in between them. `reconstruct_text_from_fragments`
+//! then walks the sorted list linearly and joins the hyphen to the wrong
+//! fragment, corrupting both the wrapped word and the unrelated text at once.
+//!
+//! Fix: fuse a hyphen-ended fragment with its wrap continuation while
+//! fragments are still in emission (content-stream) order — before the
+//! Y-sort runs — so the wrapped token becomes a single atomic fragment that
+//! nothing can be spliced into afterward.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_preserve_layout(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn hyphenated_wrap_survives_an_unrelated_fragment_sorted_between_its_two_lines() {
+    // Mirrors the real-world document that motivated #482: a phone-number-like
+    // token wraps hyphenated across two lines at y=45.72 and y=33.48. An
+    // unrelated fragment (standing in for a digital-signature annotation's
+    // appearance text) is drawn *later* in the content stream, but at
+    // y=35.62 -- a Y-coordinate that falls strictly between the two wrapped
+    // lines. Before the fix, `sort_and_merge_fragments`'s global Y-sort
+    // placed the unrelated fragment between them, and the hyphen got joined
+    // to it instead of to "0900".
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        // Line 1: ends with a hyphen, wrapping to the next line.
+        "1 0 0 1 100 45.72 Tm\n(Tel.: 3016-) Tj\n",
+        // Line 2: the wrap continuation. Y is far enough below line 1 to be a
+        // real line wrap (> newline_threshold).
+        "1 0 0 1 100 33.48 Tm\n(0900) Tj\n",
+        // An unrelated fragment, drawn *after* both lines above in emission
+        // order, but at a Y-coordinate strictly between them.
+        "1 0 0 1 300 35.62 Tm\n(Unrelated annotation text) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+
+    assert!(
+        text.contains("3016-0900") || text.contains("30160900"),
+        "the hyphen-wrapped number must survive intact, got: {text:?}"
+    );
+    assert!(
+        !text.contains("3016Unrelated") && !text.contains("3016-Unrelated"),
+        "the unrelated fragment must not be spliced into the wrapped number: {text:?}"
+    );
+    assert!(
+        text.contains("Unrelated annotation text"),
+        "the unrelated fragment's own text must still be present somewhere: {text:?}"
+    );
+}
+
+#[test]
+fn hyphenated_wrap_without_interleaving_fragment_still_merges_normally() {
+    // Baseline sanity check: with no unrelated fragment in the way, a simple
+    // hyphenated wrap must still merge exactly as before.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(hyphen-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(ated) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+    assert!(
+        text.contains("hyphenated"),
+        "plain hyphenated wrap (no interleaving fragment) must still merge, got: {text:?}"
+    );
+}
+
+#[test]
+fn same_line_hyphen_is_not_treated_as_a_wrap() {
+    // A hyphen that is part of the SAME line (e.g. "well-known") must not be
+    // merged with whatever fragment happens to be next in emission order --
+    // only a genuine line-wrap gap should trigger the merge.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(well-) Tj\n",
+        "1 0 0 1 140 700 Tm\n(known fact) Tj\nET"
+    );
+    let text = extract_preserve_layout(content);
+    assert!(
+        text.contains("well-known") || text.contains("well- known"),
+        "a same-line hyphen must not be silently dropped or merged incorrectly, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
+++ b/oxidize-pdf-core/tests/issue_482_preserve_layout_interleave_test.rs
@@ -170,9 +170,10 @@ fn non_hyphenated_overlay_does_not_interleave_with_an_earlier_flow() {
         // First emission region: two body/footer lines.
         "1 0 0 1 100 45 Tm\n(Body first) Tj\n",
         "1 0 0 1 100 30 Tm\n(Body second) Tj\n",
-        // Second region restarts above the first and overlaps its Y range.
-        "1 0 0 1 300 50 Tm\n(Overlay first) Tj\n",
-        "1 0 0 1 300 35 Tm\n(Overlay second) Tj\nET"
+        // Second region restarts only 3pt above the preceding baseline: below
+        // the old 0.5em reset threshold, but outside the visual-line tolerance.
+        "1 0 0 1 300 33 Tm\n(Overlay first) Tj\n",
+        "1 0 0 1 300 18 Tm\n(Overlay second) Tj\nET"
     );
 
     assert_eq!(
@@ -202,5 +203,22 @@ fn marked_content_regions_do_not_interleave_when_y_ranges_overlap() {
     assert_eq!(
         extract_preserve_layout_fragment_texts(content),
         vec!["Body first", "Body second", "Tagged overlay"]
+    );
+}
+
+#[test]
+fn hyphen_prefusion_does_not_cross_an_mcid_region_boundary() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "/P <</MCID 7>> BDC\n",
+        "1 0 0 1 100 45 Tm\n(Body-) Tj\nEMC\n",
+        "/Span <</MCID 8>> BDC\n",
+        "1 0 0 1 300 30 Tm\n(Unrelated overlay) Tj\nEMC\nET"
+    );
+
+    assert_eq!(
+        extract_preserve_layout_fragment_texts(content),
+        vec!["Body-", "Unrelated overlay"],
+        "the pre-sort hyphen mitigation must not fuse distinct MCID regions"
     );
 }

--- a/oxidize-pdf-core/tests/issue_486_flat_hyphen_merge_test.rs
+++ b/oxidize-pdf-core/tests/issue_486_flat_hyphen_merge_test.rs
@@ -1,0 +1,202 @@
+//! Regression tests for issue #486.
+//!
+//! `merge_hyphenated` (default `true` on `ExtractionOptions`) is documented
+//! as "merge hyphenated words at line ends," but it was only wired into
+//! `reconstruct_text_from_fragments` (`preserve_layout: true`) and
+//! `merge_into_paragraphs` (`reconstruct_paragraphs: true`). The flat
+//! (default) path -- every text-showing operator (`Tj`, `TJ`, `'`, `"`)
+//! independently deciding a `'\n'` separator via the shared `append_bounded`
+//! helper -- had no such logic: a hyphen-wrapped word or number split across
+//! two lines extracted with a raw `\n` in place of the hyphen instead of
+//! being joined.
+//!
+//! Fix: `append_bounded` now pops a trailing `-` and fuses the next run with
+//! no separator when the caller requested `'\n'` (a genuine line wrap) and
+//! `merge_hyphenated` is enabled.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+
+/// Build a minimal, valid PDF whose single page has `content` as its content
+/// stream. `/F1` maps to Helvetica (Type1) so decoding is trivial.
+fn build_pdf(content: &str) -> Vec<u8> {
+    let clen = content.len();
+    let o1 = "<< /Type /Catalog /Pages 3 0 R >>";
+    let o2 = "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>";
+    let o3 = "<< /Type /Pages /Kids [2 0 R] /Count 1 >>";
+    let o4 = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = [0usize; 6];
+    let mut push = |buf: &mut Vec<u8>, n: usize, body: &str| {
+        offsets[n] = buf.len();
+        buf.extend_from_slice(format!("{n} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut buf, 1, o1);
+    push(&mut buf, 2, o2);
+    push(&mut buf, 3, o3);
+    push(&mut buf, 4, o4);
+
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {clen} >>\nstream\n{content}\nendstream\nendobj\n").as_bytes(),
+    );
+
+    let xref_pos = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n").as_bytes(),
+    );
+    buf
+}
+
+fn extract_flat(content: &str) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    // Default options => preserve_layout = false, merge_hyphenated = true
+    // (the flat path, previously unaffected by merge_hyphenated).
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+fn extract_flat_with_options(content: &str, options: ExtractionOptions) -> String {
+    let doc = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+
+    let mut ex = TextExtractor::with_options(options);
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn tj_hyphenated_line_wrap_merges_on_the_flat_path() {
+    // Real-world shape: a phone number's "3016-" wraps to "0900" on the next
+    // line, drawn as two separate Tj (ShowText) calls.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(+55 11 3016-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(0900) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("+55 11 30160900"),
+        "hyphen-wrapped number must fuse into one token on the flat path, got: {text:?}"
+    );
+    assert!(
+        !text.contains("3016-\n0900") && !text.contains("3016-0900"),
+        "the hyphen must be dropped, not kept alongside a newline or as-is: {text:?}"
+    );
+}
+
+#[test]
+fn tj_array_hyphenated_line_wrap_merges_on_the_flat_path() {
+    // Same wrap, drawn with the TJ (ShowTextArray) operator instead of Tj.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n[(+55 11 3016-)] TJ\n",
+        "1 0 0 1 100 688 Tm\n[(0900)] TJ\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("+55 11 30160900"),
+        "TJ path must also fuse the hyphen-wrapped number, got: {text:?}"
+    );
+}
+
+#[test]
+fn quote_operator_hyphenated_line_wrap_merges() {
+    // The `'` operator (T* then Tj) always starts a new line by definition;
+    // a hyphen at the end of one `'`-drawn line must still merge with the
+    // next `'`-drawn line's text.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n10 TL\n",
+        "1 0 0 1 100 700 Tm\n(docu-) '\n",
+        "(ment) '\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("document"),
+        "the `'` operator's hyphenated wrap must merge, got: {text:?}"
+    );
+    assert!(!text.contains("docu-\nment"), "got: {text:?}");
+}
+
+#[test]
+fn double_quote_operator_hyphenated_line_wrap_merges() {
+    // The `"` operator (set spacing, then ' semantics) must behave the same
+    // way as plain `'`.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n10 TL\n",
+        "1 0 0 1 100 700 Tm\n(docu-) '\n",
+        "0 0 (ment) \"\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        text.contains("document"),
+        "the `\"` operator's hyphenated wrap must merge, got: {text:?}"
+    );
+}
+
+#[test]
+fn same_line_hyphen_is_not_merged_across_an_unrelated_boundary() {
+    // "well-" and "known" are two Tj calls on the SAME line (small forward
+    // dx, well under the newline threshold) -- this is a real same-line
+    // hyphenated word, not a line wrap, and must be left as ordinary text
+    // (either glued as-is by the small-gap rule or space-separated), never
+    // treated as a wrap-merge candidate. This only actually exercises the
+    // fusion gate at all if a '\n' separator is produced, which it should
+    // not be here.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(well-) Tj\n",
+        "1 0 0 1 140 700 Tm\n(known fact) Tj\nET"
+    );
+    let text = extract_flat(content);
+    assert!(
+        !text.contains('\n'),
+        "same-line pieces must not gain a newline at all: {text:?}"
+    );
+    assert!(
+        text.contains("well-known") || text.contains("well- known"),
+        "same-line hyphen must be preserved as ordinary text: {text:?}"
+    );
+}
+
+#[test]
+fn merge_hyphenated_false_disables_flat_path_fusion() {
+    // Opting out of merge_hyphenated must restore the pre-#486 behavior: the
+    // hyphen and the newline both survive, split across two lines.
+    let content = concat!(
+        "BT\n/F1 10 Tf\n",
+        "1 0 0 1 100 700 Tm\n(+55 11 3016-) Tj\n",
+        "1 0 0 1 100 688 Tm\n(0900) Tj\nET"
+    );
+    let text = extract_flat_with_options(
+        content,
+        ExtractionOptions {
+            merge_hyphenated: false,
+            ..Default::default()
+        },
+    );
+    assert!(
+        text.contains("3016-\n0900"),
+        "merge_hyphenated: false must keep the pre-fix split behavior, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/marked_content_roundtrip_test.rs
+++ b/oxidize-pdf-core/tests/marked_content_roundtrip_test.rs
@@ -119,3 +119,43 @@ fn writer_to_extractor_keeps_overlaid_mcid_blocks_distinct() {
         "World must carry struct_tag 'P'"
     );
 }
+
+#[test]
+fn writer_actual_text_roundtrips_unicode_and_replaces_visual_glyphs() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content_with_actual_text("Span", "^{40} € 😀")
+        .expect("begin ActualText span");
+    page.text()
+        .set_font(Font::Helvetica, 9.0)
+        .at(100.0, 705.0)
+        .write("40")
+        .expect("write visual superscript glyphs");
+    page.end_marked_content().expect("end ActualText span");
+
+    let mut doc = Document::new();
+    doc.add_page(page);
+    let bytes = doc.to_bytes().expect("serialize PDF");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("read generated PDF");
+    let document = PdfDocument::new(reader);
+    let mut extractor = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    let page = extractor
+        .extract_from_page(&document, 0)
+        .expect("extract generated page");
+
+    assert_eq!(mcid, 0);
+    assert!(
+        page.fragments
+            .iter()
+            .any(|fragment| fragment.text == "^{40} € 😀" && fragment.mcid == Some(mcid)),
+        "ActualText must replace the visual glyphs and retain its MCID: {:?}",
+        page.fragments
+    );
+    assert!(
+        page.fragments.iter().all(|fragment| fragment.text != "40"),
+        "visual glyphs must not leak into logical extraction"
+    );
+}

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -16,8 +16,10 @@ const POLICIES: [CarriageReturnHandling; 3] = [
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
-    /// Every policy must reach a fixed point. Policies that rewrite standalone
-    /// CR must also remove that representation completely.
+    /// Policies that rewrite standalone CR must remove that representation
+    /// completely and reach a fixed point. `NormalizeLineEnding` deliberately
+    /// preserves standalone CR, so overlapping input such as CR+CRLF cannot be
+    /// globally idempotent: the first pass correctly yields CRLF.
     #[test]
     fn sanitized_text_contains_no_cr_and_is_idempotent(
         input in proptest::collection::vec(any::<char>(), 0..256)
@@ -30,7 +32,9 @@ proptest! {
         if policy != CarriageReturnHandling::NormalizeLineEnding {
             prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
         }
-        prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+        if policy != CarriageReturnHandling::NormalizeLineEnding {
+            prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+        }
     }
 
     /// A standalone CR between printable, non-whitespace fragments is the only

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -16,8 +16,8 @@ const POLICIES: [CarriageReturnHandling; 3] = [
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
-    /// Sanitization must remove the ambiguous representation completely and
-    /// reaching the fixed point a second time must not change the output.
+    /// Every policy must reach a fixed point. Policies that rewrite standalone
+    /// CR must also remove that representation completely.
     #[test]
     fn sanitized_text_contains_no_cr_and_is_idempotent(
         input in proptest::collection::vec(any::<char>(), 0..256)
@@ -27,7 +27,9 @@ proptest! {
         let once = sanitize_extracted_text_with_policy(&input, policy);
         let twice = sanitize_extracted_text_with_policy(&once, policy);
 
-        prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        if policy != CarriageReturnHandling::NormalizeLineEnding {
+            prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        }
         prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
     }
 
@@ -50,7 +52,7 @@ proptest! {
         );
         prop_assert_eq!(
             sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
-            format!("{left}\n{right}")
+            input
         );
     }
 
@@ -93,7 +95,7 @@ proptest! {
         );
         prop_assert_eq!(
             sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
-            format!("{left}{}{right}", "\n".repeat(count))
+            input
         );
     }
 }

--- a/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
+++ b/oxidize-pdf-core/tests/prop_text_sanitization_invariants.rs
@@ -1,0 +1,99 @@
+//! Property invariants for carriage-return sanitization (issue #476).
+//!
+//! The examples in `text_sanitization_test` pin representative strings. These
+//! properties range over arbitrary surrounding text and CR run lengths so the
+//! policy contract is guarded independently of any one reported document.
+
+use oxidize_pdf::text::{sanitize_extracted_text_with_policy, CarriageReturnHandling};
+use proptest::prelude::*;
+
+const POLICIES: [CarriageReturnHandling; 3] = [
+    CarriageReturnHandling::Remove,
+    CarriageReturnHandling::ReplaceWithSpace,
+    CarriageReturnHandling::NormalizeLineEnding,
+];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Sanitization must remove the ambiguous representation completely and
+    /// reaching the fixed point a second time must not change the output.
+    #[test]
+    fn sanitized_text_contains_no_cr_and_is_idempotent(
+        input in proptest::collection::vec(any::<char>(), 0..256)
+            .prop_map(|chars| chars.into_iter().collect::<String>()),
+        policy in prop::sample::select(POLICIES.to_vec()),
+    ) {
+        let once = sanitize_extracted_text_with_policy(&input, policy);
+        let twice = sanitize_extracted_text_with_policy(&once, policy);
+
+        prop_assert!(!once.contains('\r'), "CR leaked for {policy:?}: {once:?}");
+        prop_assert_eq!(once, twice, "sanitization is not idempotent for {:?}", policy);
+    }
+
+    /// A standalone CR between printable, non-whitespace fragments is the only
+    /// ambiguous case and each public policy gives it one exact interpretation.
+    #[test]
+    fn standalone_cr_obeys_the_selected_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r{right}");
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}\n{right}")
+        );
+    }
+
+    /// CRLF is not ambiguous: it is one line ending under every policy.
+    #[test]
+    fn crlf_is_one_line_feed_under_every_policy(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+    ) {
+        let input = format!("{left}\r\n{right}");
+        let expected = format!("{left}\n{right}");
+
+        for policy in POLICIES {
+            prop_assert_eq!(
+                sanitize_extracted_text_with_policy(&input, policy),
+                expected.as_str(),
+                "CRLF contract changed for {:?}",
+                policy
+            );
+        }
+    }
+
+    /// Runs of standalone CR exercise deduplication and make accidental
+    /// pair-consumption visible: only the space policy collapses the run.
+    #[test]
+    fn standalone_cr_runs_follow_policy_cardinality(
+        left in "[A-Za-z0-9]{1,24}",
+        right in "[A-Za-z0-9]{1,24}",
+        count in 1usize..64,
+    ) {
+        let input = format!("{left}{}{right}", "\r".repeat(count));
+
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::Remove),
+            format!("{left}{right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::ReplaceWithSpace),
+            format!("{left} {right}")
+        );
+        prop_assert_eq!(
+            sanitize_extracted_text_with_policy(&input, CarriageReturnHandling::NormalizeLineEnding),
+            format!("{left}{}{right}", "\n".repeat(count))
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -50,10 +50,20 @@ fn test_collapse_multiple_spaces() {
 }
 
 #[test]
-fn test_default_normalizes_carriage_returns() {
+fn test_default_removes_standalone_carriage_returns() {
     let input = "unix\nwindows\r\nclassic-mac\rend";
-    let expected = "unix\nwindows\nclassic-mac\nend";
+    let expected = "unix\nwindows\nclassic-macend";
     assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_normalize_line_ending_preserves_standalone_carriage_returns() {
+    let input = "unix\nwindows\r\nclassic-mac\rend";
+    let expected = "unix\nwindows\nclassic-mac\rend";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::NormalizeLineEnding),
+        expected
+    );
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -67,6 +67,18 @@ fn test_normalize_line_ending_preserves_standalone_carriage_returns() {
 }
 
 #[test]
+fn test_crlf_normalization_is_idempotent_across_removed_controls() {
+    let input = "\r\u{1}\n";
+    let once =
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::NormalizeLineEnding);
+    let twice =
+        sanitize_extracted_text_with_policy(&once, CarriageReturnHandling::NormalizeLineEnding);
+
+    assert_eq!(once, "\n");
+    assert_eq!(twice, once);
+}
+
+#[test]
 fn test_remove_carriage_returns() {
     let input = "rating-aa\ra-exp\r\nnext";
     let expected = "rating-aaa-exp\nnext";

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -49,9 +49,50 @@ fn test_collapse_multiple_spaces() {
 
 #[test]
 fn test_preserve_allowed_whitespace() {
-    // Tab, newline, carriage return should be preserved
+    // Tab and newline should be preserved. A bare `\r` (no following `\n`)
+    // is normalized to a space rather than passed through -- see issue
+    // #476 and the dedicated `test_stray_cr_*` cases below.
     let input = "line1\nline2\ttab\rcarriage";
-    let expected = "line1\nline2\ttab\rcarriage";
+    let expected = "line1\nline2\ttab carriage";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_stray_cr_mid_word_becomes_space() {
+    // Issue #476: a literal CR embedded inside a PDF text-showing
+    // operator's string (producer noise, not a structural line break)
+    // should not survive verbatim -- it silently splits the word
+    // otherwise, e.g. "rating-aaa" -> "rating-aa\ra".
+    let input = "rating-aa\ra-exp-sf";
+    let expected = "rating-aa a-exp-sf";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_crlf_pair_collapses_to_single_newline() {
+    // A genuine CRLF pair (e.g. a Windows line ending that made it into
+    // the PDF's own text content) should collapse to a single `\n`, not
+    // become a newline plus a leading space on the next line.
+    let input = "line one\r\nline two";
+    let expected = "line one\nline two";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_multiple_stray_cr_collapse_like_spaces() {
+    // Consecutive bare CRs should collapse to a single space, matching
+    // how consecutive NULs and regular spaces already collapse.
+    let input = "word\r\r\ranother";
+    let expected = "word another";
+    assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_cr_at_end_of_string_with_no_following_char() {
+    // A trailing bare CR (no following char at all, not just no `\n`)
+    // must not panic and should still normalize to a space.
+    let input = "word\r";
+    let expected = "word ";
     assert_eq!(sanitize_extracted_text(input), expected);
 }
 

--- a/oxidize-pdf-core/tests/text_sanitization_test.rs
+++ b/oxidize-pdf-core/tests/text_sanitization_test.rs
@@ -5,7 +5,9 @@
 //!
 //! These tests follow TDD methodology - written BEFORE implementation.
 
-use oxidize_pdf::text::extraction::sanitize_extracted_text;
+use oxidize_pdf::text::extraction::{
+    sanitize_extracted_text, sanitize_extracted_text_with_policy, CarriageReturnHandling,
+};
 
 #[test]
 fn test_sanitize_nul_etx_sequence() {
@@ -48,11 +50,39 @@ fn test_collapse_multiple_spaces() {
 }
 
 #[test]
-fn test_preserve_allowed_whitespace() {
-    // Tab, newline, carriage return should be preserved
-    let input = "line1\nline2\ttab\rcarriage";
-    let expected = "line1\nline2\ttab\rcarriage";
+fn test_default_normalizes_carriage_returns() {
+    let input = "unix\nwindows\r\nclassic-mac\rend";
+    let expected = "unix\nwindows\nclassic-mac\nend";
     assert_eq!(sanitize_extracted_text(input), expected);
+}
+
+#[test]
+fn test_remove_carriage_returns() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aaa-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::Remove),
+        expected
+    );
+}
+
+#[test]
+fn test_replace_carriage_returns_with_space() {
+    let input = "rating-aa\ra-exp\r\nnext";
+    let expected = "rating-aa a-exp\nnext";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        expected
+    );
+}
+
+#[test]
+fn test_carriage_return_space_replacement_collapses_adjacent_spaces() {
+    let input = "before \r  after";
+    assert_eq!(
+        sanitize_extracted_text_with_policy(input, CarriageReturnHandling::ReplaceWithSpace),
+        "before after"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Release 4.4.0

Minor release adding public ActualText marked-content support and the latest text-extraction correctness fixes.

### Added

- ActualText marked-content generation support (#63, #490).

### Fixed

- Region-aware preserve_layout ordering for overlapping body/annotation/overlay flows (#482, #485, #489).
- Flat-path merge_hyphenated behavior (#486, #487).
- Configurable and idempotent carriage-return handling (#476, #481, #484).

### Release preparation

- Workspace version bumped to 4.4.0.
- Cargo.lock updated.
- CHANGELOG.md finalized for 2026-08-16.
- cargo check -p oxidize-pdf --lib passed.
- Pre-commit formatting, Clippy, and build checks passed.