### PR TITLE
fix(extraction): preserve narrow Type0 word gaps

### DIFF
--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -602,6 +602,10 @@ pub struct TextExtractor {
     carriage_return_handling: CarriageReturnHandling,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
+    /// Narrowest usable CID width for Type0 fonts in the current page. Derived
+    /// once when the font is cached so flat extraction does not rescan a
+    /// potentially large attacker-controlled `/W` table for every glyph.
+    type0_implicit_space_widths: HashMap<String, f64>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
     /// object across pages. Most multi-page PDFs reuse the same font objects.
     font_object_cache: HashMap<(u32, u16), FontInfo>,
@@ -615,6 +619,7 @@ impl TextExtractor {
             reading_order: false,
             carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
+            type0_implicit_space_widths: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
     }
@@ -626,6 +631,7 @@ impl TextExtractor {
             reading_order: false,
             carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
+            type0_implicit_space_widths: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
     }
@@ -820,10 +826,31 @@ impl TextExtractor {
         standard_14_space_width(&info.name).map(|em| em / 1000.0 * font_size)
     }
 
+    /// Font-derived proxy used only when a Type0 font has CID widths but no
+    /// discoverable U+0020 mapping. The narrowest declared positive advance is
+    /// a lower bound, not a guessed space CID: narrow punctuation and spacing
+    /// glyphs define how small a meaningful inter-word gap can be (#500).
+    fn type0_implicit_space_advance(&self, font_name: Option<&str>, font_size: f64) -> Option<f64> {
+        let width = self.type0_implicit_space_widths.get(font_name?)?;
+        Some(width / 1000.0 * font_size.abs())
+    }
+
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
         match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
             Some(advance) if advance > 0.0 => 0.5 * advance,
-            _ => self.options.space_threshold * state.font_size,
+            _ => {
+                let legacy = self.options.space_threshold * state.font_size.abs();
+                match self.type0_implicit_space_advance(state.font_name.as_deref(), state.font_size)
+                {
+                    Some(advance) if advance > 0.0 && legacy > 0.0 => {
+                        // Do not let a malformed near-zero `/W` entry make every
+                        // positioning residue a word gap. Conversely, never make
+                        // the fallback stricter than the established threshold.
+                        (0.5 * advance).max(0.1 * state.font_size.abs()).min(legacy)
+                    }
+                    _ => legacy,
+                }
+            }
         }
     }
 
@@ -2819,6 +2846,7 @@ impl TextExtractor {
     ) -> ParseResult<()> {
         // Clear per-page name mapping (font names like /F1 are page-local)
         self.font_cache.clear();
+        self.type0_implicit_space_widths.clear();
 
         // Try to get resources manually from page dictionary first
         // This is necessary because ParsedPage.get_resources() may not always work
@@ -2880,7 +2908,7 @@ impl TextExtractor {
                 font_name,
                 font_info.to_unicode.is_some()
             );
-            self.font_cache.insert(font_name.to_string(), font_info);
+            self.cache_page_font(font_name, font_info);
         }
     }
 
@@ -2893,8 +2921,7 @@ impl TextExtractor {
     ) {
         // Check persistent object cache first — avoids re-parsing across pages
         if let Some(cached) = self.font_object_cache.get(&font_ref) {
-            self.font_cache
-                .insert(font_name.to_string(), cached.clone());
+            let cached = cached.clone();
             tracing::debug!(
                 "Reused cached font object ({}, {}): {} (ToUnicode: {})",
                 font_ref.0,
@@ -2902,6 +2929,7 @@ impl TextExtractor {
                 font_name,
                 cached.to_unicode.is_some()
             );
+            self.cache_page_font(font_name, cached);
             return;
         }
 
@@ -2913,7 +2941,7 @@ impl TextExtractor {
                 // Store in persistent cache
                 self.font_object_cache.insert(font_ref, font_info.clone());
                 // Store in per-page name cache
-                self.font_cache.insert(font_name.to_string(), font_info);
+                self.cache_page_font(font_name, font_info);
                 tracing::debug!(
                     "Parsed and cached font ({}, {}): {} (ToUnicode: {})",
                     font_ref.0,
@@ -2923,6 +2951,24 @@ impl TextExtractor {
                 );
             }
         }
+    }
+
+    /// Add a parsed font to the page-local caches, deriving the Type0 fallback
+    /// width once rather than on every text-showing boundary.
+    fn cache_page_font(&mut self, font_name: &str, font_info: FontInfo) {
+        if font_info.font_type == "Type0" || font_info.descendant_font.is_some() {
+            let cid_font = font_info.descendant_font.as_deref().unwrap_or(&font_info);
+            if let Some(width) = cid_font
+                .metrics
+                .cid_widths
+                .as_ref()
+                .and_then(|widths| widths.narrowest_positive_width())
+            {
+                self.type0_implicit_space_widths
+                    .insert(font_name.to_string(), width);
+            }
+        }
+        self.font_cache.insert(font_name.to_string(), font_info);
     }
 
     /// Decode text using the current font encoding and ToUnicode mapping

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -45,6 +45,22 @@ impl CidWidths {
             })
             .unwrap_or(self.default_width)
     }
+
+    /// Narrowest positive width declared by `/W`, or `/DW` when `/W` has no
+    /// usable entries. This is not assumed to be the space CID; it is only a
+    /// conservative lower bound for a font-derived implicit-space heuristic.
+    pub(crate) fn narrowest_positive_width(&self) -> Option<f64> {
+        self.widths
+            .values()
+            .copied()
+            .chain(self.ranges.iter().map(|(_, _, width)| *width))
+            .filter(|width| width.is_finite() && *width > 0.0)
+            .min_by(f64::total_cmp)
+            .or_else(|| {
+                (self.default_width.is_finite() && self.default_width > 0.0)
+                    .then_some(self.default_width)
+            })
+    }
 }
 
 /// Font metrics for accurate text width calculation

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -174,18 +174,12 @@ fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
 }
 
 #[test]
-fn real_widths_fix_the_wide_cid_without_claiming_the_narrow_space_case() {
-    // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
-    // or not it clears the space threshold is a separate, pre-existing
-    // calibration question (also applies to simple fonts) that this fix does
-    // not change -- this test only pins today's behavior so a future
-    // regression there is caught, without conflating it with the CID-width
-    // fix itself.
+fn real_widths_fix_the_wide_cid_and_expose_the_narrow_word_gap() {
     let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     let without_w = extract("");
     assert_eq!(
-        with_w, "PANNo:BLUPM6342P",
-        "real CID widths must remove the wide-M space; the unmapped narrow word gap is #500"
+        with_w, "PAN No:BLUPM6342P",
+        "real CID widths must remove the wide-M space while #500's font-derived fallback preserves the narrow word gap"
     );
     assert_eq!(
         without_w, "PANNo:BLUPM6342P",

--- a/oxidize-pdf-core/tests/issue_500_type0_implicit_space_test.rs
+++ b/oxidize-pdf-core/tests/issue_500_type0_implicit_space_test.rs
@@ -1,0 +1,161 @@
+//! Regression coverage for issue #500: Type0 fonts without a discoverable
+//! U+0020 mapping still need a conservative, font-derived word-gap signal.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::TextExtractor;
+use proptest::prelude::*;
+use std::io::Cursor;
+
+#[derive(Clone, Copy)]
+enum Encoding<'a> {
+    IdentityH,
+    CMap(&'a [u8]),
+}
+
+fn content_stream(glyphs: &[(f64, u16)]) -> Vec<u8> {
+    glyphs
+        .iter()
+        .map(|(x, code)| format!("BT\n/F1 20 Tf\n1 0 0 1 {x} 700 Tm\n<{code:04X}> Tj\nET\n"))
+        .collect::<String>()
+        .into_bytes()
+}
+
+fn extract(
+    to_unicode: &[u8],
+    encoding: Encoding<'_>,
+    widths: &str,
+    glyphs: &[(f64, u16)],
+) -> String {
+    let content = content_stream(glyphs);
+    let encoding_entry = match encoding {
+        Encoding::IdentityH => "/Identity-H",
+        Encoding::CMap(_) => "9 0 R",
+    };
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", &content),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
+             /Encoding {encoding_entry} /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
+        )
+        .into_bytes(),
+        stream_obj("", to_unicode),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
+             /CIDToGIDMap /Identity \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /W [{widths}] /DW 1000 /FontDescriptor 8 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Synthetic /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    if let Encoding::CMap(cmap) = encoding {
+        objects.push(stream_obj("", cmap));
+    }
+
+    let document = PdfReader::new(Cursor::new(assemble_pdf(&objects)))
+        .expect("PDF should parse")
+        .into_document();
+    TextExtractor::new()
+        .extract_from_page(&document, 0)
+        .expect("text should extract")
+        .text
+}
+
+const IDENTITY_TOUNICODE: &[u8] = b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+5 beginbfchar <0001> <0041> <0002> <002F> <0003> <0042> <0004> <002E> <0005> <0043> endbfchar\n\
+endcmap";
+
+#[test]
+fn identity_h_uses_declared_narrow_width_as_an_implicit_space_lower_bound() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500] 9 [200]",
+        &[(0.0, 1), (14.0, 3)],
+    );
+    assert_eq!(text, "A B");
+}
+
+#[test]
+fn tight_urls_and_identifiers_are_not_split() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500 500 500] 9 [200]",
+        &[(0.0, 1), (10.0, 2), (20.0, 3), (30.0, 4), (40.0, 5)],
+    );
+    assert_eq!(text, "A/B.C");
+}
+
+#[test]
+fn backward_overlay_does_not_gain_a_space() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500] 9 [200]",
+        &[(20.0, 1), (10.0, 3)],
+    );
+    assert_eq!(text, "AB");
+}
+
+#[test]
+fn malformed_tiny_width_is_bounded_by_the_geometric_floor() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500] 9 [1]",
+        &[(0.0, 1), (11.5, 3)],
+    );
+    assert_eq!(text, "AB");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn sub_floor_positioning_residue_never_splits_an_identifier(
+        narrow_width in 1u16..=600,
+        residue in 0.0f64..1.99,
+    ) {
+        let widths = format!("1 [500 500 500] 9 [{narrow_width}]");
+        let text = extract(
+            IDENTITY_TOUNICODE,
+            Encoding::IdentityH,
+            &widths,
+            &[(0.0, 1), (10.0 + residue, 3)],
+        );
+        prop_assert_eq!(text, "AB");
+    }
+}
+
+#[test]
+fn non_identity_cmap_uses_cid_widths_without_guessing_a_space_cid() {
+    let encoding = b"begincmap\n\
+/CMapType 1 def\n/WMode 0 def\n\
+1 begincodespacerange <0100> <01FF> endcodespacerange\n\
+2 begincidchar <0101> 38 <0102> 39 endcidchar\n\
+endcmap";
+    let to_unicode = b"begincmap\n\
+1 begincodespacerange <0100> <01FF> endcodespacerange\n\
+2 beginbfchar <0101> <0041> <0102> <0042> endbfchar\n\
+endcmap";
+    let text = extract(
+        to_unicode,
+        Encoding::CMap(encoding),
+        "11 [200] 38 [500 500]",
+        &[(0.0, 0x0101), (14.0, 0x0102)],
+    );
+    assert_eq!(text, "A B");
+}


### PR DESCRIPTION
## Summary
- derive an implicit-space threshold from real CID widths when Type0 fonts do not map U+0020
- keep a 0.1em geometric floor and the legacy threshold as an upper bound to avoid splitting URLs, identifiers, kerned text, or overlays
- precompute the fallback once per page font so large untrusted /W tables are not rescanned in the glyph hot path

## Coverage
- full oshtivi PAN reproduction: `PAN No:BLUPM6342P`
- Identity-H and explicit non-Identity encoding CMap
- URLs/identifiers, backward overlays, malformed tiny widths
- proptest over CID widths and sub-floor positioning residue
- existing #496 regression updated to cover the combined behavior

## Validation
- `cargo test -p oxidize-pdf --lib` (6695 passed, 3 ignored)
- focused #500/#496 tests (13 passed)
- related #302/#441/#447/#458 and CMap/font property matrix (46 passed)
- strict clippy and formatting checks

Fixes #500