### PR TITLE
fix(parser): resolve indirect DecodeParms

### DIFF
--- a/oxidize-pdf-core/src/fonts/resolved.rs
+++ b/oxidize-pdf-core/src/fonts/resolved.rs
@@ -453,7 +453,7 @@ fn resolve_encoding<R: Read + Seek>(
             ))
         }
         PdfObject::Stream(stream) if composite => {
-            let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+            let data = document.decode_stream_with_limit(&stream, MAX_CMAP_STREAM_SIZE)?;
             let cmap = EncodingCMap::parse(&data)?;
             let mode = if cmap.wmode == 1 {
                 WritingMode::Vertical
@@ -482,7 +482,7 @@ fn resolve_cmap<R: Read + Seek>(
     let stream = resolved
         .as_stream()
         .ok_or_else(|| syntax("ToUnicode must be a stream"))?;
-    let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+    let data = document.decode_stream_with_limit(stream, MAX_CMAP_STREAM_SIZE)?;
     CMap::parse(&data).map(Some)
 }
 
@@ -497,7 +497,7 @@ fn resolve_cid_to_gid<R: Read + Seek>(
     match resolved {
         PdfObject::Name(name) if name.0 == "Identity" => Ok(Some(CidToGid::Identity)),
         PdfObject::Stream(stream) => {
-            let data = stream.decode_with_limit(&document.options(), MAX_CID_TO_GID_MAP_SIZE)?;
+            let data = document.decode_stream_with_limit(&stream, MAX_CID_TO_GID_MAP_SIZE)?;
             if data.len() % 2 != 0 {
                 return Err(syntax("CIDToGIDMap stream has odd length"));
             }
@@ -605,7 +605,7 @@ fn resolve_embedded_font<R: Read + Seek>(
         } else {
             default_format
         };
-        let data = stream.decode_with_limit(&document.options(), MAX_FONT_STREAM_SIZE)?;
+        let data = document.decode_stream_with_limit(stream, MAX_FONT_STREAM_SIZE)?;
         return Ok(Some(EmbeddedFont { format, data }));
     }
     Ok(None)

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -103,8 +103,8 @@ impl Type3Font {
             let stream = proc_object
                 .as_stream()
                 .ok_or_else(|| syntax("Type 3 CharProc must be a stream"))?;
-            let data = stream
-                .decode_with_limit(&document.options(), MAX_TYPE3_GLYPH_STREAM_SIZE)
+            let data = document
+                .decode_stream_with_limit(stream, MAX_TYPE3_GLYPH_STREAM_SIZE)
                 .map_err(|error| {
                     syntax(&format!(
                         "failed to decode Type 3 CharProc /{name} (code {code}): {error}"

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -51,12 +51,12 @@
 
 #[cfg(test)]
 use super::objects::{PdfArray, PdfName};
-use super::objects::{PdfDictionary, PdfObject};
+use super::objects::{PdfDictionary, PdfObject, PdfStream};
 use super::page_tree::{PageTree, ParsedPage};
 use super::reader::PdfReader;
 use super::{ParseError, ParseOptions, ParseResult};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::path::Path;
@@ -969,6 +969,98 @@ impl<R: Read + Seek> PdfDocument<R> {
         }
     }
 
+    /// Decode a stream after resolving document-owned `/DecodeParms` references.
+    ///
+    /// This is the document-aware counterpart to [`PdfStream::decode`]. Use it
+    /// when a stream dictionary may contain indirect filter parameter objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a parameter reference is missing, circular, has an
+    /// invalid type, or when the underlying filter decoder fails.
+    pub fn decode_stream(&self, stream: &PdfStream) -> ParseResult<Vec<u8>> {
+        let dict = self.stream_dict_with_resolved_decode_parms(&stream.dict)?;
+        super::filters::decode_stream(&stream.data, &dict, &self.options())
+    }
+
+    /// Decode a stream with resolved `/DecodeParms` and a maximum output size.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::decode_stream`], plus an error when a
+    /// filter would exceed `max_bytes` or has no bounded decoder.
+    pub fn decode_stream_with_limit(
+        &self,
+        stream: &PdfStream,
+        max_bytes: usize,
+    ) -> ParseResult<Vec<u8>> {
+        let dict = self.stream_dict_with_resolved_decode_parms(&stream.dict)?;
+        super::filters::decode_stream_with_limit(&stream.data, &dict, &self.options(), max_bytes)
+    }
+
+    fn stream_dict_with_resolved_decode_parms(
+        &self,
+        dict: &PdfDictionary,
+    ) -> ParseResult<PdfDictionary> {
+        let Some(decode_parms) = dict.get("DecodeParms") else {
+            return Ok(dict.clone());
+        };
+        let mut resolved_dict = dict.clone();
+        let resolved = match decode_parms {
+            PdfObject::Array(array) => PdfObject::Array(super::objects::PdfArray(
+                array
+                    .0
+                    .iter()
+                    .map(|entry| self.resolve_decode_parms_entry(entry, true))
+                    .collect::<ParseResult<Vec<_>>>()?,
+            )),
+            other => self.resolve_decode_parms_entry(other, false)?,
+        };
+        resolved_dict.insert("DecodeParms".into(), resolved);
+        Ok(resolved_dict)
+    }
+
+    fn resolve_decode_parms_entry(
+        &self,
+        object: &PdfObject,
+        array_entry: bool,
+    ) -> ParseResult<PdfObject> {
+        let mut current = object.clone();
+        let mut visited = HashSet::new();
+        let mut resolved_reference = false;
+        while let PdfObject::Reference(object_number, generation) = current {
+            resolved_reference = true;
+            if !visited.insert((object_number, generation)) {
+                return Err(ParseError::CircularReference);
+            }
+            if visited.len() > super::stack_safe::MAX_RECURSION_DEPTH {
+                return Err(ParseError::SyntaxError {
+                    position: 0,
+                    message: "DecodeParms reference chain exceeds maximum depth".into(),
+                });
+            }
+            current = self.get_object(object_number, generation)?;
+        }
+        match current {
+            PdfObject::Dictionary(_) => Ok(current),
+            PdfObject::Null if !resolved_reference => Ok(current),
+            PdfObject::Array(array) if !array_entry => {
+                Ok(PdfObject::Array(super::objects::PdfArray(
+                    array
+                        .0
+                        .iter()
+                        .map(|entry| self.resolve_decode_parms_entry(entry, true))
+                        .collect::<ParseResult<Vec<_>>>()?,
+                )))
+            }
+            _ => Err(ParseError::SyntaxError {
+                position: 0,
+                message: "DecodeParms must resolve to a dictionary, null, or an array of those"
+                    .into(),
+            }),
+        }
+    }
+
     /// Get content streams for a specific page.
     ///
     /// This method handles both single streams and arrays of streams,
@@ -1042,20 +1134,19 @@ impl<R: Read + Seek> PdfDocument<R> {
 
     pub fn get_page_content_streams(&self, page: &ParsedPage) -> ParseResult<Vec<Vec<u8>>> {
         let mut streams = Vec::new();
-        let options = self.options();
 
         if let Some(contents) = page.dict.get("Contents") {
             let resolved_contents = self.resolve(contents)?;
 
             match &resolved_contents {
                 PdfObject::Stream(stream) => {
-                    streams.push(stream.decode(&options)?);
+                    streams.push(self.decode_stream(stream)?);
                 }
                 PdfObject::Array(array) => {
                     for item in &array.0 {
                         let resolved = self.resolve(item)?;
                         if let PdfObject::Stream(stream) = resolved {
-                            streams.push(stream.decode(&options)?);
+                            streams.push(self.decode_stream(&stream)?);
                         }
                     }
                 }

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -1847,8 +1847,17 @@ fn apply_png_predictor_advanced(
     // Calculate bytes per pixel
     let bytes_per_pixel = (bpc * colors).div_ceil(8);
 
-    // Calculate row size (columns + 1 for predictor byte)
-    let row_size = columns + 1;
+    // Each PNG row contains the full sample payload plus one filter byte.
+    // `/Columns` counts pixels, not bytes, for multi-component images.
+    let row_bytes = columns
+        .checked_mul(colors)
+        .and_then(|samples| samples.checked_mul(bpc))
+        .and_then(|bits| bits.checked_add(7))
+        .map(|bits| bits / 8)
+        .ok_or_else(|| ParseError::StreamDecodeError("PNG predictor row size overflow".into()))?;
+    let row_size = row_bytes
+        .checked_add(1)
+        .ok_or_else(|| ParseError::StreamDecodeError("PNG predictor row size overflow".into()))?;
 
     if data.len() % row_size != 0 {
         return Err(ParseError::StreamDecodeError(
@@ -1857,7 +1866,7 @@ fn apply_png_predictor_advanced(
     }
 
     let num_rows = data.len() / row_size;
-    let mut result = Vec::with_capacity(columns * num_rows);
+    let mut result = Vec::with_capacity(row_bytes * num_rows);
 
     for row in 0..num_rows {
         let row_start = row * row_size;
@@ -1877,7 +1886,7 @@ fn apply_png_predictor_advanced(
             2 => {
                 // Up filter - each byte is prediction from byte above
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };
@@ -1886,7 +1895,7 @@ fn apply_png_predictor_advanced(
             3 => {
                 // Average filter
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };
@@ -1895,7 +1904,7 @@ fn apply_png_predictor_advanced(
             4 => {
                 // Paeth filter
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };

--- a/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
+++ b/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
@@ -211,7 +211,7 @@ fn decode_png_rgb(png: &[u8]) -> (u32, u32, Vec<u8>) {
 /// single-index-per-pixel data through the palette into RGB. Returns the
 /// expected pixel bytes the extractor must reproduce.
 fn reconstruct_indexed_image_rgb(doc: &PdfDocument<File>) -> (u32, u32, Vec<u8>) {
-    use oxidize_pdf::parser::objects::{PdfName, PdfStream};
+    use oxidize_pdf::parser::objects::PdfName;
 
     let stream = match doc.get_object(10, 0).unwrap() {
         PdfObject::Stream(s) => s,
@@ -244,18 +244,7 @@ fn reconstruct_indexed_image_rgb(doc: &PdfDocument<File>) -> (u32, u32, Vec<u8>)
         other => panic!("unexpected lookup table {other:?}"),
     };
 
-    // Resolve the indirect /DecodeParms so decode() applies the predictor.
-    let mut resolved_dict = stream.dict.clone();
-    let dp = doc
-        .resolve(dict.get(&PdfName("DecodeParms".into())).unwrap())
-        .unwrap();
-    resolved_dict.0.insert(PdfName("DecodeParms".into()), dp);
-    let indices = PdfStream {
-        dict: resolved_dict,
-        data: stream.data.clone(),
-    }
-    .decode(&doc.options())
-    .unwrap();
+    let indices = doc.decode_stream(&stream).unwrap();
 
     let pixel_count = (width * height) as usize;
     assert_eq!(

--- a/oxidize-pdf-core/tests/issue_514_indirect_decode_parms_test.rs
+++ b/oxidize-pdf-core/tests/issue_514_indirect_decode_parms_test.rs
@@ -1,0 +1,124 @@
+//! Issue #514 — resolve indirect DecodeParms through PdfDocument.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::parser::{objects::PdfObject, PdfDocument, PdfReader};
+use std::io::{Cursor, Write};
+
+const PIXELS: &[u8] = &[10, 20, 30, 40, 50, 60];
+
+fn compressed_predictor_row() -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&[0]).unwrap();
+    encoder.write_all(PIXELS).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn document_with_stream(
+    stream_dict: &str,
+    decode_parms_object: Vec<u8>,
+) -> PdfDocument<Cursor<Vec<u8>>> {
+    let compressed = compressed_predictor_row();
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b""),
+        stream_obj(stream_dict, &compressed),
+        decode_parms_object,
+    ]);
+    PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap())
+}
+
+fn image_stream(
+    document: &PdfDocument<Cursor<Vec<u8>>>,
+) -> oxidize_pdf::parser::objects::PdfStream {
+    match document.get_object(5, 0).unwrap() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("object 5 must be a stream, got {other:?}"),
+    }
+}
+
+#[test]
+fn indirect_decode_parms_matches_inline_predictor_output() {
+    let indirect = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+    let inline = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms << /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>",
+        b"null".to_vec(),
+    );
+
+    let indirect_bytes = indirect.decode_stream(&image_stream(&indirect)).unwrap();
+    let inline_bytes = inline.decode_stream(&image_stream(&inline)).unwrap();
+
+    assert_eq!(indirect_bytes, PIXELS);
+    assert_eq!(indirect_bytes, inline_bytes);
+}
+
+#[test]
+fn filter_array_resolves_its_indirect_parameter_entry() {
+    let document = document_with_stream(
+        "/Filter [/FlateDecode] /DecodeParms [6 0 R]",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+
+    assert_eq!(
+        document.decode_stream(&image_stream(&document)).unwrap(),
+        PIXELS
+    );
+}
+
+#[test]
+fn bounded_decode_keeps_the_existing_output_limit() {
+    let document = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+
+    let error = document
+        .decode_stream_with_limit(&image_stream(&document), PIXELS.len() - 1)
+        .unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}
+
+#[test]
+fn missing_indirect_decode_parms_is_an_error() {
+    let document =
+        document_with_stream("/Filter /FlateDecode /DecodeParms 99 0 R", b"null".to_vec());
+
+    assert!(document.decode_stream(&image_stream(&document)).is_err());
+}
+
+#[test]
+fn circular_indirect_decode_parms_is_an_error() {
+    let compressed = compressed_predictor_row();
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b""),
+        stream_obj("/Filter /FlateDecode /DecodeParms 6 0 R", &compressed),
+        b"7 0 R".to_vec(),
+        b"6 0 R".to_vec(),
+    ]);
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+
+    assert!(document.decode_stream(&image_stream(&document)).is_err());
+}
+
+#[test]
+fn non_dictionary_decode_parms_is_an_error() {
+    let document = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"(not a dictionary)".to_vec(),
+    );
+
+    let error = document
+        .decode_stream(&image_stream(&document))
+        .unwrap_err();
+    assert!(error.to_string().contains("DecodeParms"));
+}


### PR DESCRIPTION
Closes #514

## Summary
- add document-aware stream decoding that resolves indirect `/DecodeParms` dictionaries and array entries
- preserve bounded decoding limits and reject missing, circular, or invalid parameter references
- fix PNG predictor row sizing for multi-component images
- migrate parser font/content consumers and remove the issue #286 test workaround

## TDD and validation
- added 6 issue #514 regression tests (red first, then green)
- `cargo fmt --check`
- `cargo clippy -p oxidize-pdf --lib -- -D warnings`
- `cargo test -p oxidize-pdf --lib` (6698 passed, 3 ignored)
- focused issues #286/#509/#513/#514 matrix (33 passed)
- Kripteia test quality: 100/100; security: no issues found