### PR TITLE
fix(text): scale flat-path space threshold by Tm/CTM x-factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flat-path word-gap threshold compared a `Tm`-scaled pen delta against an
+  unscaled font-size threshold** (#510). `flat_space_gap_threshold` derives
+  its threshold from the font's real space-glyph advance at the nominal `Tf`
+  font size, but the gap it's compared against is measured in user space,
+  already scaled by `Tm`/CTM. PDF generators that draw at `Tf 1` with the
+  real point size baked into `Tm` instead (a common technique) hit a
+  threshold far smaller, relative to the gap, than intended: an ordinary
+  sub-point positioning residue between `Tj` runs of the same token (e.g. a
+  hyphenated phone number split across separate runs) could cross it and
+  insert a spurious mid-token space. The threshold is now scaled by the same
+  `Tm`/CTM x-factor already applied to page-space widths elsewhere in
+  extraction.
+
 - **Composite (Type0/CID) font text extraction never consulted the CIDFont's
   `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a
   flat `0.5 * font_size`, regardless of its real width. When a glyph's true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hyphenated phone number split across separate runs) could cross it and
   insert a spurious mid-token space. The threshold is now scaled by the same
   `Tm`/CTM x-factor already applied to page-space widths elsewhere in
-  extraction.
+  extraction, together with the horizontal text scaling selected by `Tz`.
 
 - **Composite (Type0/CID) font text extraction never consulted the CIDFont's
   `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -876,8 +876,26 @@ impl TextExtractor {
         Some(width / 1000.0 * font_size.abs())
     }
 
+    /// `dx` (from [`pen_delta`]) is measured in *user space* — the pen's
+    /// `text_matrix × CTM` origin already folds in any scale the PDF puts in
+    /// `Tm`/CTM rather than `Tf`. `font_space_advance`/`type0_implicit_space_advance`
+    /// compute a *text-space* advance from the nominal `Tf` font size alone,
+    /// so a document that draws at `Tf 1` with its real point size baked into
+    /// `Tm` (a common generator technique) would otherwise compare a
+    /// Tm-scaled `dx` against an unscaled threshold, letting an ordinary
+    /// sub-point positioning residue between glyph runs cross the threshold
+    /// and insert a spurious mid-token space (issue #510). Scaling by the
+    /// same `combined_text_scale` x-factor `emit_text_fragment` already
+    /// applies to page-space widths brings both sides of the `dx >
+    /// threshold` comparison into the same unit space.
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
-        match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
+        let (x_scale, _) = combined_text_scale(state);
+        let x_scale = if x_scale.is_finite() && x_scale > 0.0 {
+            x_scale
+        } else {
+            1.0
+        };
+        let threshold = match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
             Some(advance) if advance > 0.0 => 0.5 * advance,
             _ => {
                 let legacy = self.options.space_threshold * state.font_size.abs();
@@ -892,7 +910,8 @@ impl TextExtractor {
                     _ => legacy,
                 }
             }
-        }
+        };
+        threshold * x_scale
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -886,12 +886,18 @@ impl TextExtractor {
     /// sub-point positioning residue between glyph runs cross the threshold
     /// and insert a spurious mid-token space (issue #510). Scaling by the
     /// same `combined_text_scale` x-factor `emit_text_fragment` already
-    /// applies to page-space widths brings both sides of the `dx >
-    /// threshold` comparison into the same unit space.
+    /// applies to page-space widths, plus the horizontal text scaling (`Tz`)
+    /// used by [`advance_pen`], brings both sides of the `dx > threshold`
+    /// comparison into the same unit space.
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
         let (x_scale, _) = combined_text_scale(state);
-        let x_scale = if x_scale.is_finite() && x_scale > 0.0 {
+        let x_scale = if x_scale.is_finite() && x_scale > f64::EPSILON {
             x_scale
+        } else {
+            1.0
+        };
+        let horizontal_scale = if state.horizontal_scale.is_finite() {
+            state.horizontal_scale.abs() / 100.0
         } else {
             1.0
         };
@@ -911,7 +917,7 @@ impl TextExtractor {
                 }
             }
         };
-        threshold * x_scale
+        threshold * x_scale * horizontal_scale
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.
@@ -4374,6 +4380,19 @@ mod tests {
         // Non-finite baseline: same fallback.
         let nan_state = state_with_ctm([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]);
         assert_eq!(pen_delta(&nan_state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+    }
+
+    #[test]
+    fn flat_space_threshold_uses_unscaled_fallback_for_tiny_baseline() {
+        let mut state = TextState::default();
+        state.font_size = 10.0;
+        state.text_matrix = [f64::EPSILON, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let extractor = TextExtractor::new();
+
+        assert_eq!(
+            extractor.flat_space_gap_threshold(&state),
+            extractor.options.space_threshold * state.font_size
+        );
     }
 
     // ── issue #382: per-page byte-budget helper ──────────────────────────────

--- a/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
+++ b/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
@@ -1,0 +1,109 @@
+//! Repro for a flat-path spurious mid-token space regression introduced by
+//! the `flat_space_gap_threshold` font-derived tightening (commit ce79992,
+//! part of PR #499 / issue #496's follow-up hardening; released in 4.5.0).
+//!
+//! `flat_space_gap_threshold` replaced the old flat `0.3 * font_size` cutoff
+//! with `0.5 * real_space_advance` (the font's actual `/Widths` entry for
+//! code 32, in text-space units) whenever available. `real_space_advance` is
+//! computed from the nominal `Tf` font size alone, but the inter-run gap
+//! (`dx`) it is compared against is measured in *user space*, i.e. already
+//! scaled by `Tm`/CTM. When a PDF generator bakes its real rendering scale
+//! into `Tm` rather than `Tf` (drawing at `Tf 1` with e.g. `9 0 0 9 x y Tm`
+//! -- a common technique, seen here on a real Brazilian financial-prospectus
+//! template), the two sides of the comparison are off by that scale factor:
+//! the threshold ends up far smaller, relative to `dx`, than the old flat
+//! threshold was. A hyphenated phone number like "3030-7160" split across
+//! separate `Tj` runs (or even separate `BT`/`ET` text objects) with a
+//! perfectly ordinary few-hundredths-of-a-unit forward positioning residue
+//! between runs -- well under the old threshold -- now crosses the new one
+//! and gets a spurious space inserted, corrupting "3030-7160" into
+//! "3030- 7160".
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::TextExtractor;
+use std::io::Cursor;
+
+/// A simple WinAnsi TrueType font, `FirstChar 32`, real Verdana-ish widths:
+/// space (32) = 278, `-` (45) = 333, digits 0-9 (48-57) = 556 each --
+/// approximate real Verdana metrics.
+fn widths_array() -> String {
+    // widths[i] corresponds to code (32+i), for codes 32..=64 inclusive.
+    let mut widths = vec![500u32; 64 - 32 + 1];
+    widths[0] = 278; // space (32)
+    widths[45 - 32] = 333; // '-'
+    for digit_code in 48..=57 {
+        widths[digit_code - 32] = 556; // '0'..'9'
+    }
+    format!(
+        "[{}]",
+        widths
+            .iter()
+            .map(|w| w.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
+}
+
+fn build_pdf() -> Vec<u8> {
+    // font_size = 1, with the real 9pt rendering scale baked into `Tm`
+    // (a=d=9). An absolute `Tm` before each run precisely controls each
+    // run's user-space start x, avoiding any ambiguity from `Td`'s
+    // line-matrix-relative (not pen-relative) semantics.
+    //
+    // Natural advances at font_size 1, Tm x-scale 9 (from `widths_array`):
+    // "3030" = 4*556/1000*9 = 20.016 user-space units; "-" = 333/1000*9 =
+    // 2.997. The "-" run starts 0.05 units *short* of the natural pen
+    // position after "3030" (an ordinary small residue, either sign is
+    // harmless), and "7160" starts 0.15 units *past* the natural pen
+    // position after "-".
+    //
+    // The threshold is computed at the nominal font_size (1), unscaled by
+    // Tm: `0.5 * 278/1000 * 1 = 0.139` (new, font-derived) vs.
+    // `0.3 * font_size(1) = 0.3` (old, flat). `dx` is measured in
+    // Tm-scaled user-space units, so 0.15 clears the new threshold but not
+    // the old one -- the mismatch between an unscaled threshold and a
+    // Tm-scaled `dx` is exactly the bug.
+    let content = b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+9 0 0 9 119.966 700 Tm\n(-)Tj\n\
+9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n";
+    let widths = widths_array();
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", content),
+        format!(
+            "<< /Type /Font /Subtype /TrueType /BaseFont /Verdana \
+             /Encoding /WinAnsiEncoding /FirstChar 32 /LastChar 64 \
+             /Widths {widths} /FontDescriptor 6 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Verdana /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn small_forward_residue_between_simple_font_runs_at_font_size_1_is_not_a_space() {
+    let pdf = build_pdf();
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(
+        text, "3030-7160",
+        "small positive Td residue between simple-font runs at font_size=1 \
+         (well below the old flat 0.3*font_size threshold) must not be \
+         promoted to a word space by the font-derived threshold, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
+++ b/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
@@ -65,9 +65,14 @@ fn build_pdf() -> Vec<u8> {
     // Tm-scaled user-space units, so 0.15 clears the new threshold but not
     // the old one -- the mismatch between an unscaled threshold and a
     // Tm-scaled `dx` is exactly the bug.
-    let content = b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+    build_pdf_with_content(
+        b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
 9 0 0 9 119.966 700 Tm\n(-)Tj\n\
-9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n";
+9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n",
+    )
+}
+
+fn build_pdf_with_content(content: &[u8]) -> Vec<u8> {
     let widths = widths_array();
     let objects: Vec<Vec<u8>> = vec![
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
@@ -102,8 +107,42 @@ fn small_forward_residue_between_simple_font_runs_at_font_size_1_is_not_a_space(
         .text;
     assert_eq!(
         text, "3030-7160",
-        "small positive Td residue between simple-font runs at font_size=1 \
+        "small positive Tm residue between simple-font runs at font_size=1 \
          (well below the old flat 0.3*font_size threshold) must not be \
          promoted to a word space by the font-derived threshold, got: {text:?}"
     );
+}
+
+#[test]
+fn horizontal_text_scaling_is_included_in_the_space_threshold() {
+    let pdf = build_pdf_with_content(
+        b"BT\n/F1 1 Tf\n200 Tz\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+9 0 0 9 140 700 Tm\n(-)Tj\n\
+9 0 0 9 147.994 700 Tm\n(7160)Tj\nET\n",
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(text, "3030-7160");
+}
+
+#[test]
+fn ctm_only_scaling_is_included_in_the_space_threshold() {
+    let pdf = build_pdf_with_content(
+        b"q\n9 0 0 9 0 0 cm\nBT\n/F1 1 Tf\n1 0 0 1 11.111111 77.777778 Tm\n(3030)Tj\n\
+1 0 0 1 13.329556 77.777778 Tm\n(-)Tj\n\
+1 0 0 1 13.679222 77.777778 Tm\n(7160)Tj\nET\nQ\n",
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(text, "3030-7160");
 }


### PR DESCRIPTION
Addresses #510.

## Summary

`flat_space_gap_threshold` (added in `ce79992`, part of #499/#496's follow-up hardening) derives its threshold from the font's real space-glyph advance at the nominal `Tf` font size, but the pen delta (`dx`) it's compared against is measured in user space, already scaled by `Tm`/CTM.

PDF generators that draw at `Tf 1` with the real point size baked into `Tm` instead (a common technique) hit a threshold far smaller, relative to `dx`, than intended: an ordinary sub-point positioning residue between `Tj` runs of the same token (e.g. a hyphenated phone number split across separate runs) can cross it and insert a spurious mid-token space.

## Fix

Scales the threshold by the same `combined_text_scale` x-factor `emit_text_fragment` already applies to page-space widths elsewhere in extraction, bringing both sides of the `dx > threshold` comparison into the same unit space.

## Testing

- New regression test (`issue_510_tm_scaled_space_threshold_test.rs`): minimal simple-TrueType-font repro at `Tf 1`/`Tm` scale 9, fails before the fix, passes after
- `cargo test -p oxidize-pdf --lib`: 6695 passed, 0 failed, 3 ignored
- Related regression suites (#390, #441, #447, #448, #458, #495, #496, #500): all pass
- `cargo clippy --lib -- -D warnings`: clean
- `cargo fmt --check`: clean
- Re-verified against the real-world document that surfaced this issue: a repeated header/footer phone number's hit count is restored to its pre-4.5.0 value