### PR TITLE
feat(fonts): expose resolved parser font resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install Tesseract OCR and qpdf (Ubuntu)
+      - name: Install qpdf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev qpdf
-
-      - name: Install Tesseract OCR (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install tesseract
-
-      - name: Install Tesseract OCR (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install tesseract
-          echo "C:\Program Files\Tesseract-OCR" >> $env:GITHUB_PATH
+        run: sudo apt-get update && sudo apt-get install -y qpdf
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -146,9 +136,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install Tesseract OCR
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev
-
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -179,8 +166,8 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-msrv-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      # Build only — rusty-tesseract (ocr-tesseract) shells out to the tesseract
-      # binary at runtime via subprocess, so the C library is not needed to compile.
+      # Build only — the optional OCR adapter shells out to Tesseract at runtime,
+      # so neither the executable nor a C development package is needed here.
       - name: Build library on MSRV (all features, locked)
         run: cargo build --lib --all-features --locked
 
@@ -201,8 +188,8 @@ jobs:
       # was no such gate. With ~17K crates.io downloads and an anonymous
       # third-party consumer base, breaking changes must be batched into a planned
       # MAJOR bundle, never leak into a minor. rustdoc-JSON generation only
-      # compiles the crate; the tesseract C library is not needed (OCR shells out
-      # at runtime), same as the MSRV job.
+      # compiles the crate; the optional OCR executable is not needed, same as
+      # the MSRV and examples compile gates.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install qpdf (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y qpdf
-
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -88,22 +84,6 @@ jobs:
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
-
-      - name: Validate incremental text notes with qpdf
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: >
-          cargo test -p oxidize-pdf
-          --test issue_493_incremental_text_notes_test
-          qpdf_accepts_incremental_text_note_revision
-          -- --ignored --exact
-
-      - name: Validate AES-256 R5 interoperability with qpdf
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: >
-          cargo test -p oxidize-pdf
-          --test issue_492_aes256_perms_interop_test
-          qpdf_checks_and_linearizes_generated_aes256_r5_pdf
-          -- --ignored --exact
 
       # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
       # enricher/extra bag), so the default test step above never compiles its

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Install Tesseract OCR and PDF tools
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev poppler-utils
+      - name: Install PDF tools
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -1,0 +1,48 @@
+name: Interoperability
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  qpdf:
+    name: qpdf external validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-qpdf-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install qpdf
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y --no-install-recommends qpdf
+
+      - name: Validate incremental text notes
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_493_incremental_text_notes_test
+          qpdf_accepts_incremental_text_note_revision
+          -- --ignored --exact
+
+      - name: Validate AES-256 R5 interoperability
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_492_aes256_perms_interop_test
+          qpdf_checks_and_linearizes_generated_aes256_r5_pdf
+          -- --ignored --exact

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -102,14 +102,6 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["memoryapi", "handleapi", "winnt"] }
 
-# Image processing dependencies (optional)
-image = { workspace = true, optional = true }
-
-# OCR dependencies (optional)
-rusty-tesseract = { version = "1.1.10", optional = true }
-# tesseract = { version = "0.15.2", optional = true, features = ["tesseract_5_2"] }
-# leptonica-plumbing = { version = "1.0", optional = true }
-
 [dev-dependencies]
 # Trusted TIFF/PDF (early-change) LZW codec, used only to encode boundary-
 # crossing fixtures for the LZW decoder regression tests. Also pulled in

--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -10,6 +10,7 @@ pub mod font_cache;
 pub mod font_descriptor;
 pub mod font_metrics;
 pub mod loader;
+pub mod resolved;
 pub mod standard_14;
 pub mod ttf_parser;
 pub mod type0;
@@ -22,6 +23,9 @@ pub use font_cache::FontCache;
 pub use font_descriptor::{FontDescriptor, FontFlags};
 pub use font_metrics::{FontMetrics, TextMeasurement};
 pub use loader::{FontData, FontFormat, FontLoader};
+pub use resolved::{
+    DecodedGlyph, EmbeddedFont, EmbeddedFontFormat, FontSubtype, ResolvedFontResource, WritingMode,
+};
 pub use standard_14::Standard14Font;
 pub use ttf_parser::{GlyphMapping, TtfParser};
 pub use type0::{create_type0_from_font, needs_type0_font, Type0Font};

--- a/oxidize-pdf-core/src/fonts/resolved.rs
+++ b/oxidize-pdf-core/src/fonts/resolved.rs
@@ -1,0 +1,736 @@
+//! Parser-side resolved font resources for downstream renderers.
+
+use crate::fonts::{Type3Font, MAX_FONT_STREAM_SIZE};
+use crate::parser::document::PdfDocument;
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::{ParseError, ParseResult};
+use crate::text::cmap::CMap;
+use crate::text::encoding::TextEncoding;
+use crate::text::encoding_cmap::{decode_utf16be, resolve_predefined, CidEncoding, EncodingCMap};
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Read, Seek};
+
+const MAX_CMAP_STREAM_SIZE: usize = 8 * 1024 * 1024;
+const MAX_CID_TO_GID_MAP_SIZE: usize = (u16::MAX as usize + 1) * 2;
+
+/// Concrete PDF font subtype used for rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontSubtype {
+    Type1,
+    TrueType,
+    CidFontType0,
+    CidFontType2,
+    Type3,
+}
+
+/// Direction declared by a composite font's encoding CMap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WritingMode {
+    Horizontal,
+    Vertical,
+}
+
+/// Decoded embedded font program format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedFontFormat {
+    Type1,
+    TrueType,
+    Type1C,
+    CidFontType0C,
+    OpenType,
+}
+
+/// Embedded font bytes and their PDF-declared format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedFont {
+    /// Container/program format declared by the PDF font descriptor.
+    pub format: EmbeddedFontFormat,
+    /// Decoded, size-bounded font-program bytes.
+    pub data: Vec<u8>,
+}
+
+/// One renderer-ready glyph decoded from a `Tj` string or a string item in `TJ`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedGlyph {
+    /// Exact bytes consumed for this PDF character code.
+    pub source_code: Vec<u8>,
+    /// CID selected by a composite encoding, or `None` for simple fonts and unmapped codes.
+    pub cid: Option<u32>,
+    /// Glyph identifier selected through `CIDToGIDMap`, when applicable.
+    pub gid: Option<u16>,
+    /// Best available Unicode mapping, preferring `ToUnicode`.
+    pub unicode: Option<String>,
+    /// Horizontal or vertical advance from the font's width tables.
+    pub advance: f64,
+}
+
+#[derive(Debug, Clone)]
+enum CodeEncoding {
+    Simple,
+    Identity,
+    Composite(CidEncoding),
+}
+
+#[derive(Debug, Clone)]
+enum CidToGid {
+    Identity,
+    Table(Vec<u16>),
+}
+
+#[derive(Debug, Clone)]
+struct CidWidths {
+    explicit: HashMap<u32, f64>,
+    ranges: Vec<(u32, u32, f64)>,
+    default: f64,
+}
+
+impl CidWidths {
+    fn width(&self, cid: u32) -> f64 {
+        self.explicit
+            .get(&cid)
+            .copied()
+            .or_else(|| {
+                self.ranges
+                    .iter()
+                    .rev()
+                    .find(|(first, last, _)| cid >= *first && cid <= *last)
+                    .map(|(_, _, width)| *width)
+            })
+            .unwrap_or(self.default)
+    }
+}
+
+/// A font entry resolved entirely through [`PdfDocument`]'s parser object model.
+#[derive(Debug, Clone)]
+pub struct ResolvedFontResource {
+    /// Name used for the font in the page resource dictionary.
+    pub resource_name: String,
+    /// PDF `BaseFont`/Type3 `Name`, when present.
+    pub base_font: Option<String>,
+    /// Concrete simple, CID descendant, or Type3 subtype.
+    pub subtype: FontSubtype,
+    /// Named PDF encoding, when the font uses one.
+    pub encoding: Option<String>,
+    /// Writing direction selected by a composite encoding CMap.
+    pub writing_mode: WritingMode,
+    /// Simple-font character-code overrides from `Differences`.
+    pub differences: BTreeMap<u8, String>,
+    /// Decoded embedded font program, when present.
+    pub embedded_font: Option<EmbeddedFont>,
+    /// Parsed Type3 glyph programs, only for Type3 resources.
+    pub type3: Option<Type3Font>,
+    code_encoding: CodeEncoding,
+    to_unicode: Option<CMap>,
+    cid_to_gid: Option<CidToGid>,
+    cid_widths: Option<CidWidths>,
+    first_char: u32,
+    simple_widths: Vec<f64>,
+    missing_width: f64,
+    symbolic: bool,
+}
+
+impl ResolvedFontResource {
+    /// Resolve a named font from a page's effective, inherited resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error when the page/resource hierarchy or font data is
+    /// missing, malformed, cyclic, unsupported, or exceeds a stream limit.
+    pub fn from_page<R: Read + Seek>(
+        document: &PdfDocument<R>,
+        page_index: u32,
+        resource_name: &str,
+    ) -> ParseResult<Self> {
+        let page = document.get_page(page_index)?;
+        let resources = document
+            .get_page_resources(&page)?
+            .ok_or_else(|| missing("page Resources"))?;
+        let fonts = resolve_required(document, resources, "Font")?;
+        let fonts = expect_dict(&fonts, "page Font resources")?;
+        let font_object = fonts
+            .get(resource_name)
+            .ok_or_else(|| missing(&format!("font resource /{resource_name}")))?;
+        Self::resolve(document, resource_name, font_object)
+    }
+
+    /// Resolve a direct or indirect font dictionary.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error for malformed, cyclic, unsupported, or oversized
+    /// font resources.
+    pub fn resolve<R: Read + Seek>(
+        document: &PdfDocument<R>,
+        resource_name: &str,
+        font_object: &PdfObject,
+    ) -> ParseResult<Self> {
+        let resolved = document.resolve(font_object)?;
+        let font = expect_dict(&resolved, "font resource")?;
+        let declared_subtype = required_name(font, "Subtype")?;
+        if declared_subtype == "Type3" {
+            let type3 = Type3Font::resolve(font_object, document)?;
+            let to_unicode = resolve_cmap(document, font.get("ToUnicode"))?;
+            let mut differences = BTreeMap::new();
+            let mut widths = vec![0.0; 256];
+            for glyph in type3.glyphs() {
+                differences.insert(glyph.code, glyph.name.clone());
+                widths[glyph.code as usize] = glyph.width;
+            }
+            return Ok(Self {
+                resource_name: resource_name.into(),
+                base_font: type3.name.clone(),
+                subtype: FontSubtype::Type3,
+                encoding: None,
+                writing_mode: WritingMode::Horizontal,
+                differences,
+                embedded_font: None,
+                type3: Some(type3),
+                code_encoding: CodeEncoding::Simple,
+                to_unicode,
+                cid_to_gid: None,
+                cid_widths: None,
+                first_char: 0,
+                simple_widths: widths,
+                missing_width: 0.0,
+                symbolic: false,
+            });
+        }
+
+        let base_font = font
+            .get("BaseFont")
+            .and_then(PdfObject::as_name)
+            .map(|name| name.0.clone());
+        let to_unicode = resolve_cmap(document, font.get("ToUnicode"))?;
+        let (encoding, differences, code_encoding, writing_mode) =
+            resolve_encoding(document, font.get("Encoding"), declared_subtype == "Type0")?;
+
+        let descendant_storage;
+        let concrete = if declared_subtype == "Type0" {
+            let descendants = resolve_required(document, font, "DescendantFonts")?;
+            let descendants = descendants
+                .as_array()
+                .ok_or_else(|| syntax("DescendantFonts must be an array"))?;
+            let descendant = descendants
+                .0
+                .first()
+                .ok_or_else(|| syntax("DescendantFonts must not be empty"))?;
+            descendant_storage = document.resolve(descendant)?;
+            expect_dict(&descendant_storage, "CID descendant font")?
+        } else {
+            font
+        };
+        let concrete_name = required_name(concrete, "Subtype")?;
+        let subtype = match concrete_name {
+            "Type1" | "MMType1" => FontSubtype::Type1,
+            "TrueType" => FontSubtype::TrueType,
+            "CIDFontType0" => FontSubtype::CidFontType0,
+            "CIDFontType2" => FontSubtype::CidFontType2,
+            other => return Err(syntax(&format!("unsupported font subtype /{other}"))),
+        };
+        let composite = declared_subtype == "Type0";
+        let cid_subtype = matches!(
+            subtype,
+            FontSubtype::CidFontType0 | FontSubtype::CidFontType2
+        );
+        if composite != cid_subtype {
+            return Err(syntax(if composite {
+                "Type0 descendant must be CIDFontType0 or CIDFontType2"
+            } else {
+                "CID font subtype must be a descendant of Type0"
+            }));
+        }
+
+        let descriptor = resolve_optional_dict(document, concrete.get("FontDescriptor"))?;
+        let embedded_font = descriptor
+            .as_ref()
+            .map(|dict| resolve_embedded_font(document, dict))
+            .transpose()?
+            .flatten();
+        let missing_width = descriptor
+            .as_ref()
+            .and_then(|dict| dict.get("MissingWidth"))
+            .and_then(PdfObject::as_real)
+            .unwrap_or(0.0);
+        let symbolic = descriptor
+            .as_ref()
+            .and_then(|dict| dict.get("Flags"))
+            .and_then(PdfObject::as_integer)
+            .is_some_and(|flags| flags & 4 != 0)
+            || base_font.as_deref() == Some("Symbol");
+
+        let cid_widths = matches!(
+            subtype,
+            FontSubtype::CidFontType0 | FontSubtype::CidFontType2
+        )
+        .then(|| parse_cid_widths(document, concrete))
+        .transpose()?;
+        let cid_to_gid = if subtype == FontSubtype::CidFontType2 {
+            resolve_cid_to_gid(document, concrete.get("CIDToGIDMap"))?
+        } else {
+            None
+        };
+        let first_char = font
+            .get("FirstChar")
+            .and_then(PdfObject::as_integer)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0);
+        let simple_widths = resolve_number_array(document, font.get("Widths"))?;
+
+        Ok(Self {
+            resource_name: resource_name.into(),
+            base_font,
+            subtype,
+            encoding,
+            writing_mode,
+            differences,
+            embedded_font,
+            type3: None,
+            code_encoding,
+            to_unicode,
+            cid_to_gid,
+            cid_widths,
+            first_char,
+            simple_widths,
+            missing_width,
+            symbolic,
+        })
+    }
+
+    /// Decode a PDF string into renderer-ready glyph identities and advances.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error when a character code is truncated or wider than
+    /// the supported four-byte PDF code space.
+    pub fn decode_glyphs(&self, bytes: &[u8]) -> ParseResult<Vec<DecodedGlyph>> {
+        let mut glyphs = Vec::new();
+        let mut position = 0;
+        while position < bytes.len() {
+            let code_len = match &self.code_encoding {
+                CodeEncoding::Simple => 1,
+                CodeEncoding::Identity | CodeEncoding::Composite(CidEncoding::Utf16Be) => 2,
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)) => {
+                    cmap.code_len_at(bytes, position)
+                }
+            };
+            if position + code_len > bytes.len() {
+                return Err(syntax("truncated character code"));
+            }
+            let code = bytes[position..position + code_len].to_vec();
+            position += code_len;
+            let cid = match &self.code_encoding {
+                CodeEncoding::Simple => None,
+                CodeEncoding::Identity | CodeEncoding::Composite(CidEncoding::Utf16Be) => {
+                    Some(be_code(&code)?)
+                }
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)) => cmap
+                    .map_code_to_cid(&code)
+                    .or_else(|| cmap.map_notdef(&code))
+                    .map(u32::from),
+            };
+            let gid = cid.and_then(|cid| self.gid_for(cid));
+            let unicode = self.unicode_for(&code);
+            let advance = match &self.cid_widths {
+                Some(widths) => cid.map_or(widths.default, |cid| widths.width(cid)),
+                None => self.simple_width(be_code(&code)?),
+            };
+            glyphs.push(DecodedGlyph {
+                source_code: code,
+                cid,
+                gid,
+                unicode,
+                advance,
+            });
+        }
+        Ok(glyphs)
+    }
+
+    fn gid_for(&self, cid: u32) -> Option<u16> {
+        match self.cid_to_gid.as_ref()? {
+            CidToGid::Identity => u16::try_from(cid).ok(),
+            CidToGid::Table(table) => table.get(cid as usize).copied(),
+        }
+    }
+
+    fn unicode_for(&self, code: &[u8]) -> Option<String> {
+        if let Some(cmap) = &self.to_unicode {
+            if let Some(mapped) = cmap.map(code) {
+                return cmap.to_unicode(&mapped);
+            }
+        }
+        if matches!(
+            self.code_encoding,
+            CodeEncoding::Composite(CidEncoding::Utf16Be)
+        ) {
+            return Some(decode_utf16be(code));
+        }
+        if matches!(self.code_encoding, CodeEncoding::Simple) {
+            let value = code[0];
+            if let Some(name) = self.differences.get(&value) {
+                return glyph_name_to_unicode(name).map(str::to_owned);
+            }
+            if self.symbolic {
+                return symbol_code_to_unicode(value).map(str::to_owned);
+            }
+            let decoder = match self.encoding.as_deref() {
+                Some("WinAnsiEncoding") => TextEncoding::WinAnsiEncoding,
+                Some("MacRomanEncoding") => TextEncoding::MacRomanEncoding,
+                _ => TextEncoding::StandardEncoding,
+            };
+            return Some(decoder.decode(&[value]));
+        }
+        None
+    }
+
+    fn simple_width(&self, code: u32) -> f64 {
+        code.checked_sub(self.first_char)
+            .and_then(|offset| self.simple_widths.get(offset as usize))
+            .copied()
+            .unwrap_or(self.missing_width)
+    }
+}
+
+fn resolve_encoding<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+    composite: bool,
+) -> ParseResult<(
+    Option<String>,
+    BTreeMap<u8, String>,
+    CodeEncoding,
+    WritingMode,
+)> {
+    let Some(object) = object else {
+        if composite {
+            return Err(syntax("Type0 font is missing its Encoding"));
+        }
+        return Ok((
+            None,
+            BTreeMap::new(),
+            CodeEncoding::Simple,
+            WritingMode::Horizontal,
+        ));
+    };
+    let resolved = document.resolve(object)?;
+    match resolved {
+        PdfObject::Name(name) if composite => {
+            let vertical = name.0.ends_with("-V");
+            let code_encoding =
+                if matches!(name.0.as_str(), "Identity-H" | "Identity-V") {
+                    CodeEncoding::Identity
+                } else {
+                    CodeEncoding::Composite(resolve_predefined(&name.0).ok_or_else(|| {
+                        syntax(&format!("unsupported predefined CMap /{}", name.0))
+                    })?)
+                };
+            Ok((
+                Some(name.0),
+                BTreeMap::new(),
+                code_encoding,
+                if vertical {
+                    WritingMode::Vertical
+                } else {
+                    WritingMode::Horizontal
+                },
+            ))
+        }
+        PdfObject::Name(name) => Ok((
+            Some(name.0),
+            BTreeMap::new(),
+            CodeEncoding::Simple,
+            WritingMode::Horizontal,
+        )),
+        PdfObject::Dictionary(dict) if !composite => {
+            let base = dict
+                .get("BaseEncoding")
+                .and_then(PdfObject::as_name)
+                .map(|name| name.0.clone());
+            Ok((
+                base,
+                parse_differences(&dict)?,
+                CodeEncoding::Simple,
+                WritingMode::Horizontal,
+            ))
+        }
+        PdfObject::Stream(stream) if composite => {
+            let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+            let cmap = EncodingCMap::parse(&data)?;
+            let mode = if cmap.wmode == 1 {
+                WritingMode::Vertical
+            } else {
+                WritingMode::Horizontal
+            };
+            Ok((
+                None,
+                BTreeMap::new(),
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)),
+                mode,
+            ))
+        }
+        _ => Err(syntax("invalid font Encoding")),
+    }
+}
+
+fn resolve_cmap<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<CMap>> {
+    let Some(object) = object else {
+        return Ok(None);
+    };
+    let resolved = document.resolve(object)?;
+    let stream = resolved
+        .as_stream()
+        .ok_or_else(|| syntax("ToUnicode must be a stream"))?;
+    let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+    CMap::parse(&data).map(Some)
+}
+
+fn resolve_cid_to_gid<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<CidToGid>> {
+    let Some(object) = object else {
+        return Ok(Some(CidToGid::Identity));
+    };
+    let resolved = document.resolve(object)?;
+    match resolved {
+        PdfObject::Name(name) if name.0 == "Identity" => Ok(Some(CidToGid::Identity)),
+        PdfObject::Stream(stream) => {
+            let data = stream.decode_with_limit(&document.options(), MAX_CID_TO_GID_MAP_SIZE)?;
+            if data.len() % 2 != 0 {
+                return Err(syntax("CIDToGIDMap stream has odd length"));
+            }
+            Ok(Some(CidToGid::Table(
+                data.chunks_exact(2)
+                    .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+                    .collect(),
+            )))
+        }
+        _ => Err(syntax("CIDToGIDMap must be /Identity or a stream")),
+    }
+}
+
+fn parse_cid_widths<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+) -> ParseResult<CidWidths> {
+    let default = dict
+        .get("DW")
+        .and_then(PdfObject::as_real)
+        .unwrap_or(1000.0);
+    let entries = resolve_number_or_array_object(document, dict.get("W"))?;
+    let Some(entries) = entries.and_then(|object| object.as_array().cloned()) else {
+        return Ok(CidWidths {
+            explicit: HashMap::new(),
+            ranges: Vec::new(),
+            default,
+        });
+    };
+    let mut explicit = HashMap::new();
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    while index < entries.0.len() {
+        let first = entries.0[index]
+            .as_integer()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| syntax("invalid first CID in W"))?;
+        match entries.0.get(index + 1) {
+            Some(PdfObject::Array(widths)) => {
+                for (offset, width) in widths.0.iter().enumerate() {
+                    let cid = first
+                        .checked_add(u32::try_from(offset).map_err(|_| syntax("W range overflow"))?)
+                        .ok_or_else(|| syntax("W range overflow"))?;
+                    explicit.insert(
+                        cid,
+                        width.as_real().ok_or_else(|| syntax("invalid W width"))?,
+                    );
+                }
+                index += 2;
+            }
+            Some(last) => {
+                let last = last
+                    .as_integer()
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| syntax("invalid last CID in W"))?;
+                let width = entries
+                    .0
+                    .get(index + 2)
+                    .and_then(PdfObject::as_real)
+                    .ok_or_else(|| syntax("missing W range width"))?;
+                if last < first {
+                    return Err(syntax("reversed CID width range"));
+                }
+                ranges.push((first, last, width));
+                index += 3;
+            }
+            None => return Err(syntax("truncated W array")),
+        }
+    }
+    Ok(CidWidths {
+        explicit,
+        ranges,
+        default,
+    })
+}
+
+fn resolve_embedded_font<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    descriptor: &PdfDictionary,
+) -> ParseResult<Option<EmbeddedFont>> {
+    for (key, default_format) in [
+        ("FontFile", EmbeddedFontFormat::Type1),
+        ("FontFile2", EmbeddedFontFormat::TrueType),
+        ("FontFile3", EmbeddedFontFormat::Type1C),
+    ] {
+        let Some(object) = descriptor.get(key) else {
+            continue;
+        };
+        let resolved = document.resolve(object)?;
+        let stream = resolved
+            .as_stream()
+            .ok_or_else(|| syntax(&format!("{key} must be a stream")))?;
+        let format = if key == "FontFile3" {
+            match stream
+                .dict
+                .get("Subtype")
+                .and_then(PdfObject::as_name)
+                .map(|n| n.0.as_str())
+            {
+                Some("Type1C") => EmbeddedFontFormat::Type1C,
+                Some("CIDFontType0C") => EmbeddedFontFormat::CidFontType0C,
+                Some("OpenType") => EmbeddedFontFormat::OpenType,
+                _ => return Err(syntax("FontFile3 has unsupported or missing Subtype")),
+            }
+        } else {
+            default_format
+        };
+        let data = stream.decode_with_limit(&document.options(), MAX_FONT_STREAM_SIZE)?;
+        return Ok(Some(EmbeddedFont { format, data }));
+    }
+    Ok(None)
+}
+
+fn parse_differences(dict: &PdfDictionary) -> ParseResult<BTreeMap<u8, String>> {
+    let mut result = BTreeMap::new();
+    let Some(array) = dict.get("Differences").and_then(PdfObject::as_array) else {
+        return Ok(result);
+    };
+    let mut code = None;
+    for object in &array.0 {
+        if let Some(value) = object.as_integer() {
+            code =
+                Some(u8::try_from(value).map_err(|_| syntax("Differences code outside 0..=255"))?);
+        } else if let Some(name) = object.as_name() {
+            let current = code.ok_or_else(|| syntax("Differences name without a code"))?;
+            result.insert(current, name.0.clone());
+            code = current.checked_add(1);
+        } else {
+            return Err(syntax("invalid Differences entry"));
+        }
+    }
+    Ok(result)
+}
+
+fn resolve_number_array<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Vec<f64>> {
+    let Some(object) = resolve_number_or_array_object(document, object)? else {
+        return Ok(Vec::new());
+    };
+    let array = object
+        .as_array()
+        .ok_or_else(|| syntax("Widths must be an array"))?;
+    array
+        .0
+        .iter()
+        .map(|value| {
+            value
+                .as_real()
+                .ok_or_else(|| syntax("Widths must be numeric"))
+        })
+        .collect()
+}
+
+fn resolve_number_or_array_object<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<PdfObject>> {
+    object.map(|value| document.resolve(value)).transpose()
+}
+
+fn resolve_optional_dict<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<PdfDictionary>> {
+    let Some(object) = object else {
+        return Ok(None);
+    };
+    let resolved = document.resolve(object)?;
+    resolved
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| syntax("FontDescriptor must be a dictionary"))
+        .map(Some)
+}
+
+fn resolve_required<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+    key: &str,
+) -> ParseResult<PdfObject> {
+    document.resolve(dict.get(key).ok_or_else(|| missing(key))?)
+}
+
+fn expect_dict<'a>(object: &'a PdfObject, description: &str) -> ParseResult<&'a PdfDictionary> {
+    object
+        .as_dict()
+        .ok_or_else(|| syntax(&format!("{description} must be a dictionary")))
+}
+
+fn required_name<'a>(dict: &'a PdfDictionary, key: &str) -> ParseResult<&'a str> {
+    dict.get(key)
+        .and_then(PdfObject::as_name)
+        .map(|name| name.0.as_str())
+        .ok_or_else(|| missing(key))
+}
+
+fn be_code(code: &[u8]) -> ParseResult<u32> {
+    if code.len() > 4 {
+        return Err(syntax("character code exceeds four bytes"));
+    }
+    Ok(code
+        .iter()
+        .fold(0u32, |value, byte| (value << 8) | u32::from(*byte)))
+}
+
+fn glyph_name_to_unicode(name: &str) -> Option<&'static str> {
+    match name {
+        "bullet" => Some("•"),
+        "space" => Some(" "),
+        "hyphen" => Some("-"),
+        "minus" => Some("−"),
+        "checkmark" => Some("✓"),
+        _ => None,
+    }
+}
+
+fn symbol_code_to_unicode(code: u8) -> Option<&'static str> {
+    match code {
+        0xB7 => Some("•"),
+        b'x' => Some("ξ"),
+        _ => None,
+    }
+}
+
+fn missing(key: &str) -> ParseError {
+    ParseError::MissingKey(key.into())
+}
+
+fn syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.into(),
+    }
+}

--- a/oxidize-pdf-core/tests/issue_513_resolved_parser_fonts_test.rs
+++ b/oxidize-pdf-core/tests/issue_513_resolved_parser_fonts_test.rs
@@ -1,0 +1,296 @@
+//! Issue #513 — coherent parser-side font resources for renderers.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::fonts::{EmbeddedFontFormat, FontSubtype, ResolvedFontResource, WritingMode};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use std::io::Cursor;
+use std::io::Write;
+
+fn identity_type2_pdf() -> Vec<u8> {
+    let to_unicode = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+1 beginbfchar <0001> <00E1> endbfchar\n\
+endcmap end end";
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 /Resources << /Font << /F1 5 0 R >> >> >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b"BT /F1 12 Tf <00010002> Tj ET"),
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Demo /Encoding /Identity-H /DescendantFonts [6 0 R] /ToUnicode 9 0 R >>".to_vec(),
+        b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Demo /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /W [1 [600 700]] /DW 1000 /CIDToGIDMap 8 0 R >>".to_vec(),
+        b"<< /Type /FontDescriptor /FontName /Demo /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile2 10 0 R >>".to_vec(),
+        stream_obj("", &[0, 0, 0, 5, 0, 9]),
+        stream_obj("", to_unicode),
+        stream_obj("", b"\0\x01\0\0fake-ttf"),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_inherited_identity_type2_into_renderer_glyphs() {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(identity_type2_pdf())).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.base_font.as_deref(), Some("Demo"));
+    assert_eq!(font.subtype, FontSubtype::CidFontType2);
+    assert_eq!(font.writing_mode, WritingMode::Horizontal);
+    let embedded = font.embedded_font.as_ref().expect("FontFile2 resolved");
+    assert_eq!(embedded.format, EmbeddedFontFormat::TrueType);
+    assert_eq!(embedded.data, b"\0\x01\0\0fake-ttf");
+
+    let glyphs = font.decode_glyphs(&[0, 1, 0, 2]).unwrap();
+    assert_eq!(glyphs.len(), 2);
+    assert_eq!(glyphs[0].source_code, vec![0, 1]);
+    assert_eq!(glyphs[0].cid, Some(1));
+    assert_eq!(glyphs[0].gid, Some(5));
+    assert_eq!(glyphs[0].unicode.as_deref(), Some("á"));
+    assert_eq!(glyphs[0].advance, 600.0);
+    assert_eq!(glyphs[1].cid, Some(2));
+    assert_eq!(glyphs[1].gid, Some(9));
+    assert_eq!(glyphs[1].unicode, None);
+    assert_eq!(glyphs[1].advance, 700.0);
+}
+
+fn one_font_pdf(font: Vec<u8>, extra: Vec<Vec<u8>>) -> Vec<u8> {
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b""),
+        font,
+    ];
+    objects.extend(extra);
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_cidfont_type0_open_type_program_and_vertical_mode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /CffDemo /Encoding /Identity-V /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CffDemo /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /DW 880 >>".to_vec(),
+            b"<< /Type /FontDescriptor /FontName /CffDemo /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile3 8 0 R >>".to_vec(),
+            stream_obj("/Subtype /OpenType", b"OTTOcff-data"),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.subtype, FontSubtype::CidFontType0);
+    assert_eq!(font.writing_mode, WritingMode::Vertical);
+    assert_eq!(
+        font.embedded_font.as_ref().unwrap().format,
+        EmbeddedFontFormat::OpenType
+    );
+    let glyph = font.decode_glyphs(&[0, 7]).unwrap().remove(0);
+    assert_eq!(glyph.cid, Some(7));
+    assert_eq!(glyph.gid, None);
+    assert_eq!(glyph.advance, 880.0);
+}
+
+#[test]
+fn resolves_symbol_difference_as_a_bullet_not_latin_x() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Symbol /FirstChar 120 /LastChar 120 /Widths [500] /Encoding << /Differences [120 /bullet] >> /FontDescriptor 6 0 R >>".to_vec(),
+        vec![b"<< /Type /FontDescriptor /FontName /Symbol /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"x").unwrap().remove(0);
+
+    assert_eq!(
+        font.differences.get(&120).map(String::as_str),
+        Some("bullet")
+    );
+    assert_eq!(glyph.source_code, b"x");
+    assert_eq!(glyph.unicode.as_deref(), Some("•"));
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.advance, 500.0);
+}
+
+#[test]
+fn resolves_non_identity_encoding_cmap_and_default_identity_gid() {
+    let encoding = b"begincmap /WMode 0 def 1 begincodespacerange <00> <FF> endcodespacerange 1 begincidchar <41> 5 endcidchar endcmap";
+    let to_unicode = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange 1 beginbfchar <41> <0041> endbfchar endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Mapped /Encoding 7 0 R /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Mapped /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /W [5 [444]] >>".to_vec(),
+            stream_obj("", encoding),
+            stream_obj("", to_unicode),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"A").unwrap().remove(0);
+
+    assert_eq!(glyph.source_code, b"A");
+    assert_eq!(glyph.cid, Some(5));
+    assert_eq!(glyph.gid, Some(5));
+    assert_eq!(glyph.unicode.as_deref(), Some("A"));
+    assert_eq!(glyph.advance, 444.0);
+}
+
+#[test]
+fn utf16_encoding_preserves_unicode_without_tounicode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /UnicodeCid /Encoding /UniJIS-UTF16-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /UnicodeCid /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /W [225 [555]] >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(&[0, 0xE1]).unwrap().remove(0);
+
+    assert_eq!(glyph.cid, Some(0xE1));
+    assert_eq!(glyph.gid, Some(0xE1));
+    assert_eq!(glyph.unicode.as_deref(), Some("á"));
+    assert_eq!(glyph.advance, 555.0);
+}
+
+#[test]
+fn decodes_win_ansi_without_confusing_code_and_unicode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /TrueType /BaseFont /Arial /FirstChar 149 /LastChar 149 /Widths [350] /Encoding /WinAnsiEncoding >>".to_vec(),
+        vec![],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(&[0x95]).unwrap().remove(0);
+
+    assert_eq!(glyph.source_code, vec![0x95]);
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.unicode.as_deref(), Some("•"));
+    assert_eq!(glyph.advance, 350.0);
+}
+
+#[test]
+fn exposes_type3_through_the_coherent_resource_model() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type3 /Name /Painted /FontBBox [0 0 1 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 65 /LastChar 65 /Widths [500] /Encoding << /Differences [65 /A] >> /CharProcs << /A 6 0 R >> >>".to_vec(),
+        vec![stream_obj("", b"500 0 d0")],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.subtype, FontSubtype::Type3);
+    assert_eq!(font.type3.as_ref().unwrap().glyph(65).unwrap().width, 500.0);
+    assert_eq!(font.decode_glyphs(b"A").unwrap()[0].advance, 500.0);
+}
+
+#[test]
+fn type3_uses_tounicode_when_decoding_glyphs() {
+    let to_unicode = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange 1 beginbfchar <41> <03A9> endbfchar endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type3 /Name /Painted /FontBBox [0 0 1 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 65 /LastChar 65 /Widths [500] /Encoding << /Differences [65 /A] >> /CharProcs << /A 6 0 R >> /ToUnicode 7 0 R >>".to_vec(),
+        vec![stream_obj("", b"500 0 d0"), stream_obj("", to_unicode)],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(
+        font.decode_glyphs(b"A").unwrap()[0].unicode.as_deref(),
+        Some("Ω")
+    );
+}
+
+#[test]
+fn unmapped_composite_code_uses_default_cid_width() {
+    let encoding = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Mapped /Encoding 7 0 R /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Mapped /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /DW 777 >>".to_vec(),
+            stream_obj("", encoding),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"A").unwrap().remove(0);
+
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.advance, 777.0);
+}
+
+#[test]
+fn rejects_non_cid_descendant_in_type0_font() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /TrueType /BaseFont /Bad >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+
+    assert!(error.to_string().contains("Type0 descendant"));
+}
+
+#[test]
+fn rejects_odd_cid_to_gid_map_without_panicking() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Bad /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /CIDToGIDMap 7 0 R >>".to_vec(),
+            stream_obj("", &[0]),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("odd length"));
+}
+
+#[test]
+fn rejects_type0_font_without_required_encoding() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Bad /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("missing its Encoding"));
+}
+
+#[test]
+fn rejects_oversized_cid_to_gid_map_after_bounded_decompression() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&vec![0; (u16::MAX as usize + 1) * 2 + 1])
+        .unwrap();
+    let compressed = encoder.finish().unwrap();
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Huge /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Huge /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /CIDToGIDMap 7 0 R >>".to_vec(),
+            stream_obj("/Filter /FlateDecode", &compressed),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}
+
+#[test]
+fn rejects_circular_font_resource_without_panicking() {
+    let pdf = one_font_pdf(b"6 0 R".to_vec(), vec![b"5 0 R".to_vec()]);
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    assert!(ResolvedFontResource::from_page(&document, 0, "F1").is_err());
+}
+
+#[test]
+fn rejects_oversized_embedded_font_after_bounded_decompression() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&vec![0; 10 * 1024 * 1024 + 1]).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /TrueType /BaseFont /Huge /FirstChar 0 /LastChar 0 /Widths [500] /FontDescriptor 6 0 R >>".to_vec(),
+        vec![
+            b"<< /Type /FontDescriptor /FontName /Huge /Flags 32 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile2 7 0 R >>".to_vec(),
+            stream_obj("/Filter /FlateDecode", &compressed),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}


### PR DESCRIPTION
## Summary
- expose a coherent parser-side resolved font resource API for simple, Type0/CID, and Type3 fonts
- decode source codes through CID, GID, Unicode, and width mappings, including Symbol and embedded font programs
- bound decoded CMap, CIDToGIDMap, and embedded font streams and reject malformed font hierarchies

## Validation
- 15 issue-specific TDD acceptance and regression tests
- 8 Type3 regression tests
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- 6698 library tests passed, 3 ignored
- Quality Review: Kripteia 95/100 for the focused suite; no security findings

Closes #513