### PR TITLE
feat(annotations): add incremental text note editing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,8 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: oxidize-pdf
+          # Development accumulates backward-compatible API changes before a
+          # release version is chosen. Allow minor-level changes on develop,
+          # while release/main checks continue deriving the required bump from
+          # Cargo.toml and the published baseline.
+          release-type: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'develop') || github.ref == 'refs/heads/develop') && 'minor' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install Tesseract OCR (Ubuntu)
+      - name: Install Tesseract OCR and qpdf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev qpdf
 
       - name: Install Tesseract OCR (macOS)
         if: matrix.os == 'macos-latest'
@@ -98,6 +98,14 @@ jobs:
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
+
+      - name: Validate incremental text notes with qpdf
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_493_incremental_text_notes_test
+          qpdf_accepts_incremental_text_note_revision
+          -- --ignored --exact
 
       # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
       # enricher/extra bag), so the default test step above never compiles its

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -41,6 +41,8 @@ use crate::text::TextEncoding;
 use std::collections::HashMap;
 use std::io::Cursor;
 
+use super::incremental_update::{format_real, write_dictionary, write_object};
+
 /// Fills AcroForm fields on an existing parsed PDF by appending an
 /// ISO 32000-1 §7.5.6 incremental update. See the module docs.
 pub struct IncrementalFormFiller<'a> {
@@ -506,7 +508,7 @@ fn build_text_ap(
     let mut resources = PdfDictionary::new();
     resources.insert("Font".to_string(), PdfObject::Dictionary(font_dict));
     let mut resources_bytes = Vec::new();
-    write_dict(&mut resources_bytes, &resources)?;
+    write_dictionary(&mut resources_bytes, &resources)?;
 
     Ok((content, [0.0, 0.0, width, height], resources_bytes))
 }
@@ -714,7 +716,7 @@ fn parse_da_string(da: &str) -> Option<(String, f64)> {
 /// The content is emitted UNCOMPRESSED, so `/Length` is exactly the raw byte
 /// count — no filter, no two-pass buffering. `resources_snippet` is a
 /// pre-serialized `<< ... >>` dictionary (built by the caller via the
-/// module's `write_dict`) inlined as the `/Resources` value.
+/// shared incremental serializer) inlined as the `/Resources` value.
 fn write_indirect_stream_object(
     out: &mut Vec<u8>,
     num: u32,
@@ -752,77 +754,9 @@ fn write_indirect_object(
     dict: &PdfDictionary,
 ) -> Result<()> {
     out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
-    write_object_value(out, &PdfObject::Dictionary(dict.clone()))?;
+    write_object(out, &PdfObject::Dictionary(dict.clone()))?;
     out.extend_from_slice(b"\nendobj\n");
     Ok(())
-}
-
-/// Serialize a parser [`PdfObject`] to PDF wire bytes. Streams are rejected:
-/// AcroForm field and form dictionaries never carry an embedded stream, and
-/// emitting one without a fresh `/Length` would corrupt the file.
-fn write_object_value(out: &mut Vec<u8>, obj: &PdfObject) -> Result<()> {
-    match obj {
-        PdfObject::Null => out.extend_from_slice(b"null"),
-        PdfObject::Boolean(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
-        PdfObject::Integer(i) => out.extend_from_slice(i.to_string().as_bytes()),
-        PdfObject::Real(f) => out.extend_from_slice(format_real(*f).as_bytes()),
-        PdfObject::String(s) => write_literal_string(out, s.as_bytes()),
-        PdfObject::Name(n) => write_name(out, n),
-        PdfObject::Reference(num, gen) => {
-            out.extend_from_slice(format!("{num} {gen} R").as_bytes())
-        }
-        PdfObject::Array(arr) => {
-            out.extend_from_slice(b"[");
-            for (i, item) in arr.0.iter().enumerate() {
-                if i > 0 {
-                    out.extend_from_slice(b" ");
-                }
-                write_object_value(out, item)?;
-            }
-            out.extend_from_slice(b"]");
-        }
-        PdfObject::Dictionary(d) => write_dict(out, d)?,
-        PdfObject::Stream(_) => {
-            return Err(PdfError::InvalidStructure(
-                "unexpected stream object in AcroForm field dictionary".to_string(),
-            ))
-        }
-    }
-    Ok(())
-}
-
-fn write_dict(out: &mut Vec<u8>, dict: &PdfDictionary) -> Result<()> {
-    out.extend_from_slice(b"<< ");
-    // Deterministic key order: keeps output stable and tests reproducible.
-    let mut keys: Vec<&PdfName> = dict.0.keys().collect();
-    keys.sort_by(|a, b| a.0.cmp(&b.0));
-    for key in keys {
-        write_name(out, key);
-        out.extend_from_slice(b" ");
-        // Safe: key came from the dict.
-        write_object_value(out, &dict.0[key])?;
-        out.extend_from_slice(b" ");
-    }
-    out.extend_from_slice(b">>");
-    Ok(())
-}
-
-fn write_name(out: &mut Vec<u8>, name: &PdfName) {
-    out.extend_from_slice(b"/");
-    for &b in name.0.as_bytes() {
-        // Regular characters pass through; everything else is #XX-escaped
-        // (ISO 32000-1 §7.3.5).
-        if b.is_ascii_alphanumeric()
-            || matches!(
-                b,
-                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
-            )
-        {
-            out.push(b);
-        } else {
-            out.extend_from_slice(format!("#{b:02X}").as_bytes());
-        }
-    }
 }
 
 /// Serialize a PDF literal string `(...)`, escaping the reserved bytes and
@@ -842,27 +776,6 @@ fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
         }
     }
     out.push(b')');
-}
-
-/// Format a PDF real without scientific notation, trimming trailing zeros.
-fn format_real(f: f64) -> String {
-    // PDF has no token for NaN/Infinity; emit a benign 0 rather than a
-    // malformed numeric. Field dicts essentially never carry such values,
-    // but the serializer must stay total.
-    if !f.is_finite() {
-        return "0".to_string();
-    }
-    if f == f.trunc() {
-        return format!("{}", f as i64);
-    }
-    let mut s = format!("{f:.6}");
-    while s.ends_with('0') {
-        s.pop();
-    }
-    if s.ends_with('.') {
-        s.pop();
-    }
-    s
 }
 
 // ---------------------------------------------------------------------------

--- a/oxidize-pdf-core/src/writer/incremental_text_notes.rs
+++ b/oxidize-pdf-core/src/writer/incremental_text_notes.rs
@@ -1,0 +1,534 @@
+//! Incremental editing of standard `/Text` annotations in existing PDFs.
+
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::{PdfDocument, PdfReader};
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+
+const NOTE_SIZE: f64 = 20.0;
+
+/// Stable indirect-object identity of a text note.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TextNoteId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl TextNoteId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// A standard PDF text-note annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextNote {
+    /// Stable indirect-object identity.
+    pub id: TextNoteId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Lower-left point of the annotation rectangle.
+    pub position: Point,
+    /// Note contents decoded as Unicode.
+    pub contents: String,
+}
+
+/// A requested change to the document's text notes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TextNoteMutation {
+    /// Add a 20×20 point note to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Lower-left point of the new note.
+        position: Point,
+        /// Non-empty note contents.
+        contents: String,
+    },
+    /// Move and edit an existing note while preserving its other keys.
+    Update {
+        /// Existing text-note identity.
+        id: TextNoteId,
+        /// New lower-left point. Existing width and height are preserved.
+        position: Point,
+        /// New non-empty contents.
+        contents: String,
+    },
+    /// Remove an existing note reference from its page.
+    Remove {
+        /// Existing text-note identity.
+        id: TextNoteId,
+    },
+}
+
+/// Result of one atomic incremental text-note update.
+#[derive(Debug, Clone)]
+pub struct TextNoteUpdate {
+    /// Complete PDF bytes. The original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Notes allocated by `Add`, in mutation order.
+    pub added_notes: Vec<TextNote>,
+}
+
+/// Reads and atomically edits standard text notes in an existing PDF.
+pub struct IncrementalTextNoteEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalTextNoteEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/Text` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF is malformed or encrypted, or when a text
+    /// annotation has no stable indirect identity or is shared by pages.
+    pub fn notes(&self) -> Result<Vec<TextNote>> {
+        let snapshot = Snapshot::parse(self.base_bytes)?;
+        let mut notes: Vec<_> = snapshot
+            .annotations
+            .iter()
+            .filter_map(|(id, annotation)| annotation.is_text.then(|| annotation.note(*id)))
+            .collect();
+        notes.sort_by_key(|note| {
+            (
+                note.page_index,
+                note.id.object_number,
+                note.id.generation_number,
+            )
+        });
+        Ok(notes)
+    }
+
+    /// Validate and apply a batch as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed or encrypted PDFs, invalid pages or note
+    /// identities, conflicting mutations, invalid contents or coordinates, and
+    /// exhausted indirect-object numbers.
+    pub fn apply(&self, mutations: &[TextNoteMutation]) -> Result<TextNoteUpdate> {
+        let mut snapshot = Snapshot::parse(self.base_bytes)?;
+        if mutations.is_empty() {
+            return Ok(TextNoteUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                added_notes: Vec::new(),
+            });
+        }
+        validate_batch(&snapshot, mutations)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut added_notes = Vec::new();
+        let mut changed_pages = HashSet::new();
+        let mut rewritten_annotations: HashMap<TextNoteId, PdfDictionary> = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                TextNoteMutation::Add {
+                    page_index,
+                    position,
+                    contents,
+                } => {
+                    let id_tuple = update.allocate_id()?;
+                    let id = TextNoteId::new(id_tuple.0, id_tuple.1);
+                    let dictionary = new_note_dictionary(*position, contents);
+                    update.replace(id_tuple, PdfObject::Dictionary(dictionary.clone()))?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id_tuple.0, id_tuple.1));
+                    changed_pages.insert(*page_index);
+                    added_notes.push(TextNote {
+                        id,
+                        page_index: *page_index,
+                        position: *position,
+                        contents: contents.clone(),
+                    });
+                }
+                TextNoteMutation::Update {
+                    id,
+                    position,
+                    contents,
+                } => {
+                    let annotation = target_text_note(&snapshot, *id)?;
+                    let mut dictionary = annotation.dictionary.clone();
+                    let width = annotation.rect[2] - annotation.rect[0];
+                    let height = annotation.rect[3] - annotation.rect[1];
+                    dictionary.insert("Rect".to_string(), rectangle(*position, width, height));
+                    dictionary.insert("Contents".to_string(), pdf_text(contents));
+                    rewritten_annotations.insert(*id, dictionary);
+                }
+                TextNoteMutation::Remove { id } => {
+                    let page_index = target_text_note(&snapshot, *id)?.page_index;
+                    let page = &mut snapshot.pages[page_index as usize];
+                    page.annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+
+        for (id, dictionary) in rewritten_annotations {
+            update.replace(id.tuple(), PdfObject::Dictionary(dictionary))?;
+        }
+        for page_index in changed_pages {
+            let page = &mut snapshot.pages[page_index as usize];
+            match page.container {
+                AnnotationContainer::Page => {
+                    page.dictionary.insert(
+                        "Annots".to_string(),
+                        PdfObject::Array(PdfArray(page.annotations.clone())),
+                    );
+                    update.replace(
+                        page.reference,
+                        PdfObject::Dictionary(page.dictionary.clone()),
+                    )?;
+                }
+                AnnotationContainer::Indirect(id) => {
+                    update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?;
+                }
+            }
+        }
+
+        Ok(TextNoteUpdate {
+            pdf_bytes: update.finish()?,
+            added_notes,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct PageState {
+    reference: (u32, u16),
+    dictionary: PdfDictionary,
+    bounds: [f64; 4],
+    container: AnnotationContainer,
+    annotations: Vec<PdfObject>,
+}
+
+#[derive(Clone, Copy)]
+enum AnnotationContainer {
+    Page,
+    Indirect((u32, u16)),
+}
+
+struct AnnotationState {
+    page_index: u32,
+    dictionary: PdfDictionary,
+    rect: [f64; 4],
+    contents: String,
+    is_text: bool,
+}
+
+impl AnnotationState {
+    fn note(&self, id: TextNoteId) -> TextNote {
+        TextNote {
+            id,
+            page_index: self.page_index,
+            position: Point::new(self.rect[0], self.rect[1]),
+            contents: self.contents.clone(),
+        }
+    }
+}
+
+struct Snapshot {
+    pages: Vec<PageState>,
+    annotations: HashMap<TextNoteId, AnnotationState>,
+}
+
+impl Snapshot {
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        let reader = PdfReader::new(Cursor::new(bytes))
+            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+        if reader.is_encrypted() {
+            return Err(PdfError::PermissionDenied(
+                "incremental text-note editing is not supported on encrypted PDFs".to_string(),
+            ));
+        }
+        let document = PdfDocument::new(reader);
+        let page_count = document
+            .page_count()
+            .map_err(|e| PdfError::InvalidStructure(format!("read page tree: {e}")))?;
+        let mut pages = Vec::with_capacity(page_count as usize);
+        let mut annotations = HashMap::new();
+        let mut indirect_annots_pages = HashMap::new();
+
+        for page_index in 0..page_count {
+            let page = document
+                .get_page(page_index)
+                .map_err(|e| PdfError::InvalidStructure(format!("read page {page_index}: {e}")))?;
+            let bounds = page.crop_box.unwrap_or(page.media_box);
+            let (container, values) = match page.dict.get("Annots") {
+                None => (AnnotationContainer::Page, Vec::new()),
+                Some(PdfObject::Array(array)) => (AnnotationContainer::Page, array.0.clone()),
+                Some(PdfObject::Reference(number, generation)) => {
+                    if let Some(first_page) =
+                        indirect_annots_pages.insert((*number, *generation), page_index)
+                    {
+                        return Err(PdfError::InvalidStructure(format!(
+                            "page /Annots array {number} {generation} is shared by multiple pages ({first_page} and {page_index})"
+                        )));
+                    }
+                    let object = document.get_object(*number, *generation).map_err(|e| {
+                        PdfError::InvalidStructure(format!("resolve page /Annots: {e}"))
+                    })?;
+                    let array = object.as_array().ok_or_else(|| {
+                        PdfError::InvalidStructure("indirect /Annots is not an array".to_string())
+                    })?;
+                    (
+                        AnnotationContainer::Indirect((*number, *generation)),
+                        array.0.clone(),
+                    )
+                }
+                Some(_) => {
+                    return Err(PdfError::InvalidStructure(
+                        "page /Annots must be an array or indirect array".to_string(),
+                    ))
+                }
+            };
+
+            for value in &values {
+                match value {
+                    PdfObject::Reference(number, generation) => {
+                        let object = document.get_object(*number, *generation).map_err(|e| {
+                            PdfError::InvalidStructure(format!(
+                                "resolve annotation {number} {generation}: {e}"
+                            ))
+                        })?;
+                        let dictionary = object.as_dict().cloned().ok_or_else(|| {
+                            PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is not a dictionary"
+                            ))
+                        })?;
+                        let is_text = subtype(&dictionary) == Some("Text");
+                        let rect = if is_text {
+                            parse_rectangle(&dictionary)?
+                        } else {
+                            [0.0; 4]
+                        };
+                        let contents = dictionary
+                            .get("Contents")
+                            .and_then(PdfObject::as_string)
+                            .map(PdfString::to_text)
+                            .unwrap_or_default();
+                        let id = TextNoteId::new(*number, *generation);
+                        if annotations
+                            .get(&id)
+                            .is_some_and(|existing: &AnnotationState| {
+                                existing.page_index != page_index
+                            })
+                        {
+                            return Err(PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is referenced from multiple pages"
+                            )));
+                        }
+                        annotations.insert(
+                            id,
+                            AnnotationState {
+                                page_index,
+                                dictionary,
+                                rect,
+                                contents,
+                                is_text,
+                            },
+                        );
+                    }
+                    PdfObject::Dictionary(dictionary) if subtype(dictionary) == Some("Text") => {
+                        return Err(PdfError::InvalidStructure(
+                            "inline /Text annotations have no stable object identity".to_string(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            pages.push(PageState {
+                reference: page.obj_ref,
+                dictionary: page.dict,
+                bounds,
+                container,
+                annotations: values,
+            });
+        }
+        Ok(Self { pages, annotations })
+    }
+}
+
+fn validate_batch(snapshot: &Snapshot, mutations: &[TextNoteMutation]) -> Result<()> {
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            TextNoteMutation::Add {
+                page_index,
+                position,
+                contents,
+            } => {
+                let page = snapshot.pages.get(*page_index as usize).ok_or_else(|| {
+                    PdfError::InvalidStructure(format!("page {page_index} does not exist"))
+                })?;
+                validate_contents(contents)?;
+                validate_position(*position, NOTE_SIZE, NOTE_SIZE, page.bounds)?;
+            }
+            TextNoteMutation::Update {
+                id,
+                position,
+                contents,
+            } => {
+                if !targeted.insert(*id) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "text note {} {} is targeted more than once",
+                        id.object_number, id.generation_number
+                    )));
+                }
+                let annotation = target_text_note(snapshot, *id)?;
+                validate_contents(contents)?;
+                validate_position(
+                    *position,
+                    annotation.rect[2] - annotation.rect[0],
+                    annotation.rect[3] - annotation.rect[1],
+                    snapshot.pages[annotation.page_index as usize].bounds,
+                )?;
+            }
+            TextNoteMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "text note {} {} is targeted more than once",
+                        id.object_number, id.generation_number
+                    )));
+                }
+                target_text_note(snapshot, *id)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn target_text_note(snapshot: &Snapshot, id: TextNoteId) -> Result<&AnnotationState> {
+    let annotation = snapshot.annotations.get(&id).ok_or_else(|| {
+        PdfError::InvalidStructure(format!(
+            "annotation {} {} does not exist",
+            id.object_number, id.generation_number
+        ))
+    })?;
+    if !annotation.is_text {
+        return Err(PdfError::InvalidStructure(format!(
+            "annotation {} {} is not a /Text annotation",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(annotation)
+}
+
+fn validate_contents(contents: &str) -> Result<()> {
+    if contents.trim().is_empty() {
+        return Err(PdfError::InvalidStructure(
+            "text-note contents must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_position(position: Point, width: f64, height: f64, bounds: [f64; 4]) -> Result<()> {
+    if !position.x.is_finite()
+        || !position.y.is_finite()
+        || !width.is_finite()
+        || !height.is_finite()
+        || width <= 0.0
+        || height <= 0.0
+    {
+        return Err(PdfError::InvalidStructure(
+            "text-note coordinates and dimensions must be finite and positive".to_string(),
+        ));
+    }
+    if position.x < bounds[0]
+        || position.y < bounds[1]
+        || position.x + width > bounds[2]
+        || position.y + height > bounds[3]
+    {
+        return Err(PdfError::InvalidStructure(
+            "text-note rectangle is outside the page bounds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn subtype(dictionary: &PdfDictionary) -> Option<&str> {
+    dictionary
+        .get("Subtype")
+        .and_then(PdfObject::as_name)
+        .map(|name| name.0.as_str())
+}
+
+fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
+    let array = dictionary
+        .get("Rect")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| PdfError::InvalidStructure("/Text annotation has no /Rect".to_string()))?;
+    if array.0.len() != 4 {
+        return Err(PdfError::InvalidStructure(
+            "/Text annotation /Rect must have four numbers".to_string(),
+        ));
+    }
+    let mut result = [0.0; 4];
+    for (index, value) in array.0.iter().enumerate() {
+        result[index] = match value {
+            PdfObject::Integer(number) => *number as f64,
+            PdfObject::Real(number) if number.is_finite() => *number,
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "/Text annotation /Rect contains a non-finite or non-numeric value".to_string(),
+                ))
+            }
+        };
+    }
+    Ok(result)
+}
+
+fn new_note_dictionary(position: Point, contents: &str) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Annot".to_string())),
+    );
+    dictionary.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("Text".to_string())),
+    );
+    dictionary.insert(
+        "Rect".to_string(),
+        rectangle(position, NOTE_SIZE, NOTE_SIZE),
+    );
+    dictionary.insert("Contents".to_string(), pdf_text(contents));
+    dictionary
+}
+
+fn rectangle(position: Point, width: f64, height: f64) -> PdfObject {
+    PdfObject::Array(PdfArray(vec![
+        PdfObject::Real(position.x),
+        PdfObject::Real(position.y),
+        PdfObject::Real(position.x + width),
+        PdfObject::Real(position.y + height),
+    ]))
+}
+
+fn pdf_text(contents: &str) -> PdfObject {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in contents.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    PdfObject::String(PdfString(bytes))
+}

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -1,0 +1,290 @@
+//! Shared primitives for appending one ISO 32000 incremental revision.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::PdfReader;
+use std::io::{Cursor, Read, Seek};
+
+pub(super) struct IncrementalUpdate<'a> {
+    base: &'a [u8],
+    previous_xref: u64,
+    root: (u32, u16),
+    original_size: u32,
+    next_id: u32,
+    first_id: Option<Vec<u8>>,
+    replacements: Vec<(u32, u16, PdfObject)>,
+}
+
+impl<'a> IncrementalUpdate<'a> {
+    pub(super) fn from_reader<R: Read + Seek>(
+        base: &'a [u8],
+        reader: &PdfReader<R>,
+    ) -> Result<Self> {
+        let trailer = reader.trailer();
+        let root = trailer
+            .root()
+            .map_err(|e| PdfError::InvalidStructure(format!("base /Root: {e}")))?;
+        let size = trailer
+            .size()
+            .map_err(|e| PdfError::InvalidStructure(format!("base /Size: {e}")))?;
+        let first_id = match trailer.id() {
+            Some(PdfObject::Array(array)) => array
+                .0
+                .first()
+                .and_then(PdfObject::as_string)
+                .map(|value| value.as_bytes().to_vec()),
+            _ => None,
+        };
+        Ok(Self {
+            base,
+            previous_xref: trailer.xref_offset,
+            root,
+            original_size: size,
+            next_id: size,
+            first_id,
+            replacements: Vec::new(),
+        })
+    }
+
+    pub(super) fn from_base(base: &'a [u8]) -> Result<Self> {
+        let reader = PdfReader::new(Cursor::new(base))
+            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+        if reader.is_encrypted() {
+            return Err(PdfError::PermissionDenied(
+                "incremental updates are not supported on encrypted PDFs".to_string(),
+            ));
+        }
+        Self::from_reader(base, &reader)
+    }
+
+    pub(super) fn allocate_id(&mut self) -> Result<(u32, u16)> {
+        let id = (self.next_id, 0);
+        self.next_id = self.next_id.checked_add(1).ok_or_else(|| {
+            PdfError::InvalidStructure("PDF object number space is exhausted".to_string())
+        })?;
+        Ok(id)
+    }
+
+    pub(super) fn replace(&mut self, id: (u32, u16), object: PdfObject) -> Result<()> {
+        if self
+            .replacements
+            .iter()
+            .any(|(number, generation, _)| (*number, *generation) == id)
+        {
+            return Err(PdfError::InvalidStructure(format!(
+                "object {} {} is rewritten more than once",
+                id.0, id.1
+            )));
+        }
+        self.replacements.push((id.0, id.1, object));
+        Ok(())
+    }
+
+    pub(super) fn finish(mut self) -> Result<Vec<u8>> {
+        self.replacements
+            .sort_by_key(|(number, generation, _)| (*number, *generation));
+        let mut out = Vec::with_capacity(self.base.len() + self.replacements.len() * 256 + 512);
+        out.extend_from_slice(self.base);
+        if !out.ends_with(b"\n") && !out.ends_with(b"\r") {
+            out.push(b'\n');
+        }
+
+        let mut changed = Vec::with_capacity(self.replacements.len());
+        for (number, generation, object) in &self.replacements {
+            let offset = out.len() as u64;
+            write_indirect_object(&mut out, *number, *generation, object)?;
+            changed.push((*number, *generation, offset));
+        }
+
+        let xref_position = out.len() as u64;
+        out.extend_from_slice(&partial_xref(&changed));
+        let size = self.next_id.max(self.original_size);
+        let id_pair = self.first_id.map(|first| {
+            let mut material = first.clone();
+            material.extend_from_slice(&out[self.base.len()..]);
+            material.extend_from_slice(&xref_position.to_le_bytes());
+            (first, md5::compute(material).0.to_vec())
+        });
+        write_trailer(
+            &mut out,
+            self.previous_xref,
+            self.root,
+            size,
+            xref_position,
+            id_pair,
+        );
+        Ok(out)
+    }
+}
+
+fn write_indirect_object(
+    out: &mut Vec<u8>,
+    number: u32,
+    generation: u16,
+    object: &PdfObject,
+) -> Result<()> {
+    out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+    write_object(out, object)?;
+    out.extend_from_slice(b"\nendobj\n");
+    Ok(())
+}
+
+pub(super) fn write_object(out: &mut Vec<u8>, object: &PdfObject) -> Result<()> {
+    match object {
+        PdfObject::Null => out.extend_from_slice(b"null"),
+        PdfObject::Boolean(value) => out.extend_from_slice(if *value { b"true" } else { b"false" }),
+        PdfObject::Integer(value) => out.extend_from_slice(value.to_string().as_bytes()),
+        PdfObject::Real(value) => out.extend_from_slice(format_real(*value).as_bytes()),
+        PdfObject::String(value) => write_string(out, value),
+        PdfObject::Name(value) => write_name(out, value),
+        PdfObject::Reference(number, generation) => {
+            out.extend_from_slice(format!("{number} {generation} R").as_bytes())
+        }
+        PdfObject::Array(array) => {
+            out.push(b'[');
+            for (index, value) in array.0.iter().enumerate() {
+                if index != 0 {
+                    out.push(b' ');
+                }
+                write_object(out, value)?;
+            }
+            out.push(b']');
+        }
+        PdfObject::Dictionary(dictionary) => write_dictionary(out, dictionary)?,
+        PdfObject::Stream(_) => {
+            return Err(PdfError::InvalidStructure(
+                "generic incremental object writer does not accept streams".to_string(),
+            ))
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn write_dictionary(out: &mut Vec<u8>, dictionary: &PdfDictionary) -> Result<()> {
+    out.extend_from_slice(b"<< ");
+    let mut keys: Vec<_> = dictionary.0.keys().collect();
+    keys.sort_by(|left, right| left.0.cmp(&right.0));
+    for key in keys {
+        write_name(out, key);
+        out.push(b' ');
+        write_object(out, &dictionary.0[key])?;
+        out.push(b' ');
+    }
+    out.extend_from_slice(b">>");
+    Ok(())
+}
+
+fn write_name(out: &mut Vec<u8>, name: &PdfName) {
+    out.push(b'/');
+    for byte in name.0.bytes() {
+        if byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
+            )
+        {
+            out.push(byte);
+        } else {
+            out.extend_from_slice(format!("#{byte:02X}").as_bytes());
+        }
+    }
+}
+
+fn write_string(out: &mut Vec<u8>, value: &PdfString) {
+    out.push(b'<');
+    for byte in value.as_bytes() {
+        out.extend_from_slice(format!("{byte:02X}").as_bytes());
+    }
+    out.push(b'>');
+}
+
+pub(super) fn format_real(value: f64) -> String {
+    if !value.is_finite() {
+        return "0".to_string();
+    }
+    let shortest = value.to_string();
+    let Some(exponent_index) = shortest.find(['e', 'E']) else {
+        return if shortest == "-0" {
+            "0".to_string()
+        } else {
+            shortest
+        };
+    };
+
+    let exponent: i32 = shortest[exponent_index + 1..]
+        .parse()
+        .expect("f64 formatting always emits a valid exponent");
+    let mantissa = &shortest[..exponent_index];
+    let negative = mantissa.starts_with('-');
+    let digits: String = mantissa
+        .trim_start_matches('-')
+        .chars()
+        .filter(|character| *character != '.')
+        .collect();
+    let decimal_position = mantissa
+        .trim_start_matches('-')
+        .find('.')
+        .map_or(digits.len() as i32, |position| position as i32)
+        + exponent;
+    let sign = if negative { "-" } else { "" };
+
+    if decimal_position <= 0 {
+        format!(
+            "{sign}0.{}{digits}",
+            "0".repeat((-decimal_position) as usize)
+        )
+    } else if decimal_position as usize >= digits.len() {
+        format!(
+            "{sign}{digits}{}",
+            "0".repeat(decimal_position as usize - digits.len())
+        )
+    } else {
+        let split = decimal_position as usize;
+        format!("{sign}{}.{}", &digits[..split], &digits[split..])
+    }
+}
+
+fn partial_xref(changed: &[(u32, u16, u64)]) -> Vec<u8> {
+    let mut out = b"xref\n".to_vec();
+    let mut index = 0;
+    while index < changed.len() {
+        let start = changed[index].0;
+        let mut end = index;
+        while end + 1 < changed.len() && changed[end + 1].0 == changed[end].0 + 1 {
+            end += 1;
+        }
+        out.extend_from_slice(format!("{start} {}\n", end - index + 1).as_bytes());
+        for (_, generation, offset) in &changed[index..=end] {
+            out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes());
+        }
+        index = end + 1;
+    }
+    out
+}
+
+fn write_trailer(
+    out: &mut Vec<u8>,
+    previous_xref: u64,
+    root: (u32, u16),
+    size: u32,
+    xref_position: u64,
+    id_pair: Option<(Vec<u8>, Vec<u8>)>,
+) {
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {size} /Root {} {} R /Prev {previous_xref} ",
+            root.0, root.1
+        )
+        .as_bytes(),
+    );
+    if let Some((first, second)) = id_pair {
+        let hex = |bytes: &[u8]| {
+            bytes
+                .iter()
+                .map(|byte| format!("{byte:02X}"))
+                .collect::<String>()
+        };
+        out.extend_from_slice(format!("/ID [<{}> <{}>] ", hex(&first), hex(&second)).as_bytes());
+    }
+    out.extend_from_slice(format!(">>\nstartxref\n{xref_position}\n%%EOF\n").as_bytes());
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -2,6 +2,8 @@
 
 mod content_stream_utils;
 mod incremental_form_fill;
+mod incremental_text_notes;
+mod incremental_update;
 mod object_streams;
 mod pdf_writer;
 mod signature;
@@ -12,6 +14,9 @@ pub(crate) use content_stream_utils::{
     apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
 };
 pub use incremental_form_fill::IncrementalFormFiller;
+pub use incremental_text_notes::{
+    IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,
+};
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};
 pub(crate) use signature::{Edition, PdfSignature};

--- a/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
+++ b/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
@@ -1,0 +1,377 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{IncrementalTextNoteEditor, TextNoteId, TextNoteMutation};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn base_pdf() -> Vec<u8> {
+    build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R >>"),
+        (4, b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (old) /Name /Comment /CustomKey (preserve-me) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [50 50 80 70] /CustomLinkKey 99 >>"),
+        (6, b"[4 0 R 5 0 R]"),
+    ])
+}
+
+fn build_pdf(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    build_pdf_with_size(objects, None)
+}
+
+fn build_pdf_with_size(objects: &[(u32, &[u8])], trailer_size: Option<u32>) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n".to_vec();
+    let size = objects.iter().map(|(number, _)| *number).max().unwrap_or(0) + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (num, body) in objects {
+        offsets[*num as usize] = out.len();
+        out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    let trailer_size = trailer_size.unwrap_or(size);
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {trailer_size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n")
+            .as_bytes(),
+    );
+    out
+}
+
+fn assert_invalid_structure_contains(result: Result<impl Sized, PdfError>, expected: &str) {
+    match result {
+        Err(PdfError::InvalidStructure(message)) => assert!(
+            message.contains(expected),
+            "expected error containing {expected:?}, got {message:?}"
+        ),
+        Err(other) => panic!("expected InvalidStructure, got {other:?}"),
+        Ok(_) => panic!("expected InvalidStructure containing {expected:?}"),
+    }
+}
+
+#[test]
+fn lists_only_indirect_text_notes_with_stable_ids() {
+    let base = base_pdf();
+    let notes = IncrementalTextNoteEditor::new(&base).notes().unwrap();
+
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].id, TextNoteId::new(4, 0));
+    assert_eq!(notes[0].page_index, 0);
+    assert_eq!(notes[0].position, Point::new(10.0, 20.0));
+    assert_eq!(notes[0].contents, "old");
+}
+
+#[test]
+fn mixed_batch_is_one_atomic_incremental_revision() {
+    let base = base_pdf();
+    let editor = IncrementalTextNoteEditor::new(&base);
+    let update = editor
+        .apply(&[
+            TextNoteMutation::Update {
+                id: TextNoteId::new(4, 0),
+                position: Point::new(100.0, 110.0),
+                contents: "movida ✓".to_string(),
+            },
+            TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(200.0, 200.0),
+                contents: "nueva".to_string(),
+            },
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert_eq!(
+        update
+            .pdf_bytes
+            .windows(9)
+            .filter(|w| *w == b"startxref")
+            .count(),
+        2,
+        "base plus exactly one incremental revision"
+    );
+    assert_eq!(update.added_notes.len(), 1);
+    assert_eq!(update.added_notes[0].id, TextNoteId::new(7, 0));
+
+    let reopened = IncrementalTextNoteEditor::new(&update.pdf_bytes)
+        .notes()
+        .unwrap();
+    assert_eq!(reopened.len(), 2);
+    assert!(reopened.iter().any(|note| note.contents == "movida ✓"));
+    assert!(reopened.iter().any(|note| note.contents == "nueva"));
+
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let moved = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        moved
+            .get("CustomKey")
+            .and_then(PdfObject::as_string)
+            .unwrap()
+            .to_text(),
+        "preserve-me"
+    );
+    let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
+    assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+
+    Command::new("qpdf")
+        .arg("--version")
+        .output()
+        .expect("qpdf is required for issue #493 interoperability tests");
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.pdf");
+    std::fs::write(&path, &update.pdf_bytes).unwrap();
+    let output = Command::new("qpdf")
+        .arg("--check")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn remove_drops_only_the_target_reference() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Remove {
+            id: TextNoteId::new(4, 0),
+        }])
+        .unwrap();
+
+    assert!(IncrementalTextNoteEditor::new(&update.pdf_bytes)
+        .notes()
+        .unwrap()
+        .is_empty());
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    assert!(
+        reader.get_object(5, 0).is_ok(),
+        "unrelated annotation remains"
+    );
+    assert!(update.pdf_bytes.starts_with(&base));
+}
+
+#[test]
+fn invalid_mutation_rejects_the_whole_batch() {
+    let base = base_pdf();
+    let result = IncrementalTextNoteEditor::new(&base).apply(&[
+        TextNoteMutation::Update {
+            id: TextNoteId::new(4, 0),
+            position: Point::new(40.0, 40.0),
+            contents: "valid".to_string(),
+        },
+        TextNoteMutation::Add {
+            page_index: 99,
+            position: Point::new(10.0, 10.0),
+            contents: "invalid".to_string(),
+        },
+    ]);
+
+    assert_invalid_structure_contains(result, "page 99 does not exist");
+}
+
+#[test]
+fn empty_batch_is_a_true_noop() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base).apply(&[]).unwrap();
+    assert_eq!(update.pdf_bytes, base);
+    assert!(update.added_notes.is_empty());
+}
+
+#[test]
+fn rejects_invalid_values_duplicate_targets_and_non_text_ids() {
+    let base = base_pdf();
+    let editor = IncrementalTextNoteEditor::new(&base);
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(10.0, 10.0),
+            contents: "   ".to_string(),
+        }]),
+        "must not be empty",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(f64::NAN, 10.0),
+            contents: "note".to_string(),
+        }]),
+        "finite and positive",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Remove {
+            id: TextNoteId::new(5, 0),
+        }]),
+        "not a /Text annotation",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[
+            TextNoteMutation::Remove {
+                id: TextNoteId::new(4, 0),
+            },
+            TextNoteMutation::Remove {
+                id: TextNoteId::new(4, 0),
+            },
+        ]),
+        "targeted more than once",
+    );
+}
+
+#[test]
+fn update_preserves_unknown_real_values_without_rounding() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (old) /Precise 0.123456789012345 >>"),
+    ]);
+
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Update {
+            id: TextNoteId::new(4, 0),
+            position: Point::new(40.0, 50.0),
+            contents: "new".to_string(),
+        }])
+        .unwrap();
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let annotation = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+
+    assert_eq!(
+        annotation.get("Precise"),
+        Some(&PdfObject::Real(0.123456789012345))
+    );
+}
+
+#[test]
+fn rejects_exhausted_indirect_object_number_space_without_panicking() {
+    let base = build_pdf_with_size(
+        &[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+            ),
+        ],
+        Some(u32::MAX),
+    );
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(10.0, 10.0),
+            contents: "note".to_string(),
+        }]),
+        "object number space is exhausted",
+    );
+}
+
+#[test]
+fn rejects_annotation_identity_referenced_from_multiple_pages() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [5 0 R] >>",
+        ),
+        (
+            4,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [5 0 R] >>",
+        ),
+        (
+            5,
+            b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (shared) >>",
+        ),
+    ]);
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).notes(),
+        "referenced from multiple pages",
+    );
+}
+
+#[test]
+fn rejects_annots_array_shared_by_multiple_pages() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (
+            4,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (5, b"[]"),
+    ]);
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).notes(),
+        "/Annots array 5 0 is shared by multiple pages",
+    );
+}
+
+#[test]
+fn add_supports_inline_and_missing_annots_arrays() {
+    for page_body in [
+        &b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [] >>"[..],
+        &b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>"[..],
+    ] {
+        let base = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (3, page_body),
+        ]);
+        let update = IncrementalTextNoteEditor::new(&base)
+            .apply(&[TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(25.0, 25.0),
+                contents: "added".to_string(),
+            }])
+            .unwrap();
+        let notes = IncrementalTextNoteEditor::new(&update.pdf_bytes)
+            .notes()
+            .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].contents, "added");
+    }
+}
+
+#[test]
+fn rejects_encrypted_pdfs_inline_text_notes_and_out_of_bounds_rectangles() {
+    let mut encrypted = Document::new();
+    encrypted.add_page(Page::a4());
+    encrypted.encrypt_with_passwords("user", "owner");
+    let encrypted_bytes = encrypted.to_bytes().unwrap();
+    assert!(IncrementalTextNoteEditor::new(&encrypted_bytes)
+        .notes()
+        .is_err());
+    assert!(IncrementalTextNoteEditor::new(&encrypted_bytes)
+        .apply(&[])
+        .is_err());
+
+    let inline = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Type /Annot /Subtype /Text /Rect [10 10 30 30] /Contents (inline) >>] >>"),
+    ]);
+    assert!(IncrementalTextNoteEditor::new(&inline).notes().is_err());
+
+    let base = base_pdf();
+    assert!(IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(290.0, 290.0),
+            contents: "outside".to_string(),
+        }])
+        .is_err());
+}

--- a/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
+++ b/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
@@ -117,11 +117,26 @@ fn mixed_batch_is_one_atomic_incremental_revision() {
     );
     let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
     assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
 
-    Command::new("qpdf")
-        .arg("--version")
-        .output()
-        .expect("qpdf is required for issue #493 interoperability tests");
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_incremental_text_note_revision() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[
+            TextNoteMutation::Update {
+                id: TextNoteId::new(4, 0),
+                position: Point::new(100.0, 110.0),
+                contents: "movida ✓".to_string(),
+            },
+            TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(200.0, 200.0),
+                contents: "nueva".to_string(),
+            },
+        ])
+        .unwrap();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("notes.pdf");
     std::fs::write(&path, &update.pdf_bytes).unwrap();


### PR DESCRIPTION
## Summary

- add a typed public API for reading, adding, updating, and removing standard text-note annotations
- preserve the original PDF as an exact prefix and apply each mutation batch in one incremental revision
- share parser-object serialization with the existing incremental form filler
- reject encrypted or ambiguous structures, invalid targets and coordinates, conflicting mutations, and exhausted object identifiers
- preserve unknown annotation keys and lossless real values

## TDD and validation

- added regression tests before each QR correction and observed the expected failures
- `cargo test -p oxidize-pdf --test issue_493_incremental_text_notes_test` (12 passed)
- `cargo test -p oxidize-pdf --test incremental_form_fill_ap_test` (5 passed)
- `cargo test -p oxidize-pdf --test annotations_tests` (10 passed)
- `cargo test -p oxidize-pdf --lib` (6696 tests)
- `cargo clippy -p oxidize-pdf --lib --test issue_493_incremental_text_notes_test -- -D warnings`
- `cargo fmt -p oxidize-pdf -- --check`
- qpdf interoperability check
- Kripteia security: no findings in the writer scope

Closes #493
