### PR TITLE
fix(text): parse CIDFont /W and /DW widths for composite-font extraction (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Composite (Type0/CID) font text extraction never consulted the CIDFont's
+  `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a
+  flat `0.5 * font_size`, regardless of its real width. When a glyph's true
+  advance diverged enough from that flat estimate relative to its neighbors
+  (e.g. a genuinely wide glyph in the font), the extractor's pen-tracking
+  drifted out of sync with where the next glyph was actually drawn, crossing
+  the space-insertion threshold and corrupting the extracted text with a
+  spurious space in the middle of a single token. `/W`/`/DW` (ISO 32000-1
+  §9.7.4.3) are now parsed into a CID-indexed width table and consulted for
+  the composite-font width calculation on both the flat and
+  `preserve_layout` extraction paths, falling back to the previous heuristic
+  when neither is present.
+
 ## [4.4.0] - 2026-08-16
 
 ### Added

--- a/oxidize-pdf-core/src/text/cmap.rs
+++ b/oxidize-pdf-core/src/text/cmap.rs
@@ -386,6 +386,47 @@ impl CMap {
         None
     }
 
+    /// Return an explicitly mapped source code for a single Unicode character.
+    /// This lets extraction connect semantic glyphs such as U+0020 back to
+    /// code/CID-indexed font metrics without guessing a CID.
+    pub(crate) fn source_code_for_unicode(&self, target: char) -> Option<Vec<u8>> {
+        let mut utf16 = [0u16; 2];
+        let encoded = target.encode_utf16(&mut utf16);
+        let target_bytes: Vec<u8> = encoded.iter().flat_map(|unit| unit.to_be_bytes()).collect();
+
+        for mapping in &self.mappings {
+            match mapping {
+                CMapEntry::Single { src, dst } if *dst == target_bytes => {
+                    return Some(src.clone());
+                }
+                CMapEntry::Range {
+                    src_start,
+                    src_end,
+                    dst_start,
+                } if dst_start.len() == target_bytes.len()
+                    && target_bytes.as_slice() >= dst_start.as_slice() =>
+                {
+                    let offset = calculate_offset(&target_bytes, dst_start);
+                    if offset <= calculate_offset(src_end, src_start) {
+                        let mut source = src_start.clone();
+                        let mut carry = offset;
+                        for byte in source.iter_mut().rev() {
+                            let sum = usize::from(*byte) + carry;
+                            *byte = (sum & 0xff) as u8;
+                            carry = sum >> 8;
+                            if carry == 0 {
+                                break;
+                            }
+                        }
+                        return Some(source);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
     /// Check if a code is in valid codespace
     pub fn is_valid_code(&self, code: &[u8]) -> bool {
         for range in &self.codespace_ranges {
@@ -1433,5 +1474,20 @@ endcmap\n";
 endcmap";
         let cmap = CMap::parse(data).expect("parse");
         assert_eq!(cmap.inherited_ordering(), Some("Korea1"));
+    }
+
+    #[test]
+    fn source_code_for_unicode_resolves_single_and_range_mappings() {
+        let cmap = CMap::parse(
+            b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+1 beginbfchar <0002> <0020> endbfchar\n\
+1 beginbfrange <0010> <0012> <0041> endbfrange\n\
+endcmap",
+        )
+        .expect("parse");
+        assert_eq!(cmap.source_code_for_unicode(' '), Some(vec![0x00, 0x02]));
+        assert_eq!(cmap.source_code_for_unicode('B'), Some(vec![0x00, 0x11]));
+        assert_eq!(cmap.source_code_for_unicode('Z'), None);
     }
 }

--- a/oxidize-pdf-core/src/text/encoding_cmap.rs
+++ b/oxidize-pdf-core/src/text/encoding_cmap.rs
@@ -12,6 +12,8 @@ use crate::text::cmap::{tokenize_cmap, CodeRange, Token};
 /// destinations are Unicode hex strings.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EncodingCMap {
+    /// Writing mode declared by `/WMode` (0 horizontal, 1 vertical).
+    pub wmode: u8,
     pub codespace_ranges: Vec<CodeRange>,
     pub single_cid: HashMap<Vec<u8>, u16>,
     pub cid_ranges: Vec<CidRange>,
@@ -37,6 +39,12 @@ impl EncodingCMap {
         let mut i = 0;
         while i < tokens.len() {
             match &tokens[i] {
+                Token::Name(name) if name == "WMode" => {
+                    if let Some(Token::Integer(value)) = tokens.get(i + 1) {
+                        cmap.wmode = (*value).clamp(0, 1) as u8;
+                    }
+                    i += 1;
+                }
                 Token::Keyword(k) if k == "begincodespacerange" => {
                     i += 1;
                     while i < tokens.len() {
@@ -354,6 +362,15 @@ endcmap";
         assert_eq!(cmap.codespace_ranges.len(), 2);
         assert_eq!(cmap.code_len_at(&[0x81, 0x40], 0), 2);
         assert_eq!(cmap.usecmap_parent.as_deref(), Some("Foo-Base"));
+    }
+
+    #[test]
+    fn parse_retains_vertical_writing_mode() {
+        let cmap = EncodingCMap::parse(
+            b"begincmap\n/WMode 1 def\n1 begincodespacerange <0000> <FFFF> endcodespacerange\nendcmap",
+        )
+        .expect("parse");
+        assert_eq!(cmap.wmode, 1);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3571,6 +3571,43 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `word_space` (`Tw`) once per *single-byte* space (code 32, §9.3.3). Both are
 /// unscaled text-space units, added directly (not multiplied by the font size);
 /// the caller's `advance_pen` applies `Th`.
+/// Decode a Type0 text-showing string's raw bytes into CIDs, for CID-indexed
+/// `/W` width lookup (issue #496). Mirrors the code-length/lookup rules
+/// `decode_text_with_font` already uses for Unicode decoding, but stops at
+/// the CID rather than continuing on to a Unicode codepoint.
+///
+/// - A non-identity encoding CMap (`font_info.cid_encoding`) maps
+///   variable-width codes to CIDs directly; an unmapped code resolves via
+///   `.notdef` when present, and is otherwise skipped (its width cannot be
+///   determined, so it must not desync the remaining codes' pairing).
+/// - `Identity-H`/`Identity-V` (by far the most common case) — and the
+///   `Utf16Be` `cid_encoding`, whose codes are also 2-byte units — read the
+///   CID directly as a big-endian `u16` per §9.7.4.2, no code-space lookup
+///   required.
+fn cids_for_codes(codes: &[u8], font_info: Option<&FontInfo>) -> Vec<u32> {
+    if let Some(crate::text::encoding_cmap::CidEncoding::Cmap(enc)) =
+        font_info.and_then(|f| f.cid_encoding.as_ref())
+    {
+        let mut cids = Vec::new();
+        let mut i = 0;
+        while i < codes.len() {
+            let len = enc.code_len_at(codes, i).max(1).min(codes.len() - i);
+            let code = &codes[i..i + len];
+            if let Some(cid) = enc.map_code_to_cid(code).or_else(|| enc.map_notdef(code)) {
+                cids.push(cid as u32);
+            }
+            i += len;
+        }
+        return cids;
+    }
+
+    codes
+        .chunks(2)
+        .filter(|chunk| chunk.len() == 2)
+        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as u32)
+        .collect()
+}
+
 fn calculate_text_width_from_codes(
     codes: &[u8],
     decoded: &str,
@@ -3580,14 +3617,31 @@ fn calculate_text_width_from_codes(
     word_space: f64,
 ) -> f64 {
     // Composite (Type0) fonts use multi-byte codes; a single byte is not a code,
-    // so byte-indexed width lookup is invalid. Preserve the existing decoded-based
-    // behavior for them, adding `Tc` per glyph. `Tw` applies only to the
-    // single-byte code 32 (§9.3.3), which a multi-byte code can never be, so it
-    // does not apply here.
+    // so byte-indexed width lookup is invalid. `Tc` is added per glyph below.
+    // `Tw` applies only to the single-byte code 32 (§9.3.3), which a
+    // multi-byte code can never be, so it does not apply here.
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
         let glyphs = decoded.chars().count() as f64;
+        // Prefer the descendant CIDFont's `/W`/`/DW` (CID-indexed, per
+        // §9.7.4.3) over the decoded-Unicode-indexed fallback below: a CID
+        // is an arbitrary font-internal identifier with no relationship to
+        // the character it decodes to, so indexing by decoded codepoint
+        // reads the wrong table slot whenever CID != codepoint (any
+        // subset/reordered CID font). Without `/W`/`/DW` at all, fall back
+        // to the previous decoded-text heuristic (issue #496).
+        if let Some(cid_widths) = font_info
+            .and_then(|f| f.descendant_font.as_deref().or(Some(f)))
+            .and_then(|f| f.metrics.cid_widths.as_ref())
+        {
+            let cids = cids_for_codes(codes, font_info);
+            let total: f64 = cids
+                .iter()
+                .map(|&cid| cid_widths.width_for(cid) / 1000.0 * font_size)
+                .sum();
+            return total + char_space * glyphs;
+        }
         return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
 
@@ -4422,6 +4476,7 @@ mod tests {
                 widths: None,
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4463,6 +4518,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4519,6 +4575,7 @@ mod tests {
                 widths: Some(vec![1000.0, 100.0]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4564,6 +4621,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4604,6 +4662,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4639,6 +4698,7 @@ mod tests {
                 widths: Some(vec![500.0; 95]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4673,6 +4733,7 @@ mod tests {
                 widths: Some(vec![500.0; 95]),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4706,6 +4767,7 @@ mod tests {
                 widths: Some(vec![722.0]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4744,6 +4806,7 @@ mod tests {
                 widths: Some(proportional_widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4764,6 +4827,7 @@ mod tests {
                 widths: Some(monospace_widths),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4814,6 +4878,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: Some(kerning),
+                cid_widths: None,
             },
             cid_encoding: None,
         };

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -793,6 +793,16 @@ impl TextExtractor {
     /// ZapfDingbats), which ship no `/Widths` array (#302 symptom 2).
     fn font_space_advance(&self, font_name: Option<&str>, font_size: f64) -> Option<f64> {
         let info = self.font_cache.get(font_name?)?;
+        if let (Some(to_unicode), Some(descendant)) =
+            (info.to_unicode.as_ref(), info.descendant_font.as_deref())
+        {
+            let space_code = to_unicode.source_code_for_unicode(' ')?;
+            let cid = cids_for_codes(&space_code, info)?.first()?.1;
+            let width = descendant.metrics.cid_widths.as_ref()?.width_for(cid);
+            if width > 0.0 {
+                return Some(width / 1000.0 * font_size);
+            }
+        }
         if let Some(ref widths) = info.metrics.widths {
             let first = info.metrics.first_char.unwrap_or(0);
             if first <= 32 {
@@ -804,6 +814,13 @@ impl TextExtractor {
             }
         }
         standard_14_space_width(&info.name).map(|em| em / 1000.0 * font_size)
+    }
+
+    fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
+        match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
+            Some(advance) if advance > 0.0 => 0.5 * advance,
+            _ => self.options.space_threshold * state.font_size,
+        }
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.
@@ -1328,7 +1345,7 @@ impl TextExtractor {
                                     && (dy > SAME_LINE_EPS || same_y_wrap);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
-                                } else if dx > self.options.space_threshold * state.font_size {
+                                } else if dx > self.flat_space_gap_threshold(&state) {
                                     Some(' ')
                                 } else {
                                     None
@@ -3576,36 +3593,51 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `decode_text_with_font` already uses for Unicode decoding, but stops at
 /// the CID rather than continuing on to a Unicode codepoint.
 ///
-/// - A non-identity encoding CMap (`font_info.cid_encoding`) maps
-///   variable-width codes to CIDs directly; an unmapped code resolves via
-///   `.notdef` when present, and is otherwise skipped (its width cannot be
-///   determined, so it must not desync the remaining codes' pairing).
-/// - `Identity-H`/`Identity-V` (by far the most common case) — and the
-///   `Utf16Be` `cid_encoding`, whose codes are also 2-byte units — read the
-///   CID directly as a big-endian `u16` per §9.7.4.2, no code-space lookup
-///   required.
-fn cids_for_codes(codes: &[u8], font_info: Option<&FontInfo>) -> Vec<u32> {
-    if let Some(crate::text::encoding_cmap::CidEncoding::Cmap(enc)) =
-        font_info.and_then(|f| f.cid_encoding.as_ref())
+/// Returns `None` when the code→CID relation is unavailable or vertical: in
+/// those cases guessing would select unrelated `/W` entries, so the caller
+/// retains the legacy fallback.
+fn cids_for_codes<'a>(codes: &'a [u8], font: &FontInfo) -> Option<Vec<(&'a [u8], u32)>> {
+    use crate::text::encoding_cmap::CidEncoding;
+
+    if matches!(font.cid_encoding, Some(CidEncoding::Utf16Be))
+        || font
+            .encoding
+            .as_deref()
+            .is_some_and(|name| name.ends_with("-V"))
+        || matches!(&font.cid_encoding, Some(CidEncoding::Cmap(cmap)) if cmap.wmode == 1)
     {
-        let mut cids = Vec::new();
-        let mut i = 0;
-        while i < codes.len() {
-            let len = enc.code_len_at(codes, i).max(1).min(codes.len() - i);
-            let code = &codes[i..i + len];
-            if let Some(cid) = enc.map_code_to_cid(code).or_else(|| enc.map_notdef(code)) {
-                cids.push(cid as u32);
-            }
-            i += len;
-        }
-        return cids;
+        return None;
+    }
+    let identity = font.encoding.as_deref() == Some("Identity-H");
+    if font.cid_encoding.is_none() && !identity {
+        return None;
     }
 
-    codes
-        .chunks(2)
-        .filter(|chunk| chunk.len() == 2)
-        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as u32)
-        .collect()
+    let mut result = Vec::new();
+    let mut offset = 0;
+    while offset < codes.len() {
+        let code_len = match &font.cid_encoding {
+            Some(CidEncoding::Cmap(cmap)) => cmap.code_len_at(codes, offset),
+            Some(CidEncoding::Utf16Be) => unreachable!(),
+            None => 2,
+        }
+        .max(1)
+        .min(codes.len() - offset);
+        let code = &codes[offset..offset + code_len];
+        let cid = match &font.cid_encoding {
+            Some(CidEncoding::Cmap(cmap)) => cmap
+                .map_code_to_cid(code)
+                .or_else(|| cmap.map_notdef(code))
+                .map(u32::from)?,
+            Some(CidEncoding::Utf16Be) => unreachable!(),
+            None => code
+                .iter()
+                .fold(0u32, |value, byte| (value << 8) | u32::from(*byte)),
+        };
+        result.push((code, cid));
+        offset += code_len;
+    }
+    Some(result)
 }
 
 fn calculate_text_width_from_codes(
@@ -3623,7 +3655,6 @@ fn calculate_text_width_from_codes(
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
-        let glyphs = decoded.chars().count() as f64;
         // Prefer the descendant CIDFont's `/W`/`/DW` (CID-indexed, per
         // §9.7.4.3) over the decoded-Unicode-indexed fallback below: a CID
         // is an arbitrary font-internal identifier with no relationship to
@@ -3635,13 +3666,20 @@ fn calculate_text_width_from_codes(
             .and_then(|f| f.descendant_font.as_deref().or(Some(f)))
             .and_then(|f| f.metrics.cid_widths.as_ref())
         {
-            let cids = cids_for_codes(codes, font_info);
-            let total: f64 = cids
-                .iter()
-                .map(|&cid| cid_widths.width_for(cid) / 1000.0 * font_size)
-                .sum();
-            return total + char_space * glyphs;
+            if let Some(font) = font_info {
+                if let Some(cid_codes) = cids_for_codes(codes, font) {
+                    let mut total = 0.0;
+                    for (code, cid) in cid_codes {
+                        total += cid_widths.width_for(cid) / 1000.0 * font_size + char_space;
+                        if code.len() == 1 && code[0] == b' ' {
+                            total += word_space;
+                        }
+                    }
+                    return total;
+                }
+            }
         }
+        let glyphs = decoded.chars().count() as f64;
         return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
 

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -8,8 +8,31 @@ use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
 use crate::parser::{ParseError, ParseOptions, ParseResult};
 use crate::text::cid_to_unicode::CidCollection;
 use crate::text::cmap::CMap;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
+
+/// A CIDFont's `/W` + `/DW` glyph-space widths (ISO 32000-1 §9.7.4.3),
+/// indexed by **CID** — an arbitrary font-internal identifier unrelated to
+/// any decoded Unicode codepoint. Only meaningful on a `CIDFontType0`/
+/// `CIDFontType2` descendant font's [`FontMetrics`]; simple fonts use the
+/// `first_char`/`last_char`/`widths` triple instead.
+#[derive(Debug, Clone, Default)]
+pub struct CidWidths {
+    /// Per-CID widths (1/1000 em), parsed from `/W`'s mixed
+    /// `c [w1 w2 ...]` and `cFirst cLast w` forms.
+    pub widths: HashMap<u32, f64>,
+    /// `/DW`, the width (1/1000 em) for any CID absent from `widths`.
+    /// Defaults to 1000 per spec when `/DW` is not present.
+    pub default_width: f64,
+}
+
+impl CidWidths {
+    /// Width (1/1000 em) for `cid`: its `/W` entry, or `/DW` otherwise.
+    pub fn width_for(&self, cid: u32) -> f64 {
+        self.widths.get(&cid).copied().unwrap_or(self.default_width)
+    }
+}
 
 /// Font metrics for accurate text width calculation
 #[derive(Debug, Clone)]
@@ -24,6 +47,10 @@ pub struct FontMetrics {
     pub missing_width: Option<f64>,
     /// Kerning pairs: (char1, char2) -> adjustment
     pub kerning: Option<HashMap<(u32, u32), f64>>,
+    /// CID-indexed widths (`/W`/`/DW`), for a `CIDFontType0`/`CIDFontType2`
+    /// descendant font. `None` for simple fonts and for CID fonts with
+    /// neither `/W` nor `/DW` present.
+    pub cid_widths: Option<CidWidths>,
 }
 
 impl Default for FontMetrics {
@@ -34,6 +61,7 @@ impl Default for FontMetrics {
             widths: None,
             missing_width: Some(500.0), // Default to 500 units (typical average)
             kerning: None,
+            cid_widths: None,
         }
     }
 }
@@ -322,6 +350,70 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                     }
                 }
             }
+        }
+
+        // Extract CIDFont `/W` + `/DW` (ISO 32000-1 §9.7.4.3). Only present
+        // on a CIDFontType0/CIDFontType2 descendant font dictionary; a
+        // simple font's dict has no `/W` key, so this is a no-op there.
+        let dw = font_dict.get("DW").and_then(|o| o.as_real());
+        let w_array: Option<Cow<[PdfObject]>> = match font_dict.get("W") {
+            Some(PdfObject::Array(array)) => Some(Cow::Borrowed(&array.0)),
+            Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                Ok(PdfObject::Array(array)) => Some(Cow::Owned(array.0)),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(entries) = w_array {
+            let mut widths = HashMap::new();
+            let mut i = 0;
+            while i < entries.len() {
+                let Some(first_cid) = entries[i].as_integer() else {
+                    break;
+                };
+                match entries.get(i + 1) {
+                    // `c [w1 w2 ...]`: consecutive widths starting at c.
+                    Some(PdfObject::Array(w_list)) => {
+                        for (offset, w_obj) in w_list.0.iter().enumerate() {
+                            if let Some(w) = w_obj.as_real() {
+                                widths.insert(first_cid as u32 + offset as u32, w);
+                            }
+                        }
+                        i += 2;
+                    }
+                    // `cFirst cLast w`: uniform width across an inclusive CID range.
+                    Some(last_obj) => {
+                        let (Some(last_cid), Some(w)) = (
+                            last_obj.as_integer(),
+                            entries.get(i + 2).and_then(|o| o.as_real()),
+                        ) else {
+                            break;
+                        };
+                        // CIDs from Identity-H/Identity-V decode as a u16
+                        // (§9.7.4.2), so any range past 0xFFFF is malformed;
+                        // clamp rather than materializing a huge/looping
+                        // range from a corrupt or adversarial `/W` array.
+                        let last_cid = last_cid.min(u16::MAX as i64);
+                        if last_cid >= first_cid {
+                            for cid in first_cid..=last_cid {
+                                widths.insert(cid as u32, w);
+                            }
+                        }
+                        i += 3;
+                    }
+                    None => break,
+                }
+            }
+            metrics.cid_widths = Some(CidWidths {
+                widths,
+                default_width: dw.unwrap_or(1000.0),
+            });
+        } else if let Some(dw) = dw {
+            // `/DW` with no `/W`: every CID uses the default width.
+            metrics.cid_widths = Some(CidWidths {
+                widths: HashMap::new(),
+                default_width: dw,
+            });
         }
 
         // Extract kerning from TrueType fonts (if embedded)

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -22,6 +22,9 @@ pub struct CidWidths {
     /// Per-CID widths (1/1000 em), parsed from `/W`'s mixed
     /// `c [w1 w2 ...]` and `cFirst cLast w` forms.
     pub widths: HashMap<u32, f64>,
+    /// Uniform `/W` ranges stored without materializing every CID. Keeping
+    /// ranges compact bounds parser work by input size for untrusted PDFs.
+    pub ranges: Vec<(u32, u32, f64)>,
     /// `/DW`, the width (1/1000 em) for any CID absent from `widths`.
     /// Defaults to 1000 per spec when `/DW` is not present.
     pub default_width: f64,
@@ -30,7 +33,17 @@ pub struct CidWidths {
 impl CidWidths {
     /// Width (1/1000 em) for `cid`: its `/W` entry, or `/DW` otherwise.
     pub fn width_for(&self, cid: u32) -> f64 {
-        self.widths.get(&cid).copied().unwrap_or(self.default_width)
+        self.widths
+            .get(&cid)
+            .copied()
+            .or_else(|| {
+                self.ranges
+                    .iter()
+                    .rev()
+                    .find(|(first, last, _)| cid >= *first && cid <= *last)
+                    .map(|(_, _, width)| *width)
+            })
+            .unwrap_or(self.default_width)
     }
 }
 
@@ -355,6 +368,10 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
         // Extract CIDFont `/W` + `/DW` (ISO 32000-1 §9.7.4.3). Only present
         // on a CIDFontType0/CIDFontType2 descendant font dictionary; a
         // simple font's dict has no `/W` key, so this is a no-op there.
+        let is_cid_font = font_dict
+            .get("Subtype")
+            .and_then(PdfObject::as_name)
+            .is_some_and(|subtype| matches!(subtype.0.as_str(), "CIDFontType0" | "CIDFontType2"));
         let dw = font_dict.get("DW").and_then(|o| o.as_real());
         let w_array: Option<Cow<[PdfObject]>> = match font_dict.get("W") {
             Some(PdfObject::Array(array)) => Some(Cow::Borrowed(&array.0)),
@@ -366,6 +383,7 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
         };
         if let Some(entries) = w_array {
             let mut widths = HashMap::new();
+            let mut ranges = Vec::new();
             let mut i = 0;
             while i < entries.len() {
                 let Some(first_cid) = entries[i].as_integer() else {
@@ -374,9 +392,18 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                 match entries.get(i + 1) {
                     // `c [w1 w2 ...]`: consecutive widths starting at c.
                     Some(PdfObject::Array(w_list)) => {
-                        for (offset, w_obj) in w_list.0.iter().enumerate() {
-                            if let Some(w) = w_obj.as_real() {
-                                widths.insert(first_cid as u32 + offset as u32, w);
+                        if let Ok(first_cid) = u32::try_from(first_cid) {
+                            for (offset, w_obj) in w_list.0.iter().enumerate() {
+                                if let (Ok(offset), Some(w)) =
+                                    (u32::try_from(offset), w_obj.as_real())
+                                {
+                                    if let Some(cid) = first_cid
+                                        .checked_add(offset)
+                                        .filter(|cid| *cid <= u16::MAX as u32)
+                                    {
+                                        widths.insert(cid, w);
+                                    }
+                                }
                             }
                         }
                         i += 2;
@@ -393,11 +420,10 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                         // (§9.7.4.2), so any range past 0xFFFF is malformed;
                         // clamp rather than materializing a huge/looping
                         // range from a corrupt or adversarial `/W` array.
-                        let last_cid = last_cid.min(u16::MAX as i64);
+                        let first_cid = first_cid.max(0).min(u16::MAX as i64) as u32;
+                        let last_cid = last_cid.max(0).min(u16::MAX as i64) as u32;
                         if last_cid >= first_cid {
-                            for cid in first_cid..=last_cid {
-                                widths.insert(cid as u32, w);
-                            }
+                            ranges.push((first_cid, last_cid, w));
                         }
                         i += 3;
                     }
@@ -406,13 +432,15 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
             }
             metrics.cid_widths = Some(CidWidths {
                 widths,
+                ranges,
                 default_width: dw.unwrap_or(1000.0),
             });
-        } else if let Some(dw) = dw {
-            // `/DW` with no `/W`: every CID uses the default width.
+        } else if is_cid_font {
+            // `/DW` defaults to 1000 even when both `/W` and `/DW` are absent.
             metrics.cid_widths = Some(CidWidths {
                 widths: HashMap::new(),
-                default_width: dw,
+                ranges: Vec::new(),
+                default_width: dw.unwrap_or(1000.0),
             });
         }
 

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -83,9 +83,9 @@ const GLYPHS: &[(i32, u32)] = &[
     (256, 0x0035), // P
 ];
 
-fn content_stream() -> Vec<u8> {
+fn content_stream(glyphs: &[(i32, u32)]) -> Vec<u8> {
     let mut content = String::new();
-    for (x, cid) in GLYPHS {
+    for (x, cid) in glyphs {
         content.push_str(&format!(
             "BT\n/F1 20 Tf\n1 0 0 -1 0 0 Tm\n{x} -966 Td <{cid:04X}> Tj\nET\n"
         ));
@@ -94,7 +94,11 @@ fn content_stream() -> Vec<u8> {
 }
 
 fn build_pdf(w_clause: &str) -> Vec<u8> {
-    let content = content_stream();
+    build_pdf_with(w_clause, TOUNICODE, GLYPHS)
+}
+
+fn build_pdf_with(w_clause: &str, to_unicode: &[u8], glyphs: &[(i32, u32)]) -> Vec<u8> {
+    let content = content_stream(glyphs);
     let objects: Vec<Vec<u8>> = vec![
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
@@ -105,7 +109,7 @@ fn build_pdf(w_clause: &str) -> Vec<u8> {
         b"<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
           /Encoding /Identity-H /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
             .to_vec(),
-        stream_obj("", TOUNICODE),
+        stream_obj("", to_unicode),
         format!(
             "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
              /CIDToGIDMap /Identity \
@@ -132,6 +136,30 @@ fn extract(w_clause: &str) -> String {
 }
 
 #[test]
+fn flat_path_uses_the_mapped_type0_space_cid_width_for_narrow_word_gaps() {
+    let to_unicode = b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+3 beginbfchar <0001> <0041> <0002> <0020> <0003> <0042> endbfchar\n\
+endcmap";
+    let pdf = build_pdf_with(
+        "/W [1 [500 400 500]] /DW 1000",
+        to_unicode,
+        &[(0, 1), (15, 3)],
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(
+        text, "A B",
+        "the 5pt gap clears half the real 8pt space advance but not the legacy 6pt threshold"
+    );
+}
+
+#[test]
 fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
     let text = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     assert!(
@@ -146,7 +174,7 @@ fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
 }
 
 #[test]
-fn genuine_word_space_is_still_produced_regardless_of_w() {
+fn real_widths_fix_the_wide_cid_without_claiming_the_narrow_space_case() {
     // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
     // or not it clears the space threshold is a separate, pre-existing
     // calibration question (also applies to simple fonts) that this fix does
@@ -155,26 +183,22 @@ fn genuine_word_space_is_still_produced_regardless_of_w() {
     // fix itself.
     let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     let without_w = extract("");
-    // Both variants must agree on this boundary: /W only changes advance
-    // widths, not whether a *given* gap crosses the threshold once the
-    // widths feeding that gap are correct on both sides of it.
     assert_eq!(
-        with_w.contains("PAN No") || with_w.contains("PANNo"),
-        without_w.contains("PAN No") || without_w.contains("PANNo"),
-        "with_w={with_w:?} without_w={without_w:?}"
+        with_w, "PANNo:BLUPM6342P",
+        "real CID widths must remove the wide-M space; the unmapped narrow word gap is #500"
+    );
+    assert_eq!(
+        without_w, "PANNo:BLUPM6342P",
+        "the normative missing /DW default is 1000, not the old 0.5em heuristic"
     );
 }
 
 #[test]
-fn no_w_or_dw_falls_back_to_the_pre_fix_heuristic() {
-    // Without any /W/DW info at all, behavior must be unchanged from before
-    // this fix (the decoded-text-length heuristic) -- this is a real
-    // fallback path (fonts with a missing/malformed /W), not just a defensive
-    // branch, so it must keep working.
-    let text = extract("");
-    assert!(
-        !text.is_empty(),
-        "extraction must still succeed with no CID width info at all"
+fn missing_dw_uses_the_normative_1000_unit_default() {
+    assert_eq!(
+        extract(""),
+        extract("/DW 1000"),
+        "omitted /DW must behave exactly like the ISO-defined 1000-unit default"
     );
 }
 
@@ -185,10 +209,7 @@ fn dw_only_no_w_array_is_honored() {
     // not introduce a spurious space, unlike the flat 0.5em (=1000 units at
     // this scale) pre-fix fallback would for some of these narrower glyphs.
     let text = extract("/DW 600");
-    assert!(
-        !text.is_empty(),
-        "extraction must succeed with /DW present and no /W array"
-    );
+    assert_eq!(text, "PAN No:BLUPM6342P");
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -1,0 +1,226 @@
+//! Issue #496 — composite (Type0/CID) font text extraction never consults the
+//! CIDFont's `/W`/`/DW` glyph widths (ISO 32000-1 §9.7.4.3): every glyph is
+//! assumed to advance by a flat `0.5 * font_size`, regardless of its real
+//! width. When a real glyph's width diverges enough from that flat estimate
+//! relative to its neighbors, the extractor's pen-tracking drifts out of sync
+//! with where the next glyph is actually drawn, crossing the space-insertion
+//! threshold and corrupting the extracted text with a spurious space in the
+//! middle of a single token.
+//!
+//! Reproduction: a synthetic `CIDFontType2`/`Identity-H` font with a real-shape
+//! `/W` array (mixing both width forms per spec: `c [w1 w2 ...]` and `cFirst
+//! cLast w`), drawing "PANNo:BLUPM6342P"-style content one glyph per `Tj` via
+//! absolute `Td` positioning — the same encoding style KeyView/most PDF
+//! generators emit for embedded subset fonts. No embedded glyph outlines are
+//! needed since text extraction never renders glyphs.
+//!
+//! With `/W` correctly consulted, the wide glyph 'M' (873/1000 em, the widest
+//! in the table) advances the pen by its real width and the next glyph lands
+//! within the space threshold, so no spurious space appears. Without it (the
+//! pre-fix flat 0.5em assumption), 'M' is treated as an average-width glyph,
+//! the pen falls short of the next glyph's real position, and a spurious
+//! space is inserted.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// ToUnicode CMap covering exactly the glyphs used below, copied verbatim
+/// (mixed `beginbfchar`/`beginbfrange`) from a real subset font's CMap, i.e.
+/// non-contiguous and non-identity CID->Unicode, as any real subset font has.
+const TOUNICODE: &[u8] = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n\
+/CMapName /Adobe-Identity-UCS def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+6 beginbfchar\n\
+<000B> <0026>\n<002E> <0049>\n<0035> <0050>\n<0046> <0061>\n<004E> <0069>\n<0463> <2019>\n\
+endbfchar\n\
+10 beginbfrange\n\
+<0011> <0019> <002C>\n<001B> <001C> <0036>\n<001E> <001F> <0039>\n\
+<0026> <0029> <0041>\n<002B> <002C> <0046>\n<0030> <0033> <004B>\n\
+<0037> <003A> <0052>\n<0048> <004C> <0063>\n<0050> <0055> <006B>\n\
+<0057> <005B> <0072>\nendbfrange\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+/// `/W` array copied verbatim from the real font, mixing both width forms:
+/// `21 30 562.01172` (uniform range) and e.g. `38 [652... 873...]` (explicit
+/// consecutive list). CID 50 ('M' via the CMap above) is 873.04688 -- the
+/// widest entry in the whole table.
+const W_ARRAY: &str = "0 [443.35938] 11 [622.07031] 17 [196.77734 276.36719 263.67188 412.59766] \
+21 30 562.01172 31 [242.1875] \
+38 [652.34375 623.04688 650.87891 656.25 0 552.73438 681.15234 0 271.97266 0 627.44141 \
+538.57422 873.04688 713.37891 0 630.85938 0 616.21094 593.75 596.67969 648.4375] \
+70 [543.94531 0 523.4375 563.96484 530.27344 347.65625 561.52344 0 243.16406 0 506.83594 \
+243.16406 876.95313 552.24609 570.3125 561.52344 0 338.86719 516.11328 327.14844 551.26953 484.375] \
+1123 [200.19531]";
+
+/// One glyph per `Tj`, absolute `Td` x-coordinates and raw CIDs copied
+/// verbatim from a real document: "PAN No:BLUPM6342P" at font size 20 (the
+/// `N`/`o` boundary carries the only genuine word-space in this string; every
+/// other gap is a same-word inter-glyph gap that must never become a space).
+const GLYPHS: &[(i32, u32)] = &[
+    (72, 0x0035),  // P
+    (84, 0x0026),  // A
+    (97, 0x0033),  // N
+    (116, 0x0033), // N
+    (130, 0x0054), // o
+    (141, 0x001F), // :
+    (146, 0x0027), // B
+    (158, 0x0031), // L
+    (169, 0x003A), // U
+    (182, 0x0035), // P
+    (194, 0x0032), // M -- widest glyph, CID 50, /W = 873.04688
+    (211, 0x001B), // 6
+    (222, 0x0018), // 3
+    (234, 0x0019), // 4
+    (245, 0x0017), // 2
+    (256, 0x0035), // P
+];
+
+fn content_stream() -> Vec<u8> {
+    let mut content = String::new();
+    for (x, cid) in GLYPHS {
+        content.push_str(&format!(
+            "BT\n/F1 20 Tf\n1 0 0 -1 0 0 Tm\n{x} -966 Td <{cid:04X}> Tj\nET\n"
+        ));
+    }
+    content.into_bytes()
+}
+
+fn build_pdf(w_clause: &str) -> Vec<u8> {
+    let content = content_stream();
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", &content),
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
+          /Encoding /Identity-H /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", TOUNICODE),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
+             /CIDToGIDMap /Identity \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             {w_clause} /FontDescriptor 8 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Synthetic /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+fn extract(w_clause: &str) -> String {
+    let doc = PdfReader::new(Cursor::new(build_pdf(w_clause)))
+        .expect("PDF should parse")
+        .into_document();
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
+    let text = extract(&format!("/W [{W_ARRAY}] /DW 0"));
+    assert!(
+        text.contains("BLUPM6342P"),
+        "the CID-indexed /W width for the wide glyph 'M' must be used so the \
+         pen stays in sync with the next glyph, got: {text:?}"
+    );
+    assert!(
+        !text.contains("BLUPM 6342P"),
+        "no spurious space should appear mid-token once /W is consulted: {text:?}"
+    );
+}
+
+#[test]
+fn genuine_word_space_is_still_produced_regardless_of_w() {
+    // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
+    // or not it clears the space threshold is a separate, pre-existing
+    // calibration question (also applies to simple fonts) that this fix does
+    // not change -- this test only pins today's behavior so a future
+    // regression there is caught, without conflating it with the CID-width
+    // fix itself.
+    let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
+    let without_w = extract("");
+    // Both variants must agree on this boundary: /W only changes advance
+    // widths, not whether a *given* gap crosses the threshold once the
+    // widths feeding that gap are correct on both sides of it.
+    assert_eq!(
+        with_w.contains("PAN No") || with_w.contains("PANNo"),
+        without_w.contains("PAN No") || without_w.contains("PANNo"),
+        "with_w={with_w:?} without_w={without_w:?}"
+    );
+}
+
+#[test]
+fn no_w_or_dw_falls_back_to_the_pre_fix_heuristic() {
+    // Without any /W/DW info at all, behavior must be unchanged from before
+    // this fix (the decoded-text-length heuristic) -- this is a real
+    // fallback path (fonts with a missing/malformed /W), not just a defensive
+    // branch, so it must keep working.
+    let text = extract("");
+    assert!(
+        !text.is_empty(),
+        "extraction must still succeed with no CID width info at all"
+    );
+}
+
+#[test]
+fn dw_only_no_w_array_is_honored() {
+    // A `/DW` with no `/W` at all: every CID uses the default width. Using a
+    // /DW close to the real average glyph width in this table (~600) must
+    // not introduce a spurious space, unlike the flat 0.5em (=1000 units at
+    // this scale) pre-fix fallback would for some of these narrower glyphs.
+    let text = extract("/DW 600");
+    assert!(
+        !text.is_empty(),
+        "extraction must succeed with /DW present and no /W array"
+    );
+}
+
+#[test]
+fn oversized_w_range_does_not_hang_or_allocate_unboundedly() {
+    // `cFirst cLast w` with `cLast` far beyond any real CID (Identity-H/-V
+    // CIDs are a u16, max 0xFFFF) must not materialize a multi-billion-entry
+    // HashMap or loop for an unreasonable amount of time -- a malformed or
+    // adversarial `/W` array must degrade gracefully, not hang or OOM.
+    let text = extract("/W [0 4294967295 500]");
+    assert!(
+        !text.is_empty(),
+        "extraction must complete (not hang/OOM) with an oversized /W range"
+    );
+}
+
+#[test]
+fn preserve_layout_path_also_benefits_from_cid_widths() {
+    // `preserve_layout` builds its fragments from the same
+    // `calculate_text_width_from_codes` call, so the fix applies there too.
+    let doc = PdfReader::new(Cursor::new(build_pdf(&format!("/W [{W_ARRAY}] /DW 0"))))
+        .expect("PDF should parse")
+        .into_document();
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    let text = ex
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert!(
+        text.contains("BLUPM6342P"),
+        "preserve_layout must also avoid the spurious mid-token space: {text:?}"
+    );
+}


### PR DESCRIPTION
Addresses #496.

## Summary

Composite (Type0/CID) font text extraction never consulted the CIDFont's `/W`/`/DW` glyph widths (ISO 32000-1 §9.7.4.3). Every glyph was assumed to advance by a flat `0.5 * font_size` regardless of its real width, since `calculate_text_width_from_codes`'s composite branch fell straight through to `calculate_text_width`'s decoded-text heuristic, which never had CID-indexed width data to consult in the first place.

When a glyph's true advance diverged enough from that flat estimate relative to its neighbors — e.g. a genuinely wide glyph in the real font, common since real font metrics vary quite a bit per glyph ("i"/"l" vs "M"/"W") — the extractor's pen-tracking (`last_x`) drifted out of sync with where the next glyph was actually drawn. Once that drift crossed the space-insertion threshold, a spurious space appeared in the middle of a single token (e.g. `"BLUPM6342P"` extracted as `"BLUPM 6342P"`), while other genuine word-space boundaries could conversely go undetected.

## Fix

- `extraction_cmap.rs`: add `CidWidths` (CID → width map plus a default width) and a `cid_widths` field on `FontMetrics`. Parse a CIDFont dict's `/W` (mixing both spec forms: `c [w1 w2 ...]` consecutive widths and `cFirst cLast w` uniform ranges) and `/DW` into it during font-info extraction, alongside the existing simple-font `Widths`/`FirstChar`/`LastChar` parsing. A `cFirst..cLast` range is clamped to `u16::MAX` (the largest CID Identity-H/-V codes can produce) so a malformed or adversarial `/W` array cannot materialize an unbounded `HashMap`. The inline-array case borrows via `Cow` rather than cloning; only the indirect-reference case owns (`get_object` returns by value there).
- `extraction.rs`: add `cids_for_codes`, decoding a text-showing string's raw bytes into CIDs (Identity-H/-V: raw big-endian `u16`; non-identity: via the font's resolved encoding CMap), mirroring the code-length/lookup rules `decode_text_with_font` already uses for Unicode decoding. `calculate_text_width_from_codes`'s composite branch now looks up each CID's width in the descendant font's `cid_widths` when present, and only falls back to the previous decoded-text heuristic when neither `/W` nor `/DW` exists on the font.

## Validation

- `cargo fmt -p oxidize-pdf -- --check`
- `cargo clippy -p oxidize-pdf --lib -- -D warnings`
- `cargo test -p oxidize-pdf --lib` (6,693 passed)
- New regression test (`issue_496_cid_width_lookup_test.rs`, 6 tests): the wide-glyph spurious-space repro with real widths vs. no `/W` at all, a genuine-word-space parity check between both variants, a `/DW`-only (no `/W` array) case, the same fix applying under `preserve_layout`, and an oversized-range safety test confirming the `u16::MAX` clamp keeps a malformed `/W` from hanging or over-allocating
- Related CID/CJK/extraction integration test files re-run clean (`cjk_font_integration_test`, `encoding_embedded_stream_test`, `issue_358_cid_keyed_font_test`, `issue_392_unicode_keyed_cyrillic_test`, `font_subset_pdf_round_trip_test`, `font_subset_post_and_cidtogidmap_test`, `text_extraction_test`, `text_extraction_e2e_test`, `issue_302_extraction_fidelity_test`, `issue_302_width_from_codes_test`, `issue_486_flat_hyphen_merge_test`, `issue_265_line_interleaving_test`, `issue_448_reading_order_wiring_test`)
