### PR TITLE
fix(extraction): honor structure-element ActualText

### DIFF
--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -259,6 +259,11 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(self.reader.borrow().version().to_string())
     }
 
+    /// Return an owned catalog for crate-internal document-level consumers.
+    pub(crate) fn catalog_dictionary(&self) -> ParseResult<PdfDictionary> {
+        self.reader.borrow_mut().catalog().cloned()
+    }
+
     /// Get the parse options
     pub fn options(&self) -> ParseOptions {
         self.reader.borrow().options().clone()

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -300,6 +300,47 @@ struct PendingActualText {
     populated: bool,
 }
 
+#[derive(Default)]
+struct StructureActualText {
+    owners: Vec<crate::parser::objects::PdfObject>,
+    cache: HashMap<u32, Option<String>>,
+}
+
+impl StructureActualText {
+    fn get<R: Read + Seek>(
+        &mut self,
+        mcid: u32,
+        document: &PdfDocument<R>,
+        max_bytes: Option<usize>,
+    ) -> Result<Option<String>, ()> {
+        if let Some(cached) = self.cache.get(&mcid) {
+            return Ok(cached.clone());
+        }
+        let Some(owner) = self.owners.get(mcid as usize) else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        let Ok(owner) = document.resolve(owner) else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        let Some(crate::parser::objects::PdfObject::String(value)) =
+            owner.as_dict().and_then(|dict| dict.get("ActualText"))
+        else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        if max_bytes
+            .is_some_and(|limit| value.as_bytes().len() > limit.saturating_mul(4).saturating_add(2))
+        {
+            return Err(());
+        }
+        let decoded = decode_pdf_string(value.as_bytes());
+        self.cache.insert(mcid, Some(decoded.clone()));
+        Ok(Some(decoded))
+    }
+}
+
 /// Text extraction state
 struct TextState {
     /// Current text matrix
@@ -1010,6 +1051,9 @@ impl TextExtractor {
     ) -> ParseResult<ExtractedText> {
         // Get the page
         let page = document.get_page(page_index)?;
+        // Tagged-PDF metadata is advisory: malformed mappings fall back to
+        // visual text instead of failing otherwise valid page extraction.
+        let mut structure_actual_text = resolve_structure_actual_text(&page.dict, document);
 
         // Extract font resources first
         {
@@ -1091,6 +1135,7 @@ impl TextExtractor {
                 operations,
                 document,
                 page_resources.as_ref(),
+                &mut structure_actual_text,
                 run,
                 page_index,
                 0,
@@ -1245,6 +1290,7 @@ impl TextExtractor {
         operations: Vec<ContentOperation>,
         document: &PdfDocument<R>,
         resources: Option<&crate::parser::objects::PdfDictionary>,
+        structure_actual_text: &mut StructureActualText,
         run: OpRunState,
         page_index: u32,
         depth: u8,
@@ -1409,7 +1455,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1439,7 +1489,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1459,7 +1512,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -1589,7 +1646,11 @@ impl TextExtractor {
                                         let outcome = append_bounded(
                                             &mut extracted_text,
                                             separator,
-                                            &decoded,
+                                            if state.pending_actualtext.is_some() {
+                                                ""
+                                            } else {
+                                                &decoded
+                                            },
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
                                             self.options.merge_hyphenated,
@@ -1615,7 +1676,9 @@ impl TextExtractor {
                                         )
                                     };
 
-                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    if self.options.preserve_layout
+                                        || self.options.reorder_columns
+                                        || state.pending_actualtext.is_some()
                                     {
                                         emit_text_fragment(
                                             &mut fragments,
@@ -1636,7 +1699,11 @@ impl TextExtractor {
                                                 &mut line_groups,
                                                 &mut cur_group,
                                                 extracted_text.len(),
-                                                decoded.len(),
+                                                if state.pending_actualtext.is_some() {
+                                                    0
+                                                } else {
+                                                    decoded.len()
+                                                },
                                                 sep,
                                                 x,
                                                 y,
@@ -1786,7 +1853,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1812,7 +1883,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1831,7 +1905,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -1882,7 +1960,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1908,7 +1990,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1927,7 +2012,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -2034,7 +2123,24 @@ impl TextExtractor {
 
                 ContentOperation::BeginMarkedContentWithProps(tag, props) => {
                     let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
-                    let (mcid, actual_text) = resolve_props(&props, page_properties);
+                    let (mcid, inline_actual_text) = resolve_props(&props, page_properties);
+                    let actual_text = if inline_actual_text.is_some() {
+                        inline_actual_text
+                    } else if let Some(id) = mcid {
+                        match structure_actual_text.get(
+                            id,
+                            document,
+                            self.options.max_extracted_bytes,
+                        ) {
+                            Ok(value) => value,
+                            Err(()) => {
+                                truncated = true;
+                                break;
+                            }
+                        }
+                    } else {
+                        None
+                    };
 
                     // If this scope declares ActualText, open a pending run that will be
                     // flushed on the matching EMC. Suppresses per-Tj emission inside the
@@ -2077,9 +2183,7 @@ impl TextExtractor {
                         // If we just closed the scope that opened the pending run, flush it.
                         if pending.stack_depth + 1 == popped_depth {
                             let run = state.pending_actualtext.take().unwrap();
-                            if run.populated
-                                && (self.options.preserve_layout || self.options.reorder_columns)
-                            {
+                            if run.populated {
                                 // The ActualText owner has just been popped, so
                                 // retain its structural identity explicitly
                                 // instead of accidentally inheriting the parent.
@@ -2099,11 +2203,10 @@ impl TextExtractor {
                                     // If it would overshoot, drop the fragment and
                                     // stop — a huge override must not escape the
                                     // cap while reporting `truncated = false`.
-                                    // Always `None` separator, never `\n` —
-                                    // hyphen-wrap fusion (issue #486) does not
-                                    // apply here. This site is also only reached
-                                    // under `preserve_layout`/`reorder_columns`
-                                    // (see the gate above), not the flat path.
+                                    // The flat path already emitted only the
+                                    // geometrical separator while this scope was
+                                    // pending, so the replacement itself needs no
+                                    // additional separator here.
                                     if !append_bounded(
                                         &mut extracted_text,
                                         None,
@@ -2116,21 +2219,29 @@ impl TextExtractor {
                                     {
                                         break;
                                     }
-                                    fragments.push(TextFragment {
-                                        text: run.text,
-                                        x: run.first_x,
-                                        y: run.first_y,
-                                        width: run.width,
-                                        height: run.font_size,
-                                        font_size: run.font_size,
-                                        font_name: run.font_name,
-                                        is_bold: run.is_bold,
-                                        is_italic: run.is_italic,
-                                        color: run.color,
-                                        space_decisions: Vec::new(),
-                                        mcid,
-                                        struct_tag,
-                                    });
+                                    if self.reading_order {
+                                        if let Some(group) = cur_group.as_mut() {
+                                            group.end = extracted_text.len();
+                                        }
+                                    }
+                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    {
+                                        fragments.push(TextFragment {
+                                            text: run.text,
+                                            x: run.first_x,
+                                            y: run.first_y,
+                                            width: run.width,
+                                            height: run.font_size,
+                                            font_size: run.font_size,
+                                            font_name: run.font_name,
+                                            is_bold: run.is_bold,
+                                            is_italic: run.is_italic,
+                                            color: run.color,
+                                            space_decisions: Vec::new(),
+                                            mcid,
+                                            struct_tag,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -2146,9 +2257,11 @@ impl TextExtractor {
                     // is never extracted.
                     const MAX_XOBJECT_DEPTH: u8 = 12;
                     if depth < MAX_XOBJECT_DEPTH {
-                        if let Some((xobj_ops, xobj_res, matrix)) =
+                        if let Some((xobj_ops, xobj_res, matrix, xobj_dict)) =
                             self.load_form_xobject(resources, &name, document)
                         {
+                            let mut form_structure_actual_text =
+                                resolve_structure_actual_text(&xobj_dict, document);
                             // `Do` paints inside an IMPLICIT q/Q (§8.10.1),
                             // so the whole graphics state — text state included
                             // (issue #452) — comes back afterwards. Same
@@ -2205,6 +2318,7 @@ impl TextExtractor {
                                 xobj_ops,
                                 document,
                                 xobj_res.as_ref(),
+                                &mut form_structure_actual_text,
                                 sub,
                                 page_index,
                                 depth + 1,
@@ -2257,6 +2371,7 @@ impl TextExtractor {
         Vec<ContentOperation>,
         Option<crate::parser::objects::PdfDictionary>,
         Option<[f64; 6]>,
+        crate::parser::objects::PdfDictionary,
     )> {
         use crate::parser::objects::PdfObject;
         let res = resources?;
@@ -2307,7 +2422,7 @@ impl TextExtractor {
                     None
                 }
             });
-        Some((ops, xobj_res, matrix))
+        Some((ops, xobj_res, matrix, stream.dict.clone()))
     }
 
     /// Fuse a hyphen-ended fragment with its line-wrap continuation while
@@ -3520,6 +3635,110 @@ fn multiply_matrix(a: &[f64; 6], b: &[f64; 6]) -> [f64; 6] {
 /// typographic punctuation WinAnsi puts in `0x80..=0x9F`.
 fn decode_pdf_string(bytes: &[u8]) -> String {
     crate::parser::objects::decode_text_string(bytes)
+}
+
+/// Build the page-local MCID -> structure-element `/ActualText` map.
+///
+/// The parent tree is a PDF number tree, so it may store `/Nums` directly or
+/// split them across indirect `/Kids`. Every failure is deliberately reduced
+/// to an empty/partial map: structure metadata must not make text extraction
+/// fail. Depth, visited-reference, and node-count limits keep malformed trees
+/// from causing cycles or unbounded traversal.
+fn resolve_structure_actual_text<R: Read + Seek>(
+    container: &crate::parser::objects::PdfDictionary,
+    document: &PdfDocument<R>,
+) -> StructureActualText {
+    use crate::parser::objects::PdfObject;
+
+    const MAX_NUMBER_TREE_DEPTH: usize = 32;
+    const MAX_NUMBER_TREE_NODES: usize = 4096;
+
+    fn number_tree_value<R: Read + Seek>(
+        object: &PdfObject,
+        key: i64,
+        document: &PdfDocument<R>,
+        depth: usize,
+        visited: &mut std::collections::HashSet<(u32, u16)>,
+        nodes: &mut usize,
+    ) -> Option<PdfObject> {
+        if depth > MAX_NUMBER_TREE_DEPTH || *nodes >= MAX_NUMBER_TREE_NODES {
+            return None;
+        }
+        *nodes += 1;
+
+        let resolved = match object {
+            PdfObject::Reference(id, generation) => {
+                if !visited.insert((*id, *generation)) {
+                    return None;
+                }
+                document.get_object(*id, *generation).ok()?
+            }
+            other => other.clone(),
+        };
+        let dict = resolved.as_dict()?;
+
+        if let Some(PdfObject::Array(nums)) = dict.get("Nums") {
+            for pair in nums.0.chunks_exact(2) {
+                if pair[0] == PdfObject::Integer(key) {
+                    return Some(pair[1].clone());
+                }
+            }
+        }
+
+        let PdfObject::Array(kids) = dict.get("Kids")? else {
+            return None;
+        };
+        for kid in &kids.0 {
+            if let Some(value) = number_tree_value(kid, key, document, depth + 1, visited, nodes) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    let Some(PdfObject::Integer(struct_parent_key)) = container.get("StructParents") else {
+        return StructureActualText::default();
+    };
+    if *struct_parent_key < 0 {
+        return StructureActualText::default();
+    }
+
+    let Ok(catalog) = document.catalog_dictionary() else {
+        return StructureActualText::default();
+    };
+    let Some(struct_root_object) = catalog.get("StructTreeRoot") else {
+        return StructureActualText::default();
+    };
+    let Ok(struct_root_object) = document.resolve(struct_root_object) else {
+        return StructureActualText::default();
+    };
+    let Some(struct_root) = struct_root_object.as_dict() else {
+        return StructureActualText::default();
+    };
+    let Some(parent_tree) = struct_root.get("ParentTree") else {
+        return StructureActualText::default();
+    };
+
+    let Some(owner_array_object) = number_tree_value(
+        parent_tree,
+        *struct_parent_key,
+        document,
+        0,
+        &mut std::collections::HashSet::new(),
+        &mut 0,
+    ) else {
+        return StructureActualText::default();
+    };
+    let Ok(owner_array_object) = document.resolve(&owner_array_object) else {
+        return StructureActualText::default();
+    };
+    let PdfObject::Array(owners) = owner_array_object else {
+        return StructureActualText::default();
+    };
+    StructureActualText {
+        owners: owners.0,
+        cache: HashMap::new(),
+    }
 }
 
 /// Resolve a `MarkedContentProps` to `(mcid, actual_text)`.

--- a/oxidize-pdf-core/tests/issue_506_struct_actual_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_506_struct_actual_text_test.rs
@@ -1,0 +1,348 @@
+//! Regression tests for issue #506: text extraction must honor `/ActualText`
+//! on the structure element that owns a marked-content MCID.
+
+use std::io::Cursor;
+
+use oxidize_pdf::{
+    parser::{PdfDocument, PdfReader},
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::{ExtractionOptions, Font, TextExtractor},
+    Document, Page,
+};
+
+fn extract(mut document: Document, options: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let bytes = document.to_bytes().expect("serialize tagged PDF");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse tagged PDF");
+    let parsed = PdfDocument::new(reader);
+    TextExtractor::with_options(options)
+        .extract_from_page(&parsed, 0)
+        .expect("extract tagged page")
+}
+
+fn raw_tagged_pdf(parent_tree: &str, extra_objects: &[String], mcid: u32) -> Vec<u8> {
+    let content =
+        format!("BT /F1 12 Tf 1 0 0 1 72 720 Tm /Span << /MCID {mcid} >> BDC (VISUAL) Tj EMC ET");
+    let mut objects = vec![
+        "<< /Type /Catalog /Pages 3 0 R /StructTreeRoot 6 0 R >>".to_string(),
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] /StructParents 0 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len()),
+        "<< /Type /StructTreeRoot /ParentTree 7 0 R >>".to_string(),
+        parent_tree.to_string(),
+    ];
+    objects.extend(extra_objects.iter().cloned());
+
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (index, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn extract_raw(pdf: Vec<u8>) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse raw tagged PDF");
+    let parsed = PdfDocument::new(reader);
+    TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    })
+    .extract_from_page(&parsed, 0)
+    .expect("malformed structure metadata must not fail extraction")
+    .text
+}
+
+fn tagged_form_pdf() -> Vec<u8> {
+    let page_content = "/Fm Do";
+    let form_content =
+        "BT /F1 12 Tf 1 0 0 1 0 0 Tm /Span << /MCID 0 >> BDC (VISUAL_FORM) Tj EMC ET";
+    let objects = vec![
+        "<< /Type /Catalog /Pages 3 0 R /StructTreeRoot 7 0 R >>".to_string(),
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] /StructParents 0 /Resources << /Font << /F1 4 0 R >> /XObject << /Fm 6 0 R >> >> /Contents 5 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{page_content}\nendstream", page_content.len()),
+        format!("<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /StructParents 1 /Resources << /Font << /F1 4 0 R >> >> /Length {} >>\nstream\n{form_content}\nendstream", form_content.len()),
+        "<< /Type /StructTreeRoot /ParentTree 8 0 R >>".to_string(),
+        "<< /Nums [0 [9 0 R] 1 [10 0 R]] >>".to_string(),
+        "<< /Type /StructElem /ActualText (PAGE_WRONG) >>".to_string(),
+        "<< /Type /StructElem /ActualText (FORM_RIGHT) >>".to_string(),
+    ];
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = Vec::new();
+    for (index, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn resolves_inline_and_structure_actualtext_with_inline_precedence() {
+    let mut page = Page::a4();
+
+    let inline_only = page
+        .begin_marked_content_with_actual_text("Span", "INLINE_ONLY")
+        .expect("begin inline-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("VISUAL_A")
+        .expect("write first visual run");
+    page.end_marked_content().expect("end inline-only run");
+
+    let structure_only = page
+        .begin_marked_content("Span")
+        .expect("begin structure-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 700.0)
+        .write("VISUAL_B")
+        .expect("write second visual run");
+    page.end_marked_content().expect("end structure-only run");
+
+    let conflicting = page
+        .begin_marked_content_with_actual_text("Span", "INLINE_WINS")
+        .expect("begin conflicting run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 680.0)
+        .write("VISUAL_C")
+        .expect("write third visual run");
+    page.end_marked_content().expect("end conflicting run");
+
+    let unicode = page
+        .begin_marked_content("Span")
+        .expect("begin unicode structure run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 660.0)
+        .write("VISUAL_D")
+        .expect("write fourth visual run");
+    page.end_marked_content()
+        .expect("end unicode structure run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    for (mcid, actual_text) in [
+        (inline_only, None),
+        (structure_only, Some("STRUCT_ONLY")),
+        (conflicting, Some("STRUCT_LOSES")),
+        (unicode, Some("2⁴⁰ E = mc² Aⁿ⁺¹B")),
+    ] {
+        let mut span = StructureElement::new(StandardStructureType::Span);
+        if let Some(actual_text) = actual_text {
+            span = span.with_actual_text(actual_text);
+        }
+        span.add_mcid(0, mcid);
+        tree.add_child(root, span).expect("attach structure span");
+    }
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let extracted = extract(
+        document,
+        ExtractionOptions {
+            preserve_layout: true,
+            ..Default::default()
+        },
+    );
+    let text_for = |mcid| {
+        extracted
+            .fragments
+            .iter()
+            .find(|fragment| fragment.mcid == Some(mcid))
+            .map(|fragment| fragment.text.as_str())
+    };
+
+    assert_eq!(text_for(inline_only), Some("INLINE_ONLY"));
+    assert_eq!(text_for(structure_only), Some("STRUCT_ONLY"));
+    assert_eq!(text_for(conflicting), Some("INLINE_WINS"));
+    assert_eq!(text_for(unicode), Some("2⁴⁰ E = mc² Aⁿ⁺¹B"));
+    assert!(!extracted.text.contains("VISUAL_"), "{}", extracted.text);
+    assert!(
+        !extracted.text.contains("STRUCT_LOSES"),
+        "{}",
+        extracted.text
+    );
+}
+
+#[test]
+fn structure_actualtext_replaces_visual_text_in_flat_extraction() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("VISUAL")
+        .expect("write visual run");
+    page.end_marked_content().expect("end span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 700.0)
+        .write("TAIL")
+        .expect("write following flat run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span).with_actual_text("STRUCT");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach span");
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let bytes = document.to_bytes().expect("serialize flat fixture");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse flat fixture");
+    let parsed = PdfDocument::new(reader);
+    let extracted = TextExtractor::with_options(ExtractionOptions::default())
+        .with_reading_order(true)
+        .extract_from_page(&parsed, 0)
+        .expect("extract flat fixture");
+    assert_eq!(extracted.text, "STRUCT\nTAIL");
+    assert!(extracted.fragments.is_empty());
+}
+
+#[test]
+fn structure_actualtext_cannot_bypass_the_page_byte_budget() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content("Span")
+        .expect("begin structure-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("x")
+        .expect("write visual run");
+    page.end_marked_content().expect("end structure-only run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span)
+        .with_actual_text("STRUCT_REPLACEMENT_IS_TOO_LONG");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach structure span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let extracted = extract(
+        document,
+        ExtractionOptions {
+            preserve_layout: true,
+            max_extracted_bytes: Some(10),
+            ..Default::default()
+        },
+    );
+
+    assert!(extracted.truncated);
+    assert!(extracted.text.len() <= 10, "{}", extracted.text.len());
+    assert!(!extracted.text.contains("STRUCT_REPLACEMENT"));
+}
+
+#[test]
+fn resolves_parent_tree_kids_and_indirect_owner() {
+    let pdf = raw_tagged_pdf(
+        "<< /Kids [9 0 R] >>",
+        &[
+            "<< /Type /StructElem /ActualText <FEFF005300540052005500430054> >>".to_string(),
+            "<< /Nums [0 [8 0 R]] >>".to_string(),
+        ],
+        0,
+    );
+    assert_eq!(extract_raw(pdf), "STRUCT");
+}
+
+#[test]
+fn malformed_parent_tree_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf("<< /Nums [0 /NotAnOwnerArray] >>", &[], 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn invalid_mcid_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf(
+        "<< /Nums [0 [8 0 R]] >>",
+        &["<< /Type /StructElem /ActualText (STRUCT) >>".to_string()],
+        7,
+    );
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn cyclic_parent_tree_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf("<< /Kids [7 0 R] >>", &[], 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn overdeep_parent_tree_falls_back_to_visual_text() {
+    let depth = 34usize;
+    let owner_id = 8 + depth;
+    let mut nodes = Vec::new();
+    for index in 0..depth {
+        let object_id = 8 + index;
+        let body = if index + 1 == depth {
+            format!("<< /Nums [0 [{owner_id} 0 R]] >>")
+        } else {
+            format!("<< /Kids [{} 0 R] >>", object_id + 1)
+        };
+        nodes.push(body);
+    }
+    nodes.push("<< /Type /StructElem /ActualText (STRUCT) >>".to_string());
+    let pdf = raw_tagged_pdf("<< /Kids [8 0 R] >>", &nodes, 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn oversized_parent_tree_stops_at_the_node_limit() {
+    const CHILDREN: usize = 4097;
+    let owner_id = 8 + CHILDREN;
+    let kids = (8..8 + CHILDREN)
+        .map(|id| format!("{id} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut nodes = vec!["<< >>".to_string(); CHILDREN];
+    nodes[CHILDREN - 1] = format!("<< /Nums [0 [{owner_id} 0 R]] >>");
+    nodes.push("<< /Type /StructElem /ActualText (STRUCT) >>".to_string());
+
+    let pdf = raw_tagged_pdf(&format!("<< /Kids [{kids}] >>"), &nodes, 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn form_xobject_uses_its_own_structparents_context() {
+    assert_eq!(extract_raw(tagged_form_pdf()), "FORM_RIGHT");
+}


### PR DESCRIPTION
## Summary
- resolve structure-element ActualText through page StructParents and the document ParentTree
- preserve inline-over-structure precedence in layout and flat extraction
- resolve replacements lazily with malformed-tree, depth, node-count, byte-budget, and Form XObject safeguards

## Validation
- 31 focused tests passed, including 10 issue-specific cases
- cargo fmt --all -- --check
- cargo clippy -p oxidize-pdf --lib --test issue_506_struct_actual_text_test -- -D warnings
- git diff --check
- Kripteia focused test quality: 92/100
- Kripteia Security: no issues found

Closes #506

Target release: 4.5.1