### PR TITLE
fix(tagged-pdf): connect ActualText MCIDs to structure tree

### DIFF
--- a/oxidize-pdf-core/examples/generate_issue_498_diagnostic_fixture.rs
+++ b/oxidize-pdf-core/examples/generate_issue_498_diagnostic_fixture.rs
@@ -1,0 +1,73 @@
+//! Generates a copy/paste diagnostic matrix for issue #498.
+
+use oxidize_pdf::{
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+const OUTPUT: &str = "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf";
+
+fn write_label(page: &mut Page, y: f64, label: &str) -> Result<(), PdfError> {
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(72.0, y)
+        .write(label)?;
+    Ok(())
+}
+
+fn write_visual(page: &mut Page, y: f64, visual: &str) -> Result<(), PdfError> {
+    page.text()
+        .set_font(Font::Helvetica, 18.0)
+        .at(300.0, y)
+        .write(visual)?;
+    Ok(())
+}
+
+fn main() -> Result<(), PdfError> {
+    let mut page = Page::a4();
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+
+    write_label(&mut page, 740.0, "Inline ASCII (expect INLINE_ASCII):")?;
+    let inline_mcid = page.begin_marked_content_with_actual_text("Span", "INLINE_ASCII")?;
+    write_visual(&mut page, 740.0, "VISUAL_A")?;
+    page.end_marked_content()?;
+    let mut inline_span = StructureElement::new(StandardStructureType::Span);
+    inline_span.add_mcid(0, inline_mcid);
+    tree.add_child(root, inline_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    write_label(&mut page, 700.0, "Structural ASCII (expect STRUCT_ASCII):")?;
+    let structural_mcid = page.begin_marked_content("Span")?;
+    write_visual(&mut page, 700.0, "VISUAL_B")?;
+    page.end_marked_content()?;
+    let mut structural_span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text("STRUCT_ASCII");
+    structural_span.add_mcid(0, structural_mcid);
+    tree.add_child(root, structural_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    write_label(
+        &mut page,
+        660.0,
+        "Inline + structural Unicode (expect superscripts):",
+    )?;
+    let logical = "2⁴⁰ E = mc² Aⁿ⁺¹B";
+    let combined_mcid = page.begin_marked_content_with_actual_text("Span", logical)?;
+    write_visual(&mut page, 660.0, "VISUAL_C")?;
+    page.end_marked_content()?;
+    let mut combined_span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text(logical);
+    combined_span.add_mcid(0, combined_mcid);
+    tree.add_child(root, combined_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    let mut document = Document::new();
+    document.set_title("ActualText diagnostic matrix");
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    document.save(OUTPUT)?;
+    println!("wrote {OUTPUT}");
+    Ok(())
+}

--- a/oxidize-pdf-core/examples/generate_issue_498_interop_fixture.rs
+++ b/oxidize-pdf-core/examples/generate_issue_498_interop_fixture.rs
@@ -1,0 +1,68 @@
+//! Generates the cross-viewer copy/paste fixture for issue #498.
+//!
+//! Run from the workspace root:
+//!
+//! ```text
+//! cargo run -p oxidize-pdf --example generate_issue_498_interop_fixture
+//! ```
+
+use oxidize_pdf::{
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+const OUTPUT: &str = "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf";
+const LOGICAL_TEXT: &str = "2⁴⁰ E = mc² Aⁿ⁺¹B";
+
+fn main() -> Result<(), PdfError> {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content_with_actual_text("Span", LOGICAL_TEXT)?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(72.0, 720.0)
+        .write("2")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(86.0, 731.0)
+        .write("40")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(105.0, 720.0)
+        .write(" E = mc")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(199.0, 731.0)
+        .write("2")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(210.0, 720.0)
+        .write(" A")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(238.0, 731.0)
+        .write("n+1")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(263.0, 720.0)
+        .write("B")?;
+    page.end_marked_content()?;
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text(LOGICAL_TEXT);
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    let mut document = Document::new();
+    document.set_title("ActualText cross-viewer interoperability fixture");
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    document.save(OUTPUT)?;
+
+    println!("wrote {OUTPUT}");
+    println!("expected copied text: {LOGICAL_TEXT}");
+    Ok(())
+}

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -2037,9 +2037,15 @@ impl Page {
     /// as UTF-16BE with a byte-order mark so every Unicode scalar is preserved.
     ///
     /// The returned MCID can be attached to a structure element in the same way
-    /// as the value returned by [`Page::begin_marked_content`]. This makes the
-    /// method useful both for lightweight semantic spans and for fully tagged
-    /// documents.
+    /// as the value returned by [`Page::begin_marked_content`]. To connect the
+    /// replacement text to the Tagged PDF structure, attach it with
+    /// [`StructureElement::add_mcid`](crate::structure::StructureElement::add_mcid)
+    /// and install the completed tree on the document with
+    /// [`Document::set_struct_tree`](crate::Document::set_struct_tree). The writer
+    /// will then emit the page `/StructParents` and structure `/ParentTree`
+    /// connections required by Tagged PDF readers. Copy/paste still depends on
+    /// the viewer honoring `/ActualText`; some viewers copy the painted glyphs
+    /// even when these relationships are present.
     pub fn begin_marked_content_with_actual_text(
         &mut self,
         tag: &str,

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -198,6 +198,10 @@ impl<W: Write> PdfWriter<W> {
     }
 
     pub fn write_document(&mut self, document: &mut Document) -> Result<()> {
+        if let Some(struct_tree) = &document.struct_tree {
+            Self::validate_struct_tree(struct_tree, &document.pages)?;
+        }
+
         // Store used characters for font subsetting
         if !document.used_characters_by_font.is_empty() {
             self.document_used_chars_by_font = document.used_characters_by_font.clone();
@@ -1300,6 +1304,22 @@ impl<W: Write> PdfWriter<W> {
             element_ids.push(self.allocate_object_id());
         }
 
+        // Build the ParentTree ownership map. Each tagged page gets a
+        // /StructParents key and each MCID slot points at its owning
+        // structure element (ISO 32000-1 §14.7.4.4).
+        let mut page_owners: std::collections::BTreeMap<
+            usize,
+            std::collections::BTreeMap<u32, usize>,
+        > = std::collections::BTreeMap::new();
+        for (element_index, element) in struct_tree.iter().enumerate() {
+            for mcid_ref in &element.mcids {
+                page_owners
+                    .entry(mcid_ref.page_index)
+                    .or_default()
+                    .insert(mcid_ref.mcid, element_index);
+            }
+        }
+
         // Build parent map: element_index -> parent_id
         let mut parent_map: std::collections::HashMap<usize, ObjectId> =
             std::collections::HashMap::new();
@@ -1365,7 +1385,12 @@ impl<W: Write> PdfWriter<W> {
                 element_dict.set("Alt", Object::String(alt.clone()));
             }
             if let Some(ref actual_text) = element.attributes.actual_text {
-                element_dict.set("ActualText", Object::String(actual_text.clone()));
+                let mut encoded = Vec::with_capacity(2 + actual_text.len() * 2);
+                encoded.extend_from_slice(&[0xFE, 0xFF]);
+                for unit in actual_text.encode_utf16() {
+                    encoded.extend_from_slice(&unit.to_be_bytes());
+                }
+                element_dict.set("ActualText", Object::ByteString(encoded));
             }
             if let Some(ref title) = element.attributes.title {
                 element_dict.set("T", Object::String(title.clone()));
@@ -1394,7 +1419,7 @@ impl<W: Write> PdfWriter<W> {
             for mcid_ref in &element.mcids {
                 let mut mcr = Dictionary::new();
                 mcr.set("Type", Object::Name("MCR".to_string()));
-                mcr.set("Pg", Object::Integer(mcid_ref.page_index as i64));
+                mcr.set("Pg", Object::Reference(self.page_ids[mcid_ref.page_index]));
                 mcr.set("MCID", Object::Integer(mcid_ref.mcid as i64));
                 kids.push(Object::Dictionary(mcr));
             }
@@ -1409,6 +1434,29 @@ impl<W: Write> PdfWriter<W> {
         // Create StructTreeRoot dictionary
         let mut struct_tree_root = Dictionary::new();
         struct_tree_root.set("Type", Object::Name("StructTreeRoot".to_string()));
+
+        if !page_owners.is_empty() {
+            let parent_tree_id = self.allocate_object_id();
+            let mut nums = Vec::new();
+            for (struct_parent_key, (_page_index, owners)) in page_owners.iter().enumerate() {
+                let max_mcid = *owners.keys().next_back().expect("non-empty owner map");
+                let mut owner_array = vec![Object::Null; max_mcid as usize + 1];
+                for (&mcid, &element_index) in owners {
+                    owner_array[mcid as usize] = Object::Reference(element_ids[element_index]);
+                }
+                nums.push(Object::Integer(struct_parent_key as i64));
+                nums.push(Object::Array(owner_array));
+            }
+
+            let mut parent_tree = Dictionary::new();
+            parent_tree.set("Nums", Object::Array(nums));
+            self.write_object(parent_tree_id, Object::Dictionary(parent_tree))?;
+            struct_tree_root.set("ParentTree", Object::Reference(parent_tree_id));
+            struct_tree_root.set(
+                "ParentTreeNextKey",
+                Object::Integer(page_owners.len() as i64),
+            );
+        }
 
         // Add root element(s) as K entry
         if let Some(root_index) = struct_tree.root_index() {
@@ -1429,6 +1477,52 @@ impl<W: Write> PdfWriter<W> {
 
         self.write_object(struct_tree_root_id, Object::Dictionary(struct_tree_root))?;
         Ok(struct_tree_root_id)
+    }
+
+    fn validate_struct_tree(
+        struct_tree: &crate::structure::StructTree,
+        pages: &[crate::page::Page],
+    ) -> Result<()> {
+        let mut owners = std::collections::HashSet::new();
+        for element in struct_tree.iter() {
+            for mcid_ref in &element.mcids {
+                if mcid_ref.page_index >= pages.len() {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "structure element references page {} but document has {} pages",
+                        mcid_ref.page_index,
+                        pages.len()
+                    )));
+                }
+                if mcid_ref.mcid >= pages[mcid_ref.page_index].next_mcid() {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "structure element references MCID {} on page {}, but that page has only {} marked-content sequences",
+                        mcid_ref.mcid,
+                        mcid_ref.page_index,
+                        pages[mcid_ref.page_index].next_mcid()
+                    )));
+                }
+                if !owners.insert((mcid_ref.page_index, mcid_ref.mcid)) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "MCID {} on page {} is owned by more than one structure element",
+                        mcid_ref.mcid, mcid_ref.page_index
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn struct_parent_keys(
+        struct_tree: &crate::structure::StructTree,
+    ) -> std::collections::BTreeMap<usize, i64> {
+        struct_tree
+            .iter()
+            .flat_map(|element| element.mcids.iter().map(|mcid| mcid.page_index))
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .enumerate()
+            .map(|(key, page_index)| (page_index, key as i64))
+            .collect()
     }
 
     /// Reserve an `ObjectId` for every field owned by `document.form_manager`
@@ -2544,6 +2638,14 @@ impl<W: Write> PdfWriter<W> {
         // Store page IDs for form field references
         self.page_ids = page_ids.clone();
 
+        // Compute the page-index -> /StructParents mapping once. Rebuilding it
+        // while serializing every page makes large tagged documents quadratic.
+        let struct_parent_keys = document
+            .struct_tree
+            .as_ref()
+            .map(Self::struct_parent_keys)
+            .unwrap_or_default();
+
         // Write individual pages with font references
         for (i, page) in document.pages.iter().enumerate() {
             let page_id = page_ids[i];
@@ -2559,7 +2661,7 @@ impl<W: Write> PdfWriter<W> {
                 pages_id,
                 content_id,
                 page,
-                document,
+                struct_parent_keys.get(&i).copied(),
                 font_refs,
                 &preserved_font_map,
             )?;
@@ -2585,7 +2687,7 @@ impl<W: Write> PdfWriter<W> {
         parent_id: ObjectId,
         content_id: ObjectId,
         page: &crate::page::Page,
-        _document: &Document,
+        struct_parent_key: Option<i64>,
         font_refs: &HashMap<String, ObjectId>,
         preserved_font_map: &HashMap<String, String>,
     ) -> Result<()> {
@@ -2595,6 +2697,10 @@ impl<W: Write> PdfWriter<W> {
         page_dict.set("Type", Object::Name("Page".to_string()));
         page_dict.set("Parent", Object::Reference(parent_id));
         page_dict.set("Contents", Object::Reference(content_id));
+
+        if let Some(key) = struct_parent_key {
+            page_dict.set("StructParents", Object::Integer(key));
+        }
 
         // Get resources dictionary or create new one
         let mut resources = if let Some(Object::Dictionary(res)) = page_dict.get("Resources") {

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.md
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.md
@@ -1,0 +1,23 @@
+# Issue #498 diagnostic matrix
+
+Select and copy only the value in the right column of each row.
+
+| Visible value | Expected copied value | Mechanism |
+|---|---|---|
+| `VISUAL_A` | `INLINE_ASCII` | Marked-content `/ActualText` only |
+| `VISUAL_B` | `STRUCT_ASCII` | Structure-element `/ActualText` only |
+| `VISUAL_C` | `2⁴⁰ E = mc² Aⁿ⁺¹B` | Both locations, Unicode |
+
+Interpretation:
+
+- If A works but B does not, the engine only reads marked-content properties.
+- If B works but A does not, the engine only reads the structure tree.
+- If A and B work but C does not, Unicode or font-coverage handling is at fault.
+- If all three copy their visible `VISUAL_*` value, the engine ignores
+  `/ActualText` during selection/copy.
+
+Regenerate with:
+
+```sh
+cargo run -p oxidize-pdf --example generate_issue_498_diagnostic_fixture
+```

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf
@@ -1,0 +1,235 @@
+%PDF-1.7
+%‚„œ”
+2 0 obj
+<<
+/Count 1
+/Kids [4 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<<
+/Contents 5 0 R
+/MediaBox [0 0 595 842]
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/Courier <<
+/BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Bold <<
+/BaseFont /Courier-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-BoldOblique <<
+/BaseFont /Courier-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Oblique <<
+/BaseFont /Courier-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica <<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Bold <<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-BoldOblique <<
+/BaseFont /Helvetica-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Oblique <<
+/BaseFont /Helvetica-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Bold <<
+/BaseFont /Times-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-BoldItalic <<
+/BaseFont /Times-BoldItalic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Italic <<
+/BaseFont /Times-Italic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Roman <<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+/StructParents 0
+/Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Filter /FlateDecode
+/Length 289
+>>
+stream
+xúïë›jÉ@ÖÔ}äπL(‘q5⁄¸•I.Í⁄´@≥-±‚O…„wllcmJÒb8ª;ÀÏwˆxBQdÒ.€<KA”@<+xãà¢Xå`˝ƒQY≤»K	nÏs˚Ö<U2kÅÔ6|>O˜À˚%àW%§±qïñ`€Í÷Á ®n÷vi!‰©;
+£—XSÖT˛hΩB\ı=çT'’áﬁ⁄q_Ò~"ﬂçëÈÚÑ˘â«âª9∏_X·ˆ◊Ñk¶Ò{@‹÷ë◊i15ã«ƒˇ◊fP„î⁄õGmö”®n†π‡'eûΩÂ≈@”U≤n≤:Ø⁄ÊOÏZr:chTÙ<√sjΩÍ¡YMRìlylËkt7¢rÈ¨OìÕHsdk¯¸/Çh≥Ú
+endstream
+endobj
+7 0 obj
+<<
+/K [8 0 R 9 0 R 10 0 R]
+/P 6 0 R
+/S /Document
+/Type /StructElem
+>>
+endobj
+8 0 obj
+<<
+/K [<<
+/MCID 0
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+9 0 obj
+<<
+/ActualText <FEFF005300540052005500430054005F00410053004300490049>
+/K [<<
+/MCID 1
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+10 0 obj
+<<
+/ActualText <FEFF003220742070002000450020003D0020006D006300B200200041207F207A00B90042>
+/K [<<
+/MCID 2
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+11 0 obj
+<<
+/Nums [0 [8 0 R 9 0 R 10 0 R]]
+>>
+endobj
+6 0 obj
+<<
+/K 7 0 R
+/ParentTree 11 0 R
+/ParentTreeNextKey 1
+/Type /StructTreeRoot
+>>
+endobj
+12 0 obj
+<<
+/Length 2759
+/Subtype /XML
+/Type /Metadata
+>>
+stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="oxidize-pdf 1.4.0">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <dc:title>ActualText diagnostic matrix</dc:title>
+      <xmp:CreatorTool>oxidize_pdf</xmp:CreatorTool>
+      <xmp:CreateDate>2026-08-17T21:35:18.385494684+00:00</xmp:CreateDate>
+      <xmp:ModifyDate>2026-08-17T21:35:18.385544146+00:00</xmp:ModifyDate>
+      <pdf:Producer>oxidize_pdf v4.4.0 (MIT)</pdf:Producer>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+endstream
+endobj
+1 0 obj
+<<
+/MarkInfo <<
+/Marked true
+>>
+/Metadata 12 0 R
+/Pages 2 0 R
+/StructTreeRoot 6 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20260817213518+00'00)
+/Creator (oxidize_pdf)
+/ModDate (D:20260817213518+00'00)
+/Producer (oxidize_pdf v4.4.0 \(MIT\))
+/Title (ActualText diagnostic matrix)
+/oxidize-pdf-build (oxpdf-89f970d19ac6002c)
+/oxidize-pdf-edition (OpenSource)
+/oxidize-pdf-features (0200)
+>>
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000005310 00000 n 
+0000000015 00000 n 
+0000005427 00000 n 
+0000000072 00000 n 
+0000001431 00000 n 
+0000002376 00000 n 
+0000001792 00000 n 
+0000001877 00000 n 
+0000001974 00000 n 
+0000002138 00000 n 
+0000002323 00000 n 
+0000002468 00000 n 
+trailer
+<<
+/Info 3 0 R
+/Root 1 0 R
+/Size 13
+>>
+startxref
+5728
+%%EOF

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.md
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.md
@@ -1,0 +1,26 @@
+# Issue #498 ActualText interoperability fixture
+
+Regenerate the adjacent PDF from the workspace root:
+
+```sh
+cargo run -p oxidize-pdf --example generate_issue_498_interop_fixture
+```
+
+Open `issue_498_actual_text_interop.pdf`, select the visible formula, copy it,
+and paste into a plain-text editor. The expected text is:
+
+```text
+2⁴⁰ E = mc² Aⁿ⁺¹B
+```
+
+Record the application name, version, operating-system version, copied text,
+and result for both:
+
+- Apple Preview on macOS.
+- One independent graphical PDF engine.
+
+The automated regression test verifies the underlying `/ActualText`, MCID,
+`/StructParents`, `/ParentTree`, and page-reference relationships. This manual
+check verifies the viewer behavior that an internal parser cannot establish.
+Viewer support is not guaranteed: a viewer that ignores `/ActualText` during
+selection will copy the painted fallback glyphs despite a valid structure tree.

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf
@@ -1,0 +1,207 @@
+%PDF-1.7
+%‚„œ”
+2 0 obj
+<<
+/Count 1
+/Kids [4 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<<
+/Contents 5 0 R
+/MediaBox [0 0 595 842]
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/Courier <<
+/BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Bold <<
+/BaseFont /Courier-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-BoldOblique <<
+/BaseFont /Courier-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Oblique <<
+/BaseFont /Courier-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica <<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Bold <<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-BoldOblique <<
+/BaseFont /Helvetica-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Oblique <<
+/BaseFont /Helvetica-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Bold <<
+/BaseFont /Times-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-BoldItalic <<
+/BaseFont /Times-BoldItalic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Italic <<
+/BaseFont /Times-Italic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Roman <<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+/StructParents 0
+/Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Filter /FlateDecode
+/Length 199
+>>
+stream
+xúççªÇ@E˚˝ä)5&2;ã<$·-®‹ àFÉƒçüÔ(R∞±ÿ‚ÊÓÏÃ…q˜∫á(r™lüÇì4√£Ót˚ *ã≤DTDËªD$éª[Âc{‹ûBLÈ∑ó|[r˛y¶8é!Õ3ëj·Ï⁄ÓŸó¶rAüÆÅ≥â‡”g}ZÇæäBîúQÅ˜•îú(ˇcsôƒçaÉ∂pklú2)Ÿ8I¢ÈLlt§C◊Ø§ï–SÜ0ù∞¢ ƒ¬´t¡
+endstream
+endobj
+7 0 obj
+<<
+/K [8 0 R]
+/P 6 0 R
+/S /Document
+/Type /StructElem
+>>
+endobj
+8 0 obj
+<<
+/ActualText <FEFF003220742070002000450020003D0020006D006300B200200041207F207A00B90042>
+/K [<<
+/MCID 0
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+9 0 obj
+<<
+/Nums [0 [8 0 R]]
+>>
+endobj
+6 0 obj
+<<
+/K 7 0 R
+/ParentTree 9 0 R
+/ParentTreeNextKey 1
+/Type /StructTreeRoot
+>>
+endobj
+10 0 obj
+<<
+/Length 2779
+/Subtype /XML
+/Type /Metadata
+>>
+stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="oxidize-pdf 1.4.0">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <dc:title>ActualText cross-viewer interoperability fixture</dc:title>
+      <xmp:CreatorTool>oxidize_pdf</xmp:CreatorTool>
+      <xmp:CreateDate>2026-08-17T21:27:39.872374287+00:00</xmp:CreateDate>
+      <xmp:ModifyDate>2026-08-17T21:27:39.872412599+00:00</xmp:ModifyDate>
+      <pdf:Producer>oxidize_pdf v4.4.0 (MIT)</pdf:Producer>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+endstream
+endobj
+1 0 obj
+<<
+/MarkInfo <<
+/Marked true
+>>
+/Metadata 10 0 R
+/Pages 2 0 R
+/StructTreeRoot 6 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20260817212739+00'00)
+/Creator (oxidize_pdf)
+/ModDate (D:20260817212739+00'00)
+/Producer (oxidize_pdf v4.4.0 \(MIT\))
+/Title (ActualText cross-viewer interoperability fixture)
+/oxidize-pdf-build (oxpdf-89f970d19ac6002c)
+/oxidize-pdf-edition (OpenSource)
+/oxidize-pdf-features (0200)
+>>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000004950 00000 n 
+0000000015 00000 n 
+0000005067 00000 n 
+0000000072 00000 n 
+0000001431 00000 n 
+0000001997 00000 n 
+0000001702 00000 n 
+0000001774 00000 n 
+0000001958 00000 n 
+0000002088 00000 n 
+trailer
+<<
+/Info 3 0 R
+/Root 1 0 R
+/Size 11
+>>
+startxref
+5388
+%%EOF

--- a/oxidize-pdf-core/tests/issue_498_tagged_actual_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_498_tagged_actual_text_test.rs
@@ -1,0 +1,336 @@
+//! Regression tests for issue #498: tagged `/ActualText` must be connected
+//! to the page and structure tree, not emitted as an orphan MCID.
+
+use std::io::Cursor;
+
+use oxidize_pdf::{
+    parser::{objects::PdfObject, PdfReader},
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+fn object_ref(object: &PdfObject) -> (u32, u16) {
+    match object {
+        PdfObject::Reference(id, generation) => (*id, *generation),
+        other => panic!("expected indirect reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn actual_text_mcid_is_connected_through_the_parent_tree() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content_with_actual_text("Span", "2⁴⁰")
+        .expect("begin ActualText span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("240")
+        .expect("write visual fallback");
+    page.end_marked_content().expect("end ActualText span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span).with_actual_text("2⁴⁰");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let pdf = document.to_bytes().expect("serialize tagged PDF");
+
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse generated PDF");
+    let catalog = reader.catalog().expect("catalog").clone();
+
+    let pages_ref = object_ref(catalog.get("Pages").expect("catalog /Pages"));
+    let pages = reader
+        .get_object(pages_ref.0, pages_ref.1)
+        .expect("pages object");
+    let page_ref = match pages {
+        PdfObject::Dictionary(dict) => match dict.get("Kids").expect("pages /Kids") {
+            PdfObject::Array(kids) => object_ref(&kids.0[0]),
+            other => panic!("expected /Kids array, got {other:?}"),
+        },
+        other => panic!("expected pages dictionary, got {other:?}"),
+    };
+    let page_object = reader
+        .get_object(page_ref.0, page_ref.1)
+        .expect("page object");
+    let struct_parents = match page_object {
+        PdfObject::Dictionary(dict) => match dict.get("StructParents") {
+            Some(PdfObject::Integer(key)) => *key,
+            other => panic!("expected page /StructParents integer, got {other:?}"),
+        },
+        other => panic!("expected page dictionary, got {other:?}"),
+    };
+
+    let tree_ref = object_ref(
+        catalog
+            .get("StructTreeRoot")
+            .expect("catalog /StructTreeRoot"),
+    );
+    let tree_object = reader
+        .get_object(tree_ref.0, tree_ref.1)
+        .expect("structure tree root");
+    let parent_tree_ref = match tree_object {
+        PdfObject::Dictionary(dict) => {
+            object_ref(dict.get("ParentTree").expect("StructTreeRoot /ParentTree"))
+        }
+        other => panic!("expected structure tree root dictionary, got {other:?}"),
+    };
+    let parent_tree = reader
+        .get_object(parent_tree_ref.0, parent_tree_ref.1)
+        .expect("parent tree");
+    let owner_ref = match parent_tree {
+        PdfObject::Dictionary(dict) => match dict.get("Nums").expect("ParentTree /Nums") {
+            PdfObject::Array(nums) => {
+                assert_eq!(nums.0[0], PdfObject::Integer(struct_parents));
+                match &nums.0[1] {
+                    PdfObject::Array(owners) => object_ref(&owners.0[mcid as usize]),
+                    other => panic!("expected parent array, got {other:?}"),
+                }
+            }
+            other => panic!("expected /Nums array, got {other:?}"),
+        },
+        other => panic!("expected parent tree dictionary, got {other:?}"),
+    };
+
+    let owner = reader
+        .get_object(owner_ref.0, owner_ref.1)
+        .expect("owning structure element");
+    match owner {
+        PdfObject::Dictionary(dict) => match dict.get("K").expect("StructElem /K") {
+            PdfObject::Array(kids) => match &kids.0[0] {
+                PdfObject::Dictionary(mcr) => {
+                    assert_eq!(object_ref(mcr.get("Pg").expect("MCR /Pg")), page_ref);
+                    assert_eq!(mcr.get("MCID"), Some(&PdfObject::Integer(mcid as i64)));
+                }
+                other => panic!("expected MCR dictionary, got {other:?}"),
+            },
+            other => panic!("expected StructElem /K array, got {other:?}"),
+        },
+        other => panic!("expected StructElem dictionary, got {other:?}"),
+    }
+
+    let owner = reader
+        .get_object(owner_ref.0, owner_ref.1)
+        .expect("owning structure element");
+    match owner {
+        PdfObject::Dictionary(dict) => match dict.get("ActualText") {
+            Some(PdfObject::String(value)) => {
+                let mut expected = vec![0xFE, 0xFF];
+                for unit in "2⁴⁰".encode_utf16() {
+                    expected.extend_from_slice(&unit.to_be_bytes());
+                }
+                assert_eq!(value.as_bytes(), expected.as_slice());
+            }
+            other => panic!("expected UTF-16BE StructElem /ActualText, got {other:?}"),
+        },
+        other => panic!("expected StructElem dictionary, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_an_mcid_owned_by_multiple_structure_elements() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.end_marked_content().expect("end span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    for _ in 0..2 {
+        let mut span = StructureElement::new(StandardStructureType::Span);
+        span.add_mcid(0, mcid);
+        tree.add_child(root, span).expect("attach span");
+    }
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("duplicate MCID ownership must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(message.contains("owned by more than one"), "{message}");
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_a_structure_reference_to_an_unknown_mcid() {
+    let page = Page::a4();
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span);
+    span.add_mcid(0, 0);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("unknown MCID must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(
+                message.contains("only 0 marked-content sequences"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_a_structure_reference_to_an_unknown_page() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.end_marked_content().expect("end span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span);
+    span.add_mcid(1, mcid);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("unknown page reference must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(
+                message.contains("references page 1 but document has 1 pages"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn parent_tree_maps_multiple_pages_and_preserves_mcid_holes() {
+    let mut first_page = Page::a4();
+    let unused_mcid = first_page
+        .begin_marked_content("Artifact")
+        .expect("begin unowned marked content");
+    first_page
+        .end_marked_content()
+        .expect("end unowned marked content");
+    let first_owned_mcid = first_page
+        .begin_marked_content_with_actual_text("Span", "first")
+        .expect("begin first owned span");
+    first_page
+        .end_marked_content()
+        .expect("end first owned span");
+    assert_eq!(unused_mcid, 0);
+    assert_eq!(first_owned_mcid, 1);
+
+    let untagged_page = Page::a4();
+
+    let mut last_page = Page::a4();
+    let last_mcid = last_page
+        .begin_marked_content_with_actual_text("Span", "last")
+        .expect("begin last span");
+    last_page.end_marked_content().expect("end last span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut first_span = StructureElement::new(StandardStructureType::Span);
+    first_span.add_mcid(0, first_owned_mcid);
+    tree.add_child(root, first_span).expect("attach first span");
+    let mut last_span = StructureElement::new(StandardStructureType::Span);
+    last_span.add_mcid(2, last_mcid);
+    tree.add_child(root, last_span).expect("attach last span");
+
+    let mut document = Document::new();
+    document.add_page(first_page);
+    document.add_page(untagged_page);
+    document.add_page(last_page);
+    document.set_struct_tree(tree);
+    let pdf = document.to_bytes().expect("serialize multipage tagged PDF");
+
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse generated PDF");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let pages_ref = object_ref(catalog.get("Pages").expect("catalog /Pages"));
+    let page_refs = match reader
+        .get_object(pages_ref.0, pages_ref.1)
+        .expect("pages object")
+    {
+        PdfObject::Dictionary(dict) => match dict.get("Kids").expect("pages /Kids") {
+            PdfObject::Array(kids) => kids.0.iter().map(object_ref).collect::<Vec<_>>(),
+            other => panic!("expected /Kids array, got {other:?}"),
+        },
+        other => panic!("expected pages dictionary, got {other:?}"),
+    };
+
+    let mut keys = Vec::new();
+    for (index, page_ref) in page_refs.iter().enumerate() {
+        match reader
+            .get_object(page_ref.0, page_ref.1)
+            .expect("page object")
+        {
+            PdfObject::Dictionary(dict) => match (index, dict.get("StructParents")) {
+                (0 | 2, Some(PdfObject::Integer(key))) => keys.push(*key),
+                (1, None) => {}
+                (_, other) => panic!("unexpected /StructParents on page {index}: {other:?}"),
+            },
+            other => panic!("expected page dictionary, got {other:?}"),
+        }
+    }
+    assert_eq!(keys, vec![0, 1]);
+
+    let tree_ref = object_ref(
+        catalog
+            .get("StructTreeRoot")
+            .expect("catalog /StructTreeRoot"),
+    );
+    let parent_tree_ref = match reader
+        .get_object(tree_ref.0, tree_ref.1)
+        .expect("structure tree root")
+    {
+        PdfObject::Dictionary(dict) => {
+            assert_eq!(dict.get("ParentTreeNextKey"), Some(&PdfObject::Integer(2)));
+            object_ref(dict.get("ParentTree").expect("StructTreeRoot /ParentTree"))
+        }
+        other => panic!("expected structure tree root dictionary, got {other:?}"),
+    };
+    let nums = match reader
+        .get_object(parent_tree_ref.0, parent_tree_ref.1)
+        .expect("parent tree")
+    {
+        PdfObject::Dictionary(dict) => match dict.get("Nums").expect("ParentTree /Nums") {
+            PdfObject::Array(nums) => nums.0.clone(),
+            other => panic!("expected /Nums array, got {other:?}"),
+        },
+        other => panic!("expected parent tree dictionary, got {other:?}"),
+    };
+    assert_eq!(nums.len(), 4);
+    assert_eq!(nums[0], PdfObject::Integer(0));
+    match &nums[1] {
+        PdfObject::Array(owners) => {
+            assert_eq!(owners.0.len(), 2);
+            assert_eq!(owners.0[0], PdfObject::Null);
+            assert!(matches!(owners.0[1], PdfObject::Reference(_, _)));
+        }
+        other => panic!("expected first owner array, got {other:?}"),
+    }
+    assert_eq!(nums[2], PdfObject::Integer(1));
+    match &nums[3] {
+        PdfObject::Array(owners) => {
+            assert_eq!(owners.0.len(), 1);
+            assert!(matches!(owners.0[0], PdfObject::Reference(_, _)));
+        }
+        other => panic!("expected second owner array, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Addresses #498.

## What changed
- validates page, MCID, and unique structure ownership before serialization
- emits page /StructParents plus the StructTreeRoot /ParentTree and /ParentTreeNextKey
- writes MCR /Pg as the page reference and encodes structure /ActualText as UTF-16BE
- adds reproducible interoperability and diagnostic fixtures
- documents that viewer copy/paste still depends on /ActualText support

## Validation
- targeted ActualText, Tagged PDF, and marked-content tests: 17 passed
- library suite: 6695 passed, 0 failed, 3 ignored
- formatting and clippy with warnings denied passed
- qpdf reports no syntax or stream errors for both fixtures
- pdftotext returns the expected logical superscript text

## Interoperability scope
The generated PDF now has the standard Tagged PDF relationships missing from the original fixture. Manual diagnostics nevertheless show that some graphical viewers ignore both inline and structure-element /ActualText during selection. This PR does not add an invisible-text workaround because that would change selection, accessibility, and extraction behavior for conforming readers.