### PR TITLE
Release v4.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,8 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: oxidize-pdf
+          # Development accumulates backward-compatible API changes before a
+          # release version is chosen. Allow minor-level changes on develop,
+          # while release/main checks continue deriving the required bump from
+          # Cargo.toml and the published baseline.
+          release-type: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'develop') || github.ref == 'refs/heads/develop') && 'minor' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install Tesseract OCR (Ubuntu)
+      - name: Install Tesseract OCR and qpdf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev qpdf
 
       - name: Install Tesseract OCR (macOS)
         if: matrix.os == 'macos-latest'
@@ -98,6 +98,14 @@ jobs:
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
+
+      - name: Validate AES-256 R5 interoperability with qpdf
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_492_aes256_perms_interop_test
+          qpdf_checks_and_linearizes_generated_aes256_r5_pdf
+          -- --ignored --exact
 
       # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
       # enricher/extra bag), so the default test step above never compiles its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install Tesseract OCR (Ubuntu)
+      - name: Install Tesseract OCR and qpdf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev qpdf
 
       - name: Install Tesseract OCR (macOS)
         if: matrix.os == 'macos-latest'
@@ -98,6 +98,14 @@ jobs:
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
+
+      - name: Validate incremental text notes with qpdf
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_493_incremental_text_notes_test
+          qpdf_accepts_incremental_text_note_revision
+          -- --ignored --exact
 
       # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
       # enricher/extra bag), so the default test step above never compiles its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.5.0] - 2026-08-18
+
+### Added
+
+- **Incremental editing for standard text-note annotations** (#493). The new
+  typed `IncrementalTextNoteEditor` API can enumerate, add, move, edit, and
+  remove `/Text` annotations while preserving the original PDF bytes and
+  applying each validated batch as one incremental revision.
+
 ### Fixed
 
+- **AES-256 revision 5 encryption dictionaries now emit `/Perms`** (#492),
+  restoring interoperability with external readers while retaining strict
+  validation of the encrypted permissions block.
+- **Flat extraction could fuse adjacent cells in label/value grids** (#495).
+  Separate text objects that return backward on the same baseline now receive
+  neutral whitespace when the geometry is ambiguous, while genuine long wraps
+  still become newlines and legitimate repositioned overlays remain intact.
 - **Composite (Type0/CID) font text extraction never consulted the CIDFont's
   `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a
   flat `0.5 * font_size`, regardless of its real width. When a glyph's true
@@ -22,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the composite-font width calculation on both the flat and
   `preserve_layout` extraction paths, falling back to the previous heuristic
   when neither is present.
+- **Tagged `ActualText` extraction lost the marked-content association**
+  (#498). Generated `ActualText` sequences now carry an MCID connected to the
+  structure tree, so tagged extraction returns the replacement text instead
+  of dropping it.
+- **Real Type0 widths could hide narrow implicit word spaces** (#500). When a
+  composite font has no discoverable U+0020 mapping, flat extraction now uses
+  a bounded, font-derived CID-width signal that preserves narrow word gaps
+  without splitting URLs, identifiers, kerned runs, or positioned overlays.
 
 ## [4.4.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **Composite (Type0/CID) font text extraction never consulted the CIDFont's
+  `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a
+  flat `0.5 * font_size`, regardless of its real width. When a glyph's true
+  advance diverged enough from that flat estimate relative to its neighbors
+  (e.g. a genuinely wide glyph in the font), the extractor's pen-tracking
+  drifted out of sync with where the next glyph was actually drawn, crossing
+  the space-insertion threshold and corrupting the extracted text with a
+  spurious space in the middle of a single token. `/W`/`/DW` (ISO 32000-1
+  §9.7.4.3) are now parsed into a CID-indexed width table and consulted for
+  the composite-font width calculation on both the flat and
+  `preserve_layout` extraction paths, falling back to the previous heuristic
+  when neither is present.
+
 ## [4.4.0] - 2026-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.4.0"
+version = "4.5.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/examples/generate_issue_498_diagnostic_fixture.rs
+++ b/oxidize-pdf-core/examples/generate_issue_498_diagnostic_fixture.rs
@@ -1,0 +1,73 @@
+//! Generates a copy/paste diagnostic matrix for issue #498.
+
+use oxidize_pdf::{
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+const OUTPUT: &str = "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf";
+
+fn write_label(page: &mut Page, y: f64, label: &str) -> Result<(), PdfError> {
+    page.text()
+        .set_font(Font::Helvetica, 11.0)
+        .at(72.0, y)
+        .write(label)?;
+    Ok(())
+}
+
+fn write_visual(page: &mut Page, y: f64, visual: &str) -> Result<(), PdfError> {
+    page.text()
+        .set_font(Font::Helvetica, 18.0)
+        .at(300.0, y)
+        .write(visual)?;
+    Ok(())
+}
+
+fn main() -> Result<(), PdfError> {
+    let mut page = Page::a4();
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+
+    write_label(&mut page, 740.0, "Inline ASCII (expect INLINE_ASCII):")?;
+    let inline_mcid = page.begin_marked_content_with_actual_text("Span", "INLINE_ASCII")?;
+    write_visual(&mut page, 740.0, "VISUAL_A")?;
+    page.end_marked_content()?;
+    let mut inline_span = StructureElement::new(StandardStructureType::Span);
+    inline_span.add_mcid(0, inline_mcid);
+    tree.add_child(root, inline_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    write_label(&mut page, 700.0, "Structural ASCII (expect STRUCT_ASCII):")?;
+    let structural_mcid = page.begin_marked_content("Span")?;
+    write_visual(&mut page, 700.0, "VISUAL_B")?;
+    page.end_marked_content()?;
+    let mut structural_span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text("STRUCT_ASCII");
+    structural_span.add_mcid(0, structural_mcid);
+    tree.add_child(root, structural_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    write_label(
+        &mut page,
+        660.0,
+        "Inline + structural Unicode (expect superscripts):",
+    )?;
+    let logical = "2⁴⁰ E = mc² Aⁿ⁺¹B";
+    let combined_mcid = page.begin_marked_content_with_actual_text("Span", logical)?;
+    write_visual(&mut page, 660.0, "VISUAL_C")?;
+    page.end_marked_content()?;
+    let mut combined_span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text(logical);
+    combined_span.add_mcid(0, combined_mcid);
+    tree.add_child(root, combined_span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    let mut document = Document::new();
+    document.set_title("ActualText diagnostic matrix");
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    document.save(OUTPUT)?;
+    println!("wrote {OUTPUT}");
+    Ok(())
+}

--- a/oxidize-pdf-core/examples/generate_issue_498_interop_fixture.rs
+++ b/oxidize-pdf-core/examples/generate_issue_498_interop_fixture.rs
@@ -1,0 +1,68 @@
+//! Generates the cross-viewer copy/paste fixture for issue #498.
+//!
+//! Run from the workspace root:
+//!
+//! ```text
+//! cargo run -p oxidize-pdf --example generate_issue_498_interop_fixture
+//! ```
+
+use oxidize_pdf::{
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+const OUTPUT: &str = "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf";
+const LOGICAL_TEXT: &str = "2⁴⁰ E = mc² Aⁿ⁺¹B";
+
+fn main() -> Result<(), PdfError> {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content_with_actual_text("Span", LOGICAL_TEXT)?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(72.0, 720.0)
+        .write("2")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(86.0, 731.0)
+        .write("40")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(105.0, 720.0)
+        .write(" E = mc")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(199.0, 731.0)
+        .write("2")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(210.0, 720.0)
+        .write(" A")?;
+    page.text()
+        .set_font(Font::Helvetica, 14.0)
+        .at(238.0, 731.0)
+        .write("n+1")?;
+    page.text()
+        .set_font(Font::Helvetica, 24.0)
+        .at(263.0, 720.0)
+        .write("B")?;
+    page.end_marked_content()?;
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span =
+        StructureElement::new(StandardStructureType::Span).with_actual_text(LOGICAL_TEXT);
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span)
+        .map_err(PdfError::InvalidStructure)?;
+
+    let mut document = Document::new();
+    document.set_title("ActualText cross-viewer interoperability fixture");
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    document.save(OUTPUT)?;
+
+    println!("wrote {OUTPUT}");
+    println!("expected copied text: {LOGICAL_TEXT}");
+    Ok(())
+}

--- a/oxidize-pdf-core/src/document/encryption.rs
+++ b/oxidize-pdf-core/src/document/encryption.rs
@@ -138,14 +138,16 @@ impl DocumentEncryption {
             &u_entry,
             &encryption_key,
         )?;
+        let perms_entry = handler.compute_perms_entry(self.permissions, &enc_key_obj, true)?;
 
-        Ok(EncryptionDictionary::aes_256(
+        EncryptionDictionary::aes_256(
             o_entry,
             u_entry,
             self.permissions,
             file_id.map(|id| id.to_vec()),
         )
-        .with_r5_entries(ue_entry, oe_entry))
+        .with_r5_entries(ue_entry, oe_entry)
+        .with_perms(perms_entry)
     }
 
     /// Get the object encryption key used to encrypt streams and strings.

--- a/oxidize-pdf-core/src/encryption/encryption_dict.rs
+++ b/oxidize-pdf-core/src/encryption/encryption_dict.rs
@@ -1,6 +1,7 @@
 //! PDF encryption dictionary structures
 
 use crate::encryption::Permissions;
+use crate::error::{PdfError, Result};
 use crate::objects::{Dictionary, Object};
 
 /// Encryption algorithm
@@ -134,7 +135,7 @@ pub struct EncryptionDictionary {
     pub ue: Option<Vec<u8>>,
     /// OE entry: encrypted file encryption key (owner password, R5/R6 only)
     pub oe: Option<Vec<u8>>,
-    /// Perms entry: encrypted permissions verification (R6 only)
+    /// Perms entry: encrypted permissions verification (R5/R6)
     pub perms: Option<Vec<u8>>,
 }
 
@@ -264,6 +265,18 @@ impl EncryptionDictionary {
         self
     }
 
+    /// Set the encrypted permissions entry required by V=5 dictionaries.
+    pub fn with_perms(mut self, perms: Vec<u8>) -> Result<Self> {
+        if perms.len() != 16 {
+            return Err(PdfError::EncryptionError(format!(
+                "V=5 Perms entry must be 16 bytes, got {}",
+                perms.len()
+            )));
+        }
+        self.perms = Some(perms);
+        Ok(self)
+    }
+
     /// Convert to PDF dictionary
     pub fn to_dict(&self) -> Dictionary {
         let mut dict = Dictionary::new();
@@ -324,10 +337,7 @@ impl EncryptionDictionary {
             dict.set("OE", Object::ByteString(oe.clone()));
         }
         if let Some(ref perms) = self.perms {
-            dict.set(
-                "Perms",
-                Object::String(String::from_utf8_lossy(perms).to_string()),
-            );
+            dict.set("Perms", Object::ByteString(perms.clone()));
         }
 
         dict

--- a/oxidize-pdf-core/src/encryption/standard_security.rs
+++ b/oxidize-pdf-core/src/encryption/standard_security.rs
@@ -1030,10 +1030,10 @@ impl StandardSecurityHandler {
     }
 
     // ========================================================================
-    // R6 Perms Entry (ISO 32000-2 Table 25)
+    // R5/R6 Perms Entry (ISO 32000-2 Table 25)
     // ========================================================================
 
-    /// Compute R6 Perms entry (encrypted permissions)
+    /// Compute R5/R6 Perms entry (encrypted permissions)
     ///
     /// The Perms entry is a 16-byte value that encrypts permissions using AES-256-ECB.
     /// This allows verification that permissions haven't been tampered with.
@@ -1041,28 +1041,31 @@ impl StandardSecurityHandler {
     /// # Plaintext Structure (16 bytes)
     /// - Bytes 0-3: Permissions (P value, little-endian)
     /// - Bytes 4-7: 0xFFFFFFFF (fixed marker)
-    /// - Bytes 8-10: "adb" (literal verification string)
-    /// - Byte 11: 'T' or 'F' (EncryptMetadata flag)
-    /// - Bytes 12-15: 0x00 (padding)
-    pub fn compute_r6_perms_entry(
+    /// - Byte 8: 'T' or 'F' (EncryptMetadata flag)
+    /// - Bytes 9-11: "adb" (literal verification string)
+    /// - Bytes 12-15: random padding
+    pub fn compute_perms_entry(
         &self,
         permissions: Permissions,
         encryption_key: &EncryptionKey,
         encrypt_metadata: bool,
     ) -> Result<Vec<u8>> {
-        if self.revision != SecurityHandlerRevision::R6 {
+        if !matches!(
+            self.revision,
+            SecurityHandlerRevision::R5 | SecurityHandlerRevision::R6
+        ) {
             return Err(crate::error::PdfError::EncryptionError(
-                "Perms entry only for Revision 6".to_string(),
+                "Perms entry only for Revision 5 or 6".to_string(),
             ));
         }
         if encryption_key.len() != UE_ENTRY_LENGTH {
             return Err(crate::error::PdfError::EncryptionError(format!(
-                "Encryption key must be {} bytes for R6 Perms",
+                "Encryption key must be {} bytes for R5/R6 Perms",
                 UE_ENTRY_LENGTH
             )));
         }
 
-        // Construct plaintext: P + 0xFFFFFFFF + "adb" + T/F + padding
+        // Construct plaintext: P + 0xFFFFFFFF + T/F + "adb" + random padding
         let mut plaintext = vec![0u8; PERMS_ENTRY_LENGTH];
 
         // Permissions (4 bytes, little-endian)
@@ -1072,13 +1075,15 @@ impl StandardSecurityHandler {
         // Fixed marker bytes (0xFFFFFFFF)
         plaintext[PERMS_MARKER_START..PERMS_MARKER_END].copy_from_slice(&PERMS_MARKER);
 
-        // Literal "adb" verification string
-        plaintext[PERMS_LITERAL_START..PERMS_LITERAL_END].copy_from_slice(PERMS_LITERAL);
-
         // EncryptMetadata flag
         plaintext[PERMS_ENCRYPT_META_BYTE] = if encrypt_metadata { b'T' } else { b'F' };
 
-        // Bytes 12-15 remain 0x00 (padding)
+        // Literal "adb" verification string
+        plaintext[PERMS_LITERAL_START..PERMS_LITERAL_END].copy_from_slice(PERMS_LITERAL);
+
+        // The final four bytes are intentionally unpredictable.
+        use rand::Rng;
+        rand::rng().fill_bytes(&mut plaintext[PERMS_RANDOM_START..]);
 
         // Encrypt with AES-256-ECB
         let aes_key = AesKey::new_256(encryption_key.key.clone())?;
@@ -1089,6 +1094,20 @@ impl StandardSecurityHandler {
         })?;
 
         Ok(encrypted)
+    }
+
+    /// Compatibility alias for [`Self::compute_perms_entry`].
+    #[deprecated(
+        since = "4.4.1",
+        note = "use compute_perms_entry; the algorithm applies to both R5 and R6"
+    )]
+    pub fn compute_r6_perms_entry(
+        &self,
+        permissions: Permissions,
+        encryption_key: &EncryptionKey,
+        encrypt_metadata: bool,
+    ) -> Result<Vec<u8>> {
+        self.compute_perms_entry(permissions, encryption_key, encrypt_metadata)
     }
 
     /// Validate R6 Perms entry by decrypting and checking structure
@@ -1963,14 +1982,17 @@ const PERMS_MARKER_START: usize = 4;
 /// End offset of fixed marker in decrypted Perms
 const PERMS_MARKER_END: usize = 8;
 
+/// Offset of EncryptMetadata flag byte ('T' or 'F') in decrypted Perms
+const PERMS_ENCRYPT_META_BYTE: usize = 8;
+
 /// Start offset of "adb" literal in decrypted Perms
-const PERMS_LITERAL_START: usize = 8;
+const PERMS_LITERAL_START: usize = 9;
 
 /// End offset of "adb" literal in decrypted Perms
-const PERMS_LITERAL_END: usize = 11;
+const PERMS_LITERAL_END: usize = 12;
 
-/// Offset of EncryptMetadata flag byte ('T' or 'F') in decrypted Perms
-const PERMS_ENCRYPT_META_BYTE: usize = 11;
+/// Start offset of the four random bytes in decrypted Perms
+const PERMS_RANDOM_START: usize = 12;
 
 /// Fixed marker value in Perms entry
 const PERMS_MARKER: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
@@ -2992,7 +3014,7 @@ mod tests {
         let key = EncryptionKey::new(vec![0x42; 32]);
 
         let perms = handler
-            .compute_r6_perms_entry(permissions, &key, true)
+            .compute_perms_entry(permissions, &key, true)
             .unwrap();
 
         assert_eq!(perms.len(), 16, "Perms entry must be 16 bytes");
@@ -3005,7 +3027,7 @@ mod tests {
         let key = EncryptionKey::new(vec![0x55; 32]);
 
         let perms = handler
-            .compute_r6_perms_entry(permissions, &key, false)
+            .compute_perms_entry(permissions, &key, false)
             .unwrap();
 
         let is_valid = handler
@@ -3022,7 +3044,7 @@ mod tests {
         let wrong_key = EncryptionKey::new(vec![0xBB; 32]);
 
         let perms = handler
-            .compute_r6_perms_entry(permissions, &correct_key, true)
+            .compute_perms_entry(permissions, &correct_key, true)
             .unwrap();
 
         // Validation with wrong key should fail (structure won't match)
@@ -3038,10 +3060,10 @@ mod tests {
         let key = EncryptionKey::new(vec![0x33; 32]);
 
         let perms_true = handler
-            .compute_r6_perms_entry(permissions, &key, true)
+            .compute_perms_entry(permissions, &key, true)
             .unwrap();
         let perms_false = handler
-            .compute_r6_perms_entry(permissions, &key, false)
+            .compute_perms_entry(permissions, &key, false)
             .unwrap();
 
         // Different encrypt_metadata flag should produce different Perms
@@ -3098,7 +3120,7 @@ mod tests {
 
         // Step 4: Compute Perms entry (encrypted permissions)
         let perms = handler
-            .compute_r6_perms_entry(permissions, &encryption_key, true)
+            .compute_perms_entry(permissions, &encryption_key, true)
             .unwrap();
         assert_eq!(perms.len(), 16);
 

--- a/oxidize-pdf-core/src/page.rs
+++ b/oxidize-pdf-core/src/page.rs
@@ -2037,9 +2037,15 @@ impl Page {
     /// as UTF-16BE with a byte-order mark so every Unicode scalar is preserved.
     ///
     /// The returned MCID can be attached to a structure element in the same way
-    /// as the value returned by [`Page::begin_marked_content`]. This makes the
-    /// method useful both for lightweight semantic spans and for fully tagged
-    /// documents.
+    /// as the value returned by [`Page::begin_marked_content`]. To connect the
+    /// replacement text to the Tagged PDF structure, attach it with
+    /// [`StructureElement::add_mcid`](crate::structure::StructureElement::add_mcid)
+    /// and install the completed tree on the document with
+    /// [`Document::set_struct_tree`](crate::Document::set_struct_tree). The writer
+    /// will then emit the page `/StructParents` and structure `/ParentTree`
+    /// connections required by Tagged PDF readers. Copy/paste still depends on
+    /// the viewer honoring `/ActualText`; some viewers copy the painted glyphs
+    /// even when these relationships are present.
     pub fn begin_marked_content_with_actual_text(
         &mut self,
         tag: &str,

--- a/oxidize-pdf-core/src/text/cmap.rs
+++ b/oxidize-pdf-core/src/text/cmap.rs
@@ -386,6 +386,47 @@ impl CMap {
         None
     }
 
+    /// Return an explicitly mapped source code for a single Unicode character.
+    /// This lets extraction connect semantic glyphs such as U+0020 back to
+    /// code/CID-indexed font metrics without guessing a CID.
+    pub(crate) fn source_code_for_unicode(&self, target: char) -> Option<Vec<u8>> {
+        let mut utf16 = [0u16; 2];
+        let encoded = target.encode_utf16(&mut utf16);
+        let target_bytes: Vec<u8> = encoded.iter().flat_map(|unit| unit.to_be_bytes()).collect();
+
+        for mapping in &self.mappings {
+            match mapping {
+                CMapEntry::Single { src, dst } if *dst == target_bytes => {
+                    return Some(src.clone());
+                }
+                CMapEntry::Range {
+                    src_start,
+                    src_end,
+                    dst_start,
+                } if dst_start.len() == target_bytes.len()
+                    && target_bytes.as_slice() >= dst_start.as_slice() =>
+                {
+                    let offset = calculate_offset(&target_bytes, dst_start);
+                    if offset <= calculate_offset(src_end, src_start) {
+                        let mut source = src_start.clone();
+                        let mut carry = offset;
+                        for byte in source.iter_mut().rev() {
+                            let sum = usize::from(*byte) + carry;
+                            *byte = (sum & 0xff) as u8;
+                            carry = sum >> 8;
+                            if carry == 0 {
+                                break;
+                            }
+                        }
+                        return Some(source);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
     /// Check if a code is in valid codespace
     pub fn is_valid_code(&self, code: &[u8]) -> bool {
         for range in &self.codespace_ranges {
@@ -1433,5 +1474,20 @@ endcmap\n";
 endcmap";
         let cmap = CMap::parse(data).expect("parse");
         assert_eq!(cmap.inherited_ordering(), Some("Korea1"));
+    }
+
+    #[test]
+    fn source_code_for_unicode_resolves_single_and_range_mappings() {
+        let cmap = CMap::parse(
+            b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+1 beginbfchar <0002> <0020> endbfchar\n\
+1 beginbfrange <0010> <0012> <0041> endbfrange\n\
+endcmap",
+        )
+        .expect("parse");
+        assert_eq!(cmap.source_code_for_unicode(' '), Some(vec![0x00, 0x02]));
+        assert_eq!(cmap.source_code_for_unicode('B'), Some(vec![0x00, 0x11]));
+        assert_eq!(cmap.source_code_for_unicode('Z'), None);
     }
 }

--- a/oxidize-pdf-core/src/text/encoding_cmap.rs
+++ b/oxidize-pdf-core/src/text/encoding_cmap.rs
@@ -12,6 +12,8 @@ use crate::text::cmap::{tokenize_cmap, CodeRange, Token};
 /// destinations are Unicode hex strings.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EncodingCMap {
+    /// Writing mode declared by `/WMode` (0 horizontal, 1 vertical).
+    pub wmode: u8,
     pub codespace_ranges: Vec<CodeRange>,
     pub single_cid: HashMap<Vec<u8>, u16>,
     pub cid_ranges: Vec<CidRange>,
@@ -37,6 +39,12 @@ impl EncodingCMap {
         let mut i = 0;
         while i < tokens.len() {
             match &tokens[i] {
+                Token::Name(name) if name == "WMode" => {
+                    if let Some(Token::Integer(value)) = tokens.get(i + 1) {
+                        cmap.wmode = (*value).clamp(0, 1) as u8;
+                    }
+                    i += 1;
+                }
                 Token::Keyword(k) if k == "begincodespacerange" => {
                     i += 1;
                     while i < tokens.len() {
@@ -354,6 +362,15 @@ endcmap";
         assert_eq!(cmap.codespace_ranges.len(), 2);
         assert_eq!(cmap.code_len_at(&[0x81, 0x40], 0), 2);
         assert_eq!(cmap.usecmap_parent.as_deref(), Some("Foo-Base"));
+    }
+
+    #[test]
+    fn parse_retains_vertical_writing_mode() {
+        let cmap = EncodingCMap::parse(
+            b"begincmap\n/WMode 1 def\n1 begincodespacerange <0000> <FFFF> endcodespacerange\nendcmap",
+        )
+        .expect("parse");
+        assert_eq!(cmap.wmode, 1);
     }
 
     #[test]

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -1346,18 +1346,23 @@ impl TextExtractor {
                                 // `SAME_Y_WRAP_EM` font sizes is a wrap even at dy == 0
                                 // (issue #447). dx/dy are baseline-relative (issue
                                 // #443), so this holds under rotation. A new text
-                                // object is a stronger boundary: its first run is
-                                // independently positioned, so a large backward
-                                // jump cannot be intra-object kerning (#495). The
+                                // object's first run is independently positioned:
+                                // a large backward jump warrants a separator, but
+                                // does not by itself prove a line wrap (#495). The
                                 // epsilon absorbs projection rounding noise.
                                 let same_y_wrap = dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
                                 let large_backward_jump =
                                     dx < -(self.options.newline_threshold * 2.0);
-                                let line_wrap = large_backward_jump
-                                    && (dy > SAME_LINE_EPS || same_y_wrap || at_text_object_start);
+                                let line_wrap =
+                                    large_backward_jump && (dy > SAME_LINE_EPS || same_y_wrap);
+                                let positioned_run_boundary = large_backward_jump
+                                    && dy <= SAME_LINE_EPS
+                                    && at_text_object_start;
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
-                                } else if dx > self.flat_space_gap_threshold(&state) {
+                                } else if positioned_run_boundary
+                                    || dx > self.flat_space_gap_threshold(&state)
+                                {
                                     Some(' ')
                                 } else {
                                     None
@@ -1490,10 +1495,10 @@ impl TextExtractor {
                                     // as a same-Y wrap (issue #447). Deltas are
                                     // baseline-relative (issue #443), so both gates hold
                                     // under rotation. At the start of a new text
-                                    // object, a large backward jump is independently
-                                    // positioned rather than intra-array kerning
-                                    // (issue #495). The epsilon absorbs projection
-                                    // rounding noise.
+                                    // object, a large backward jump warrants a
+                                    // separator but does not by itself prove a line
+                                    // wrap (issue #495). The epsilon absorbs
+                                    // projection rounding noise.
                                     let (dx, dy_signed) =
                                         pen_delta(&state, (last_x, last_y), (x, y));
                                     let dy = dy_signed.abs();
@@ -1501,10 +1506,12 @@ impl TextExtractor {
                                         dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
                                     let large_backward_jump =
                                         dx < -(self.options.newline_threshold * 2.0);
-                                    let line_wrap = large_backward_jump
-                                        && (dy > SAME_LINE_EPS
-                                            || same_y_wrap
-                                            || (at_text_object_start && at_array_start));
+                                    let line_wrap =
+                                        large_backward_jump && (dy > SAME_LINE_EPS || same_y_wrap);
+                                    let positioned_run_boundary = large_backward_jump
+                                        && dy <= SAME_LINE_EPS
+                                        && at_text_object_start
+                                        && at_array_start;
                                     // Separator of the run actually appended, for the
                                     // reading-order line grouping (issue #448).
                                     let mut emitted_sep: Option<Option<char>> = None;
@@ -1540,7 +1547,7 @@ impl TextExtractor {
                                             None
                                         } else if dy > self.options.newline_threshold || line_wrap {
                                             Some('\n')
-                                        } else if boundary_space {
+                                        } else if positioned_run_boundary || boundary_space {
                                             Some(' ')
                                         } else {
                                             None
@@ -3396,10 +3403,11 @@ const TJ_BOUNDARY_SPACE_EM: f64 = 0.7;
 ///
 /// Accepted, documented limitation (the #417/#422 trade-off) within one text
 /// object: a same-line reposition that jumps back more than this many em is
-/// misread as a wrap, and a same-Y wrap shorter than this is glued. A new
-/// `BT`/`ET` object supplies an independent-positioning boundary, so #495 does
-/// not depend on this magnitude. A wrap with any nonzero leading (the common
-/// case, issue #390) is also unaffected: it breaks on the `dy`-aware gate.
+/// misread as a wrap, and a same-Y wrap shorter than this is not recognized as
+/// a wrap. A new `BT`/`ET` object supplies enough evidence to separate #495's
+/// runs with whitespace, but not enough to promote the separator to a newline.
+/// A wrap with any nonzero leading (the common case, issue #390) is unaffected:
+/// it breaks on the `dy`-aware gate.
 const SAME_Y_WRAP_EM: f64 = 10.0;
 
 /// Pen movement from the previous post-advance pen point `last` to the

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -3571,6 +3571,43 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `word_space` (`Tw`) once per *single-byte* space (code 32, §9.3.3). Both are
 /// unscaled text-space units, added directly (not multiplied by the font size);
 /// the caller's `advance_pen` applies `Th`.
+/// Decode a Type0 text-showing string's raw bytes into CIDs, for CID-indexed
+/// `/W` width lookup (issue #496). Mirrors the code-length/lookup rules
+/// `decode_text_with_font` already uses for Unicode decoding, but stops at
+/// the CID rather than continuing on to a Unicode codepoint.
+///
+/// - A non-identity encoding CMap (`font_info.cid_encoding`) maps
+///   variable-width codes to CIDs directly; an unmapped code resolves via
+///   `.notdef` when present, and is otherwise skipped (its width cannot be
+///   determined, so it must not desync the remaining codes' pairing).
+/// - `Identity-H`/`Identity-V` (by far the most common case) — and the
+///   `Utf16Be` `cid_encoding`, whose codes are also 2-byte units — read the
+///   CID directly as a big-endian `u16` per §9.7.4.2, no code-space lookup
+///   required.
+fn cids_for_codes(codes: &[u8], font_info: Option<&FontInfo>) -> Vec<u32> {
+    if let Some(crate::text::encoding_cmap::CidEncoding::Cmap(enc)) =
+        font_info.and_then(|f| f.cid_encoding.as_ref())
+    {
+        let mut cids = Vec::new();
+        let mut i = 0;
+        while i < codes.len() {
+            let len = enc.code_len_at(codes, i).max(1).min(codes.len() - i);
+            let code = &codes[i..i + len];
+            if let Some(cid) = enc.map_code_to_cid(code).or_else(|| enc.map_notdef(code)) {
+                cids.push(cid as u32);
+            }
+            i += len;
+        }
+        return cids;
+    }
+
+    codes
+        .chunks(2)
+        .filter(|chunk| chunk.len() == 2)
+        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as u32)
+        .collect()
+}
+
 fn calculate_text_width_from_codes(
     codes: &[u8],
     decoded: &str,
@@ -3580,14 +3617,31 @@ fn calculate_text_width_from_codes(
     word_space: f64,
 ) -> f64 {
     // Composite (Type0) fonts use multi-byte codes; a single byte is not a code,
-    // so byte-indexed width lookup is invalid. Preserve the existing decoded-based
-    // behavior for them, adding `Tc` per glyph. `Tw` applies only to the
-    // single-byte code 32 (§9.3.3), which a multi-byte code can never be, so it
-    // does not apply here.
+    // so byte-indexed width lookup is invalid. `Tc` is added per glyph below.
+    // `Tw` applies only to the single-byte code 32 (§9.3.3), which a
+    // multi-byte code can never be, so it does not apply here.
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
         let glyphs = decoded.chars().count() as f64;
+        // Prefer the descendant CIDFont's `/W`/`/DW` (CID-indexed, per
+        // §9.7.4.3) over the decoded-Unicode-indexed fallback below: a CID
+        // is an arbitrary font-internal identifier with no relationship to
+        // the character it decodes to, so indexing by decoded codepoint
+        // reads the wrong table slot whenever CID != codepoint (any
+        // subset/reordered CID font). Without `/W`/`/DW` at all, fall back
+        // to the previous decoded-text heuristic (issue #496).
+        if let Some(cid_widths) = font_info
+            .and_then(|f| f.descendant_font.as_deref().or(Some(f)))
+            .and_then(|f| f.metrics.cid_widths.as_ref())
+        {
+            let cids = cids_for_codes(codes, font_info);
+            let total: f64 = cids
+                .iter()
+                .map(|&cid| cid_widths.width_for(cid) / 1000.0 * font_size)
+                .sum();
+            return total + char_space * glyphs;
+        }
         return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
 
@@ -4422,6 +4476,7 @@ mod tests {
                 widths: None,
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4463,6 +4518,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4519,6 +4575,7 @@ mod tests {
                 widths: Some(vec![1000.0, 100.0]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4564,6 +4621,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4604,6 +4662,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4639,6 +4698,7 @@ mod tests {
                 widths: Some(vec![500.0; 95]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4673,6 +4733,7 @@ mod tests {
                 widths: Some(vec![500.0; 95]),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4706,6 +4767,7 @@ mod tests {
                 widths: Some(vec![722.0]),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4744,6 +4806,7 @@ mod tests {
                 widths: Some(proportional_widths),
                 missing_width: Some(500.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4764,6 +4827,7 @@ mod tests {
                 widths: Some(monospace_widths),
                 missing_width: Some(600.0),
                 kerning: None,
+                cid_widths: None,
             },
             cid_encoding: None,
         };
@@ -4814,6 +4878,7 @@ mod tests {
                 widths: Some(widths),
                 missing_width: Some(500.0),
                 kerning: Some(kerning),
+                cid_widths: None,
             },
             cid_encoding: None,
         };

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -602,6 +602,10 @@ pub struct TextExtractor {
     carriage_return_handling: CarriageReturnHandling,
     /// Font cache for the current page (name-keyed, rebuilt per page since names are page-local)
     font_cache: HashMap<String, FontInfo>,
+    /// Narrowest usable CID width for Type0 fonts in the current page. Derived
+    /// once when the font is cached so flat extraction does not rescan a
+    /// potentially large attacker-controlled `/W` table for every glyph.
+    type0_implicit_space_widths: HashMap<String, f64>,
     /// Persistent font cache keyed by PDF object reference — avoids re-parsing the same font
     /// object across pages. Most multi-page PDFs reuse the same font objects.
     font_object_cache: HashMap<(u32, u16), FontInfo>,
@@ -615,6 +619,7 @@ impl TextExtractor {
             reading_order: false,
             carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
+            type0_implicit_space_widths: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
     }
@@ -626,6 +631,7 @@ impl TextExtractor {
             reading_order: false,
             carriage_return_handling: CarriageReturnHandling::default(),
             font_cache: HashMap::new(),
+            type0_implicit_space_widths: HashMap::new(),
             font_object_cache: HashMap::new(),
         }
     }
@@ -820,10 +826,31 @@ impl TextExtractor {
         standard_14_space_width(&info.name).map(|em| em / 1000.0 * font_size)
     }
 
+    /// Font-derived proxy used only when a Type0 font has CID widths but no
+    /// discoverable U+0020 mapping. The narrowest declared positive advance is
+    /// a lower bound, not a guessed space CID: narrow punctuation and spacing
+    /// glyphs define how small a meaningful inter-word gap can be (#500).
+    fn type0_implicit_space_advance(&self, font_name: Option<&str>, font_size: f64) -> Option<f64> {
+        let width = self.type0_implicit_space_widths.get(font_name?)?;
+        Some(width / 1000.0 * font_size.abs())
+    }
+
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
         match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
             Some(advance) if advance > 0.0 => 0.5 * advance,
-            _ => self.options.space_threshold * state.font_size,
+            _ => {
+                let legacy = self.options.space_threshold * state.font_size.abs();
+                match self.type0_implicit_space_advance(state.font_name.as_deref(), state.font_size)
+                {
+                    Some(advance) if advance > 0.0 && legacy > 0.0 => {
+                        // Do not let a malformed near-zero `/W` entry make every
+                        // positioning residue a word gap. Conversely, never make
+                        // the fallback stricter than the established threshold.
+                        (0.5 * advance).max(0.1 * state.font_size.abs()).min(legacy)
+                    }
+                    _ => legacy,
+                }
+            }
         }
     }
 
@@ -2819,6 +2846,7 @@ impl TextExtractor {
     ) -> ParseResult<()> {
         // Clear per-page name mapping (font names like /F1 are page-local)
         self.font_cache.clear();
+        self.type0_implicit_space_widths.clear();
 
         // Try to get resources manually from page dictionary first
         // This is necessary because ParsedPage.get_resources() may not always work
@@ -2880,7 +2908,7 @@ impl TextExtractor {
                 font_name,
                 font_info.to_unicode.is_some()
             );
-            self.font_cache.insert(font_name.to_string(), font_info);
+            self.cache_page_font(font_name, font_info);
         }
     }
 
@@ -2893,8 +2921,7 @@ impl TextExtractor {
     ) {
         // Check persistent object cache first — avoids re-parsing across pages
         if let Some(cached) = self.font_object_cache.get(&font_ref) {
-            self.font_cache
-                .insert(font_name.to_string(), cached.clone());
+            let cached = cached.clone();
             tracing::debug!(
                 "Reused cached font object ({}, {}): {} (ToUnicode: {})",
                 font_ref.0,
@@ -2902,6 +2929,7 @@ impl TextExtractor {
                 font_name,
                 cached.to_unicode.is_some()
             );
+            self.cache_page_font(font_name, cached);
             return;
         }
 
@@ -2913,7 +2941,7 @@ impl TextExtractor {
                 // Store in persistent cache
                 self.font_object_cache.insert(font_ref, font_info.clone());
                 // Store in per-page name cache
-                self.font_cache.insert(font_name.to_string(), font_info);
+                self.cache_page_font(font_name, font_info);
                 tracing::debug!(
                     "Parsed and cached font ({}, {}): {} (ToUnicode: {})",
                     font_ref.0,
@@ -2923,6 +2951,24 @@ impl TextExtractor {
                 );
             }
         }
+    }
+
+    /// Add a parsed font to the page-local caches, deriving the Type0 fallback
+    /// width once rather than on every text-showing boundary.
+    fn cache_page_font(&mut self, font_name: &str, font_info: FontInfo) {
+        if font_info.font_type == "Type0" || font_info.descendant_font.is_some() {
+            let cid_font = font_info.descendant_font.as_deref().unwrap_or(&font_info);
+            if let Some(width) = cid_font
+                .metrics
+                .cid_widths
+                .as_ref()
+                .and_then(|widths| widths.narrowest_positive_width())
+            {
+                self.type0_implicit_space_widths
+                    .insert(font_name.to_string(), width);
+            }
+        }
+        self.font_cache.insert(font_name.to_string(), font_info);
     }
 
     /// Decode text using the current font encoding and ToUnicode mapping

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -793,6 +793,16 @@ impl TextExtractor {
     /// ZapfDingbats), which ship no `/Widths` array (#302 symptom 2).
     fn font_space_advance(&self, font_name: Option<&str>, font_size: f64) -> Option<f64> {
         let info = self.font_cache.get(font_name?)?;
+        if let (Some(to_unicode), Some(descendant)) =
+            (info.to_unicode.as_ref(), info.descendant_font.as_deref())
+        {
+            let space_code = to_unicode.source_code_for_unicode(' ')?;
+            let cid = cids_for_codes(&space_code, info)?.first()?.1;
+            let width = descendant.metrics.cid_widths.as_ref()?.width_for(cid);
+            if width > 0.0 {
+                return Some(width / 1000.0 * font_size);
+            }
+        }
         if let Some(ref widths) = info.metrics.widths {
             let first = info.metrics.first_char.unwrap_or(0);
             if first <= 32 {
@@ -804,6 +814,13 @@ impl TextExtractor {
             }
         }
         standard_14_space_width(&info.name).map(|em| em / 1000.0 * font_size)
+    }
+
+    fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
+        match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
+            Some(advance) if advance > 0.0 => 0.5 * advance,
+            _ => self.options.space_threshold * state.font_size,
+        }
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.
@@ -1328,7 +1345,7 @@ impl TextExtractor {
                                     && (dy > SAME_LINE_EPS || same_y_wrap);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
-                                } else if dx > self.options.space_threshold * state.font_size {
+                                } else if dx > self.flat_space_gap_threshold(&state) {
                                     Some(' ')
                                 } else {
                                     None
@@ -3576,36 +3593,51 @@ fn calculate_text_width(text: &str, font_size: f64, font_info: Option<&FontInfo>
 /// `decode_text_with_font` already uses for Unicode decoding, but stops at
 /// the CID rather than continuing on to a Unicode codepoint.
 ///
-/// - A non-identity encoding CMap (`font_info.cid_encoding`) maps
-///   variable-width codes to CIDs directly; an unmapped code resolves via
-///   `.notdef` when present, and is otherwise skipped (its width cannot be
-///   determined, so it must not desync the remaining codes' pairing).
-/// - `Identity-H`/`Identity-V` (by far the most common case) — and the
-///   `Utf16Be` `cid_encoding`, whose codes are also 2-byte units — read the
-///   CID directly as a big-endian `u16` per §9.7.4.2, no code-space lookup
-///   required.
-fn cids_for_codes(codes: &[u8], font_info: Option<&FontInfo>) -> Vec<u32> {
-    if let Some(crate::text::encoding_cmap::CidEncoding::Cmap(enc)) =
-        font_info.and_then(|f| f.cid_encoding.as_ref())
+/// Returns `None` when the code→CID relation is unavailable or vertical: in
+/// those cases guessing would select unrelated `/W` entries, so the caller
+/// retains the legacy fallback.
+fn cids_for_codes<'a>(codes: &'a [u8], font: &FontInfo) -> Option<Vec<(&'a [u8], u32)>> {
+    use crate::text::encoding_cmap::CidEncoding;
+
+    if matches!(font.cid_encoding, Some(CidEncoding::Utf16Be))
+        || font
+            .encoding
+            .as_deref()
+            .is_some_and(|name| name.ends_with("-V"))
+        || matches!(&font.cid_encoding, Some(CidEncoding::Cmap(cmap)) if cmap.wmode == 1)
     {
-        let mut cids = Vec::new();
-        let mut i = 0;
-        while i < codes.len() {
-            let len = enc.code_len_at(codes, i).max(1).min(codes.len() - i);
-            let code = &codes[i..i + len];
-            if let Some(cid) = enc.map_code_to_cid(code).or_else(|| enc.map_notdef(code)) {
-                cids.push(cid as u32);
-            }
-            i += len;
-        }
-        return cids;
+        return None;
+    }
+    let identity = font.encoding.as_deref() == Some("Identity-H");
+    if font.cid_encoding.is_none() && !identity {
+        return None;
     }
 
-    codes
-        .chunks(2)
-        .filter(|chunk| chunk.len() == 2)
-        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]) as u32)
-        .collect()
+    let mut result = Vec::new();
+    let mut offset = 0;
+    while offset < codes.len() {
+        let code_len = match &font.cid_encoding {
+            Some(CidEncoding::Cmap(cmap)) => cmap.code_len_at(codes, offset),
+            Some(CidEncoding::Utf16Be) => unreachable!(),
+            None => 2,
+        }
+        .max(1)
+        .min(codes.len() - offset);
+        let code = &codes[offset..offset + code_len];
+        let cid = match &font.cid_encoding {
+            Some(CidEncoding::Cmap(cmap)) => cmap
+                .map_code_to_cid(code)
+                .or_else(|| cmap.map_notdef(code))
+                .map(u32::from)?,
+            Some(CidEncoding::Utf16Be) => unreachable!(),
+            None => code
+                .iter()
+                .fold(0u32, |value, byte| (value << 8) | u32::from(*byte)),
+        };
+        result.push((code, cid));
+        offset += code_len;
+    }
+    Some(result)
 }
 
 fn calculate_text_width_from_codes(
@@ -3623,7 +3655,6 @@ fn calculate_text_width_from_codes(
     let is_composite =
         font_info.is_some_and(|f| f.font_type == "Type0" || f.descendant_font.is_some());
     if is_composite {
-        let glyphs = decoded.chars().count() as f64;
         // Prefer the descendant CIDFont's `/W`/`/DW` (CID-indexed, per
         // §9.7.4.3) over the decoded-Unicode-indexed fallback below: a CID
         // is an arbitrary font-internal identifier with no relationship to
@@ -3635,13 +3666,20 @@ fn calculate_text_width_from_codes(
             .and_then(|f| f.descendant_font.as_deref().or(Some(f)))
             .and_then(|f| f.metrics.cid_widths.as_ref())
         {
-            let cids = cids_for_codes(codes, font_info);
-            let total: f64 = cids
-                .iter()
-                .map(|&cid| cid_widths.width_for(cid) / 1000.0 * font_size)
-                .sum();
-            return total + char_space * glyphs;
+            if let Some(font) = font_info {
+                if let Some(cid_codes) = cids_for_codes(codes, font) {
+                    let mut total = 0.0;
+                    for (code, cid) in cid_codes {
+                        total += cid_widths.width_for(cid) / 1000.0 * font_size + char_space;
+                        if code.len() == 1 && code[0] == b' ' {
+                            total += word_space;
+                        }
+                    }
+                    return total;
+                }
+            }
         }
+        let glyphs = decoded.chars().count() as f64;
         return calculate_text_width(decoded, font_size, font_info) + char_space * glyphs;
     }
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -443,6 +443,10 @@ impl SavedGraphicsState {
 struct OpRunState {
     state: TextState,
     in_text_object: bool,
+    /// True until the first show-text operator after `BT`. A backward jump at
+    /// this boundary is an independent positioned run, not intra-object
+    /// kerning, and can therefore delimit a grid cell (issue #495).
+    at_text_object_start: bool,
     last_x: f64,
     last_y: f64,
     extracted_text: String,
@@ -1014,6 +1018,7 @@ impl TextExtractor {
         let mut run = OpRunState {
             state,
             in_text_object,
+            at_text_object_start: false,
             last_x,
             last_y,
             extracted_text,
@@ -1220,6 +1225,7 @@ impl TextExtractor {
         let OpRunState {
             mut state,
             mut in_text_object,
+            mut at_text_object_start,
             mut last_x,
             mut last_y,
             mut extracted_text,
@@ -1246,6 +1252,7 @@ impl TextExtractor {
             match op {
                 ContentOperation::BeginText => {
                     in_text_object = true;
+                    at_text_object_start = true;
                     // Reset text matrix to identity
                     state.text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
                     state.text_line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -1338,11 +1345,16 @@ impl TextExtractor {
                                 // returns across the whole column, so a jump beyond
                                 // `SAME_Y_WRAP_EM` font sizes is a wrap even at dy == 0
                                 // (issue #447). dx/dy are baseline-relative (issue
-                                // #443), so this holds under rotation; the epsilon
-                                // absorbs projection rounding noise.
+                                // #443), so this holds under rotation. A new text
+                                // object is a stronger boundary: its first run is
+                                // independently positioned, so a large backward
+                                // jump cannot be intra-object kerning (#495). The
+                                // epsilon absorbs projection rounding noise.
                                 let same_y_wrap = dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
-                                let line_wrap = dx < -(self.options.newline_threshold * 2.0)
-                                    && (dy > SAME_LINE_EPS || same_y_wrap);
+                                let large_backward_jump =
+                                    dx < -(self.options.newline_threshold * 2.0);
+                                let line_wrap = large_backward_jump
+                                    && (dy > SAME_LINE_EPS || same_y_wrap || at_text_object_start);
                                 if dy > self.options.newline_threshold || line_wrap {
                                     Some('\n')
                                 } else if dx > self.flat_space_gap_threshold(&state) {
@@ -1429,6 +1441,7 @@ impl TextExtractor {
                         // pen point (folds in Tz and CTM scale, issue #386; a
                         // full point so rotated baselines advance y too, #443).
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -1476,15 +1489,22 @@ impl TextExtractor {
                                     // treating a jump beyond `SAME_Y_WRAP_EM` font sizes
                                     // as a same-Y wrap (issue #447). Deltas are
                                     // baseline-relative (issue #443), so both gates hold
-                                    // under rotation; the epsilon absorbs projection
+                                    // under rotation. At the start of a new text
+                                    // object, a large backward jump is independently
+                                    // positioned rather than intra-array kerning
+                                    // (issue #495). The epsilon absorbs projection
                                     // rounding noise.
                                     let (dx, dy_signed) =
                                         pen_delta(&state, (last_x, last_y), (x, y));
                                     let dy = dy_signed.abs();
                                     let same_y_wrap =
                                         dx < -(state.font_size.abs() * SAME_Y_WRAP_EM);
-                                    let line_wrap = dx < -(self.options.newline_threshold * 2.0)
-                                        && (dy > SAME_LINE_EPS || same_y_wrap);
+                                    let large_backward_jump =
+                                        dx < -(self.options.newline_threshold * 2.0);
+                                    let line_wrap = large_backward_jump
+                                        && (dy > SAME_LINE_EPS
+                                            || same_y_wrap
+                                            || (at_text_object_start && at_array_start));
                                     // Separator of the run actually appended, for the
                                     // reading-order line grouping (issue #448).
                                     let mut emitted_sep: Option<Option<char>> = None;
@@ -1598,6 +1618,7 @@ impl TextExtractor {
                                     // issue #386: the pen must fold in Tz/CTM scale).
                                     (last_x, last_y) = advance_pen(&mut state, text_width);
                                     at_array_start = false;
+                                    at_text_object_start = false;
                                 }
                                 TextElement::Spacing(adjustment) => {
                                     // `at_array_start` is deliberately NOT cleared
@@ -1787,6 +1808,7 @@ impl TextExtractor {
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -1882,6 +1904,7 @@ impl TextExtractor {
                         }
 
                         (last_x, last_y) = advance_pen(&mut state, text_width);
+                        at_text_object_start = false;
                     }
                 }
 
@@ -2132,6 +2155,10 @@ impl TextExtractor {
                             let sub = OpRunState {
                                 state,
                                 in_text_object: false,
+                                // Preserve the outer boundary if the form emits
+                                // no text. A `BT` inside the form will replace it
+                                // with the form's own boundary.
+                                at_text_object_start,
                                 last_x,
                                 last_y,
                                 extracted_text,
@@ -2154,6 +2181,7 @@ impl TextExtractor {
                             self.font_cache = saved_fonts;
 
                             state = out.state;
+                            at_text_object_start = out.at_text_object_start;
                             last_x = out.last_x;
                             last_y = out.last_y;
                             extracted_text = out.extracted_text;
@@ -2173,6 +2201,7 @@ impl TextExtractor {
         Ok(OpRunState {
             state,
             in_text_object,
+            at_text_object_start,
             last_x,
             last_y,
             extracted_text,
@@ -3365,12 +3394,12 @@ const TJ_BOUNDARY_SPACE_EM: f64 = 0.7;
 /// threshold's sense — otherwise a negative size makes every backward jump a
 /// "wrap" and resurrects the #441 defect.
 ///
-/// Accepted, documented limitation (the #417/#422 trade-off): a same-line
-/// reposition that jumps back more than this many em is misread as a wrap, and
-/// a same-Y wrap of a line shorter than this is glued. Both are rare and
-/// neither loses a glyph — only the separator is wrong. A wrap with any
-/// nonzero leading (the common case, issue #390) is unaffected: it breaks on
-/// the `dy`-aware gate regardless of magnitude.
+/// Accepted, documented limitation (the #417/#422 trade-off) within one text
+/// object: a same-line reposition that jumps back more than this many em is
+/// misread as a wrap, and a same-Y wrap shorter than this is glued. A new
+/// `BT`/`ET` object supplies an independent-positioning boundary, so #495 does
+/// not depend on this magnitude. A wrap with any nonzero leading (the common
+/// case, issue #390) is also unaffected: it breaks on the `dy`-aware gate.
 const SAME_Y_WRAP_EM: f64 = 10.0;
 
 /// Pen movement from the previous post-advance pen point `last` to the

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -8,8 +8,31 @@ use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
 use crate::parser::{ParseError, ParseOptions, ParseResult};
 use crate::text::cid_to_unicode::CidCollection;
 use crate::text::cmap::CMap;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
+
+/// A CIDFont's `/W` + `/DW` glyph-space widths (ISO 32000-1 §9.7.4.3),
+/// indexed by **CID** — an arbitrary font-internal identifier unrelated to
+/// any decoded Unicode codepoint. Only meaningful on a `CIDFontType0`/
+/// `CIDFontType2` descendant font's [`FontMetrics`]; simple fonts use the
+/// `first_char`/`last_char`/`widths` triple instead.
+#[derive(Debug, Clone, Default)]
+pub struct CidWidths {
+    /// Per-CID widths (1/1000 em), parsed from `/W`'s mixed
+    /// `c [w1 w2 ...]` and `cFirst cLast w` forms.
+    pub widths: HashMap<u32, f64>,
+    /// `/DW`, the width (1/1000 em) for any CID absent from `widths`.
+    /// Defaults to 1000 per spec when `/DW` is not present.
+    pub default_width: f64,
+}
+
+impl CidWidths {
+    /// Width (1/1000 em) for `cid`: its `/W` entry, or `/DW` otherwise.
+    pub fn width_for(&self, cid: u32) -> f64 {
+        self.widths.get(&cid).copied().unwrap_or(self.default_width)
+    }
+}
 
 /// Font metrics for accurate text width calculation
 #[derive(Debug, Clone)]
@@ -24,6 +47,10 @@ pub struct FontMetrics {
     pub missing_width: Option<f64>,
     /// Kerning pairs: (char1, char2) -> adjustment
     pub kerning: Option<HashMap<(u32, u32), f64>>,
+    /// CID-indexed widths (`/W`/`/DW`), for a `CIDFontType0`/`CIDFontType2`
+    /// descendant font. `None` for simple fonts and for CID fonts with
+    /// neither `/W` nor `/DW` present.
+    pub cid_widths: Option<CidWidths>,
 }
 
 impl Default for FontMetrics {
@@ -34,6 +61,7 @@ impl Default for FontMetrics {
             widths: None,
             missing_width: Some(500.0), // Default to 500 units (typical average)
             kerning: None,
+            cid_widths: None,
         }
     }
 }
@@ -322,6 +350,70 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                     }
                 }
             }
+        }
+
+        // Extract CIDFont `/W` + `/DW` (ISO 32000-1 §9.7.4.3). Only present
+        // on a CIDFontType0/CIDFontType2 descendant font dictionary; a
+        // simple font's dict has no `/W` key, so this is a no-op there.
+        let dw = font_dict.get("DW").and_then(|o| o.as_real());
+        let w_array: Option<Cow<[PdfObject]>> = match font_dict.get("W") {
+            Some(PdfObject::Array(array)) => Some(Cow::Borrowed(&array.0)),
+            Some(PdfObject::Reference(num, gen)) => match document.get_object(*num, *gen) {
+                Ok(PdfObject::Array(array)) => Some(Cow::Owned(array.0)),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(entries) = w_array {
+            let mut widths = HashMap::new();
+            let mut i = 0;
+            while i < entries.len() {
+                let Some(first_cid) = entries[i].as_integer() else {
+                    break;
+                };
+                match entries.get(i + 1) {
+                    // `c [w1 w2 ...]`: consecutive widths starting at c.
+                    Some(PdfObject::Array(w_list)) => {
+                        for (offset, w_obj) in w_list.0.iter().enumerate() {
+                            if let Some(w) = w_obj.as_real() {
+                                widths.insert(first_cid as u32 + offset as u32, w);
+                            }
+                        }
+                        i += 2;
+                    }
+                    // `cFirst cLast w`: uniform width across an inclusive CID range.
+                    Some(last_obj) => {
+                        let (Some(last_cid), Some(w)) = (
+                            last_obj.as_integer(),
+                            entries.get(i + 2).and_then(|o| o.as_real()),
+                        ) else {
+                            break;
+                        };
+                        // CIDs from Identity-H/Identity-V decode as a u16
+                        // (§9.7.4.2), so any range past 0xFFFF is malformed;
+                        // clamp rather than materializing a huge/looping
+                        // range from a corrupt or adversarial `/W` array.
+                        let last_cid = last_cid.min(u16::MAX as i64);
+                        if last_cid >= first_cid {
+                            for cid in first_cid..=last_cid {
+                                widths.insert(cid as u32, w);
+                            }
+                        }
+                        i += 3;
+                    }
+                    None => break,
+                }
+            }
+            metrics.cid_widths = Some(CidWidths {
+                widths,
+                default_width: dw.unwrap_or(1000.0),
+            });
+        } else if let Some(dw) = dw {
+            // `/DW` with no `/W`: every CID uses the default width.
+            metrics.cid_widths = Some(CidWidths {
+                widths: HashMap::new(),
+                default_width: dw,
+            });
         }
 
         // Extract kerning from TrueType fonts (if embedded)

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -22,6 +22,9 @@ pub struct CidWidths {
     /// Per-CID widths (1/1000 em), parsed from `/W`'s mixed
     /// `c [w1 w2 ...]` and `cFirst cLast w` forms.
     pub widths: HashMap<u32, f64>,
+    /// Uniform `/W` ranges stored without materializing every CID. Keeping
+    /// ranges compact bounds parser work by input size for untrusted PDFs.
+    pub ranges: Vec<(u32, u32, f64)>,
     /// `/DW`, the width (1/1000 em) for any CID absent from `widths`.
     /// Defaults to 1000 per spec when `/DW` is not present.
     pub default_width: f64,
@@ -30,7 +33,17 @@ pub struct CidWidths {
 impl CidWidths {
     /// Width (1/1000 em) for `cid`: its `/W` entry, or `/DW` otherwise.
     pub fn width_for(&self, cid: u32) -> f64 {
-        self.widths.get(&cid).copied().unwrap_or(self.default_width)
+        self.widths
+            .get(&cid)
+            .copied()
+            .or_else(|| {
+                self.ranges
+                    .iter()
+                    .rev()
+                    .find(|(first, last, _)| cid >= *first && cid <= *last)
+                    .map(|(_, _, width)| *width)
+            })
+            .unwrap_or(self.default_width)
     }
 }
 
@@ -355,6 +368,10 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
         // Extract CIDFont `/W` + `/DW` (ISO 32000-1 §9.7.4.3). Only present
         // on a CIDFontType0/CIDFontType2 descendant font dictionary; a
         // simple font's dict has no `/W` key, so this is a no-op there.
+        let is_cid_font = font_dict
+            .get("Subtype")
+            .and_then(PdfObject::as_name)
+            .is_some_and(|subtype| matches!(subtype.0.as_str(), "CIDFontType0" | "CIDFontType2"));
         let dw = font_dict.get("DW").and_then(|o| o.as_real());
         let w_array: Option<Cow<[PdfObject]>> = match font_dict.get("W") {
             Some(PdfObject::Array(array)) => Some(Cow::Borrowed(&array.0)),
@@ -366,6 +383,7 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
         };
         if let Some(entries) = w_array {
             let mut widths = HashMap::new();
+            let mut ranges = Vec::new();
             let mut i = 0;
             while i < entries.len() {
                 let Some(first_cid) = entries[i].as_integer() else {
@@ -374,9 +392,18 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                 match entries.get(i + 1) {
                     // `c [w1 w2 ...]`: consecutive widths starting at c.
                     Some(PdfObject::Array(w_list)) => {
-                        for (offset, w_obj) in w_list.0.iter().enumerate() {
-                            if let Some(w) = w_obj.as_real() {
-                                widths.insert(first_cid as u32 + offset as u32, w);
+                        if let Ok(first_cid) = u32::try_from(first_cid) {
+                            for (offset, w_obj) in w_list.0.iter().enumerate() {
+                                if let (Ok(offset), Some(w)) =
+                                    (u32::try_from(offset), w_obj.as_real())
+                                {
+                                    if let Some(cid) = first_cid
+                                        .checked_add(offset)
+                                        .filter(|cid| *cid <= u16::MAX as u32)
+                                    {
+                                        widths.insert(cid, w);
+                                    }
+                                }
                             }
                         }
                         i += 2;
@@ -393,11 +420,10 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
                         // (§9.7.4.2), so any range past 0xFFFF is malformed;
                         // clamp rather than materializing a huge/looping
                         // range from a corrupt or adversarial `/W` array.
-                        let last_cid = last_cid.min(u16::MAX as i64);
+                        let first_cid = first_cid.max(0).min(u16::MAX as i64) as u32;
+                        let last_cid = last_cid.max(0).min(u16::MAX as i64) as u32;
                         if last_cid >= first_cid {
-                            for cid in first_cid..=last_cid {
-                                widths.insert(cid as u32, w);
-                            }
+                            ranges.push((first_cid, last_cid, w));
                         }
                         i += 3;
                     }
@@ -406,13 +432,15 @@ impl<R: Read + Seek> CMapTextExtractor<R> {
             }
             metrics.cid_widths = Some(CidWidths {
                 widths,
+                ranges,
                 default_width: dw.unwrap_or(1000.0),
             });
-        } else if let Some(dw) = dw {
-            // `/DW` with no `/W`: every CID uses the default width.
+        } else if is_cid_font {
+            // `/DW` defaults to 1000 even when both `/W` and `/DW` are absent.
             metrics.cid_widths = Some(CidWidths {
                 widths: HashMap::new(),
-                default_width: dw,
+                ranges: Vec::new(),
+                default_width: dw.unwrap_or(1000.0),
             });
         }
 

--- a/oxidize-pdf-core/src/text/extraction_cmap.rs
+++ b/oxidize-pdf-core/src/text/extraction_cmap.rs
@@ -45,6 +45,22 @@ impl CidWidths {
             })
             .unwrap_or(self.default_width)
     }
+
+    /// Narrowest positive width declared by `/W`, or `/DW` when `/W` has no
+    /// usable entries. This is not assumed to be the space CID; it is only a
+    /// conservative lower bound for a font-derived implicit-space heuristic.
+    pub(crate) fn narrowest_positive_width(&self) -> Option<f64> {
+        self.widths
+            .values()
+            .copied()
+            .chain(self.ranges.iter().map(|(_, _, width)| *width))
+            .filter(|width| width.is_finite() && *width > 0.0)
+            .min_by(f64::total_cmp)
+            .or_else(|| {
+                (self.default_width.is_finite() && self.default_width > 0.0)
+                    .then_some(self.default_width)
+            })
+    }
 }
 
 /// Font metrics for accurate text width calculation

--- a/oxidize-pdf-core/src/writer/incremental_form_fill.rs
+++ b/oxidize-pdf-core/src/writer/incremental_form_fill.rs
@@ -41,6 +41,8 @@ use crate::text::TextEncoding;
 use std::collections::HashMap;
 use std::io::Cursor;
 
+use super::incremental_update::{format_real, write_dictionary, write_object};
+
 /// Fills AcroForm fields on an existing parsed PDF by appending an
 /// ISO 32000-1 §7.5.6 incremental update. See the module docs.
 pub struct IncrementalFormFiller<'a> {
@@ -506,7 +508,7 @@ fn build_text_ap(
     let mut resources = PdfDictionary::new();
     resources.insert("Font".to_string(), PdfObject::Dictionary(font_dict));
     let mut resources_bytes = Vec::new();
-    write_dict(&mut resources_bytes, &resources)?;
+    write_dictionary(&mut resources_bytes, &resources)?;
 
     Ok((content, [0.0, 0.0, width, height], resources_bytes))
 }
@@ -714,7 +716,7 @@ fn parse_da_string(da: &str) -> Option<(String, f64)> {
 /// The content is emitted UNCOMPRESSED, so `/Length` is exactly the raw byte
 /// count — no filter, no two-pass buffering. `resources_snippet` is a
 /// pre-serialized `<< ... >>` dictionary (built by the caller via the
-/// module's `write_dict`) inlined as the `/Resources` value.
+/// shared incremental serializer) inlined as the `/Resources` value.
 fn write_indirect_stream_object(
     out: &mut Vec<u8>,
     num: u32,
@@ -752,77 +754,9 @@ fn write_indirect_object(
     dict: &PdfDictionary,
 ) -> Result<()> {
     out.extend_from_slice(format!("{num} {gen} obj\n").as_bytes());
-    write_object_value(out, &PdfObject::Dictionary(dict.clone()))?;
+    write_object(out, &PdfObject::Dictionary(dict.clone()))?;
     out.extend_from_slice(b"\nendobj\n");
     Ok(())
-}
-
-/// Serialize a parser [`PdfObject`] to PDF wire bytes. Streams are rejected:
-/// AcroForm field and form dictionaries never carry an embedded stream, and
-/// emitting one without a fresh `/Length` would corrupt the file.
-fn write_object_value(out: &mut Vec<u8>, obj: &PdfObject) -> Result<()> {
-    match obj {
-        PdfObject::Null => out.extend_from_slice(b"null"),
-        PdfObject::Boolean(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
-        PdfObject::Integer(i) => out.extend_from_slice(i.to_string().as_bytes()),
-        PdfObject::Real(f) => out.extend_from_slice(format_real(*f).as_bytes()),
-        PdfObject::String(s) => write_literal_string(out, s.as_bytes()),
-        PdfObject::Name(n) => write_name(out, n),
-        PdfObject::Reference(num, gen) => {
-            out.extend_from_slice(format!("{num} {gen} R").as_bytes())
-        }
-        PdfObject::Array(arr) => {
-            out.extend_from_slice(b"[");
-            for (i, item) in arr.0.iter().enumerate() {
-                if i > 0 {
-                    out.extend_from_slice(b" ");
-                }
-                write_object_value(out, item)?;
-            }
-            out.extend_from_slice(b"]");
-        }
-        PdfObject::Dictionary(d) => write_dict(out, d)?,
-        PdfObject::Stream(_) => {
-            return Err(PdfError::InvalidStructure(
-                "unexpected stream object in AcroForm field dictionary".to_string(),
-            ))
-        }
-    }
-    Ok(())
-}
-
-fn write_dict(out: &mut Vec<u8>, dict: &PdfDictionary) -> Result<()> {
-    out.extend_from_slice(b"<< ");
-    // Deterministic key order: keeps output stable and tests reproducible.
-    let mut keys: Vec<&PdfName> = dict.0.keys().collect();
-    keys.sort_by(|a, b| a.0.cmp(&b.0));
-    for key in keys {
-        write_name(out, key);
-        out.extend_from_slice(b" ");
-        // Safe: key came from the dict.
-        write_object_value(out, &dict.0[key])?;
-        out.extend_from_slice(b" ");
-    }
-    out.extend_from_slice(b">>");
-    Ok(())
-}
-
-fn write_name(out: &mut Vec<u8>, name: &PdfName) {
-    out.extend_from_slice(b"/");
-    for &b in name.0.as_bytes() {
-        // Regular characters pass through; everything else is #XX-escaped
-        // (ISO 32000-1 §7.3.5).
-        if b.is_ascii_alphanumeric()
-            || matches!(
-                b,
-                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
-            )
-        {
-            out.push(b);
-        } else {
-            out.extend_from_slice(format!("#{b:02X}").as_bytes());
-        }
-    }
 }
 
 /// Serialize a PDF literal string `(...)`, escaping the reserved bytes and
@@ -842,27 +776,6 @@ fn write_literal_string(out: &mut Vec<u8>, bytes: &[u8]) {
         }
     }
     out.push(b')');
-}
-
-/// Format a PDF real without scientific notation, trimming trailing zeros.
-fn format_real(f: f64) -> String {
-    // PDF has no token for NaN/Infinity; emit a benign 0 rather than a
-    // malformed numeric. Field dicts essentially never carry such values,
-    // but the serializer must stay total.
-    if !f.is_finite() {
-        return "0".to_string();
-    }
-    if f == f.trunc() {
-        return format!("{}", f as i64);
-    }
-    let mut s = format!("{f:.6}");
-    while s.ends_with('0') {
-        s.pop();
-    }
-    if s.ends_with('.') {
-        s.pop();
-    }
-    s
 }
 
 // ---------------------------------------------------------------------------

--- a/oxidize-pdf-core/src/writer/incremental_text_notes.rs
+++ b/oxidize-pdf-core/src/writer/incremental_text_notes.rs
@@ -1,0 +1,534 @@
+//! Incremental editing of standard `/Text` annotations in existing PDFs.
+
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::{PdfDocument, PdfReader};
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+
+const NOTE_SIZE: f64 = 20.0;
+
+/// Stable indirect-object identity of a text note.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TextNoteId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl TextNoteId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// A standard PDF text-note annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextNote {
+    /// Stable indirect-object identity.
+    pub id: TextNoteId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Lower-left point of the annotation rectangle.
+    pub position: Point,
+    /// Note contents decoded as Unicode.
+    pub contents: String,
+}
+
+/// A requested change to the document's text notes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TextNoteMutation {
+    /// Add a 20×20 point note to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Lower-left point of the new note.
+        position: Point,
+        /// Non-empty note contents.
+        contents: String,
+    },
+    /// Move and edit an existing note while preserving its other keys.
+    Update {
+        /// Existing text-note identity.
+        id: TextNoteId,
+        /// New lower-left point. Existing width and height are preserved.
+        position: Point,
+        /// New non-empty contents.
+        contents: String,
+    },
+    /// Remove an existing note reference from its page.
+    Remove {
+        /// Existing text-note identity.
+        id: TextNoteId,
+    },
+}
+
+/// Result of one atomic incremental text-note update.
+#[derive(Debug, Clone)]
+pub struct TextNoteUpdate {
+    /// Complete PDF bytes. The original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Notes allocated by `Add`, in mutation order.
+    pub added_notes: Vec<TextNote>,
+}
+
+/// Reads and atomically edits standard text notes in an existing PDF.
+pub struct IncrementalTextNoteEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalTextNoteEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/Text` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF is malformed or encrypted, or when a text
+    /// annotation has no stable indirect identity or is shared by pages.
+    pub fn notes(&self) -> Result<Vec<TextNote>> {
+        let snapshot = Snapshot::parse(self.base_bytes)?;
+        let mut notes: Vec<_> = snapshot
+            .annotations
+            .iter()
+            .filter_map(|(id, annotation)| annotation.is_text.then(|| annotation.note(*id)))
+            .collect();
+        notes.sort_by_key(|note| {
+            (
+                note.page_index,
+                note.id.object_number,
+                note.id.generation_number,
+            )
+        });
+        Ok(notes)
+    }
+
+    /// Validate and apply a batch as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed or encrypted PDFs, invalid pages or note
+    /// identities, conflicting mutations, invalid contents or coordinates, and
+    /// exhausted indirect-object numbers.
+    pub fn apply(&self, mutations: &[TextNoteMutation]) -> Result<TextNoteUpdate> {
+        let mut snapshot = Snapshot::parse(self.base_bytes)?;
+        if mutations.is_empty() {
+            return Ok(TextNoteUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                added_notes: Vec::new(),
+            });
+        }
+        validate_batch(&snapshot, mutations)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut added_notes = Vec::new();
+        let mut changed_pages = HashSet::new();
+        let mut rewritten_annotations: HashMap<TextNoteId, PdfDictionary> = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                TextNoteMutation::Add {
+                    page_index,
+                    position,
+                    contents,
+                } => {
+                    let id_tuple = update.allocate_id()?;
+                    let id = TextNoteId::new(id_tuple.0, id_tuple.1);
+                    let dictionary = new_note_dictionary(*position, contents);
+                    update.replace(id_tuple, PdfObject::Dictionary(dictionary.clone()))?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id_tuple.0, id_tuple.1));
+                    changed_pages.insert(*page_index);
+                    added_notes.push(TextNote {
+                        id,
+                        page_index: *page_index,
+                        position: *position,
+                        contents: contents.clone(),
+                    });
+                }
+                TextNoteMutation::Update {
+                    id,
+                    position,
+                    contents,
+                } => {
+                    let annotation = target_text_note(&snapshot, *id)?;
+                    let mut dictionary = annotation.dictionary.clone();
+                    let width = annotation.rect[2] - annotation.rect[0];
+                    let height = annotation.rect[3] - annotation.rect[1];
+                    dictionary.insert("Rect".to_string(), rectangle(*position, width, height));
+                    dictionary.insert("Contents".to_string(), pdf_text(contents));
+                    rewritten_annotations.insert(*id, dictionary);
+                }
+                TextNoteMutation::Remove { id } => {
+                    let page_index = target_text_note(&snapshot, *id)?.page_index;
+                    let page = &mut snapshot.pages[page_index as usize];
+                    page.annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+
+        for (id, dictionary) in rewritten_annotations {
+            update.replace(id.tuple(), PdfObject::Dictionary(dictionary))?;
+        }
+        for page_index in changed_pages {
+            let page = &mut snapshot.pages[page_index as usize];
+            match page.container {
+                AnnotationContainer::Page => {
+                    page.dictionary.insert(
+                        "Annots".to_string(),
+                        PdfObject::Array(PdfArray(page.annotations.clone())),
+                    );
+                    update.replace(
+                        page.reference,
+                        PdfObject::Dictionary(page.dictionary.clone()),
+                    )?;
+                }
+                AnnotationContainer::Indirect(id) => {
+                    update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?;
+                }
+            }
+        }
+
+        Ok(TextNoteUpdate {
+            pdf_bytes: update.finish()?,
+            added_notes,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct PageState {
+    reference: (u32, u16),
+    dictionary: PdfDictionary,
+    bounds: [f64; 4],
+    container: AnnotationContainer,
+    annotations: Vec<PdfObject>,
+}
+
+#[derive(Clone, Copy)]
+enum AnnotationContainer {
+    Page,
+    Indirect((u32, u16)),
+}
+
+struct AnnotationState {
+    page_index: u32,
+    dictionary: PdfDictionary,
+    rect: [f64; 4],
+    contents: String,
+    is_text: bool,
+}
+
+impl AnnotationState {
+    fn note(&self, id: TextNoteId) -> TextNote {
+        TextNote {
+            id,
+            page_index: self.page_index,
+            position: Point::new(self.rect[0], self.rect[1]),
+            contents: self.contents.clone(),
+        }
+    }
+}
+
+struct Snapshot {
+    pages: Vec<PageState>,
+    annotations: HashMap<TextNoteId, AnnotationState>,
+}
+
+impl Snapshot {
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        let reader = PdfReader::new(Cursor::new(bytes))
+            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+        if reader.is_encrypted() {
+            return Err(PdfError::PermissionDenied(
+                "incremental text-note editing is not supported on encrypted PDFs".to_string(),
+            ));
+        }
+        let document = PdfDocument::new(reader);
+        let page_count = document
+            .page_count()
+            .map_err(|e| PdfError::InvalidStructure(format!("read page tree: {e}")))?;
+        let mut pages = Vec::with_capacity(page_count as usize);
+        let mut annotations = HashMap::new();
+        let mut indirect_annots_pages = HashMap::new();
+
+        for page_index in 0..page_count {
+            let page = document
+                .get_page(page_index)
+                .map_err(|e| PdfError::InvalidStructure(format!("read page {page_index}: {e}")))?;
+            let bounds = page.crop_box.unwrap_or(page.media_box);
+            let (container, values) = match page.dict.get("Annots") {
+                None => (AnnotationContainer::Page, Vec::new()),
+                Some(PdfObject::Array(array)) => (AnnotationContainer::Page, array.0.clone()),
+                Some(PdfObject::Reference(number, generation)) => {
+                    if let Some(first_page) =
+                        indirect_annots_pages.insert((*number, *generation), page_index)
+                    {
+                        return Err(PdfError::InvalidStructure(format!(
+                            "page /Annots array {number} {generation} is shared by multiple pages ({first_page} and {page_index})"
+                        )));
+                    }
+                    let object = document.get_object(*number, *generation).map_err(|e| {
+                        PdfError::InvalidStructure(format!("resolve page /Annots: {e}"))
+                    })?;
+                    let array = object.as_array().ok_or_else(|| {
+                        PdfError::InvalidStructure("indirect /Annots is not an array".to_string())
+                    })?;
+                    (
+                        AnnotationContainer::Indirect((*number, *generation)),
+                        array.0.clone(),
+                    )
+                }
+                Some(_) => {
+                    return Err(PdfError::InvalidStructure(
+                        "page /Annots must be an array or indirect array".to_string(),
+                    ))
+                }
+            };
+
+            for value in &values {
+                match value {
+                    PdfObject::Reference(number, generation) => {
+                        let object = document.get_object(*number, *generation).map_err(|e| {
+                            PdfError::InvalidStructure(format!(
+                                "resolve annotation {number} {generation}: {e}"
+                            ))
+                        })?;
+                        let dictionary = object.as_dict().cloned().ok_or_else(|| {
+                            PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is not a dictionary"
+                            ))
+                        })?;
+                        let is_text = subtype(&dictionary) == Some("Text");
+                        let rect = if is_text {
+                            parse_rectangle(&dictionary)?
+                        } else {
+                            [0.0; 4]
+                        };
+                        let contents = dictionary
+                            .get("Contents")
+                            .and_then(PdfObject::as_string)
+                            .map(PdfString::to_text)
+                            .unwrap_or_default();
+                        let id = TextNoteId::new(*number, *generation);
+                        if annotations
+                            .get(&id)
+                            .is_some_and(|existing: &AnnotationState| {
+                                existing.page_index != page_index
+                            })
+                        {
+                            return Err(PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is referenced from multiple pages"
+                            )));
+                        }
+                        annotations.insert(
+                            id,
+                            AnnotationState {
+                                page_index,
+                                dictionary,
+                                rect,
+                                contents,
+                                is_text,
+                            },
+                        );
+                    }
+                    PdfObject::Dictionary(dictionary) if subtype(dictionary) == Some("Text") => {
+                        return Err(PdfError::InvalidStructure(
+                            "inline /Text annotations have no stable object identity".to_string(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            pages.push(PageState {
+                reference: page.obj_ref,
+                dictionary: page.dict,
+                bounds,
+                container,
+                annotations: values,
+            });
+        }
+        Ok(Self { pages, annotations })
+    }
+}
+
+fn validate_batch(snapshot: &Snapshot, mutations: &[TextNoteMutation]) -> Result<()> {
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            TextNoteMutation::Add {
+                page_index,
+                position,
+                contents,
+            } => {
+                let page = snapshot.pages.get(*page_index as usize).ok_or_else(|| {
+                    PdfError::InvalidStructure(format!("page {page_index} does not exist"))
+                })?;
+                validate_contents(contents)?;
+                validate_position(*position, NOTE_SIZE, NOTE_SIZE, page.bounds)?;
+            }
+            TextNoteMutation::Update {
+                id,
+                position,
+                contents,
+            } => {
+                if !targeted.insert(*id) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "text note {} {} is targeted more than once",
+                        id.object_number, id.generation_number
+                    )));
+                }
+                let annotation = target_text_note(snapshot, *id)?;
+                validate_contents(contents)?;
+                validate_position(
+                    *position,
+                    annotation.rect[2] - annotation.rect[0],
+                    annotation.rect[3] - annotation.rect[1],
+                    snapshot.pages[annotation.page_index as usize].bounds,
+                )?;
+            }
+            TextNoteMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "text note {} {} is targeted more than once",
+                        id.object_number, id.generation_number
+                    )));
+                }
+                target_text_note(snapshot, *id)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn target_text_note(snapshot: &Snapshot, id: TextNoteId) -> Result<&AnnotationState> {
+    let annotation = snapshot.annotations.get(&id).ok_or_else(|| {
+        PdfError::InvalidStructure(format!(
+            "annotation {} {} does not exist",
+            id.object_number, id.generation_number
+        ))
+    })?;
+    if !annotation.is_text {
+        return Err(PdfError::InvalidStructure(format!(
+            "annotation {} {} is not a /Text annotation",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(annotation)
+}
+
+fn validate_contents(contents: &str) -> Result<()> {
+    if contents.trim().is_empty() {
+        return Err(PdfError::InvalidStructure(
+            "text-note contents must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_position(position: Point, width: f64, height: f64, bounds: [f64; 4]) -> Result<()> {
+    if !position.x.is_finite()
+        || !position.y.is_finite()
+        || !width.is_finite()
+        || !height.is_finite()
+        || width <= 0.0
+        || height <= 0.0
+    {
+        return Err(PdfError::InvalidStructure(
+            "text-note coordinates and dimensions must be finite and positive".to_string(),
+        ));
+    }
+    if position.x < bounds[0]
+        || position.y < bounds[1]
+        || position.x + width > bounds[2]
+        || position.y + height > bounds[3]
+    {
+        return Err(PdfError::InvalidStructure(
+            "text-note rectangle is outside the page bounds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn subtype(dictionary: &PdfDictionary) -> Option<&str> {
+    dictionary
+        .get("Subtype")
+        .and_then(PdfObject::as_name)
+        .map(|name| name.0.as_str())
+}
+
+fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
+    let array = dictionary
+        .get("Rect")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| PdfError::InvalidStructure("/Text annotation has no /Rect".to_string()))?;
+    if array.0.len() != 4 {
+        return Err(PdfError::InvalidStructure(
+            "/Text annotation /Rect must have four numbers".to_string(),
+        ));
+    }
+    let mut result = [0.0; 4];
+    for (index, value) in array.0.iter().enumerate() {
+        result[index] = match value {
+            PdfObject::Integer(number) => *number as f64,
+            PdfObject::Real(number) if number.is_finite() => *number,
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "/Text annotation /Rect contains a non-finite or non-numeric value".to_string(),
+                ))
+            }
+        };
+    }
+    Ok(result)
+}
+
+fn new_note_dictionary(position: Point, contents: &str) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Annot".to_string())),
+    );
+    dictionary.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("Text".to_string())),
+    );
+    dictionary.insert(
+        "Rect".to_string(),
+        rectangle(position, NOTE_SIZE, NOTE_SIZE),
+    );
+    dictionary.insert("Contents".to_string(), pdf_text(contents));
+    dictionary
+}
+
+fn rectangle(position: Point, width: f64, height: f64) -> PdfObject {
+    PdfObject::Array(PdfArray(vec![
+        PdfObject::Real(position.x),
+        PdfObject::Real(position.y),
+        PdfObject::Real(position.x + width),
+        PdfObject::Real(position.y + height),
+    ]))
+}
+
+fn pdf_text(contents: &str) -> PdfObject {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in contents.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    PdfObject::String(PdfString(bytes))
+}

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -1,0 +1,290 @@
+//! Shared primitives for appending one ISO 32000 incremental revision.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::PdfReader;
+use std::io::{Cursor, Read, Seek};
+
+pub(super) struct IncrementalUpdate<'a> {
+    base: &'a [u8],
+    previous_xref: u64,
+    root: (u32, u16),
+    original_size: u32,
+    next_id: u32,
+    first_id: Option<Vec<u8>>,
+    replacements: Vec<(u32, u16, PdfObject)>,
+}
+
+impl<'a> IncrementalUpdate<'a> {
+    pub(super) fn from_reader<R: Read + Seek>(
+        base: &'a [u8],
+        reader: &PdfReader<R>,
+    ) -> Result<Self> {
+        let trailer = reader.trailer();
+        let root = trailer
+            .root()
+            .map_err(|e| PdfError::InvalidStructure(format!("base /Root: {e}")))?;
+        let size = trailer
+            .size()
+            .map_err(|e| PdfError::InvalidStructure(format!("base /Size: {e}")))?;
+        let first_id = match trailer.id() {
+            Some(PdfObject::Array(array)) => array
+                .0
+                .first()
+                .and_then(PdfObject::as_string)
+                .map(|value| value.as_bytes().to_vec()),
+            _ => None,
+        };
+        Ok(Self {
+            base,
+            previous_xref: trailer.xref_offset,
+            root,
+            original_size: size,
+            next_id: size,
+            first_id,
+            replacements: Vec::new(),
+        })
+    }
+
+    pub(super) fn from_base(base: &'a [u8]) -> Result<Self> {
+        let reader = PdfReader::new(Cursor::new(base))
+            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+        if reader.is_encrypted() {
+            return Err(PdfError::PermissionDenied(
+                "incremental updates are not supported on encrypted PDFs".to_string(),
+            ));
+        }
+        Self::from_reader(base, &reader)
+    }
+
+    pub(super) fn allocate_id(&mut self) -> Result<(u32, u16)> {
+        let id = (self.next_id, 0);
+        self.next_id = self.next_id.checked_add(1).ok_or_else(|| {
+            PdfError::InvalidStructure("PDF object number space is exhausted".to_string())
+        })?;
+        Ok(id)
+    }
+
+    pub(super) fn replace(&mut self, id: (u32, u16), object: PdfObject) -> Result<()> {
+        if self
+            .replacements
+            .iter()
+            .any(|(number, generation, _)| (*number, *generation) == id)
+        {
+            return Err(PdfError::InvalidStructure(format!(
+                "object {} {} is rewritten more than once",
+                id.0, id.1
+            )));
+        }
+        self.replacements.push((id.0, id.1, object));
+        Ok(())
+    }
+
+    pub(super) fn finish(mut self) -> Result<Vec<u8>> {
+        self.replacements
+            .sort_by_key(|(number, generation, _)| (*number, *generation));
+        let mut out = Vec::with_capacity(self.base.len() + self.replacements.len() * 256 + 512);
+        out.extend_from_slice(self.base);
+        if !out.ends_with(b"\n") && !out.ends_with(b"\r") {
+            out.push(b'\n');
+        }
+
+        let mut changed = Vec::with_capacity(self.replacements.len());
+        for (number, generation, object) in &self.replacements {
+            let offset = out.len() as u64;
+            write_indirect_object(&mut out, *number, *generation, object)?;
+            changed.push((*number, *generation, offset));
+        }
+
+        let xref_position = out.len() as u64;
+        out.extend_from_slice(&partial_xref(&changed));
+        let size = self.next_id.max(self.original_size);
+        let id_pair = self.first_id.map(|first| {
+            let mut material = first.clone();
+            material.extend_from_slice(&out[self.base.len()..]);
+            material.extend_from_slice(&xref_position.to_le_bytes());
+            (first, md5::compute(material).0.to_vec())
+        });
+        write_trailer(
+            &mut out,
+            self.previous_xref,
+            self.root,
+            size,
+            xref_position,
+            id_pair,
+        );
+        Ok(out)
+    }
+}
+
+fn write_indirect_object(
+    out: &mut Vec<u8>,
+    number: u32,
+    generation: u16,
+    object: &PdfObject,
+) -> Result<()> {
+    out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+    write_object(out, object)?;
+    out.extend_from_slice(b"\nendobj\n");
+    Ok(())
+}
+
+pub(super) fn write_object(out: &mut Vec<u8>, object: &PdfObject) -> Result<()> {
+    match object {
+        PdfObject::Null => out.extend_from_slice(b"null"),
+        PdfObject::Boolean(value) => out.extend_from_slice(if *value { b"true" } else { b"false" }),
+        PdfObject::Integer(value) => out.extend_from_slice(value.to_string().as_bytes()),
+        PdfObject::Real(value) => out.extend_from_slice(format_real(*value).as_bytes()),
+        PdfObject::String(value) => write_string(out, value),
+        PdfObject::Name(value) => write_name(out, value),
+        PdfObject::Reference(number, generation) => {
+            out.extend_from_slice(format!("{number} {generation} R").as_bytes())
+        }
+        PdfObject::Array(array) => {
+            out.push(b'[');
+            for (index, value) in array.0.iter().enumerate() {
+                if index != 0 {
+                    out.push(b' ');
+                }
+                write_object(out, value)?;
+            }
+            out.push(b']');
+        }
+        PdfObject::Dictionary(dictionary) => write_dictionary(out, dictionary)?,
+        PdfObject::Stream(_) => {
+            return Err(PdfError::InvalidStructure(
+                "generic incremental object writer does not accept streams".to_string(),
+            ))
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn write_dictionary(out: &mut Vec<u8>, dictionary: &PdfDictionary) -> Result<()> {
+    out.extend_from_slice(b"<< ");
+    let mut keys: Vec<_> = dictionary.0.keys().collect();
+    keys.sort_by(|left, right| left.0.cmp(&right.0));
+    for key in keys {
+        write_name(out, key);
+        out.push(b' ');
+        write_object(out, &dictionary.0[key])?;
+        out.push(b' ');
+    }
+    out.extend_from_slice(b">>");
+    Ok(())
+}
+
+fn write_name(out: &mut Vec<u8>, name: &PdfName) {
+    out.push(b'/');
+    for byte in name.0.bytes() {
+        if byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'+' | b'-' | b'.' | b'_' | b'@' | b'$' | b':' | b';' | b'*' | b'?'
+            )
+        {
+            out.push(byte);
+        } else {
+            out.extend_from_slice(format!("#{byte:02X}").as_bytes());
+        }
+    }
+}
+
+fn write_string(out: &mut Vec<u8>, value: &PdfString) {
+    out.push(b'<');
+    for byte in value.as_bytes() {
+        out.extend_from_slice(format!("{byte:02X}").as_bytes());
+    }
+    out.push(b'>');
+}
+
+pub(super) fn format_real(value: f64) -> String {
+    if !value.is_finite() {
+        return "0".to_string();
+    }
+    let shortest = value.to_string();
+    let Some(exponent_index) = shortest.find(['e', 'E']) else {
+        return if shortest == "-0" {
+            "0".to_string()
+        } else {
+            shortest
+        };
+    };
+
+    let exponent: i32 = shortest[exponent_index + 1..]
+        .parse()
+        .expect("f64 formatting always emits a valid exponent");
+    let mantissa = &shortest[..exponent_index];
+    let negative = mantissa.starts_with('-');
+    let digits: String = mantissa
+        .trim_start_matches('-')
+        .chars()
+        .filter(|character| *character != '.')
+        .collect();
+    let decimal_position = mantissa
+        .trim_start_matches('-')
+        .find('.')
+        .map_or(digits.len() as i32, |position| position as i32)
+        + exponent;
+    let sign = if negative { "-" } else { "" };
+
+    if decimal_position <= 0 {
+        format!(
+            "{sign}0.{}{digits}",
+            "0".repeat((-decimal_position) as usize)
+        )
+    } else if decimal_position as usize >= digits.len() {
+        format!(
+            "{sign}{digits}{}",
+            "0".repeat(decimal_position as usize - digits.len())
+        )
+    } else {
+        let split = decimal_position as usize;
+        format!("{sign}{}.{}", &digits[..split], &digits[split..])
+    }
+}
+
+fn partial_xref(changed: &[(u32, u16, u64)]) -> Vec<u8> {
+    let mut out = b"xref\n".to_vec();
+    let mut index = 0;
+    while index < changed.len() {
+        let start = changed[index].0;
+        let mut end = index;
+        while end + 1 < changed.len() && changed[end + 1].0 == changed[end].0 + 1 {
+            end += 1;
+        }
+        out.extend_from_slice(format!("{start} {}\n", end - index + 1).as_bytes());
+        for (_, generation, offset) in &changed[index..=end] {
+            out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes());
+        }
+        index = end + 1;
+    }
+    out
+}
+
+fn write_trailer(
+    out: &mut Vec<u8>,
+    previous_xref: u64,
+    root: (u32, u16),
+    size: u32,
+    xref_position: u64,
+    id_pair: Option<(Vec<u8>, Vec<u8>)>,
+) {
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {size} /Root {} {} R /Prev {previous_xref} ",
+            root.0, root.1
+        )
+        .as_bytes(),
+    );
+    if let Some((first, second)) = id_pair {
+        let hex = |bytes: &[u8]| {
+            bytes
+                .iter()
+                .map(|byte| format!("{byte:02X}"))
+                .collect::<String>()
+        };
+        out.extend_from_slice(format!("/ID [<{}> <{}>] ", hex(&first), hex(&second)).as_bytes());
+    }
+    out.extend_from_slice(format!(">>\nstartxref\n{xref_position}\n%%EOF\n").as_bytes());
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -2,6 +2,8 @@
 
 mod content_stream_utils;
 mod incremental_form_fill;
+mod incremental_text_notes;
+mod incremental_update;
 mod object_streams;
 mod pdf_writer;
 mod signature;
@@ -12,6 +14,9 @@ pub(crate) use content_stream_utils::{
     apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
 };
 pub use incremental_form_fill::IncrementalFormFiller;
+pub use incremental_text_notes::{
+    IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,
+};
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};
 pub(crate) use signature::{Edition, PdfSignature};

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -198,6 +198,10 @@ impl<W: Write> PdfWriter<W> {
     }
 
     pub fn write_document(&mut self, document: &mut Document) -> Result<()> {
+        if let Some(struct_tree) = &document.struct_tree {
+            Self::validate_struct_tree(struct_tree, &document.pages)?;
+        }
+
         // Store used characters for font subsetting
         if !document.used_characters_by_font.is_empty() {
             self.document_used_chars_by_font = document.used_characters_by_font.clone();
@@ -1300,6 +1304,22 @@ impl<W: Write> PdfWriter<W> {
             element_ids.push(self.allocate_object_id());
         }
 
+        // Build the ParentTree ownership map. Each tagged page gets a
+        // /StructParents key and each MCID slot points at its owning
+        // structure element (ISO 32000-1 §14.7.4.4).
+        let mut page_owners: std::collections::BTreeMap<
+            usize,
+            std::collections::BTreeMap<u32, usize>,
+        > = std::collections::BTreeMap::new();
+        for (element_index, element) in struct_tree.iter().enumerate() {
+            for mcid_ref in &element.mcids {
+                page_owners
+                    .entry(mcid_ref.page_index)
+                    .or_default()
+                    .insert(mcid_ref.mcid, element_index);
+            }
+        }
+
         // Build parent map: element_index -> parent_id
         let mut parent_map: std::collections::HashMap<usize, ObjectId> =
             std::collections::HashMap::new();
@@ -1365,7 +1385,12 @@ impl<W: Write> PdfWriter<W> {
                 element_dict.set("Alt", Object::String(alt.clone()));
             }
             if let Some(ref actual_text) = element.attributes.actual_text {
-                element_dict.set("ActualText", Object::String(actual_text.clone()));
+                let mut encoded = Vec::with_capacity(2 + actual_text.len() * 2);
+                encoded.extend_from_slice(&[0xFE, 0xFF]);
+                for unit in actual_text.encode_utf16() {
+                    encoded.extend_from_slice(&unit.to_be_bytes());
+                }
+                element_dict.set("ActualText", Object::ByteString(encoded));
             }
             if let Some(ref title) = element.attributes.title {
                 element_dict.set("T", Object::String(title.clone()));
@@ -1394,7 +1419,7 @@ impl<W: Write> PdfWriter<W> {
             for mcid_ref in &element.mcids {
                 let mut mcr = Dictionary::new();
                 mcr.set("Type", Object::Name("MCR".to_string()));
-                mcr.set("Pg", Object::Integer(mcid_ref.page_index as i64));
+                mcr.set("Pg", Object::Reference(self.page_ids[mcid_ref.page_index]));
                 mcr.set("MCID", Object::Integer(mcid_ref.mcid as i64));
                 kids.push(Object::Dictionary(mcr));
             }
@@ -1409,6 +1434,29 @@ impl<W: Write> PdfWriter<W> {
         // Create StructTreeRoot dictionary
         let mut struct_tree_root = Dictionary::new();
         struct_tree_root.set("Type", Object::Name("StructTreeRoot".to_string()));
+
+        if !page_owners.is_empty() {
+            let parent_tree_id = self.allocate_object_id();
+            let mut nums = Vec::new();
+            for (struct_parent_key, (_page_index, owners)) in page_owners.iter().enumerate() {
+                let max_mcid = *owners.keys().next_back().expect("non-empty owner map");
+                let mut owner_array = vec![Object::Null; max_mcid as usize + 1];
+                for (&mcid, &element_index) in owners {
+                    owner_array[mcid as usize] = Object::Reference(element_ids[element_index]);
+                }
+                nums.push(Object::Integer(struct_parent_key as i64));
+                nums.push(Object::Array(owner_array));
+            }
+
+            let mut parent_tree = Dictionary::new();
+            parent_tree.set("Nums", Object::Array(nums));
+            self.write_object(parent_tree_id, Object::Dictionary(parent_tree))?;
+            struct_tree_root.set("ParentTree", Object::Reference(parent_tree_id));
+            struct_tree_root.set(
+                "ParentTreeNextKey",
+                Object::Integer(page_owners.len() as i64),
+            );
+        }
 
         // Add root element(s) as K entry
         if let Some(root_index) = struct_tree.root_index() {
@@ -1429,6 +1477,52 @@ impl<W: Write> PdfWriter<W> {
 
         self.write_object(struct_tree_root_id, Object::Dictionary(struct_tree_root))?;
         Ok(struct_tree_root_id)
+    }
+
+    fn validate_struct_tree(
+        struct_tree: &crate::structure::StructTree,
+        pages: &[crate::page::Page],
+    ) -> Result<()> {
+        let mut owners = std::collections::HashSet::new();
+        for element in struct_tree.iter() {
+            for mcid_ref in &element.mcids {
+                if mcid_ref.page_index >= pages.len() {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "structure element references page {} but document has {} pages",
+                        mcid_ref.page_index,
+                        pages.len()
+                    )));
+                }
+                if mcid_ref.mcid >= pages[mcid_ref.page_index].next_mcid() {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "structure element references MCID {} on page {}, but that page has only {} marked-content sequences",
+                        mcid_ref.mcid,
+                        mcid_ref.page_index,
+                        pages[mcid_ref.page_index].next_mcid()
+                    )));
+                }
+                if !owners.insert((mcid_ref.page_index, mcid_ref.mcid)) {
+                    return Err(PdfError::InvalidStructure(format!(
+                        "MCID {} on page {} is owned by more than one structure element",
+                        mcid_ref.mcid, mcid_ref.page_index
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn struct_parent_keys(
+        struct_tree: &crate::structure::StructTree,
+    ) -> std::collections::BTreeMap<usize, i64> {
+        struct_tree
+            .iter()
+            .flat_map(|element| element.mcids.iter().map(|mcid| mcid.page_index))
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .enumerate()
+            .map(|(key, page_index)| (page_index, key as i64))
+            .collect()
     }
 
     /// Reserve an `ObjectId` for every field owned by `document.form_manager`
@@ -2544,6 +2638,14 @@ impl<W: Write> PdfWriter<W> {
         // Store page IDs for form field references
         self.page_ids = page_ids.clone();
 
+        // Compute the page-index -> /StructParents mapping once. Rebuilding it
+        // while serializing every page makes large tagged documents quadratic.
+        let struct_parent_keys = document
+            .struct_tree
+            .as_ref()
+            .map(Self::struct_parent_keys)
+            .unwrap_or_default();
+
         // Write individual pages with font references
         for (i, page) in document.pages.iter().enumerate() {
             let page_id = page_ids[i];
@@ -2559,7 +2661,7 @@ impl<W: Write> PdfWriter<W> {
                 pages_id,
                 content_id,
                 page,
-                document,
+                struct_parent_keys.get(&i).copied(),
                 font_refs,
                 &preserved_font_map,
             )?;
@@ -2585,7 +2687,7 @@ impl<W: Write> PdfWriter<W> {
         parent_id: ObjectId,
         content_id: ObjectId,
         page: &crate::page::Page,
-        _document: &Document,
+        struct_parent_key: Option<i64>,
         font_refs: &HashMap<String, ObjectId>,
         preserved_font_map: &HashMap<String, String>,
     ) -> Result<()> {
@@ -2595,6 +2697,10 @@ impl<W: Write> PdfWriter<W> {
         page_dict.set("Type", Object::Name("Page".to_string()));
         page_dict.set("Parent", Object::Reference(parent_id));
         page_dict.set("Contents", Object::Reference(content_id));
+
+        if let Some(key) = struct_parent_key {
+            page_dict.set("StructParents", Object::Integer(key));
+        }
 
         // Get resources dictionary or create new one
         let mut resources = if let Some(Object::Dictionary(res)) = page_dict.get("Resources") {

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.md
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.md
@@ -1,0 +1,23 @@
+# Issue #498 diagnostic matrix
+
+Select and copy only the value in the right column of each row.
+
+| Visible value | Expected copied value | Mechanism |
+|---|---|---|
+| `VISUAL_A` | `INLINE_ASCII` | Marked-content `/ActualText` only |
+| `VISUAL_B` | `STRUCT_ASCII` | Structure-element `/ActualText` only |
+| `VISUAL_C` | `2⁴⁰ E = mc² Aⁿ⁺¹B` | Both locations, Unicode |
+
+Interpretation:
+
+- If A works but B does not, the engine only reads marked-content properties.
+- If B works but A does not, the engine only reads the structure tree.
+- If A and B work but C does not, Unicode or font-coverage handling is at fault.
+- If all three copy their visible `VISUAL_*` value, the engine ignores
+  `/ActualText` during selection/copy.
+
+Regenerate with:
+
+```sh
+cargo run -p oxidize-pdf --example generate_issue_498_diagnostic_fixture
+```

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf
@@ -1,0 +1,235 @@
+%PDF-1.7
+%‚„œ”
+2 0 obj
+<<
+/Count 1
+/Kids [4 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<<
+/Contents 5 0 R
+/MediaBox [0 0 595 842]
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/Courier <<
+/BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Bold <<
+/BaseFont /Courier-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-BoldOblique <<
+/BaseFont /Courier-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Oblique <<
+/BaseFont /Courier-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica <<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Bold <<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-BoldOblique <<
+/BaseFont /Helvetica-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Oblique <<
+/BaseFont /Helvetica-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Bold <<
+/BaseFont /Times-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-BoldItalic <<
+/BaseFont /Times-BoldItalic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Italic <<
+/BaseFont /Times-Italic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Roman <<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+/StructParents 0
+/Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Filter /FlateDecode
+/Length 289
+>>
+stream
+xúïë›jÉ@ÖÔ}äπL(‘q5⁄¸•I.Í⁄´@≥-±‚O…„wllcmJÒb8ª;ÀÏwˆxBQdÒ.€<KA”@<+xãà¢Xå`˝ƒQY≤»K	nÏs˚Ö<U2kÅÔ6|>O˜À˚%àW%§±qïñ`€Í÷Á ®n÷vi!‰©;
+£—XSÖT˛hΩB\ı=çT'’áﬁ⁄q_Ò~"ﬂçëÈÚÑ˘â«âª9∏_X·ˆ◊Ñk¶Ò{@‹÷ë◊i15ã«ƒˇ◊fP„î⁄õGmö”®n†π‡'eûΩÂ≈@”U≤n≤:Ø⁄ÊOÏZr:chTÙ<√sjΩÍ¡YMRìlylËkt7¢rÈ¨OìÕHsdk¯¸/Çh≥Ú
+endstream
+endobj
+7 0 obj
+<<
+/K [8 0 R 9 0 R 10 0 R]
+/P 6 0 R
+/S /Document
+/Type /StructElem
+>>
+endobj
+8 0 obj
+<<
+/K [<<
+/MCID 0
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+9 0 obj
+<<
+/ActualText <FEFF005300540052005500430054005F00410053004300490049>
+/K [<<
+/MCID 1
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+10 0 obj
+<<
+/ActualText <FEFF003220742070002000450020003D0020006D006300B200200041207F207A00B90042>
+/K [<<
+/MCID 2
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+11 0 obj
+<<
+/Nums [0 [8 0 R 9 0 R 10 0 R]]
+>>
+endobj
+6 0 obj
+<<
+/K 7 0 R
+/ParentTree 11 0 R
+/ParentTreeNextKey 1
+/Type /StructTreeRoot
+>>
+endobj
+12 0 obj
+<<
+/Length 2759
+/Subtype /XML
+/Type /Metadata
+>>
+stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="oxidize-pdf 1.4.0">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <dc:title>ActualText diagnostic matrix</dc:title>
+      <xmp:CreatorTool>oxidize_pdf</xmp:CreatorTool>
+      <xmp:CreateDate>2026-08-17T21:35:18.385494684+00:00</xmp:CreateDate>
+      <xmp:ModifyDate>2026-08-17T21:35:18.385544146+00:00</xmp:ModifyDate>
+      <pdf:Producer>oxidize_pdf v4.4.0 (MIT)</pdf:Producer>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+endstream
+endobj
+1 0 obj
+<<
+/MarkInfo <<
+/Marked true
+>>
+/Metadata 12 0 R
+/Pages 2 0 R
+/StructTreeRoot 6 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20260817213518+00'00)
+/Creator (oxidize_pdf)
+/ModDate (D:20260817213518+00'00)
+/Producer (oxidize_pdf v4.4.0 \(MIT\))
+/Title (ActualText diagnostic matrix)
+/oxidize-pdf-build (oxpdf-89f970d19ac6002c)
+/oxidize-pdf-edition (OpenSource)
+/oxidize-pdf-features (0200)
+>>
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000005310 00000 n 
+0000000015 00000 n 
+0000005427 00000 n 
+0000000072 00000 n 
+0000001431 00000 n 
+0000002376 00000 n 
+0000001792 00000 n 
+0000001877 00000 n 
+0000001974 00000 n 
+0000002138 00000 n 
+0000002323 00000 n 
+0000002468 00000 n 
+trailer
+<<
+/Info 3 0 R
+/Root 1 0 R
+/Size 13
+>>
+startxref
+5728
+%%EOF

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.md
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.md
@@ -1,0 +1,26 @@
+# Issue #498 ActualText interoperability fixture
+
+Regenerate the adjacent PDF from the workspace root:
+
+```sh
+cargo run -p oxidize-pdf --example generate_issue_498_interop_fixture
+```
+
+Open `issue_498_actual_text_interop.pdf`, select the visible formula, copy it,
+and paste into a plain-text editor. The expected text is:
+
+```text
+2⁴⁰ E = mc² Aⁿ⁺¹B
+```
+
+Record the application name, version, operating-system version, copied text,
+and result for both:
+
+- Apple Preview on macOS.
+- One independent graphical PDF engine.
+
+The automated regression test verifies the underlying `/ActualText`, MCID,
+`/StructParents`, `/ParentTree`, and page-reference relationships. This manual
+check verifies the viewer behavior that an internal parser cannot establish.
+Viewer support is not guaranteed: a viewer that ignores `/ActualText` during
+selection will copy the painted fallback glyphs despite a valid structure tree.

--- a/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf
+++ b/oxidize-pdf-core/tests/fixtures/issue_498_actual_text_interop.pdf
@@ -1,0 +1,207 @@
+%PDF-1.7
+%‚„œ”
+2 0 obj
+<<
+/Count 1
+/Kids [4 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<<
+/Contents 5 0 R
+/MediaBox [0 0 595 842]
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/Courier <<
+/BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Bold <<
+/BaseFont /Courier-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-BoldOblique <<
+/BaseFont /Courier-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Courier-Oblique <<
+/BaseFont /Courier-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica <<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Bold <<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-BoldOblique <<
+/BaseFont /Helvetica-BoldOblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Helvetica-Oblique <<
+/BaseFont /Helvetica-Oblique
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Bold <<
+/BaseFont /Times-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-BoldItalic <<
+/BaseFont /Times-BoldItalic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Italic <<
+/BaseFont /Times-Italic
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+/Times-Roman <<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+/StructParents 0
+/Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Filter /FlateDecode
+/Length 199
+>>
+stream
+xúççªÇ@E˚˝ä)5&2;ã<$·-®‹ àFÉƒçüÔ(R∞±ÿ‚ÊÓÏÃ…q˜∫á(r™lüÇì4√£Ót˚ *ã≤DTDËªD$éª[Âc{‹ûBLÈ∑ó|[r˛y¶8é!Õ3ëj·Ï⁄ÓŸó¶rAüÆÅ≥â‡”g}ZÇæäBîúQÅ˜•îú(ˇcsôƒçaÉ∂pklú2)Ÿ8I¢ÈLlt§C◊Ø§ï–SÜ0ù∞¢ ƒ¬´t¡
+endstream
+endobj
+7 0 obj
+<<
+/K [8 0 R]
+/P 6 0 R
+/S /Document
+/Type /StructElem
+>>
+endobj
+8 0 obj
+<<
+/ActualText <FEFF003220742070002000450020003D0020006D006300B200200041207F207A00B90042>
+/K [<<
+/MCID 0
+/Pg 4 0 R
+/Type /MCR
+>>]
+/P 7 0 R
+/S /Span
+/Type /StructElem
+>>
+endobj
+9 0 obj
+<<
+/Nums [0 [8 0 R]]
+>>
+endobj
+6 0 obj
+<<
+/K 7 0 R
+/ParentTree 9 0 R
+/ParentTreeNextKey 1
+/Type /StructTreeRoot
+>>
+endobj
+10 0 obj
+<<
+/Length 2779
+/Subtype /XML
+/Type /Metadata
+>>
+stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="oxidize-pdf 1.4.0">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <dc:title>ActualText cross-viewer interoperability fixture</dc:title>
+      <xmp:CreatorTool>oxidize_pdf</xmp:CreatorTool>
+      <xmp:CreateDate>2026-08-17T21:27:39.872374287+00:00</xmp:CreateDate>
+      <xmp:ModifyDate>2026-08-17T21:27:39.872412599+00:00</xmp:ModifyDate>
+      <pdf:Producer>oxidize_pdf v4.4.0 (MIT)</pdf:Producer>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+endstream
+endobj
+1 0 obj
+<<
+/MarkInfo <<
+/Marked true
+>>
+/Metadata 10 0 R
+/Pages 2 0 R
+/StructTreeRoot 6 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20260817212739+00'00)
+/Creator (oxidize_pdf)
+/ModDate (D:20260817212739+00'00)
+/Producer (oxidize_pdf v4.4.0 \(MIT\))
+/Title (ActualText cross-viewer interoperability fixture)
+/oxidize-pdf-build (oxpdf-89f970d19ac6002c)
+/oxidize-pdf-edition (OpenSource)
+/oxidize-pdf-features (0200)
+>>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000004950 00000 n 
+0000000015 00000 n 
+0000005067 00000 n 
+0000000072 00000 n 
+0000001431 00000 n 
+0000001997 00000 n 
+0000001702 00000 n 
+0000001774 00000 n 
+0000001958 00000 n 
+0000002088 00000 n 
+trailer
+<<
+/Info 3 0 R
+/Root 1 0 R
+/Size 11
+>>
+startxref
+5388
+%%EOF

--- a/oxidize-pdf-core/tests/issue_492_aes256_perms_interop_test.rs
+++ b/oxidize-pdf-core/tests/issue_492_aes256_perms_interop_test.rs
@@ -55,9 +55,8 @@ fn r5_uses_the_revision_neutral_perms_api() {
 }
 
 #[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
 fn qpdf_checks_and_linearizes_generated_aes256_r5_pdf() {
-    require_qpdf();
-
     let temp = tempfile::tempdir().expect("temporary directory");
     let input = temp.path().join("aes256.pdf");
     let linearized = temp.path().join("aes256-linearized.pdf");
@@ -112,14 +111,6 @@ fn qpdf_checks_and_linearizes_generated_aes256_r5_pdf() {
     assert_eq!(actual_permissions.bits(), expected_permissions.bits());
     assert!(actual_permissions.can_print());
     assert!(!actual_permissions.can_copy());
-}
-
-fn require_qpdf() {
-    let result = Command::new("qpdf")
-        .arg("--version")
-        .output()
-        .expect("qpdf is required for the AES-256 interoperability regression test");
-    assert!(result.status.success(), "{}", output(&result));
 }
 
 fn path(path: &std::path::Path) -> &str {

--- a/oxidize-pdf-core/tests/issue_492_aes256_perms_interop_test.rs
+++ b/oxidize-pdf-core/tests/issue_492_aes256_perms_interop_test.rs
@@ -1,0 +1,145 @@
+//! Regression tests for issue #492: AES-256 R5 output must include the
+//! encrypted `/Perms` entry required by strict PDF consumers such as qpdf.
+
+use oxidize_pdf::document::{DocumentEncryption, EncryptionStrength};
+use oxidize_pdf::encryption::{
+    EncryptionDictionary, EncryptionKey, Permissions, StandardSecurityHandler,
+};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+use std::io::Cursor;
+use std::process::Command;
+
+#[test]
+fn aes256_r5_dictionary_contains_binary_perms_entry() {
+    let encryption = DocumentEncryption::new(
+        "view",
+        "modify",
+        Permissions::new(),
+        EncryptionStrength::Aes256,
+    );
+
+    let dictionary = encryption
+        .create_encryption_dict(Some(b"issue-492-file-id"))
+        .expect("AES-256 dictionary should be created");
+
+    assert_eq!(dictionary.v, 5);
+    assert_eq!(dictionary.r, 5);
+    assert_eq!(dictionary.perms.as_deref().map(<[u8]>::len), Some(16));
+
+    let serialized = dictionary.to_dict();
+    assert!(matches!(
+        serialized.get("Perms"),
+        Some(oxidize_pdf::objects::Object::ByteString(bytes)) if bytes.len() == 16
+    ));
+}
+
+#[test]
+fn aes256_dictionary_rejects_a_perms_entry_with_the_wrong_size() {
+    let result = EncryptionDictionary::aes_256(vec![0; 48], vec![0; 48], Permissions::new(), None)
+        .with_perms(vec![0; 15]);
+
+    assert!(result.is_err(), "V=5 /Perms must be exactly 16 bytes");
+}
+
+#[test]
+fn r5_uses_the_revision_neutral_perms_api() {
+    let handler = StandardSecurityHandler::aes_256_r5();
+    let key = EncryptionKey::new(vec![0x42; 32]);
+
+    let perms = handler
+        .compute_perms_entry(Permissions::new(), &key, true)
+        .expect("R5 should support the shared permissions algorithm");
+
+    assert_eq!(perms.len(), 16, "encrypted /Perms length");
+}
+
+#[test]
+fn qpdf_checks_and_linearizes_generated_aes256_r5_pdf() {
+    require_qpdf();
+
+    let temp = tempfile::tempdir().expect("temporary directory");
+    let input = temp.path().join("aes256.pdf");
+    let linearized = temp.path().join("aes256-linearized.pdf");
+
+    let mut expected_permissions = Permissions::new();
+    expected_permissions.set_print(true).set_copy(false);
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.set_encryption(DocumentEncryption::new(
+        "view",
+        "modify",
+        expected_permissions,
+        EncryptionStrength::Aes256,
+    ));
+    document.save(&input).expect("write encrypted PDF");
+
+    assert_qpdf_success(&["--password=view", "--check", path(&input)]);
+    assert_qpdf_success(&[
+        "--password=modify",
+        "--linearize",
+        path(&input),
+        path(&linearized),
+    ]);
+    assert_qpdf_success(&["--password=view", "--check", path(&linearized)]);
+    assert_qpdf_success(&[
+        "--password=view",
+        "--check-linearization",
+        path(&linearized),
+    ]);
+
+    let permissions = qpdf(&["--password=view", "--show-encryption", path(&linearized)]);
+    assert!(permissions.status.success(), "{}", output(&permissions));
+    let stdout = String::from_utf8_lossy(&permissions.stdout);
+    assert!(
+        stdout.contains(&format!("P = {}", expected_permissions.bits() as i32)),
+        "permissions changed:\n{stdout}"
+    );
+
+    let bytes = std::fs::read(&linearized).expect("read qpdf output");
+    let mut reader = PdfReader::new(Cursor::new(bytes)).expect("parse qpdf output");
+    assert!(
+        reader
+            .unlock_with_password("view")
+            .expect("unlock qpdf output"),
+        "user password must unlock the qpdf output"
+    );
+    let actual_permissions = reader
+        .encryption_handler()
+        .expect("linearized PDF should remain encrypted")
+        .permissions();
+    assert_eq!(actual_permissions.bits(), expected_permissions.bits());
+    assert!(actual_permissions.can_print());
+    assert!(!actual_permissions.can_copy());
+}
+
+fn require_qpdf() {
+    let result = Command::new("qpdf")
+        .arg("--version")
+        .output()
+        .expect("qpdf is required for the AES-256 interoperability regression test");
+    assert!(result.status.success(), "{}", output(&result));
+}
+
+fn path(path: &std::path::Path) -> &str {
+    path.to_str().expect("temporary path should be UTF-8")
+}
+
+fn qpdf(args: &[&str]) -> std::process::Output {
+    Command::new("qpdf").args(args).output().expect("run qpdf")
+}
+
+fn assert_qpdf_success(args: &[&str]) {
+    let result = qpdf(args);
+    assert!(result.status.success(), "{}", output(&result));
+}
+
+fn output(result: &std::process::Output) -> String {
+    format!(
+        "qpdf failed with {}\nstdout:\n{}\nstderr:\n{}",
+        result.status,
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    )
+}

--- a/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
+++ b/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
@@ -1,0 +1,377 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{IncrementalTextNoteEditor, TextNoteId, TextNoteMutation};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn base_pdf() -> Vec<u8> {
+    build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R >>"),
+        (4, b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (old) /Name /Comment /CustomKey (preserve-me) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [50 50 80 70] /CustomLinkKey 99 >>"),
+        (6, b"[4 0 R 5 0 R]"),
+    ])
+}
+
+fn build_pdf(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    build_pdf_with_size(objects, None)
+}
+
+fn build_pdf_with_size(objects: &[(u32, &[u8])], trailer_size: Option<u32>) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n".to_vec();
+    let size = objects.iter().map(|(number, _)| *number).max().unwrap_or(0) + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (num, body) in objects {
+        offsets[*num as usize] = out.len();
+        out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    let trailer_size = trailer_size.unwrap_or(size);
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {trailer_size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n")
+            .as_bytes(),
+    );
+    out
+}
+
+fn assert_invalid_structure_contains(result: Result<impl Sized, PdfError>, expected: &str) {
+    match result {
+        Err(PdfError::InvalidStructure(message)) => assert!(
+            message.contains(expected),
+            "expected error containing {expected:?}, got {message:?}"
+        ),
+        Err(other) => panic!("expected InvalidStructure, got {other:?}"),
+        Ok(_) => panic!("expected InvalidStructure containing {expected:?}"),
+    }
+}
+
+#[test]
+fn lists_only_indirect_text_notes_with_stable_ids() {
+    let base = base_pdf();
+    let notes = IncrementalTextNoteEditor::new(&base).notes().unwrap();
+
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].id, TextNoteId::new(4, 0));
+    assert_eq!(notes[0].page_index, 0);
+    assert_eq!(notes[0].position, Point::new(10.0, 20.0));
+    assert_eq!(notes[0].contents, "old");
+}
+
+#[test]
+fn mixed_batch_is_one_atomic_incremental_revision() {
+    let base = base_pdf();
+    let editor = IncrementalTextNoteEditor::new(&base);
+    let update = editor
+        .apply(&[
+            TextNoteMutation::Update {
+                id: TextNoteId::new(4, 0),
+                position: Point::new(100.0, 110.0),
+                contents: "movida ✓".to_string(),
+            },
+            TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(200.0, 200.0),
+                contents: "nueva".to_string(),
+            },
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert_eq!(
+        update
+            .pdf_bytes
+            .windows(9)
+            .filter(|w| *w == b"startxref")
+            .count(),
+        2,
+        "base plus exactly one incremental revision"
+    );
+    assert_eq!(update.added_notes.len(), 1);
+    assert_eq!(update.added_notes[0].id, TextNoteId::new(7, 0));
+
+    let reopened = IncrementalTextNoteEditor::new(&update.pdf_bytes)
+        .notes()
+        .unwrap();
+    assert_eq!(reopened.len(), 2);
+    assert!(reopened.iter().any(|note| note.contents == "movida ✓"));
+    assert!(reopened.iter().any(|note| note.contents == "nueva"));
+
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let moved = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        moved
+            .get("CustomKey")
+            .and_then(PdfObject::as_string)
+            .unwrap()
+            .to_text(),
+        "preserve-me"
+    );
+    let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
+    assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+
+    Command::new("qpdf")
+        .arg("--version")
+        .output()
+        .expect("qpdf is required for issue #493 interoperability tests");
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.pdf");
+    std::fs::write(&path, &update.pdf_bytes).unwrap();
+    let output = Command::new("qpdf")
+        .arg("--check")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn remove_drops_only_the_target_reference() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Remove {
+            id: TextNoteId::new(4, 0),
+        }])
+        .unwrap();
+
+    assert!(IncrementalTextNoteEditor::new(&update.pdf_bytes)
+        .notes()
+        .unwrap()
+        .is_empty());
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    assert!(
+        reader.get_object(5, 0).is_ok(),
+        "unrelated annotation remains"
+    );
+    assert!(update.pdf_bytes.starts_with(&base));
+}
+
+#[test]
+fn invalid_mutation_rejects_the_whole_batch() {
+    let base = base_pdf();
+    let result = IncrementalTextNoteEditor::new(&base).apply(&[
+        TextNoteMutation::Update {
+            id: TextNoteId::new(4, 0),
+            position: Point::new(40.0, 40.0),
+            contents: "valid".to_string(),
+        },
+        TextNoteMutation::Add {
+            page_index: 99,
+            position: Point::new(10.0, 10.0),
+            contents: "invalid".to_string(),
+        },
+    ]);
+
+    assert_invalid_structure_contains(result, "page 99 does not exist");
+}
+
+#[test]
+fn empty_batch_is_a_true_noop() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base).apply(&[]).unwrap();
+    assert_eq!(update.pdf_bytes, base);
+    assert!(update.added_notes.is_empty());
+}
+
+#[test]
+fn rejects_invalid_values_duplicate_targets_and_non_text_ids() {
+    let base = base_pdf();
+    let editor = IncrementalTextNoteEditor::new(&base);
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(10.0, 10.0),
+            contents: "   ".to_string(),
+        }]),
+        "must not be empty",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(f64::NAN, 10.0),
+            contents: "note".to_string(),
+        }]),
+        "finite and positive",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[TextNoteMutation::Remove {
+            id: TextNoteId::new(5, 0),
+        }]),
+        "not a /Text annotation",
+    );
+    assert_invalid_structure_contains(
+        editor.apply(&[
+            TextNoteMutation::Remove {
+                id: TextNoteId::new(4, 0),
+            },
+            TextNoteMutation::Remove {
+                id: TextNoteId::new(4, 0),
+            },
+        ]),
+        "targeted more than once",
+    );
+}
+
+#[test]
+fn update_preserves_unknown_real_values_without_rounding() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (old) /Precise 0.123456789012345 >>"),
+    ]);
+
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Update {
+            id: TextNoteId::new(4, 0),
+            position: Point::new(40.0, 50.0),
+            contents: "new".to_string(),
+        }])
+        .unwrap();
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let annotation = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+
+    assert_eq!(
+        annotation.get("Precise"),
+        Some(&PdfObject::Real(0.123456789012345))
+    );
+}
+
+#[test]
+fn rejects_exhausted_indirect_object_number_space_without_panicking() {
+    let base = build_pdf_with_size(
+        &[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+            ),
+        ],
+        Some(u32::MAX),
+    );
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(10.0, 10.0),
+            contents: "note".to_string(),
+        }]),
+        "object number space is exhausted",
+    );
+}
+
+#[test]
+fn rejects_annotation_identity_referenced_from_multiple_pages() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [5 0 R] >>",
+        ),
+        (
+            4,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [5 0 R] >>",
+        ),
+        (
+            5,
+            b"<< /Type /Annot /Subtype /Text /Rect [10 20 30 40] /Contents (shared) >>",
+        ),
+    ]);
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).notes(),
+        "referenced from multiple pages",
+    );
+}
+
+#[test]
+fn rejects_annots_array_shared_by_multiple_pages() {
+    let base = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (
+            4,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (5, b"[]"),
+    ]);
+
+    assert_invalid_structure_contains(
+        IncrementalTextNoteEditor::new(&base).notes(),
+        "/Annots array 5 0 is shared by multiple pages",
+    );
+}
+
+#[test]
+fn add_supports_inline_and_missing_annots_arrays() {
+    for page_body in [
+        &b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [] >>"[..],
+        &b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>"[..],
+    ] {
+        let base = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (3, page_body),
+        ]);
+        let update = IncrementalTextNoteEditor::new(&base)
+            .apply(&[TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(25.0, 25.0),
+                contents: "added".to_string(),
+            }])
+            .unwrap();
+        let notes = IncrementalTextNoteEditor::new(&update.pdf_bytes)
+            .notes()
+            .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].contents, "added");
+    }
+}
+
+#[test]
+fn rejects_encrypted_pdfs_inline_text_notes_and_out_of_bounds_rectangles() {
+    let mut encrypted = Document::new();
+    encrypted.add_page(Page::a4());
+    encrypted.encrypt_with_passwords("user", "owner");
+    let encrypted_bytes = encrypted.to_bytes().unwrap();
+    assert!(IncrementalTextNoteEditor::new(&encrypted_bytes)
+        .notes()
+        .is_err());
+    assert!(IncrementalTextNoteEditor::new(&encrypted_bytes)
+        .apply(&[])
+        .is_err());
+
+    let inline = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Type /Annot /Subtype /Text /Rect [10 10 30 30] /Contents (inline) >>] >>"),
+    ]);
+    assert!(IncrementalTextNoteEditor::new(&inline).notes().is_err());
+
+    let base = base_pdf();
+    assert!(IncrementalTextNoteEditor::new(&base)
+        .apply(&[TextNoteMutation::Add {
+            page_index: 0,
+            position: Point::new(290.0, 290.0),
+            contents: "outside".to_string(),
+        }])
+        .is_err());
+}

--- a/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
+++ b/oxidize-pdf-core/tests/issue_493_incremental_text_notes_test.rs
@@ -117,11 +117,26 @@ fn mixed_batch_is_one_atomic_incremental_revision() {
     );
     let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
     assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
 
-    Command::new("qpdf")
-        .arg("--version")
-        .output()
-        .expect("qpdf is required for issue #493 interoperability tests");
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_incremental_text_note_revision() {
+    let base = base_pdf();
+    let update = IncrementalTextNoteEditor::new(&base)
+        .apply(&[
+            TextNoteMutation::Update {
+                id: TextNoteId::new(4, 0),
+                position: Point::new(100.0, 110.0),
+                contents: "movida ✓".to_string(),
+            },
+            TextNoteMutation::Add {
+                page_index: 0,
+                position: Point::new(200.0, 200.0),
+                contents: "nueva".to_string(),
+            },
+        ])
+        .unwrap();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("notes.pdf");
     std::fs::write(&path, &update.pdf_bytes).unwrap();

--- a/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
+++ b/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
@@ -1,0 +1,75 @@
+//! Regression tests for issue #495: independently positioned grid cells must
+//! not be fused when a new text object jumps backward on the same baseline.
+
+use oxidize_pdf::parser::{ParseOptions, PdfReader};
+use oxidize_pdf::text::TextExtractor;
+
+fn build_pdf(content: &str) -> Vec<u8> {
+    let content_len = content.len();
+    let objects = [
+        "<< /Type /Catalog /Pages 3 0 R >>",
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 595 842] \
+         /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ];
+
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = [0usize; 6];
+    for (index, body) in objects.iter().enumerate() {
+        let object_number = index + 1;
+        offsets[object_number] = pdf.len();
+        pdf.extend_from_slice(format!("{object_number} 0 obj\n{body}\nendobj\n").as_bytes());
+    }
+    offsets[5] = pdf.len();
+    pdf.extend_from_slice(
+        format!("5 0 obj\n<< /Length {content_len} >>\nstream\n{content}\nendstream\nendobj\n")
+            .as_bytes(),
+    );
+
+    let xref = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    pdf
+}
+
+fn extract_flat(content: &str) -> String {
+    let document = PdfReader::new_with_options(
+        std::io::Cursor::new(build_pdf(content)),
+        ParseOptions::lenient(),
+    )
+    .expect("PDF should parse")
+    .into_document();
+    TextExtractor::new()
+        .extract_from_page(&document, 0)
+        .expect("text should extract")
+        .text
+}
+
+#[test]
+fn separate_tj_objects_do_not_fuse_backward_positioned_grid_cells() {
+    let content = concat!(
+        "BT\n/F1 9 Tf\n1 0 0 1 32.1 653.33 Tm\n( ABCDE1234F) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 653.33 Tm\n(PAN:) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 28.73 635.66 Tm\n( U12345DL2019PTC123456) Tj\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 635.66 Tm\n(CIN:) Tj\nET"
+    );
+
+    let text = extract_flat(content);
+    assert_eq!(text, " ABCDE1234F\nPAN:\n U12345DL2019PTC123456\nCIN:");
+}
+
+#[test]
+fn separate_tj_array_objects_use_the_same_grid_boundary() {
+    let content = concat!(
+        "BT\n/F1 9 Tf\n1 0 0 1 32.1 653.33 Tm\n[( ABCDE1234F)] TJ\nET\n",
+        "BT\n/F1 9 Tf\n1 0 0 1 11.32 653.33 Tm\n[(PAN:)] TJ\nET"
+    );
+
+    assert_eq!(extract_flat(content), " ABCDE1234F\nPAN:");
+}

--- a/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
+++ b/oxidize-pdf-core/tests/issue_495_flat_grid_order_test.rs
@@ -61,7 +61,7 @@ fn separate_tj_objects_do_not_fuse_backward_positioned_grid_cells() {
     );
 
     let text = extract_flat(content);
-    assert_eq!(text, " ABCDE1234F\nPAN:\n U12345DL2019PTC123456\nCIN:");
+    assert_eq!(text, " ABCDE1234F PAN:\n U12345DL2019PTC123456\nCIN:");
 }
 
 #[test]
@@ -71,5 +71,20 @@ fn separate_tj_array_objects_use_the_same_grid_boundary() {
         "BT\n/F1 9 Tf\n1 0 0 1 11.32 653.33 Tm\n[(PAN:)] TJ\nET"
     );
 
-    assert_eq!(extract_flat(content), " ABCDE1234F\nPAN:");
+    assert_eq!(extract_flat(content), " ABCDE1234F PAN:");
+}
+
+#[test]
+fn separate_text_objects_do_not_turn_same_line_repositioning_into_a_wrap() {
+    let content = concat!(
+        "BT\n/F1 10 Tf\n1 0 0 1 200 500 Tm\n(right) Tj\nET\n",
+        "BT\n/F1 10 Tf\n1 0 0 1 140 500 Tm\n(left) Tj\nET"
+    );
+
+    let text = extract_flat(content);
+    assert_eq!(text, "right left");
+    assert!(
+        !text.contains('\n'),
+        "same-line reposition wrapped: {text:?}"
+    );
 }

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -83,9 +83,9 @@ const GLYPHS: &[(i32, u32)] = &[
     (256, 0x0035), // P
 ];
 
-fn content_stream() -> Vec<u8> {
+fn content_stream(glyphs: &[(i32, u32)]) -> Vec<u8> {
     let mut content = String::new();
-    for (x, cid) in GLYPHS {
+    for (x, cid) in glyphs {
         content.push_str(&format!(
             "BT\n/F1 20 Tf\n1 0 0 -1 0 0 Tm\n{x} -966 Td <{cid:04X}> Tj\nET\n"
         ));
@@ -94,7 +94,11 @@ fn content_stream() -> Vec<u8> {
 }
 
 fn build_pdf(w_clause: &str) -> Vec<u8> {
-    let content = content_stream();
+    build_pdf_with(w_clause, TOUNICODE, GLYPHS)
+}
+
+fn build_pdf_with(w_clause: &str, to_unicode: &[u8], glyphs: &[(i32, u32)]) -> Vec<u8> {
+    let content = content_stream(glyphs);
     let objects: Vec<Vec<u8>> = vec![
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
@@ -105,7 +109,7 @@ fn build_pdf(w_clause: &str) -> Vec<u8> {
         b"<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
           /Encoding /Identity-H /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
             .to_vec(),
-        stream_obj("", TOUNICODE),
+        stream_obj("", to_unicode),
         format!(
             "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
              /CIDToGIDMap /Identity \
@@ -132,6 +136,30 @@ fn extract(w_clause: &str) -> String {
 }
 
 #[test]
+fn flat_path_uses_the_mapped_type0_space_cid_width_for_narrow_word_gaps() {
+    let to_unicode = b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+3 beginbfchar <0001> <0041> <0002> <0020> <0003> <0042> endbfchar\n\
+endcmap";
+    let pdf = build_pdf_with(
+        "/W [1 [500 400 500]] /DW 1000",
+        to_unicode,
+        &[(0, 1), (15, 3)],
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(
+        text, "A B",
+        "the 5pt gap clears half the real 8pt space advance but not the legacy 6pt threshold"
+    );
+}
+
+#[test]
 fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
     let text = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     assert!(
@@ -146,7 +174,7 @@ fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
 }
 
 #[test]
-fn genuine_word_space_is_still_produced_regardless_of_w() {
+fn real_widths_fix_the_wide_cid_without_claiming_the_narrow_space_case() {
     // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
     // or not it clears the space threshold is a separate, pre-existing
     // calibration question (also applies to simple fonts) that this fix does
@@ -155,26 +183,22 @@ fn genuine_word_space_is_still_produced_regardless_of_w() {
     // fix itself.
     let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     let without_w = extract("");
-    // Both variants must agree on this boundary: /W only changes advance
-    // widths, not whether a *given* gap crosses the threshold once the
-    // widths feeding that gap are correct on both sides of it.
     assert_eq!(
-        with_w.contains("PAN No") || with_w.contains("PANNo"),
-        without_w.contains("PAN No") || without_w.contains("PANNo"),
-        "with_w={with_w:?} without_w={without_w:?}"
+        with_w, "PANNo:BLUPM6342P",
+        "real CID widths must remove the wide-M space; the unmapped narrow word gap is #500"
+    );
+    assert_eq!(
+        without_w, "PANNo:BLUPM6342P",
+        "the normative missing /DW default is 1000, not the old 0.5em heuristic"
     );
 }
 
 #[test]
-fn no_w_or_dw_falls_back_to_the_pre_fix_heuristic() {
-    // Without any /W/DW info at all, behavior must be unchanged from before
-    // this fix (the decoded-text-length heuristic) -- this is a real
-    // fallback path (fonts with a missing/malformed /W), not just a defensive
-    // branch, so it must keep working.
-    let text = extract("");
-    assert!(
-        !text.is_empty(),
-        "extraction must still succeed with no CID width info at all"
+fn missing_dw_uses_the_normative_1000_unit_default() {
+    assert_eq!(
+        extract(""),
+        extract("/DW 1000"),
+        "omitted /DW must behave exactly like the ISO-defined 1000-unit default"
     );
 }
 
@@ -185,10 +209,7 @@ fn dw_only_no_w_array_is_honored() {
     // not introduce a spurious space, unlike the flat 0.5em (=1000 units at
     // this scale) pre-fix fallback would for some of these narrower glyphs.
     let text = extract("/DW 600");
-    assert!(
-        !text.is_empty(),
-        "extraction must succeed with /DW present and no /W array"
-    );
+    assert_eq!(text, "PAN No:BLUPM6342P");
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -174,18 +174,12 @@ fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
 }
 
 #[test]
-fn real_widths_fix_the_wide_cid_without_claiming_the_narrow_space_case() {
-    // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
-    // or not it clears the space threshold is a separate, pre-existing
-    // calibration question (also applies to simple fonts) that this fix does
-    // not change -- this test only pins today's behavior so a future
-    // regression there is caught, without conflating it with the CID-width
-    // fix itself.
+fn real_widths_fix_the_wide_cid_and_expose_the_narrow_word_gap() {
     let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
     let without_w = extract("");
     assert_eq!(
-        with_w, "PANNo:BLUPM6342P",
-        "real CID widths must remove the wide-M space; the unmapped narrow word gap is #500"
+        with_w, "PAN No:BLUPM6342P",
+        "real CID widths must remove the wide-M space while #500's font-derived fallback preserves the narrow word gap"
     );
     assert_eq!(
         without_w, "PANNo:BLUPM6342P",

--- a/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
+++ b/oxidize-pdf-core/tests/issue_496_cid_width_lookup_test.rs
@@ -1,0 +1,226 @@
+//! Issue #496 — composite (Type0/CID) font text extraction never consults the
+//! CIDFont's `/W`/`/DW` glyph widths (ISO 32000-1 §9.7.4.3): every glyph is
+//! assumed to advance by a flat `0.5 * font_size`, regardless of its real
+//! width. When a real glyph's width diverges enough from that flat estimate
+//! relative to its neighbors, the extractor's pen-tracking drifts out of sync
+//! with where the next glyph is actually drawn, crossing the space-insertion
+//! threshold and corrupting the extracted text with a spurious space in the
+//! middle of a single token.
+//!
+//! Reproduction: a synthetic `CIDFontType2`/`Identity-H` font with a real-shape
+//! `/W` array (mixing both width forms per spec: `c [w1 w2 ...]` and `cFirst
+//! cLast w`), drawing "PANNo:BLUPM6342P"-style content one glyph per `Tj` via
+//! absolute `Td` positioning — the same encoding style KeyView/most PDF
+//! generators emit for embedded subset fonts. No embedded glyph outlines are
+//! needed since text extraction never renders glyphs.
+//!
+//! With `/W` correctly consulted, the wide glyph 'M' (873/1000 em, the widest
+//! in the table) advances the pen by its real width and the next glyph lands
+//! within the space threshold, so no spurious space appears. Without it (the
+//! pre-fix flat 0.5em assumption), 'M' is treated as an average-width glyph,
+//! the pen falls short of the next glyph's real position, and a spurious
+//! space is inserted.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// ToUnicode CMap covering exactly the glyphs used below, copied verbatim
+/// (mixed `beginbfchar`/`beginbfrange`) from a real subset font's CMap, i.e.
+/// non-contiguous and non-identity CID->Unicode, as any real subset font has.
+const TOUNICODE: &[u8] = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n\
+/CMapName /Adobe-Identity-UCS def\n\
+/CMapType 2 def\n\
+1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+6 beginbfchar\n\
+<000B> <0026>\n<002E> <0049>\n<0035> <0050>\n<0046> <0061>\n<004E> <0069>\n<0463> <2019>\n\
+endbfchar\n\
+10 beginbfrange\n\
+<0011> <0019> <002C>\n<001B> <001C> <0036>\n<001E> <001F> <0039>\n\
+<0026> <0029> <0041>\n<002B> <002C> <0046>\n<0030> <0033> <004B>\n\
+<0037> <003A> <0052>\n<0048> <004C> <0063>\n<0050> <0055> <006B>\n\
+<0057> <005B> <0072>\nendbfrange\n\
+endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+/// `/W` array copied verbatim from the real font, mixing both width forms:
+/// `21 30 562.01172` (uniform range) and e.g. `38 [652... 873...]` (explicit
+/// consecutive list). CID 50 ('M' via the CMap above) is 873.04688 -- the
+/// widest entry in the whole table.
+const W_ARRAY: &str = "0 [443.35938] 11 [622.07031] 17 [196.77734 276.36719 263.67188 412.59766] \
+21 30 562.01172 31 [242.1875] \
+38 [652.34375 623.04688 650.87891 656.25 0 552.73438 681.15234 0 271.97266 0 627.44141 \
+538.57422 873.04688 713.37891 0 630.85938 0 616.21094 593.75 596.67969 648.4375] \
+70 [543.94531 0 523.4375 563.96484 530.27344 347.65625 561.52344 0 243.16406 0 506.83594 \
+243.16406 876.95313 552.24609 570.3125 561.52344 0 338.86719 516.11328 327.14844 551.26953 484.375] \
+1123 [200.19531]";
+
+/// One glyph per `Tj`, absolute `Td` x-coordinates and raw CIDs copied
+/// verbatim from a real document: "PAN No:BLUPM6342P" at font size 20 (the
+/// `N`/`o` boundary carries the only genuine word-space in this string; every
+/// other gap is a same-word inter-glyph gap that must never become a space).
+const GLYPHS: &[(i32, u32)] = &[
+    (72, 0x0035),  // P
+    (84, 0x0026),  // A
+    (97, 0x0033),  // N
+    (116, 0x0033), // N
+    (130, 0x0054), // o
+    (141, 0x001F), // :
+    (146, 0x0027), // B
+    (158, 0x0031), // L
+    (169, 0x003A), // U
+    (182, 0x0035), // P
+    (194, 0x0032), // M -- widest glyph, CID 50, /W = 873.04688
+    (211, 0x001B), // 6
+    (222, 0x0018), // 3
+    (234, 0x0019), // 4
+    (245, 0x0017), // 2
+    (256, 0x0035), // P
+];
+
+fn content_stream() -> Vec<u8> {
+    let mut content = String::new();
+    for (x, cid) in GLYPHS {
+        content.push_str(&format!(
+            "BT\n/F1 20 Tf\n1 0 0 -1 0 0 Tm\n{x} -966 Td <{cid:04X}> Tj\nET\n"
+        ));
+    }
+    content.into_bytes()
+}
+
+fn build_pdf(w_clause: &str) -> Vec<u8> {
+    let content = content_stream();
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", &content),
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
+          /Encoding /Identity-H /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
+            .to_vec(),
+        stream_obj("", TOUNICODE),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
+             /CIDToGIDMap /Identity \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             {w_clause} /FontDescriptor 8 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Synthetic /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+fn extract(w_clause: &str) -> String {
+    let doc = PdfReader::new(Cursor::new(build_pdf(w_clause)))
+        .expect("PDF should parse")
+        .into_document();
+    let mut ex = TextExtractor::new();
+    ex.extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text
+}
+
+#[test]
+fn wide_cid_glyph_does_not_get_a_spurious_space_when_w_is_present() {
+    let text = extract(&format!("/W [{W_ARRAY}] /DW 0"));
+    assert!(
+        text.contains("BLUPM6342P"),
+        "the CID-indexed /W width for the wide glyph 'M' must be used so the \
+         pen stays in sync with the next glyph, got: {text:?}"
+    );
+    assert!(
+        !text.contains("BLUPM 6342P"),
+        "no spurious space should appear mid-token once /W is consulted: {text:?}"
+    );
+}
+
+#[test]
+fn genuine_word_space_is_still_produced_regardless_of_w() {
+    // The "PAN"/"No" boundary is a real (if narrow) positional gap; whether
+    // or not it clears the space threshold is a separate, pre-existing
+    // calibration question (also applies to simple fonts) that this fix does
+    // not change -- this test only pins today's behavior so a future
+    // regression there is caught, without conflating it with the CID-width
+    // fix itself.
+    let with_w = extract(&format!("/W [{W_ARRAY}] /DW 0"));
+    let without_w = extract("");
+    // Both variants must agree on this boundary: /W only changes advance
+    // widths, not whether a *given* gap crosses the threshold once the
+    // widths feeding that gap are correct on both sides of it.
+    assert_eq!(
+        with_w.contains("PAN No") || with_w.contains("PANNo"),
+        without_w.contains("PAN No") || without_w.contains("PANNo"),
+        "with_w={with_w:?} without_w={without_w:?}"
+    );
+}
+
+#[test]
+fn no_w_or_dw_falls_back_to_the_pre_fix_heuristic() {
+    // Without any /W/DW info at all, behavior must be unchanged from before
+    // this fix (the decoded-text-length heuristic) -- this is a real
+    // fallback path (fonts with a missing/malformed /W), not just a defensive
+    // branch, so it must keep working.
+    let text = extract("");
+    assert!(
+        !text.is_empty(),
+        "extraction must still succeed with no CID width info at all"
+    );
+}
+
+#[test]
+fn dw_only_no_w_array_is_honored() {
+    // A `/DW` with no `/W` at all: every CID uses the default width. Using a
+    // /DW close to the real average glyph width in this table (~600) must
+    // not introduce a spurious space, unlike the flat 0.5em (=1000 units at
+    // this scale) pre-fix fallback would for some of these narrower glyphs.
+    let text = extract("/DW 600");
+    assert!(
+        !text.is_empty(),
+        "extraction must succeed with /DW present and no /W array"
+    );
+}
+
+#[test]
+fn oversized_w_range_does_not_hang_or_allocate_unboundedly() {
+    // `cFirst cLast w` with `cLast` far beyond any real CID (Identity-H/-V
+    // CIDs are a u16, max 0xFFFF) must not materialize a multi-billion-entry
+    // HashMap or loop for an unreasonable amount of time -- a malformed or
+    // adversarial `/W` array must degrade gracefully, not hang or OOM.
+    let text = extract("/W [0 4294967295 500]");
+    assert!(
+        !text.is_empty(),
+        "extraction must complete (not hang/OOM) with an oversized /W range"
+    );
+}
+
+#[test]
+fn preserve_layout_path_also_benefits_from_cid_widths() {
+    // `preserve_layout` builds its fragments from the same
+    // `calculate_text_width_from_codes` call, so the fix applies there too.
+    let doc = PdfReader::new(Cursor::new(build_pdf(&format!("/W [{W_ARRAY}] /DW 0"))))
+        .expect("PDF should parse")
+        .into_document();
+    let mut ex = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    });
+    let text = ex
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert!(
+        text.contains("BLUPM6342P"),
+        "preserve_layout must also avoid the spurious mid-token space: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_498_tagged_actual_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_498_tagged_actual_text_test.rs
@@ -1,0 +1,336 @@
+//! Regression tests for issue #498: tagged `/ActualText` must be connected
+//! to the page and structure tree, not emitted as an orphan MCID.
+
+use std::io::Cursor;
+
+use oxidize_pdf::{
+    parser::{objects::PdfObject, PdfReader},
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::Font,
+    Document, Page, PdfError,
+};
+
+fn object_ref(object: &PdfObject) -> (u32, u16) {
+    match object {
+        PdfObject::Reference(id, generation) => (*id, *generation),
+        other => panic!("expected indirect reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn actual_text_mcid_is_connected_through_the_parent_tree() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content_with_actual_text("Span", "2⁴⁰")
+        .expect("begin ActualText span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("240")
+        .expect("write visual fallback");
+    page.end_marked_content().expect("end ActualText span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span).with_actual_text("2⁴⁰");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let pdf = document.to_bytes().expect("serialize tagged PDF");
+
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse generated PDF");
+    let catalog = reader.catalog().expect("catalog").clone();
+
+    let pages_ref = object_ref(catalog.get("Pages").expect("catalog /Pages"));
+    let pages = reader
+        .get_object(pages_ref.0, pages_ref.1)
+        .expect("pages object");
+    let page_ref = match pages {
+        PdfObject::Dictionary(dict) => match dict.get("Kids").expect("pages /Kids") {
+            PdfObject::Array(kids) => object_ref(&kids.0[0]),
+            other => panic!("expected /Kids array, got {other:?}"),
+        },
+        other => panic!("expected pages dictionary, got {other:?}"),
+    };
+    let page_object = reader
+        .get_object(page_ref.0, page_ref.1)
+        .expect("page object");
+    let struct_parents = match page_object {
+        PdfObject::Dictionary(dict) => match dict.get("StructParents") {
+            Some(PdfObject::Integer(key)) => *key,
+            other => panic!("expected page /StructParents integer, got {other:?}"),
+        },
+        other => panic!("expected page dictionary, got {other:?}"),
+    };
+
+    let tree_ref = object_ref(
+        catalog
+            .get("StructTreeRoot")
+            .expect("catalog /StructTreeRoot"),
+    );
+    let tree_object = reader
+        .get_object(tree_ref.0, tree_ref.1)
+        .expect("structure tree root");
+    let parent_tree_ref = match tree_object {
+        PdfObject::Dictionary(dict) => {
+            object_ref(dict.get("ParentTree").expect("StructTreeRoot /ParentTree"))
+        }
+        other => panic!("expected structure tree root dictionary, got {other:?}"),
+    };
+    let parent_tree = reader
+        .get_object(parent_tree_ref.0, parent_tree_ref.1)
+        .expect("parent tree");
+    let owner_ref = match parent_tree {
+        PdfObject::Dictionary(dict) => match dict.get("Nums").expect("ParentTree /Nums") {
+            PdfObject::Array(nums) => {
+                assert_eq!(nums.0[0], PdfObject::Integer(struct_parents));
+                match &nums.0[1] {
+                    PdfObject::Array(owners) => object_ref(&owners.0[mcid as usize]),
+                    other => panic!("expected parent array, got {other:?}"),
+                }
+            }
+            other => panic!("expected /Nums array, got {other:?}"),
+        },
+        other => panic!("expected parent tree dictionary, got {other:?}"),
+    };
+
+    let owner = reader
+        .get_object(owner_ref.0, owner_ref.1)
+        .expect("owning structure element");
+    match owner {
+        PdfObject::Dictionary(dict) => match dict.get("K").expect("StructElem /K") {
+            PdfObject::Array(kids) => match &kids.0[0] {
+                PdfObject::Dictionary(mcr) => {
+                    assert_eq!(object_ref(mcr.get("Pg").expect("MCR /Pg")), page_ref);
+                    assert_eq!(mcr.get("MCID"), Some(&PdfObject::Integer(mcid as i64)));
+                }
+                other => panic!("expected MCR dictionary, got {other:?}"),
+            },
+            other => panic!("expected StructElem /K array, got {other:?}"),
+        },
+        other => panic!("expected StructElem dictionary, got {other:?}"),
+    }
+
+    let owner = reader
+        .get_object(owner_ref.0, owner_ref.1)
+        .expect("owning structure element");
+    match owner {
+        PdfObject::Dictionary(dict) => match dict.get("ActualText") {
+            Some(PdfObject::String(value)) => {
+                let mut expected = vec![0xFE, 0xFF];
+                for unit in "2⁴⁰".encode_utf16() {
+                    expected.extend_from_slice(&unit.to_be_bytes());
+                }
+                assert_eq!(value.as_bytes(), expected.as_slice());
+            }
+            other => panic!("expected UTF-16BE StructElem /ActualText, got {other:?}"),
+        },
+        other => panic!("expected StructElem dictionary, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_an_mcid_owned_by_multiple_structure_elements() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.end_marked_content().expect("end span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    for _ in 0..2 {
+        let mut span = StructureElement::new(StandardStructureType::Span);
+        span.add_mcid(0, mcid);
+        tree.add_child(root, span).expect("attach span");
+    }
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("duplicate MCID ownership must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(message.contains("owned by more than one"), "{message}");
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_a_structure_reference_to_an_unknown_mcid() {
+    let page = Page::a4();
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span);
+    span.add_mcid(0, 0);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("unknown MCID must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(
+                message.contains("only 0 marked-content sequences"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_a_structure_reference_to_an_unknown_page() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.end_marked_content().expect("end span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span);
+    span.add_mcid(1, mcid);
+    tree.add_child(root, span).expect("attach span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let error = document
+        .to_bytes()
+        .expect_err("unknown page reference must be rejected");
+    match error {
+        PdfError::InvalidStructure(message) => {
+            assert!(
+                message.contains("references page 1 but document has 1 pages"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidStructure, got {other:?}"),
+    }
+}
+
+#[test]
+fn parent_tree_maps_multiple_pages_and_preserves_mcid_holes() {
+    let mut first_page = Page::a4();
+    let unused_mcid = first_page
+        .begin_marked_content("Artifact")
+        .expect("begin unowned marked content");
+    first_page
+        .end_marked_content()
+        .expect("end unowned marked content");
+    let first_owned_mcid = first_page
+        .begin_marked_content_with_actual_text("Span", "first")
+        .expect("begin first owned span");
+    first_page
+        .end_marked_content()
+        .expect("end first owned span");
+    assert_eq!(unused_mcid, 0);
+    assert_eq!(first_owned_mcid, 1);
+
+    let untagged_page = Page::a4();
+
+    let mut last_page = Page::a4();
+    let last_mcid = last_page
+        .begin_marked_content_with_actual_text("Span", "last")
+        .expect("begin last span");
+    last_page.end_marked_content().expect("end last span");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut first_span = StructureElement::new(StandardStructureType::Span);
+    first_span.add_mcid(0, first_owned_mcid);
+    tree.add_child(root, first_span).expect("attach first span");
+    let mut last_span = StructureElement::new(StandardStructureType::Span);
+    last_span.add_mcid(2, last_mcid);
+    tree.add_child(root, last_span).expect("attach last span");
+
+    let mut document = Document::new();
+    document.add_page(first_page);
+    document.add_page(untagged_page);
+    document.add_page(last_page);
+    document.set_struct_tree(tree);
+    let pdf = document.to_bytes().expect("serialize multipage tagged PDF");
+
+    let mut reader = PdfReader::new(Cursor::new(pdf)).expect("parse generated PDF");
+    let catalog = reader.catalog().expect("catalog").clone();
+    let pages_ref = object_ref(catalog.get("Pages").expect("catalog /Pages"));
+    let page_refs = match reader
+        .get_object(pages_ref.0, pages_ref.1)
+        .expect("pages object")
+    {
+        PdfObject::Dictionary(dict) => match dict.get("Kids").expect("pages /Kids") {
+            PdfObject::Array(kids) => kids.0.iter().map(object_ref).collect::<Vec<_>>(),
+            other => panic!("expected /Kids array, got {other:?}"),
+        },
+        other => panic!("expected pages dictionary, got {other:?}"),
+    };
+
+    let mut keys = Vec::new();
+    for (index, page_ref) in page_refs.iter().enumerate() {
+        match reader
+            .get_object(page_ref.0, page_ref.1)
+            .expect("page object")
+        {
+            PdfObject::Dictionary(dict) => match (index, dict.get("StructParents")) {
+                (0 | 2, Some(PdfObject::Integer(key))) => keys.push(*key),
+                (1, None) => {}
+                (_, other) => panic!("unexpected /StructParents on page {index}: {other:?}"),
+            },
+            other => panic!("expected page dictionary, got {other:?}"),
+        }
+    }
+    assert_eq!(keys, vec![0, 1]);
+
+    let tree_ref = object_ref(
+        catalog
+            .get("StructTreeRoot")
+            .expect("catalog /StructTreeRoot"),
+    );
+    let parent_tree_ref = match reader
+        .get_object(tree_ref.0, tree_ref.1)
+        .expect("structure tree root")
+    {
+        PdfObject::Dictionary(dict) => {
+            assert_eq!(dict.get("ParentTreeNextKey"), Some(&PdfObject::Integer(2)));
+            object_ref(dict.get("ParentTree").expect("StructTreeRoot /ParentTree"))
+        }
+        other => panic!("expected structure tree root dictionary, got {other:?}"),
+    };
+    let nums = match reader
+        .get_object(parent_tree_ref.0, parent_tree_ref.1)
+        .expect("parent tree")
+    {
+        PdfObject::Dictionary(dict) => match dict.get("Nums").expect("ParentTree /Nums") {
+            PdfObject::Array(nums) => nums.0.clone(),
+            other => panic!("expected /Nums array, got {other:?}"),
+        },
+        other => panic!("expected parent tree dictionary, got {other:?}"),
+    };
+    assert_eq!(nums.len(), 4);
+    assert_eq!(nums[0], PdfObject::Integer(0));
+    match &nums[1] {
+        PdfObject::Array(owners) => {
+            assert_eq!(owners.0.len(), 2);
+            assert_eq!(owners.0[0], PdfObject::Null);
+            assert!(matches!(owners.0[1], PdfObject::Reference(_, _)));
+        }
+        other => panic!("expected first owner array, got {other:?}"),
+    }
+    assert_eq!(nums[2], PdfObject::Integer(1));
+    match &nums[3] {
+        PdfObject::Array(owners) => {
+            assert_eq!(owners.0.len(), 1);
+            assert!(matches!(owners.0[0], PdfObject::Reference(_, _)));
+        }
+        other => panic!("expected second owner array, got {other:?}"),
+    }
+}

--- a/oxidize-pdf-core/tests/issue_500_type0_implicit_space_test.rs
+++ b/oxidize-pdf-core/tests/issue_500_type0_implicit_space_test.rs
@@ -1,0 +1,161 @@
+//! Regression coverage for issue #500: Type0 fonts without a discoverable
+//! U+0020 mapping still need a conservative, font-derived word-gap signal.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::TextExtractor;
+use proptest::prelude::*;
+use std::io::Cursor;
+
+#[derive(Clone, Copy)]
+enum Encoding<'a> {
+    IdentityH,
+    CMap(&'a [u8]),
+}
+
+fn content_stream(glyphs: &[(f64, u16)]) -> Vec<u8> {
+    glyphs
+        .iter()
+        .map(|(x, code)| format!("BT\n/F1 20 Tf\n1 0 0 1 {x} 700 Tm\n<{code:04X}> Tj\nET\n"))
+        .collect::<String>()
+        .into_bytes()
+}
+
+fn extract(
+    to_unicode: &[u8],
+    encoding: Encoding<'_>,
+    widths: &str,
+    glyphs: &[(f64, u16)],
+) -> String {
+    let content = content_stream(glyphs);
+    let encoding_entry = match encoding {
+        Encoding::IdentityH => "/Identity-H",
+        Encoding::CMap(_) => "9 0 R",
+    };
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", &content),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /Synthetic \
+             /Encoding {encoding_entry} /DescendantFonts [7 0 R] /ToUnicode 6 0 R >>"
+        )
+        .into_bytes(),
+        stream_obj("", to_unicode),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Synthetic \
+             /CIDToGIDMap /Identity \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /W [{widths}] /DW 1000 /FontDescriptor 8 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Synthetic /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    if let Encoding::CMap(cmap) = encoding {
+        objects.push(stream_obj("", cmap));
+    }
+
+    let document = PdfReader::new(Cursor::new(assemble_pdf(&objects)))
+        .expect("PDF should parse")
+        .into_document();
+    TextExtractor::new()
+        .extract_from_page(&document, 0)
+        .expect("text should extract")
+        .text
+}
+
+const IDENTITY_TOUNICODE: &[u8] = b"begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+5 beginbfchar <0001> <0041> <0002> <002F> <0003> <0042> <0004> <002E> <0005> <0043> endbfchar\n\
+endcmap";
+
+#[test]
+fn identity_h_uses_declared_narrow_width_as_an_implicit_space_lower_bound() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500] 9 [200]",
+        &[(0.0, 1), (14.0, 3)],
+    );
+    assert_eq!(text, "A B");
+}
+
+#[test]
+fn tight_urls_and_identifiers_are_not_split() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500 500 500] 9 [200]",
+        &[(0.0, 1), (10.0, 2), (20.0, 3), (30.0, 4), (40.0, 5)],
+    );
+    assert_eq!(text, "A/B.C");
+}
+
+#[test]
+fn backward_overlay_does_not_gain_a_space() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500] 9 [200]",
+        &[(20.0, 1), (10.0, 3)],
+    );
+    assert_eq!(text, "AB");
+}
+
+#[test]
+fn malformed_tiny_width_is_bounded_by_the_geometric_floor() {
+    let text = extract(
+        IDENTITY_TOUNICODE,
+        Encoding::IdentityH,
+        "1 [500 500 500] 9 [1]",
+        &[(0.0, 1), (11.5, 3)],
+    );
+    assert_eq!(text, "AB");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn sub_floor_positioning_residue_never_splits_an_identifier(
+        narrow_width in 1u16..=600,
+        residue in 0.0f64..1.99,
+    ) {
+        let widths = format!("1 [500 500 500] 9 [{narrow_width}]");
+        let text = extract(
+            IDENTITY_TOUNICODE,
+            Encoding::IdentityH,
+            &widths,
+            &[(0.0, 1), (10.0 + residue, 3)],
+        );
+        prop_assert_eq!(text, "AB");
+    }
+}
+
+#[test]
+fn non_identity_cmap_uses_cid_widths_without_guessing_a_space_cid() {
+    let encoding = b"begincmap\n\
+/CMapType 1 def\n/WMode 0 def\n\
+1 begincodespacerange <0100> <01FF> endcodespacerange\n\
+2 begincidchar <0101> 38 <0102> 39 endcidchar\n\
+endcmap";
+    let to_unicode = b"begincmap\n\
+1 begincodespacerange <0100> <01FF> endcodespacerange\n\
+2 beginbfchar <0101> <0041> <0102> <0042> endbfchar\n\
+endcmap";
+    let text = extract(
+        to_unicode,
+        Encoding::CMap(encoding),
+        "11 [200] 38 [500 500]",
+        &[(0.0, 0x0101), (14.0, 0x0102)],
+    );
+    assert_eq!(text, "A B");
+}


### PR DESCRIPTION
## Release highlights

- Add typed incremental editing for standard text-note annotations (#493).
- Fix AES-256 R5 `/Perms` interoperability (#492).
- Improve flat extraction for label/value grids and ambiguous same-baseline repositioning (#495).
- Use real Type0/CID `/W` and `/DW` widths for pen tracking (#496).
- Preserve tagged `ActualText` through MCID/structure-tree extraction (#498).
- Preserve narrow implicit Type0 word gaps without splitting identifiers or overlays (#500).

## Versioning

This is a minor release because #493 adds new backward-compatible public API.

## Validation

- `cargo test --workspace` (including T0-T6 and differential Poppler/veraPDF corpus gates)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/verify-examples.sh --run` (5/5 documents, 1,611 chunks)
- `cargo package -p oxidize-pdf --allow-dirty --locked --no-verify` (4.9 MiB compressed)

Issue #495 remains open for the reporter to confirm the original real-world fixture; its covered fix is included in this release.