### PR TITLE
feat(fonts): expose Type 3 CharProc glyphs

### DIFF
--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -14,6 +14,7 @@ pub mod standard_14;
 pub mod ttf_parser;
 pub mod type0;
 pub mod type0_parsing;
+pub mod type3;
 
 pub use cid_mapper::{analyze_unicode_ranges, CidMapping, UnicodeRanges};
 pub use embedder::{EmbeddingOptions, FontEmbedder, FontEncoding};
@@ -29,6 +30,7 @@ pub use type0_parsing::{
     extract_font_descriptor_ref, extract_font_file_ref, extract_tounicode_ref, extract_widths_ref,
     resolve_type0_hierarchy, CIDFontSubtype, FontFileType, Type0FontInfo, MAX_FONT_STREAM_SIZE,
 };
+pub use type3::{Type3Font, Type3Glyph};
 
 use crate::Result;
 

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -37,7 +37,9 @@ pub struct Type3Glyph {
     pub procedure_width: (f64, f64),
     /// Glyph bounding box declared by `d1`, when present.
     pub bbox: Option<[f64; 4]>,
-    /// Parsed, renderer-neutral glyph operations, including `d0`/`d1`.
+    /// Parsed, renderer-neutral glyph drawing operations. The leading `d0` or
+    /// `d1` operator is represented by [`Self::procedure_width`] and
+    /// [`Self::bbox`] rather than duplicated here.
     pub operations: Vec<ContentOperation>,
 }
 

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -1,0 +1,754 @@
+//! Renderer-neutral resolution of embedded Type 3 glyph programs.
+
+use crate::parser::content::{ContentOperation, ContentParser};
+use crate::parser::document::PdfDocument;
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::{ParseError, ParseResult};
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Read, Seek};
+
+/// Maximum decoded size accepted for one glyph program.
+pub const MAX_TYPE3_GLYPH_STREAM_SIZE: usize = 8 * 1024 * 1024;
+
+/// A resolved Type 3 font suitable for use by a downstream renderer.
+#[derive(Debug, Clone)]
+pub struct Type3Font {
+    /// Optional PDF font name (`/Name` or `/BaseFont`).
+    pub name: Option<String>,
+    /// Glyph-space to text-space transformation.
+    pub font_matrix: [f64; 6],
+    /// Font bounding box in glyph space.
+    pub font_bbox: [f64; 4],
+    /// Resolved private resources used by glyph programs.
+    pub resources: Option<PdfDictionary>,
+    glyphs: BTreeMap<u8, Type3Glyph>,
+}
+
+/// One resolved Type 3 character procedure.
+#[derive(Debug, Clone)]
+pub struct Type3Glyph {
+    /// Character code used by page text-showing operators.
+    pub code: u8,
+    /// Name selected through the font encoding.
+    pub name: String,
+    /// Advance declared by `/Widths` (glyph-space units).
+    pub width: f64,
+    /// Displacement declared by the `d0` or `d1` operator.
+    pub procedure_width: (f64, f64),
+    /// Glyph bounding box declared by `d1`, when present.
+    pub bbox: Option<[f64; 4]>,
+    /// Parsed, renderer-neutral glyph operations, including `d0`/`d1`.
+    pub operations: Vec<ContentOperation>,
+}
+
+impl Type3Font {
+    /// Resolve a direct or indirect Type 3 font dictionary and its character
+    /// procedures. Glyph names are not interpreted as Unicode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid Type 3 dictionary, unsupported encoding,
+    /// malformed or oversized character procedure, or an unresolved required
+    /// indirect object. Codes without a name or `CharProc` are omitted so
+    /// [`Self::glyph`] returns `None` and downstream fallback remains possible.
+    pub fn resolve<R: Read + Seek>(
+        font_object: &PdfObject,
+        document: &PdfDocument<R>,
+    ) -> ParseResult<Self> {
+        let font_object = document.resolve(font_object)?;
+        let font = expect_dict(&font_object, "Type 3 font")?;
+        if font
+            .get("Subtype")
+            .and_then(PdfObject::as_name)
+            .map(|n| n.0.as_str())
+            != Some("Type3")
+        {
+            return Err(syntax("font subtype is not Type3"));
+        }
+
+        let font_matrix = number_array::<6>(font, "FontMatrix")?;
+        let font_bbox = number_array::<4>(font, "FontBBox")?;
+        let first = integer(font, "FirstChar")?;
+        let last = integer(font, "LastChar")?;
+        if !(0..=255).contains(&first) || !(0..=255).contains(&last) || first > last {
+            return Err(syntax("invalid Type 3 FirstChar/LastChar range"));
+        }
+
+        let widths_object = resolve_required(document, font, "Widths")?;
+        let widths = widths_object
+            .as_array()
+            .ok_or_else(|| syntax("Type 3 Widths must be an array"))?;
+        let expected = (last - first + 1) as usize;
+        if widths.0.len() < expected {
+            return Err(syntax("Type 3 Widths is shorter than the character range"));
+        }
+
+        let encoding_object = resolve_required(document, font, "Encoding")?;
+        let names = encoding_names(&encoding_object)?;
+        let charprocs_object = resolve_required(document, font, "CharProcs")?;
+        let charprocs = expect_dict(&charprocs_object, "Type 3 CharProcs")?;
+
+        let mut glyphs = BTreeMap::new();
+        for code in first..=last {
+            let code = code as u8;
+            let Some(name) = names.get(&code) else {
+                continue;
+            };
+            let Some(proc_object) = charprocs.get(name) else {
+                continue;
+            };
+            let proc_object = document.resolve(proc_object)?;
+            let stream = proc_object
+                .as_stream()
+                .ok_or_else(|| syntax("Type 3 CharProc must be a stream"))?;
+            let data = stream
+                .decode_with_limit(&document.options(), MAX_TYPE3_GLYPH_STREAM_SIZE)
+                .map_err(|error| {
+                    syntax(&format!(
+                        "failed to decode Type 3 CharProc /{name} (code {code}): {error}"
+                    ))
+                })?;
+            let parsed = ContentParser::parse_type3_charproc(&data).map_err(|error| {
+                syntax(&format!(
+                    "invalid Type 3 CharProc /{name} (code {code}): {error}"
+                ))
+            })?;
+            let width = widths.0[(i64::from(code) - first) as usize]
+                .as_real()
+                .ok_or_else(|| syntax("Type 3 width must be numeric"))?;
+            glyphs.insert(
+                code,
+                Type3Glyph {
+                    code,
+                    name: name.clone(),
+                    width,
+                    procedure_width: parsed.width,
+                    bbox: parsed.bbox,
+                    operations: parsed.operations,
+                },
+            );
+        }
+
+        let resources = match font.get("Resources") {
+            Some(value) => {
+                Some(expect_dict(&document.resolve(value)?, "Type 3 Resources")?.clone())
+            }
+            None => None,
+        };
+        let name = font
+            .get("Name")
+            .or_else(|| font.get("BaseFont"))
+            .and_then(PdfObject::as_name)
+            .map(|value| value.0.clone());
+        Ok(Self {
+            name,
+            font_matrix,
+            font_bbox,
+            resources,
+            glyphs,
+        })
+    }
+
+    /// Return the resolved glyph for a character code, or `None` when its
+    /// encoding is undefined or the font provides no corresponding `CharProc`.
+    pub fn glyph(&self, code: u8) -> Option<&Type3Glyph> {
+        self.glyphs.get(&code)
+    }
+
+    /// Iterate over all resolved glyphs.
+    pub fn glyphs(&self) -> impl Iterator<Item = &Type3Glyph> {
+        self.glyphs.values()
+    }
+
+    /// Resolve one entry from the font's private resource dictionary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the category is not a dictionary or an indirect
+    /// resource cannot be resolved.
+    pub fn resolve_resource<R: Read + Seek>(
+        &self,
+        category: &str,
+        name: &str,
+        document: &PdfDocument<R>,
+    ) -> ParseResult<Option<PdfObject>> {
+        let Some(resources) = &self.resources else {
+            return Ok(None);
+        };
+        let Some(category_object) = resources.get(category) else {
+            return Ok(None);
+        };
+        let category_object = document.resolve(category_object)?;
+        let category_dict = expect_dict(&category_object, "Type 3 resource category")?;
+        category_dict
+            .get(name)
+            .map(|value| document.resolve(value))
+            .transpose()
+    }
+}
+
+fn resolve_required<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+    key: &str,
+) -> ParseResult<PdfObject> {
+    document.resolve(
+        dict.get(key)
+            .ok_or_else(|| ParseError::MissingKey(key.into()))?,
+    )
+}
+
+fn expect_dict<'a>(object: &'a PdfObject, description: &str) -> ParseResult<&'a PdfDictionary> {
+    object
+        .as_dict()
+        .ok_or_else(|| syntax(&format!("{description} must be a dictionary")))
+}
+
+fn integer(dict: &PdfDictionary, key: &str) -> ParseResult<i64> {
+    dict.get(key)
+        .and_then(PdfObject::as_integer)
+        .ok_or_else(|| ParseError::MissingKey(key.into()))
+}
+
+fn number_array<const N: usize>(dict: &PdfDictionary, key: &str) -> ParseResult<[f64; N]> {
+    let array = dict
+        .get(key)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| ParseError::MissingKey(key.into()))?;
+    if array.0.len() != N {
+        return Err(syntax(&format!("{key} must contain {N} numbers")));
+    }
+    let mut result = [0.0; N];
+    for (target, object) in result.iter_mut().zip(&array.0) {
+        *target = object
+            .as_real()
+            .ok_or_else(|| syntax(&format!("{key} must contain only numbers")))?;
+    }
+    Ok(result)
+}
+
+fn encoding_names(encoding: &PdfObject) -> ParseResult<HashMap<u8, String>> {
+    match encoding {
+        PdfObject::Name(name) => predefined_encoding(name.as_str()),
+        PdfObject::Dictionary(dict) => {
+            let mut names = match dict.get("BaseEncoding").and_then(PdfObject::as_name) {
+                Some(name) => predefined_encoding(name.as_str())?,
+                None => predefined_encoding("StandardEncoding")?,
+            };
+            apply_encoding_differences(dict, &mut names)?;
+            Ok(names)
+        }
+        _ => Err(syntax("Type 3 Encoding must be a name or dictionary")),
+    }
+}
+
+fn apply_encoding_differences(
+    encoding: &PdfDictionary,
+    result: &mut HashMap<u8, String>,
+) -> ParseResult<()> {
+    let Some(differences) = encoding.get("Differences").and_then(PdfObject::as_array) else {
+        return Ok(());
+    };
+    let mut code: Option<i64> = None;
+    for object in &differences.0 {
+        if let Some(value) = object.as_integer() {
+            if !(0..=255).contains(&value) {
+                return Err(syntax("Encoding Differences code is outside 0..=255"));
+            }
+            code = Some(value);
+        } else if let Some(name) = object.as_name() {
+            let value =
+                code.ok_or_else(|| syntax("Encoding Differences name has no starting code"))?;
+            result.insert(value as u8, name.0.clone());
+            code = value.checked_add(1);
+        } else {
+            return Err(syntax("invalid object in Encoding Differences"));
+        }
+    }
+    Ok(())
+}
+
+fn predefined_encoding(name: &str) -> ParseResult<HashMap<u8, String>> {
+    if !matches!(
+        name,
+        "StandardEncoding" | "WinAnsiEncoding" | "MacRomanEncoding"
+    ) {
+        return Err(syntax(&format!("unsupported Type 3 encoding /{name}")));
+    }
+    let mut names = HashMap::new();
+    for code in 32u8..=126 {
+        names.insert(code, ascii_glyph_name(code).to_string());
+    }
+    match name {
+        "StandardEncoding" => {
+            names.insert(39, "quoteright".into());
+            names.insert(96, "quoteleft".into());
+            for &(code, glyph) in STANDARD_ENCODING_EXTENDED {
+                names.insert(code, glyph.into());
+            }
+        }
+        "WinAnsiEncoding" => {
+            for &(code, glyph) in WIN_ANSI_EXTENDED {
+                names.insert(code, glyph.into());
+            }
+        }
+        "MacRomanEncoding" => {
+            for (offset, glyph) in MAC_ROMAN_EXTENDED.iter().enumerate() {
+                names.insert(0x80 + offset as u8, (*glyph).into());
+            }
+        }
+        _ => unreachable!(),
+    }
+    Ok(names)
+}
+
+const STANDARD_ENCODING_EXTENDED: &[(u8, &str)] = &[
+    (161, "exclamdown"),
+    (162, "cent"),
+    (163, "sterling"),
+    (164, "fraction"),
+    (165, "yen"),
+    (166, "florin"),
+    (167, "section"),
+    (168, "currency"),
+    (169, "quotesingle"),
+    (170, "quotedblleft"),
+    (171, "guillemotleft"),
+    (172, "guilsinglleft"),
+    (173, "guilsinglright"),
+    (174, "fi"),
+    (175, "fl"),
+    (177, "endash"),
+    (178, "dagger"),
+    (179, "daggerdbl"),
+    (180, "periodcentered"),
+    (182, "paragraph"),
+    (183, "bullet"),
+    (184, "quotesinglbase"),
+    (185, "quotedblbase"),
+    (186, "quotedblright"),
+    (187, "guillemotright"),
+    (188, "ellipsis"),
+    (189, "perthousand"),
+    (191, "questiondown"),
+    (193, "grave"),
+    (194, "acute"),
+    (195, "circumflex"),
+    (196, "tilde"),
+    (197, "macron"),
+    (198, "breve"),
+    (199, "dotaccent"),
+    (200, "dieresis"),
+    (202, "ring"),
+    (203, "cedilla"),
+    (205, "hungarumlaut"),
+    (206, "ogonek"),
+    (207, "caron"),
+    (208, "emdash"),
+    (225, "AE"),
+    (227, "ordfeminine"),
+    (232, "Lslash"),
+    (233, "Oslash"),
+    (234, "OE"),
+    (235, "ordmasculine"),
+    (241, "ae"),
+    (245, "dotlessi"),
+    (248, "lslash"),
+    (249, "oslash"),
+    (250, "oe"),
+    (251, "germandbls"),
+];
+
+const WIN_ANSI_EXTENDED: &[(u8, &str)] = &[
+    (128, "Euro"),
+    (130, "quotesinglbase"),
+    (131, "florin"),
+    (132, "quotedblbase"),
+    (133, "ellipsis"),
+    (134, "dagger"),
+    (135, "daggerdbl"),
+    (136, "circumflex"),
+    (137, "perthousand"),
+    (138, "Scaron"),
+    (139, "guilsinglleft"),
+    (140, "OE"),
+    (142, "Zcaron"),
+    (145, "quoteleft"),
+    (146, "quoteright"),
+    (147, "quotedblleft"),
+    (148, "quotedblright"),
+    (149, "bullet"),
+    (150, "endash"),
+    (151, "emdash"),
+    (152, "tilde"),
+    (153, "trademark"),
+    (154, "scaron"),
+    (155, "guilsinglright"),
+    (156, "oe"),
+    (158, "zcaron"),
+    (159, "Ydieresis"),
+    (160, "space"),
+    (161, "exclamdown"),
+    (162, "cent"),
+    (163, "sterling"),
+    (164, "currency"),
+    (165, "yen"),
+    (166, "brokenbar"),
+    (167, "section"),
+    (168, "dieresis"),
+    (169, "copyright"),
+    (170, "ordfeminine"),
+    (171, "guillemotleft"),
+    (172, "logicalnot"),
+    (173, "hyphen"),
+    (174, "registered"),
+    (175, "macron"),
+    (176, "degree"),
+    (177, "plusminus"),
+    (178, "twosuperior"),
+    (179, "threesuperior"),
+    (180, "acute"),
+    (181, "mu"),
+    (182, "paragraph"),
+    (183, "periodcentered"),
+    (184, "cedilla"),
+    (185, "onesuperior"),
+    (186, "ordmasculine"),
+    (187, "guillemotright"),
+    (188, "onequarter"),
+    (189, "onehalf"),
+    (190, "threequarters"),
+    (191, "questiondown"),
+    (192, "Agrave"),
+    (193, "Aacute"),
+    (194, "Acircumflex"),
+    (195, "Atilde"),
+    (196, "Adieresis"),
+    (197, "Aring"),
+    (198, "AE"),
+    (199, "Ccedilla"),
+    (200, "Egrave"),
+    (201, "Eacute"),
+    (202, "Ecircumflex"),
+    (203, "Edieresis"),
+    (204, "Igrave"),
+    (205, "Iacute"),
+    (206, "Icircumflex"),
+    (207, "Idieresis"),
+    (208, "Eth"),
+    (209, "Ntilde"),
+    (210, "Ograve"),
+    (211, "Oacute"),
+    (212, "Ocircumflex"),
+    (213, "Otilde"),
+    (214, "Odieresis"),
+    (215, "multiply"),
+    (216, "Oslash"),
+    (217, "Ugrave"),
+    (218, "Uacute"),
+    (219, "Ucircumflex"),
+    (220, "Udieresis"),
+    (221, "Yacute"),
+    (222, "Thorn"),
+    (223, "germandbls"),
+    (224, "agrave"),
+    (225, "aacute"),
+    (226, "acircumflex"),
+    (227, "atilde"),
+    (228, "adieresis"),
+    (229, "aring"),
+    (230, "ae"),
+    (231, "ccedilla"),
+    (232, "egrave"),
+    (233, "eacute"),
+    (234, "ecircumflex"),
+    (235, "edieresis"),
+    (236, "igrave"),
+    (237, "iacute"),
+    (238, "icircumflex"),
+    (239, "idieresis"),
+    (240, "eth"),
+    (241, "ntilde"),
+    (242, "ograve"),
+    (243, "oacute"),
+    (244, "ocircumflex"),
+    (245, "otilde"),
+    (246, "odieresis"),
+    (247, "divide"),
+    (248, "oslash"),
+    (249, "ugrave"),
+    (250, "uacute"),
+    (251, "ucircumflex"),
+    (252, "udieresis"),
+    (253, "yacute"),
+    (254, "thorn"),
+    (255, "ydieresis"),
+];
+
+const MAC_ROMAN_EXTENDED: [&str; 128] = [
+    "Adieresis",
+    "Aring",
+    "Ccedilla",
+    "Eacute",
+    "Ntilde",
+    "Odieresis",
+    "Udieresis",
+    "aacute",
+    "agrave",
+    "acircumflex",
+    "adieresis",
+    "atilde",
+    "aring",
+    "ccedilla",
+    "eacute",
+    "egrave",
+    "ecircumflex",
+    "edieresis",
+    "iacute",
+    "igrave",
+    "icircumflex",
+    "idieresis",
+    "ntilde",
+    "oacute",
+    "ograve",
+    "ocircumflex",
+    "odieresis",
+    "otilde",
+    "uacute",
+    "ugrave",
+    "ucircumflex",
+    "udieresis",
+    "dagger",
+    "degree",
+    "cent",
+    "sterling",
+    "section",
+    "bullet",
+    "paragraph",
+    "germandbls",
+    "registered",
+    "copyright",
+    "trademark",
+    "acute",
+    "dieresis",
+    "notequal",
+    "AE",
+    "Oslash",
+    "infinity",
+    "plusminus",
+    "lessequal",
+    "greaterequal",
+    "yen",
+    "mu",
+    "partialdiff",
+    "summation",
+    "product",
+    "pi",
+    "integral",
+    "ordfeminine",
+    "ordmasculine",
+    "Omega",
+    "ae",
+    "oslash",
+    "questiondown",
+    "exclamdown",
+    "logicalnot",
+    "radical",
+    "florin",
+    "approxequal",
+    "Delta",
+    "guillemotleft",
+    "guillemotright",
+    "ellipsis",
+    "space",
+    "Agrave",
+    "Atilde",
+    "Otilde",
+    "OE",
+    "oe",
+    "endash",
+    "emdash",
+    "quotedblleft",
+    "quotedblright",
+    "quoteleft",
+    "quoteright",
+    "divide",
+    "lozenge",
+    "ydieresis",
+    "Ydieresis",
+    "fraction",
+    "currency",
+    "guilsinglleft",
+    "guilsinglright",
+    "fi",
+    "fl",
+    "daggerdbl",
+    "periodcentered",
+    "quotesinglbase",
+    "quotedblbase",
+    "perthousand",
+    "Acircumflex",
+    "Ecircumflex",
+    "Aacute",
+    "Edieresis",
+    "Egrave",
+    "Iacute",
+    "Icircumflex",
+    "Idieresis",
+    "Igrave",
+    "Oacute",
+    "Ocircumflex",
+    "apple",
+    "Ograve",
+    "Uacute",
+    "Ucircumflex",
+    "Ugrave",
+    "dotlessi",
+    "circumflex",
+    "tilde",
+    "macron",
+    "breve",
+    "dotaccent",
+    "ring",
+    "cedilla",
+    "hungarumlaut",
+    "ogonek",
+    "caron",
+];
+
+fn ascii_glyph_name(code: u8) -> &'static str {
+    const DIGITS: [&str; 10] = [
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+    ];
+    match code {
+        b'A'..=b'Z' | b'a'..=b'z' => match code {
+            b'A' => "A",
+            b'B' => "B",
+            b'C' => "C",
+            b'D' => "D",
+            b'E' => "E",
+            b'F' => "F",
+            b'G' => "G",
+            b'H' => "H",
+            b'I' => "I",
+            b'J' => "J",
+            b'K' => "K",
+            b'L' => "L",
+            b'M' => "M",
+            b'N' => "N",
+            b'O' => "O",
+            b'P' => "P",
+            b'Q' => "Q",
+            b'R' => "R",
+            b'S' => "S",
+            b'T' => "T",
+            b'U' => "U",
+            b'V' => "V",
+            b'W' => "W",
+            b'X' => "X",
+            b'Y' => "Y",
+            b'Z' => "Z",
+            b'a' => "a",
+            b'b' => "b",
+            b'c' => "c",
+            b'd' => "d",
+            b'e' => "e",
+            b'f' => "f",
+            b'g' => "g",
+            b'h' => "h",
+            b'i' => "i",
+            b'j' => "j",
+            b'k' => "k",
+            b'l' => "l",
+            b'm' => "m",
+            b'n' => "n",
+            b'o' => "o",
+            b'p' => "p",
+            b'q' => "q",
+            b'r' => "r",
+            b's' => "s",
+            b't' => "t",
+            b'u' => "u",
+            b'v' => "v",
+            b'w' => "w",
+            b'x' => "x",
+            b'y' => "y",
+            _ => "z",
+        },
+        b'0'..=b'9' => DIGITS[(code - b'0') as usize],
+        b' ' => "space",
+        b'!' => "exclam",
+        b'\"' => "quotedbl",
+        b'#' => "numbersign",
+        b'$' => "dollar",
+        b'%' => "percent",
+        b'&' => "ampersand",
+        b'\'' => "quotesingle",
+        b'(' => "parenleft",
+        b')' => "parenright",
+        b'*' => "asterisk",
+        b'+' => "plus",
+        b',' => "comma",
+        b'-' => "hyphen",
+        b'.' => "period",
+        b'/' => "slash",
+        b':' => "colon",
+        b';' => "semicolon",
+        b'<' => "less",
+        b'=' => "equal",
+        b'>' => "greater",
+        b'?' => "question",
+        b'@' => "at",
+        b'[' => "bracketleft",
+        b'\\' => "backslash",
+        b']' => "bracketright",
+        b'^' => "asciicircum",
+        b'_' => "underscore",
+        b'`' => "grave",
+        b'{' => "braceleft",
+        b'|' => "bar",
+        b'}' => "braceright",
+        b'~' => "asciitilde",
+        _ => ".notdef",
+    }
+}
+
+fn syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::objects::{PdfArray, PdfName};
+
+    #[test]
+    fn named_standard_encoding_maps_ascii_glyph_names() {
+        let names = encoding_names(&PdfObject::Name(PdfName("StandardEncoding".into())))
+            .expect("known encoding");
+        assert_eq!(names.get(&65).map(String::as_str), Some("A"));
+        assert_eq!(names.get(&48).map(String::as_str), Some("zero"));
+    }
+
+    #[test]
+    fn differences_override_base_encoding() {
+        let mut encoding = PdfDictionary::new();
+        encoding.insert(
+            "BaseEncoding".into(),
+            PdfObject::Name(PdfName("WinAnsiEncoding".into())),
+        );
+        encoding.insert(
+            "Differences".into(),
+            PdfObject::Array(PdfArray(vec![
+                PdfObject::Integer(65),
+                PdfObject::Name(PdfName("OpaqueA".into())),
+            ])),
+        );
+        let names = encoding_names(&PdfObject::Dictionary(encoding)).expect("valid encoding");
+        assert_eq!(names.get(&65).map(String::as_str), Some("OpaqueA"));
+        assert_eq!(names.get(&66).map(String::as_str), Some("B"));
+    }
+}

--- a/oxidize-pdf-core/src/parser/content.rs
+++ b/oxidize-pdf-core/src/parser/content.rs
@@ -888,6 +888,12 @@ pub struct ContentParser {
     position: usize,
 }
 
+pub(crate) struct ParsedType3CharProc {
+    pub(crate) width: (f64, f64),
+    pub(crate) bbox: Option<[f64; 4]>,
+    pub(crate) operations: Vec<ContentOperation>,
+}
+
 impl ContentParser {
     /// Create a new content parser
     pub fn new(_content: &[u8]) -> Self {
@@ -932,6 +938,111 @@ impl ContentParser {
     /// ```
     pub fn parse(content: &[u8]) -> ParseResult<Vec<ContentOperation>> {
         Self::parse_content(content)
+    }
+
+    /// Parse a content stream without best-effort recovery.
+    ///
+    /// Unlike [`Self::parse`], malformed or unknown operators are returned to
+    /// the caller. This is intended for self-contained programs such as Type 3
+    /// character procedures, where silently dropping an operation could alter
+    /// the rendered glyph.
+    pub fn parse_strict(content: &[u8]) -> ParseResult<Vec<ContentOperation>> {
+        let mut tokenizer = ContentTokenizer::new(content);
+        let mut tokens = Vec::new();
+        while let Some(token) = tokenizer.next_token()? {
+            tokens.push(token);
+        }
+        Self {
+            tokens,
+            position: 0,
+        }
+        .parse_operators_strict()
+    }
+
+    pub(crate) fn parse_type3_charproc(content: &[u8]) -> ParseResult<ParsedType3CharProc> {
+        let mut tokenizer = ContentTokenizer::new(content);
+        let mut tokens = Vec::new();
+        while let Some(token) = tokenizer.next_token()? {
+            tokens.push(token);
+        }
+        let mut parser = Self {
+            tokens,
+            position: 0,
+        };
+        let mut operations = Vec::new();
+        let mut operands = Vec::new();
+        let mut metrics = None;
+        while parser.position < parser.tokens.len() {
+            let token = parser.tokens[parser.position].clone();
+            parser.position += 1;
+            match token {
+                Token::Operator(op) if op == "d0" => {
+                    if metrics.is_some() || !operations.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0/d1 must be the first Type 3 CharProc operator".into(),
+                        });
+                    }
+                    let wy = parser.pop_number(&mut operands)?;
+                    let wx = parser.pop_number(&mut operands)?;
+                    if !operands.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0 has extra operands".into(),
+                        });
+                    }
+                    metrics = Some(((f64::from(wx), f64::from(wy)), None));
+                }
+                Token::Operator(op) if op == "d1" => {
+                    if metrics.is_some() || !operations.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0/d1 must be the first Type 3 CharProc operator".into(),
+                        });
+                    }
+                    let ury = parser.pop_number(&mut operands)?;
+                    let urx = parser.pop_number(&mut operands)?;
+                    let lly = parser.pop_number(&mut operands)?;
+                    let llx = parser.pop_number(&mut operands)?;
+                    let wy = parser.pop_number(&mut operands)?;
+                    let wx = parser.pop_number(&mut operands)?;
+                    if !operands.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d1 has extra operands".into(),
+                        });
+                    }
+                    metrics = Some((
+                        (f64::from(wx), f64::from(wy)),
+                        Some([
+                            f64::from(llx),
+                            f64::from(lly),
+                            f64::from(urx),
+                            f64::from(ury),
+                        ]),
+                    ));
+                }
+                Token::Operator(op) => {
+                    operations.push(parser.parse_operator(&op, &mut operands)?);
+                }
+                operand => operands.push(operand),
+            }
+        }
+        if !operands.is_empty() {
+            return Err(ParseError::SyntaxError {
+                position: parser.position,
+                message: "trailing operands without an operator".into(),
+            });
+        }
+        let (width, bbox) = metrics.ok_or_else(|| ParseError::SyntaxError {
+            position: 0,
+            message: "Type 3 CharProc must begin with d0 or d1".into(),
+        })?;
+        Ok(ParsedType3CharProc {
+            width,
+            bbox,
+            operations,
+        })
     }
 
     /// Parse a content stream into a vector of operators.
@@ -1002,6 +1113,29 @@ impl ContentParser {
         }
 
         Ok(operators)
+    }
+
+    fn parse_operators_strict(&mut self) -> ParseResult<Vec<ContentOperation>> {
+        let mut operators = Vec::new();
+        let mut operand_stack = Vec::new();
+        while self.position < self.tokens.len() {
+            let token = self.tokens[self.position].clone();
+            self.position += 1;
+            match token {
+                Token::Operator(op) => {
+                    operators.push(self.parse_operator(&op, &mut operand_stack)?);
+                }
+                operand => operand_stack.push(operand),
+            }
+        }
+        if operand_stack.is_empty() {
+            Ok(operators)
+        } else {
+            Err(ParseError::SyntaxError {
+                position: self.position,
+                message: "trailing operands without an operator".to_string(),
+            })
+        }
     }
 
     fn parse_operator(

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -224,6 +224,80 @@ pub fn decode_stream(
     Ok(result)
 }
 
+/// Decode stream data while enforcing a caller-provided output bound.
+///
+/// The bound is applied before copying unfiltered data, incrementally while
+/// inflating Flate data, and after every filter in a filter chain.
+pub fn decode_stream_with_limit(
+    data: &[u8],
+    dict: &PdfDictionary,
+    _options: &ParseOptions,
+    max_bytes: usize,
+) -> ParseResult<Vec<u8>> {
+    let filters = match dict.get("Filter") {
+        Some(PdfObject::Name(name)) => vec![name.as_str()],
+        Some(PdfObject::Array(array)) => array
+            .0
+            .iter()
+            .map(|object| {
+                object
+                    .as_name()
+                    .map(|name| name.as_str())
+                    .ok_or_else(|| bounded_decode_syntax("Invalid filter in array"))
+            })
+            .collect::<ParseResult<Vec<_>>>()?,
+        None => return copy_with_limit(data, max_bytes),
+        _ => return Err(bounded_decode_syntax("Invalid Filter type")),
+    };
+    let decode_params = dict.get("DecodeParms");
+    let mut result = copy_with_limit(data, max_bytes)?;
+    for (index, filter_name) in filters.iter().enumerate() {
+        let filter = Filter::from_name(filter_name)
+            .ok_or_else(|| bounded_decode_syntax(&format!("Unknown filter: {filter_name}")))?;
+        let params = get_filter_params(decode_params, index);
+        result = match filter {
+            Filter::FlateDecode => {
+                let decoded = decode_flate_with_limit(&result, max_bytes)?;
+                if let Some(params) = params {
+                    if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer)
+                    {
+                        apply_predictor(&decoded, predictor as u32, params).unwrap_or(decoded)
+                    } else {
+                        decoded
+                    }
+                } else {
+                    decoded
+                }
+            }
+            Filter::LZWDecode => decode_lzw_with_limit(&result, params, max_bytes)?,
+            Filter::RunLengthDecode => decode_run_length_with_limit(&result, max_bytes)?,
+            other => apply_filter_with_params(&result, other, params)?,
+        };
+        if result.len() > max_bytes {
+            return Err(ParseError::StreamDecodeError(format!(
+                "decoded stream exceeds limit of {max_bytes} bytes"
+            )));
+        }
+    }
+    Ok(result)
+}
+
+fn copy_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
+    if data.len() > max_bytes {
+        return Err(ParseError::StreamDecodeError(format!(
+            "stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    Ok(data.to_vec())
+}
+
+fn bounded_decode_syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.to_string(),
+    }
+}
+
 /// Apply a single filter to data (legacy function, use apply_filter_with_params)
 #[allow(dead_code)]
 pub(crate) fn apply_filter(data: &[u8], filter: Filter) -> ParseResult<Vec<u8>> {
@@ -311,6 +385,21 @@ fn decode_flate(data: &[u8]) -> ParseResult<Vec<u8>> {
     // Strategy 8: Last resort - return empty data instead of garbage
     tracing::debug!("Warning: All FlateDecode strategies failed, returning empty data");
     Ok(Vec::new())
+}
+
+#[cfg(feature = "compression")]
+fn decode_flate_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
+    let mut decoder = ZlibDecoder::new(data);
+    read_to_end_limited(&mut decoder, max_bytes).map_err(|error| {
+        ParseError::StreamDecodeError(format!("bounded FlateDecode failed: {error}"))
+    })
+}
+
+#[cfg(not(feature = "compression"))]
+fn decode_flate_with_limit(_data: &[u8], _max_bytes: usize) -> ParseResult<Vec<u8>> {
+    Err(ParseError::StreamDecodeError(
+        "FlateDecode requires the compression feature".to_string(),
+    ))
 }
 
 #[cfg(feature = "compression")]
@@ -1887,6 +1976,14 @@ fn paeth_predictor(left: u8, up: u8, up_left: u8) -> u8 {
 /// Section 3.3.3. The PDF variant of LZW uses variable-length codes starting at
 /// 9 bits and growing up to 12 bits.
 fn decode_lzw(data: &[u8], params: Option<&PdfDictionary>) -> ParseResult<Vec<u8>> {
+    decode_lzw_with_limit(data, params, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_lzw_with_limit(
+    data: &[u8],
+    params: Option<&PdfDictionary>,
+    max_bytes: usize,
+) -> ParseResult<Vec<u8>> {
     // Get parameters
     let early_change = params
         .and_then(|p| p.get("EarlyChange"))
@@ -1951,10 +2048,9 @@ fn decode_lzw(data: &[u8], params: Option<&PdfDictionary>) -> ParseResult<Vec<u8
             result.extend_from_slice(&string);
 
             // Decompression bomb check
-            if result.len() > MAX_DECOMPRESSED_SIZE {
+            if result.len() > max_bytes {
                 return Err(ParseError::StreamDecodeError(format!(
-                    "LZW decompressed size exceeds {} MB limit",
-                    MAX_DECOMPRESSED_SIZE / (1024 * 1024)
+                    "LZW decompressed size exceeds {max_bytes} byte limit"
                 )));
             }
 
@@ -2055,6 +2151,10 @@ impl<'a> LzwBitReader<'a> {
 /// Implements the Run Length Encoding decompression as specified in PDF Reference 1.7
 /// Section 3.3.4. Run-length encoding compresses sequences of identical bytes.
 fn decode_run_length(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_run_length_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_run_length_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut i = 0;
 
@@ -2091,10 +2191,9 @@ fn decode_run_length(data: &[u8]) -> ParseResult<Vec<u8>> {
         }
 
         // Decompression bomb check
-        if result.len() > MAX_DECOMPRESSED_SIZE {
+        if result.len() > max_bytes {
             return Err(ParseError::StreamDecodeError(format!(
-                "RunLength decompressed size exceeds {} MB limit",
-                MAX_DECOMPRESSED_SIZE / (1024 * 1024)
+                "RunLength decompressed size exceeds {max_bytes} byte limit"
             )));
         }
     }

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -226,8 +226,9 @@ pub fn decode_stream(
 
 /// Decode stream data while enforcing a caller-provided output bound.
 ///
-/// The bound is applied before copying unfiltered data, incrementally while
-/// inflating Flate data, and after every filter in a filter chain.
+/// Unfiltered data is copied only when it fits. Expanding filters enforce the
+/// bound while producing output; filters without a bounded implementation are
+/// rejected rather than allocating an unchecked intermediate buffer.
 pub fn decode_stream_with_limit(
     data: &[u8],
     dict: &PdfDictionary,
@@ -250,36 +251,40 @@ pub fn decode_stream_with_limit(
         _ => return Err(bounded_decode_syntax("Invalid Filter type")),
     };
     let decode_params = dict.get("DecodeParms");
-    let mut result = copy_with_limit(data, max_bytes)?;
+    let mut result: Option<Vec<u8>> = None;
     for (index, filter_name) in filters.iter().enumerate() {
         let filter = Filter::from_name(filter_name)
             .ok_or_else(|| bounded_decode_syntax(&format!("Unknown filter: {filter_name}")))?;
         let params = get_filter_params(decode_params, index);
-        result = match filter {
-            Filter::FlateDecode => {
-                let decoded = decode_flate_with_limit(&result, max_bytes)?;
-                if let Some(params) = params {
-                    if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer)
-                    {
-                        apply_predictor(&decoded, predictor as u32, params).unwrap_or(decoded)
-                    } else {
-                        decoded
-                    }
-                } else {
-                    decoded
+        let input = result.as_deref().unwrap_or(data);
+        let applies_predictor = matches!(filter, Filter::FlateDecode | Filter::LZWDecode);
+        let mut decoded = match filter {
+            Filter::FlateDecode => decode_flate_with_limit(input, max_bytes)?,
+            Filter::ASCIIHexDecode => decode_ascii_hex_with_limit(input, max_bytes)?,
+            Filter::ASCII85Decode => decode_ascii85_with_limit(input, max_bytes)?,
+            Filter::LZWDecode => decode_lzw_with_limit(input, params, max_bytes)?,
+            Filter::RunLengthDecode => decode_run_length_with_limit(input, max_bytes)?,
+            other => {
+                return Err(ParseError::StreamDecodeError(format!(
+                    "filter {other:?} has no bounded decoder"
+                )))
+            }
+        };
+        if applies_predictor {
+            if let Some(params) = params {
+                if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer) {
+                    decoded = apply_predictor(&decoded, predictor as u32, params)?;
                 }
             }
-            Filter::LZWDecode => decode_lzw_with_limit(&result, params, max_bytes)?,
-            Filter::RunLengthDecode => decode_run_length_with_limit(&result, max_bytes)?,
-            other => apply_filter_with_params(&result, other, params)?,
-        };
-        if result.len() > max_bytes {
+        }
+        if decoded.len() > max_bytes {
             return Err(ParseError::StreamDecodeError(format!(
                 "decoded stream exceeds limit of {max_bytes} bytes"
             )));
         }
+        result = Some(decoded);
     }
-    Ok(result)
+    Ok(result.unwrap_or_default())
 }
 
 fn copy_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
@@ -586,6 +591,10 @@ fn decode_flate(_data: &[u8]) -> ParseResult<Vec<u8>> {
 
 /// Decode ASCIIHexDecode data
 fn decode_ascii_hex(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_ascii_hex_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_ascii_hex_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut chars = data.iter().filter(|&&b| !b.is_ascii_whitespace());
 
@@ -612,7 +621,7 @@ fn decode_ascii_hex(data: &[u8]) -> ParseResult<Vec<u8>> {
             ParseError::StreamDecodeError(format!("Invalid hex digit: {}", low as char))
         })?;
 
-        result.push((high_val << 4) | low_val);
+        push_bounded(&mut result, (high_val << 4) | low_val, max_bytes)?;
 
         if low == b'>' {
             break;
@@ -634,6 +643,10 @@ fn hex_digit_value(ch: u8) -> Option<u8> {
 
 /// Decode ASCII85Decode data
 fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_ascii85_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_ascii85_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut chars = data.iter().filter(|&&b| !b.is_ascii_whitespace());
     let mut group = Vec::with_capacity(5);
@@ -666,7 +679,7 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
             }
             b'z' if group.is_empty() => {
                 // Special case: 'z' represents four zero bytes
-                result.extend_from_slice(&[0, 0, 0, 0]);
+                extend_bounded(&mut result, &[0, 0, 0, 0], max_bytes)?;
             }
             b'!'..=b'u' => {
                 group.push(c);
@@ -678,10 +691,16 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
                         .map(|(i, &ch)| (ch - b'!') as u32 * 85u32.pow(4 - i as u32))
                         .sum::<u32>();
 
-                    result.push((value >> 24) as u8);
-                    result.push((value >> 16) as u8);
-                    result.push((value >> 8) as u8);
-                    result.push(value as u8);
+                    extend_bounded(
+                        &mut result,
+                        &[
+                            (value >> 24) as u8,
+                            (value >> 16) as u8,
+                            (value >> 8) as u8,
+                            value as u8,
+                        ],
+                        max_bytes,
+                    )?;
 
                     group.clear();
                 }
@@ -715,11 +734,31 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
         // Only output the number of bytes that were actually encoded
         let output_bytes = original_len - 1;
         for i in 0..output_bytes {
-            result.push((value >> (24 - 8 * i)) as u8);
+            push_bounded(&mut result, (value >> (24 - 8 * i)) as u8, max_bytes)?;
         }
     }
 
     Ok(result)
+}
+
+fn push_bounded(result: &mut Vec<u8>, byte: u8, max_bytes: usize) -> ParseResult<()> {
+    if result.len() >= max_bytes {
+        return Err(ParseError::StreamDecodeError(format!(
+            "decoded stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    result.push(byte);
+    Ok(())
+}
+
+fn extend_bounded(result: &mut Vec<u8>, bytes: &[u8], max_bytes: usize) -> ParseResult<()> {
+    if bytes.len() > max_bytes.saturating_sub(result.len()) {
+        return Err(ParseError::StreamDecodeError(format!(
+            "decoded stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    result.extend_from_slice(bytes);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1753,14 +1792,10 @@ pub(crate) fn apply_filter_with_params(
 }
 
 /// Get filter parameters for a specific filter index
-fn get_filter_params(decode_params: Option<&PdfObject>, _index: usize) -> Option<&PdfDictionary> {
+fn get_filter_params(decode_params: Option<&PdfObject>, index: usize) -> Option<&PdfDictionary> {
     match decode_params {
         Some(PdfObject::Dictionary(dict)) => Some(dict),
-        Some(PdfObject::Array(array)) => {
-            // For multiple filters, each can have its own decode params
-            // For now, use the first one
-            array.0.first().and_then(|obj| obj.as_dict())
-        }
+        Some(PdfObject::Array(array)) => array.0.get(index).and_then(PdfObject::as_dict),
         _ => None,
     }
 }

--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -232,6 +232,15 @@ impl PdfStream {
         super::filters::decode_stream(&self.data, &self.dict, options)
     }
 
+    /// Decode the stream with a caller-defined maximum output size.
+    pub fn decode_with_limit(
+        &self,
+        options: &ParseOptions,
+        max_bytes: usize,
+    ) -> ParseResult<Vec<u8>> {
+        super::filters::decode_stream_with_limit(&self.data, &self.dict, options, max_bytes)
+    }
+
     /// Get the raw (possibly compressed) stream data.
     ///
     /// Returns the stream data exactly as stored in the PDF file,

--- a/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
+++ b/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
@@ -1,0 +1,132 @@
+//! Issue #509 — downstream renderers need resolved Type 3 glyph programs.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::fonts::Type3Font;
+use oxidize_pdf::parser::content::ContentOperation;
+use oxidize_pdf::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
+use oxidize_pdf::parser::ParseOptions;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use std::io::Cursor;
+use std::io::Write;
+
+fn build_pdf() -> Vec<u8> {
+    build_pdf_with_glyph(b"500 0 0 0 8 1 d1 0 0 8 1 re f BI /W 8 /H 1 /BPC 1 /IM true ID \xAA EI")
+}
+
+fn build_pdf_with_glyph(glyph: &[u8]) -> Vec<u8> {
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b"BT /F1 12 Tf <10> Tj ET"),
+        b"<< /Type /Font /Subtype /Type3 /Name /OpaquePdfTeX /FontBBox [0 0 8 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 16 /LastChar 16 /Widths 7 0 R /Encoding << /Differences [16 /a16] >> /CharProcs 6 0 R /Resources << /XObject << /Dot 9 0 R >> >> >>".to_vec(),
+        b"<< /a16 8 0 R >>".to_vec(),
+        b"[500]".to_vec(),
+        stream_obj("", glyph),
+        b"<< /Subtype /Form /BBox [0 0 1 1] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_opaque_control_code_to_parsed_charproc() {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(build_pdf())).unwrap());
+    let page = document.get_page(0).unwrap();
+    let resources = document.get_page_resources(&page).unwrap().unwrap();
+    let fonts = document.resolve(resources.get("Font").unwrap()).unwrap();
+    let font_ref = fonts.as_dict().unwrap().get("F1").unwrap();
+
+    let font = Type3Font::resolve(font_ref, &document).unwrap();
+    let direct_font_object = document.get_object(5, 0).unwrap();
+    assert!(Type3Font::resolve(&direct_font_object, &document)
+        .unwrap()
+        .glyph(0x10)
+        .is_some());
+    assert_eq!(font.name.as_deref(), Some("OpaquePdfTeX"));
+    assert_eq!(font.font_matrix, [0.001, 0.0, 0.0, 0.001, 0.0, 0.0]);
+
+    let glyph = font
+        .glyph(0x10)
+        .expect("code 0x10 must resolve through Differences");
+    assert_eq!(glyph.name, "a16");
+    assert_eq!(glyph.width, 500.0);
+    assert_eq!(glyph.procedure_width, (500.0, 0.0));
+    assert_eq!(glyph.bbox, Some([0.0, 0.0, 8.0, 1.0]));
+    assert!(glyph
+        .operations
+        .iter()
+        .any(|op| matches!(op, ContentOperation::InlineImage { .. })));
+    assert!(font
+        .resolve_resource("XObject", "Dot", &document)
+        .unwrap()
+        .unwrap()
+        .as_dict()
+        .is_some());
+    assert_eq!(
+        font.glyphs().map(|glyph| glyph.code).collect::<Vec<_>>(),
+        vec![0x10]
+    );
+}
+
+#[test]
+fn non_type3_font_is_rejected() {
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 1 1] >>".to_vec(),
+        b"<< >>".to_vec(),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+    ];
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(assemble_pdf(&objects))).unwrap());
+    assert!(
+        Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document).is_err()
+    );
+}
+
+#[test]
+fn d0_metrics_are_exposed_without_changing_content_operation() {
+    let document = PdfDocument::new(
+        PdfReader::new(Cursor::new(build_pdf_with_glyph(b"600 0 d0 0 0 m"))).unwrap(),
+    );
+    let font =
+        Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document).unwrap();
+    let glyph = font.glyph(0x10).unwrap();
+    assert_eq!(glyph.procedure_width, (600.0, 0.0));
+    assert_eq!(glyph.bbox, None);
+}
+
+#[test]
+fn malformed_charproc_is_rejected_with_glyph_context() {
+    let document = PdfDocument::new(
+        PdfReader::new(Cursor::new(build_pdf_with_glyph(b"500 d1 0 0 m"))).unwrap(),
+    );
+    let error = Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document)
+        .expect_err("malformed d1 must not be silently skipped");
+    let message = error.to_string();
+    assert!(message.contains("/a16"), "missing glyph name: {message}");
+    assert!(message.contains("code 16"), "missing glyph code: {message}");
+}
+
+#[test]
+fn bounded_decode_stops_flate_expansion_at_the_local_limit() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&vec![b'x'; 4096]).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("FlateDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: compressed,
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 1024)
+        .expect_err("the decoder must stop before allocating the full output");
+    assert!(error.to_string().contains("1024"));
+}

--- a/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
+++ b/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
@@ -130,3 +130,59 @@ fn bounded_decode_stops_flate_expansion_at_the_local_limit() {
         .expect_err("the decoder must stop before allocating the full output");
     assert!(error.to_string().contains("1024"));
 }
+
+#[test]
+fn bounded_decode_limits_output_not_ascii_encoded_input() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("ASCIIHexDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: b"00>".to_vec(),
+    };
+
+    assert_eq!(
+        stream
+            .decode_with_limit(&ParseOptions::default(), 1)
+            .expect("one decoded byte is within the output limit"),
+        vec![0]
+    );
+}
+
+#[test]
+fn bounded_decode_stops_ascii85_expansion_during_output() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("ASCII85Decode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: b"z".to_vec(),
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 3)
+        .expect_err("z expands to four bytes and must stop at the limit");
+    assert!(error.to_string().contains("3"));
+}
+
+#[test]
+fn bounded_decode_rejects_filters_without_a_bounded_decoder() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("CCITTFaxDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: Vec::new(),
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 1024)
+        .expect_err("an unbounded codec must not run behind the bounded API");
+    assert!(error.to_string().contains("no bounded decoder"));
+}


### PR DESCRIPTION
## Summary
- expose renderer-neutral Type 3 fonts and resolved glyph programs
- parse d0/d1 metrics and Type 3 private resources without Unicode
- add strict bounded CharProc decoding and predefined encoding support

## Validation
- 6,697 library tests passed (3 ignored)
- issue 509 tests: 5 passed
- Clippy library: clean
- Kripteia test score: 100/100
- Kripteia security: no findings

Closes #509