### PR TITLE
fix(text): separate backward-positioned grid cells

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -443,6 +443,10 @@ impl SavedGraphicsState {
 struct OpRunState {
     state: TextState,
     in_text_object: bool,
+    /// True until the first show-text operator after `BT`. A backward jump at
+    /// this boundary is an independent positioned run, not intra-object
+    /// kerning, and can therefore delimit a grid cell (issue #495).
+    at_text_object_start: bool,
     last_x: f64,
     last_y: f64,
     extracted_text: String,
@@ -1014,6 +1018,7 @@ impl TextExtractor {
         let mut run = OpRunState {
             state,
             in_text_object,
+            at_text_object_start: false,
             last_x,
             last_y,
             extracted_text,
@@ -1220,6 +1225,7 @@ impl TextExtractor {
         let OpRunState {
             mut state,
             mut in_text_object,
+            mut at_text_object_start,
             mut last_x,
             mut last_y,
             mut extracted_text,
@@ -1246,6 +1252,7 @@ impl TextExtractor {
             match op {
                 ContentOperation::BeginText => {
                     in_text_object = true;
+                    at_text_object_start = true;
                     // Reset text matrix to identity
                     state.text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
                     state.text_line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -1338,11 +1345,16 @@ impl TextExtractor {
                                 // returns across the whole column, so a jump beyond
                                 // `SAME_Y_WRAP_EM` font sizes is a wrap even at dy == 0
                                 // (issue #447). dx/dy are baseline-relative (issue
-                                // #443), so this holds under rotation; the epsilon
-                                // absorbs projection rounding noise.
+                                // #443), so this holds under rotation. A new text
+                                // object is a stronger boundary: its first run is
+                                // independently positioned, so a large backward
+                                // jump cannot be intra-object kerning (#495). The
+                                // epsilon absorbs projection rounding noise.
                                 let same_y_wrap = dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
-                                let line_wrap = dx < -(self.options.newline_threshold * 2.0)
-                                    && (dy > SAME_LINE_EPS || same_y_wrap);
+                                let large_backward_jump =
+                                    dx < -(self.options.newline_threshold * 2.0);
+                                let line_wrap = large_backward_jump
+                                    && (dy > SAME_LINE_EPS || same_y_wrap || at_text_object_start);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.flat_space_gap_threshold(&state) {
@@ -1429,6 +1441,7 @@ impl TextExtractor {
                         // pen point (folds in Tz and CTM scale, issue #386; a
                         // full point so rotated baselines advance y too, #443).
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -1476,15 +1489,22 @@ impl TextExtractor {
                                     // treating a jump beyond `SAME_Y_WRAP_EM` font sizes
                                     // as a same-Y wrap (issue #447). Deltas are
                                     // baseline-relative (issue #443), so both gates hold
-                                    // under rotation; the epsilon absorbs projection
+                                    // under rotation. At the start of a new text
+                                    // object, a large backward jump is independently
+                                    // positioned rather than intra-array kerning
+                                    // (issue #495). The epsilon absorbs projection
                                     // rounding noise.
                                     let (dx, dy_signed) =
                                         pen_delta(&state, (last_x, last_y), (x, y));
                                     let dy = dy_signed.abs();
                                     let same_y_wrap =
                                         dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
-                                    let line_wrap = dx < -(self.options.newline_threshold * 2.0)
-                                        && (dy > SAME_LINE_EPS || same_y_wrap);
+                                    let large_backward_jump =
+                                        dx < -(self.options.newline_threshold * 2.0);
+                                    let line_wrap = large_backward_jump
+                                        && (dy > SAME_LINE_EPS
+                                            || same_y_wrap
+                                            || (at_text_object_start && at_array_start));
                                     // Separator of the run actually appended, for the
                                     // reading-order line grouping (issue #448).
                                     let mut emitted_sep: Option<Option<char>> = None;
@@ -1598,6 +1618,7 @@ impl TextExtractor {
                                     // issue #386: the pen must fold in Tz/CTM scale).
                                     (last_x, last_y) = advance_pen(&mut state, text_width);
                                     at_array_start = false;
+                                    at_text_object_start = false;
                                 }
                                 TextElement::Spacing(adjustment) => {
                                     // `at_array_start` is deliberately NOT cleared
@@ -1787,6 +1808,7 @@ impl TextExtractor {
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -1882,6 +1904,7 @@ impl TextExtractor {
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -2132,6 +2155,10 @@ impl TextExtractor {
                             let sub = OpRunState {
                                 state,
                                 in_text_object: false,
+                                // Preserve the outer boundary if the form emits
+                                // no text. A `BT` inside the form will replace it
+                                // with the form's own boundary.
+                                at_text_object_start,
                                 last_x,
                                 last_y,
                                 extracted_text,
@@ -2154,6 +2181,7 @@ impl TextExtractor {
                             self.font_cache = saved_fonts;
 
                             state = out.state;
+                            at_text_object_start = out.at_text_object_start;
                             last_x = out.last_x;
                             last_y = out.last_y;
                             extracted_text = out.extracted_text;
@@ -2173,6 +2201,7 @@ impl TextExtractor {
         Ok(OpRunState {
             state,
             in_text_object,
+            at_text_object_start,
             last_x,
             last_y,
             extracted_text,
@@ -3365,12 +3394,12 @@ const TJ_BOUNDARY_SPACE_EM: f64 = 0.7;
 /// threshold's sense — otherwise a negative size makes every backward jump a
 /// "wrap" and resurrects the #441 defect.
 ///
-/// Accepted, documented limitation (the #417/#422 trade-off): a same-line
-/// reposition that jumps back more than this many em is misread as a wrap, and
-/// a same-Y wrap of a line shorter than this is glued. Both are rare and
-/// neither loses a glyph — only the separator is wrong. A wrap with any
-/// nonzero leading (the common case, issue #390) is unaffected: it breaks on
-/// the `dy`-aware gate regardless of magnitude.
+/// Accepted, documented limitation (the #417/#422 trade-off) within one text
+/// object: a same-line reposition that jumps back more than this many em is
+/// misread as a wrap, and a same-Y wrap shorter than this is glued. A new
+/// `BT`/`ET` object supplies an independent-positioning boundary, so #495 does
+/// not depend on this magnitude. A wrap with any nonzero leading (the common
+/// case, issue #390) is also unaffected: it breaks on the `dy`-aware gate.
 const SAME_Y_WRAP_EM: f64 = 10.0;
 
 /// Pen movement from the previous post-advance pen point `last` to the

--- a/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
+++ b/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
@@ -1,0 +1,75 @@
+//! Regression tests for issue #495: independently positioned grid cells must
+//! not be fused when a new text object jumps backward on the same baseline.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+fn build_pdf(content: &str) -> Vec<u8> {
+    let content_len = content.len();
+    let objects = [
+        "<< /Type /Catalog /Pages 3 0 R >>",
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+         /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ];
+
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = [0usize; 6];
+    for (index, body) in objects.iter().enumerate() {
+        let object_number = index + 1;
+        offsets[object_number] = pdf.len();
+        pdf.extend_from_slice(format!("{object_number} 0 obj\n{body}\nendobj\n").as_bytes());
+    }
+    offsets[5] = pdf.len();
+    pdf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {content_len} >>\nstream\n{content}\nendstream\nendobj\n")
+            .as_bytes(),
+    );
+
+    let xref = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+fn extract_flat(content: &str) -> String {
+    let document = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::new()
+        .extract_from_page(&document, 0)
+        .expect("text should extract")
+        .text
+}
+
+#[test]
+fn separate_tj_objects_do_not_fuse_backward_positioned_grid_cells() {
+    let content = concat!(
+        "BT\n/F1 9 Tf\n1 0 0 1 32.1 653.33 Tm\n( ABCDE1234F) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 653.33 Tm\n(PAN:) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 28.73 635.66 Tm\n( U12345DL2019PTC123456) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 635.66 Tm\n(CIN:) Tj\nET"
+    );
+
+    let text = extract_flat(content);
+    assert_eq!(text, " ABCDE1234F\nPAN:\n U12345DL2019PTC123456\nCIN:");
+}
+
+#[test]
+fn separate_tj_array_objects_use_the_same_grid_boundary() {
+    let content = concat!(
+        "BT\n/F1 9 Tf\n1 0 0 1 32.1 653.33 Tm\n[( ABCDE1234F)] TJ\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 653.33 Tm\n[(PAN:)] TJ\nET"
+    );
+
+    assert_eq!(extract_flat(content), " ABCDE1234F\nPAN:");
+}


### PR DESCRIPTION
Addresses #495.

## What changed
- tracks whether a show-text run is the first one in a new BT/ET text object
- treats a large backward jump at that independent-positioning boundary as a line separator
- keeps the existing 10em same-object discriminator unchanged, preserving the #441/#447 trade-off
- applies the same rule to Tj and the first text element of TJ

## Regression coverage
- includes oshtivi's complete two-row PAN/CIN repro with exact expected output
- covers the equivalent TJ-array path
- #390, #441, #447, and #458 regression suites remain green

## Validation
- 22 focused regression tests passed
- library suite: 6695 passed, 0 failed, 3 ignored
- formatting, strict library clippy, build, and diff checks passed

The repository-wide clippy tests command also encounters a pre-existing manual_range_contains warning in tests/partition_confidence_test.rs; this PR does not modify that file.