### PR TITLE
Release v4.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install Tesseract OCR and qpdf (Ubuntu)
+      - name: Install qpdf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev qpdf
-
-      - name: Install Tesseract OCR (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install tesseract
-
-      - name: Install Tesseract OCR (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install tesseract
-          echo "C:\Program Files\Tesseract-OCR" >> $env:GITHUB_PATH
+        run: sudo apt-get update && sudo apt-get install -y qpdf
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -146,9 +136,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install Tesseract OCR
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev
-
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -179,8 +166,8 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-msrv-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      # Build only — rusty-tesseract (ocr-tesseract) shells out to the tesseract
-      # binary at runtime via subprocess, so the C library is not needed to compile.
+      # Build only — the optional OCR adapter shells out to Tesseract at runtime,
+      # so neither the executable nor a C development package is needed here.
       - name: Build library on MSRV (all features, locked)
         run: cargo build --lib --all-features --locked
 
@@ -201,8 +188,8 @@ jobs:
       # was no such gate. With ~17K crates.io downloads and an anonymous
       # third-party consumer base, breaking changes must be batched into a planned
       # MAJOR bundle, never leak into a minor. rustdoc-JSON generation only
-      # compiles the crate; the tesseract C library is not needed (OCR shells out
-      # at runtime), same as the MSRV job.
+      # compiles the crate; the optional OCR executable is not needed, same as
+      # the MSRV and examples compile gates.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - name: Install qpdf (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y qpdf
-
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -88,22 +84,6 @@ jobs:
       - name: Run tests (all others)
         if: matrix.os != 'macos-latest' || matrix.rust != 'beta'
         run: cargo test --all --features internal-testing --verbose
-
-      - name: Validate incremental text notes with qpdf
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: >
-          cargo test -p oxidize-pdf
-          --test issue_493_incremental_text_notes_test
-          qpdf_accepts_incremental_text_note_revision
-          -- --ignored --exact
-
-      - name: Validate AES-256 R5 interoperability with qpdf
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: >
-          cargo test -p oxidize-pdf
-          --test issue_492_aes256_perms_interop_test
-          qpdf_checks_and_linearizes_generated_aes256_r5_pdf
-          -- --ignored --exact
 
       # The analysis SPI is gated behind `unstable-spi` (+ `semantic` for the
       # enricher/extra bag), so the default test step above never compiles its

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Install Tesseract OCR and PDF tools
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr libtesseract-dev poppler-utils
+      - name: Install PDF tools
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -1,0 +1,48 @@
+name: Interoperability
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  qpdf:
+    name: qpdf external validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-qpdf-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install qpdf
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y --no-install-recommends qpdf
+
+      - name: Validate incremental text notes
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_493_incremental_text_notes_test
+          qpdf_accepts_incremental_text_note_revision
+          -- --ignored --exact
+
+      - name: Validate AES-256 R5 interoperability
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_492_aes256_perms_interop_test
+          qpdf_checks_and_linearizes_generated_aes256_r5_pdf
+          -- --ignored --exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flat-path word-gap threshold compared a `Tm`-scaled pen delta against an
+  unscaled font-size threshold** (#510). `flat_space_gap_threshold` derives
+  its threshold from the font's real space-glyph advance at the nominal `Tf`
+  font size, but the gap it's compared against is measured in user space,
+  already scaled by `Tm`/CTM. PDF generators that draw at `Tf 1` with the
+  real point size baked into `Tm` instead (a common technique) hit a
+  threshold far smaller, relative to the gap, than intended: an ordinary
+  sub-point positioning residue between `Tj` runs of the same token (e.g. a
+  hyphenated phone number split across separate runs) could cross it and
+  insert a spurious mid-token space. The threshold is now scaled by the same
+  `Tm`/CTM x-factor already applied to page-space widths elsewhere in
+  extraction.
+
 - **Composite (Type0/CID) font text extraction never consulted the CIDFont's
   `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a
   flat `0.5 * font_size`, regardless of its real width. When a glyph's true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.6.0] - 2026-08-20
+
+### Added
+
+- **Type 3 font glyph resolution for downstream renderers** (#509). Parser
+  consumers can resolve bounded CharProc content streams together with the
+  glyph resources and metrics needed to render Type 3 fonts safely.
+- **Resolved parser font resources** (#513). The parser now exposes resolved
+  Type0, CID, simple, and Symbol font data through public, renderer-oriented
+  font resource types while retaining safe fallbacks for malformed PDFs.
+- **Bounded in-memory image extraction** (#516). New visitor and collection
+  APIs expose encoded image data without temporary files, with configurable
+  limits for image count, per-image and total encoded bytes, and decoded
+  pixels. Existing file-based extraction APIs remain compatible.
+
 ### Fixed
 
 - **Flat-path word-gap threshold compared a `Tm`-scaled pen delta against an
@@ -22,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   insert a spurious mid-token space. The threshold is now scaled by the same
   `Tm`/CTM x-factor already applied to page-space widths elsewhere in
   extraction, together with the horizontal text scaling selected by `Tz`.
+- **Indirect `/DecodeParms` references bypassed stream predictors** (#514).
+  Filter decoding now resolves indirect parameter dictionaries before
+  applying PNG and TIFF predictors, including parameters nested in filter
+  arrays, while rejecting cycles and invalid references safely.
 
 ## [4.5.1] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hyphenated phone number split across separate runs) could cross it and
   insert a spurious mid-token space. The threshold is now scaled by the same
   `Tm`/CTM x-factor already applied to page-space widths elsewhere in
-  extraction.
+  extraction, together with the horizontal text scaling selected by `Tz`.
 
 - **Composite (Type0/CID) font text extraction never consulted the CIDFont's
   `/W`/`/DW` glyph widths** (#496). Every glyph was assumed to advance by a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.5.1"
+version = "4.6.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.5.1"
+version = "4.6.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/oxidize-pdf-core/Cargo.toml
+++ b/oxidize-pdf-core/Cargo.toml
@@ -102,14 +102,6 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["memoryapi", "handleapi", "winnt"] }
 
-# Image processing dependencies (optional)
-image = { workspace = true, optional = true }
-
-# OCR dependencies (optional)
-rusty-tesseract = { version = "1.1.10", optional = true }
-# tesseract = { version = "0.15.2", optional = true, features = ["tesseract_5_2"] }
-# leptonica-plumbing = { version = "1.0", optional = true }
-
 [dev-dependencies]
 # Trusted TIFF/PDF (early-change) LZW codec, used only to encode boundary-
 # crossing fixtures for the LZW decoder regression tests. Also pulled in

--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -14,6 +14,7 @@ pub mod standard_14;
 pub mod ttf_parser;
 pub mod type0;
 pub mod type0_parsing;
+pub mod type3;
 
 pub use cid_mapper::{analyze_unicode_ranges, CidMapping, UnicodeRanges};
 pub use embedder::{EmbeddingOptions, FontEmbedder, FontEncoding};
@@ -29,6 +30,7 @@ pub use type0_parsing::{
     extract_font_descriptor_ref, extract_font_file_ref, extract_tounicode_ref, extract_widths_ref,
     resolve_type0_hierarchy, CIDFontSubtype, FontFileType, Type0FontInfo, MAX_FONT_STREAM_SIZE,
 };
+pub use type3::{Type3Font, Type3Glyph};
 
 use crate::Result;
 

--- a/oxidize-pdf-core/src/fonts/mod.rs
+++ b/oxidize-pdf-core/src/fonts/mod.rs
@@ -10,6 +10,7 @@ pub mod font_cache;
 pub mod font_descriptor;
 pub mod font_metrics;
 pub mod loader;
+pub mod resolved;
 pub mod standard_14;
 pub mod ttf_parser;
 pub mod type0;
@@ -22,6 +23,9 @@ pub use font_cache::FontCache;
 pub use font_descriptor::{FontDescriptor, FontFlags};
 pub use font_metrics::{FontMetrics, TextMeasurement};
 pub use loader::{FontData, FontFormat, FontLoader};
+pub use resolved::{
+    DecodedGlyph, EmbeddedFont, EmbeddedFontFormat, FontSubtype, ResolvedFontResource, WritingMode,
+};
 pub use standard_14::Standard14Font;
 pub use ttf_parser::{GlyphMapping, TtfParser};
 pub use type0::{create_type0_from_font, needs_type0_font, Type0Font};

--- a/oxidize-pdf-core/src/fonts/resolved.rs
+++ b/oxidize-pdf-core/src/fonts/resolved.rs
@@ -453,7 +453,7 @@ fn resolve_encoding<R: Read + Seek>(
             ))
         }
         PdfObject::Stream(stream) if composite => {
-            let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+            let data = document.decode_stream_with_limit(&stream, MAX_CMAP_STREAM_SIZE)?;
             let cmap = EncodingCMap::parse(&data)?;
             let mode = if cmap.wmode == 1 {
                 WritingMode::Vertical
@@ -482,7 +482,7 @@ fn resolve_cmap<R: Read + Seek>(
     let stream = resolved
         .as_stream()
         .ok_or_else(|| syntax("ToUnicode must be a stream"))?;
-    let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+    let data = document.decode_stream_with_limit(stream, MAX_CMAP_STREAM_SIZE)?;
     CMap::parse(&data).map(Some)
 }
 
@@ -497,7 +497,7 @@ fn resolve_cid_to_gid<R: Read + Seek>(
     match resolved {
         PdfObject::Name(name) if name.0 == "Identity" => Ok(Some(CidToGid::Identity)),
         PdfObject::Stream(stream) => {
-            let data = stream.decode_with_limit(&document.options(), MAX_CID_TO_GID_MAP_SIZE)?;
+            let data = document.decode_stream_with_limit(&stream, MAX_CID_TO_GID_MAP_SIZE)?;
             if data.len() % 2 != 0 {
                 return Err(syntax("CIDToGIDMap stream has odd length"));
             }
@@ -605,7 +605,7 @@ fn resolve_embedded_font<R: Read + Seek>(
         } else {
             default_format
         };
-        let data = stream.decode_with_limit(&document.options(), MAX_FONT_STREAM_SIZE)?;
+        let data = document.decode_stream_with_limit(stream, MAX_FONT_STREAM_SIZE)?;
         return Ok(Some(EmbeddedFont { format, data }));
     }
     Ok(None)

--- a/oxidize-pdf-core/src/fonts/resolved.rs
+++ b/oxidize-pdf-core/src/fonts/resolved.rs
@@ -1,0 +1,736 @@
+//! Parser-side resolved font resources for downstream renderers.
+
+use crate::fonts::{Type3Font, MAX_FONT_STREAM_SIZE};
+use crate::parser::document::PdfDocument;
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::{ParseError, ParseResult};
+use crate::text::cmap::CMap;
+use crate::text::encoding::TextEncoding;
+use crate::text::encoding_cmap::{decode_utf16be, resolve_predefined, CidEncoding, EncodingCMap};
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Read, Seek};
+
+const MAX_CMAP_STREAM_SIZE: usize = 8 * 1024 * 1024;
+const MAX_CID_TO_GID_MAP_SIZE: usize = (u16::MAX as usize + 1) * 2;
+
+/// Concrete PDF font subtype used for rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontSubtype {
+    Type1,
+    TrueType,
+    CidFontType0,
+    CidFontType2,
+    Type3,
+}
+
+/// Direction declared by a composite font's encoding CMap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WritingMode {
+    Horizontal,
+    Vertical,
+}
+
+/// Decoded embedded font program format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedFontFormat {
+    Type1,
+    TrueType,
+    Type1C,
+    CidFontType0C,
+    OpenType,
+}
+
+/// Embedded font bytes and their PDF-declared format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedFont {
+    /// Container/program format declared by the PDF font descriptor.
+    pub format: EmbeddedFontFormat,
+    /// Decoded, size-bounded font-program bytes.
+    pub data: Vec<u8>,
+}
+
+/// One renderer-ready glyph decoded from a `Tj` string or a string item in `TJ`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedGlyph {
+    /// Exact bytes consumed for this PDF character code.
+    pub source_code: Vec<u8>,
+    /// CID selected by a composite encoding, or `None` for simple fonts and unmapped codes.
+    pub cid: Option<u32>,
+    /// Glyph identifier selected through `CIDToGIDMap`, when applicable.
+    pub gid: Option<u16>,
+    /// Best available Unicode mapping, preferring `ToUnicode`.
+    pub unicode: Option<String>,
+    /// Horizontal or vertical advance from the font's width tables.
+    pub advance: f64,
+}
+
+#[derive(Debug, Clone)]
+enum CodeEncoding {
+    Simple,
+    Identity,
+    Composite(CidEncoding),
+}
+
+#[derive(Debug, Clone)]
+enum CidToGid {
+    Identity,
+    Table(Vec<u16>),
+}
+
+#[derive(Debug, Clone)]
+struct CidWidths {
+    explicit: HashMap<u32, f64>,
+    ranges: Vec<(u32, u32, f64)>,
+    default: f64,
+}
+
+impl CidWidths {
+    fn width(&self, cid: u32) -> f64 {
+        self.explicit
+            .get(&cid)
+            .copied()
+            .or_else(|| {
+                self.ranges
+                    .iter()
+                    .rev()
+                    .find(|(first, last, _)| cid >= *first && cid <= *last)
+                    .map(|(_, _, width)| *width)
+            })
+            .unwrap_or(self.default)
+    }
+}
+
+/// A font entry resolved entirely through [`PdfDocument`]'s parser object model.
+#[derive(Debug, Clone)]
+pub struct ResolvedFontResource {
+    /// Name used for the font in the page resource dictionary.
+    pub resource_name: String,
+    /// PDF `BaseFont`/Type3 `Name`, when present.
+    pub base_font: Option<String>,
+    /// Concrete simple, CID descendant, or Type3 subtype.
+    pub subtype: FontSubtype,
+    /// Named PDF encoding, when the font uses one.
+    pub encoding: Option<String>,
+    /// Writing direction selected by a composite encoding CMap.
+    pub writing_mode: WritingMode,
+    /// Simple-font character-code overrides from `Differences`.
+    pub differences: BTreeMap<u8, String>,
+    /// Decoded embedded font program, when present.
+    pub embedded_font: Option<EmbeddedFont>,
+    /// Parsed Type3 glyph programs, only for Type3 resources.
+    pub type3: Option<Type3Font>,
+    code_encoding: CodeEncoding,
+    to_unicode: Option<CMap>,
+    cid_to_gid: Option<CidToGid>,
+    cid_widths: Option<CidWidths>,
+    first_char: u32,
+    simple_widths: Vec<f64>,
+    missing_width: f64,
+    symbolic: bool,
+}
+
+impl ResolvedFontResource {
+    /// Resolve a named font from a page's effective, inherited resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error when the page/resource hierarchy or font data is
+    /// missing, malformed, cyclic, unsupported, or exceeds a stream limit.
+    pub fn from_page<R: Read + Seek>(
+        document: &PdfDocument<R>,
+        page_index: u32,
+        resource_name: &str,
+    ) -> ParseResult<Self> {
+        let page = document.get_page(page_index)?;
+        let resources = document
+            .get_page_resources(&page)?
+            .ok_or_else(|| missing("page Resources"))?;
+        let fonts = resolve_required(document, resources, "Font")?;
+        let fonts = expect_dict(&fonts, "page Font resources")?;
+        let font_object = fonts
+            .get(resource_name)
+            .ok_or_else(|| missing(&format!("font resource /{resource_name}")))?;
+        Self::resolve(document, resource_name, font_object)
+    }
+
+    /// Resolve a direct or indirect font dictionary.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error for malformed, cyclic, unsupported, or oversized
+    /// font resources.
+    pub fn resolve<R: Read + Seek>(
+        document: &PdfDocument<R>,
+        resource_name: &str,
+        font_object: &PdfObject,
+    ) -> ParseResult<Self> {
+        let resolved = document.resolve(font_object)?;
+        let font = expect_dict(&resolved, "font resource")?;
+        let declared_subtype = required_name(font, "Subtype")?;
+        if declared_subtype == "Type3" {
+            let type3 = Type3Font::resolve(font_object, document)?;
+            let to_unicode = resolve_cmap(document, font.get("ToUnicode"))?;
+            let mut differences = BTreeMap::new();
+            let mut widths = vec![0.0; 256];
+            for glyph in type3.glyphs() {
+                differences.insert(glyph.code, glyph.name.clone());
+                widths[glyph.code as usize] = glyph.width;
+            }
+            return Ok(Self {
+                resource_name: resource_name.into(),
+                base_font: type3.name.clone(),
+                subtype: FontSubtype::Type3,
+                encoding: None,
+                writing_mode: WritingMode::Horizontal,
+                differences,
+                embedded_font: None,
+                type3: Some(type3),
+                code_encoding: CodeEncoding::Simple,
+                to_unicode,
+                cid_to_gid: None,
+                cid_widths: None,
+                first_char: 0,
+                simple_widths: widths,
+                missing_width: 0.0,
+                symbolic: false,
+            });
+        }
+
+        let base_font = font
+            .get("BaseFont")
+            .and_then(PdfObject::as_name)
+            .map(|name| name.0.clone());
+        let to_unicode = resolve_cmap(document, font.get("ToUnicode"))?;
+        let (encoding, differences, code_encoding, writing_mode) =
+            resolve_encoding(document, font.get("Encoding"), declared_subtype == "Type0")?;
+
+        let descendant_storage;
+        let concrete = if declared_subtype == "Type0" {
+            let descendants = resolve_required(document, font, "DescendantFonts")?;
+            let descendants = descendants
+                .as_array()
+                .ok_or_else(|| syntax("DescendantFonts must be an array"))?;
+            let descendant = descendants
+                .0
+                .first()
+                .ok_or_else(|| syntax("DescendantFonts must not be empty"))?;
+            descendant_storage = document.resolve(descendant)?;
+            expect_dict(&descendant_storage, "CID descendant font")?
+        } else {
+            font
+        };
+        let concrete_name = required_name(concrete, "Subtype")?;
+        let subtype = match concrete_name {
+            "Type1" | "MMType1" => FontSubtype::Type1,
+            "TrueType" => FontSubtype::TrueType,
+            "CIDFontType0" => FontSubtype::CidFontType0,
+            "CIDFontType2" => FontSubtype::CidFontType2,
+            other => return Err(syntax(&format!("unsupported font subtype /{other}"))),
+        };
+        let composite = declared_subtype == "Type0";
+        let cid_subtype = matches!(
+            subtype,
+            FontSubtype::CidFontType0 | FontSubtype::CidFontType2
+        );
+        if composite != cid_subtype {
+            return Err(syntax(if composite {
+                "Type0 descendant must be CIDFontType0 or CIDFontType2"
+            } else {
+                "CID font subtype must be a descendant of Type0"
+            }));
+        }
+
+        let descriptor = resolve_optional_dict(document, concrete.get("FontDescriptor"))?;
+        let embedded_font = descriptor
+            .as_ref()
+            .map(|dict| resolve_embedded_font(document, dict))
+            .transpose()?
+            .flatten();
+        let missing_width = descriptor
+            .as_ref()
+            .and_then(|dict| dict.get("MissingWidth"))
+            .and_then(PdfObject::as_real)
+            .unwrap_or(0.0);
+        let symbolic = descriptor
+            .as_ref()
+            .and_then(|dict| dict.get("Flags"))
+            .and_then(PdfObject::as_integer)
+            .is_some_and(|flags| flags & 4 != 0)
+            || base_font.as_deref() == Some("Symbol");
+
+        let cid_widths = matches!(
+            subtype,
+            FontSubtype::CidFontType0 | FontSubtype::CidFontType2
+        )
+        .then(|| parse_cid_widths(document, concrete))
+        .transpose()?;
+        let cid_to_gid = if subtype == FontSubtype::CidFontType2 {
+            resolve_cid_to_gid(document, concrete.get("CIDToGIDMap"))?
+        } else {
+            None
+        };
+        let first_char = font
+            .get("FirstChar")
+            .and_then(PdfObject::as_integer)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0);
+        let simple_widths = resolve_number_array(document, font.get("Widths"))?;
+
+        Ok(Self {
+            resource_name: resource_name.into(),
+            base_font,
+            subtype,
+            encoding,
+            writing_mode,
+            differences,
+            embedded_font,
+            type3: None,
+            code_encoding,
+            to_unicode,
+            cid_to_gid,
+            cid_widths,
+            first_char,
+            simple_widths,
+            missing_width,
+            symbolic,
+        })
+    }
+
+    /// Decode a PDF string into renderer-ready glyph identities and advances.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parser error when a character code is truncated or wider than
+    /// the supported four-byte PDF code space.
+    pub fn decode_glyphs(&self, bytes: &[u8]) -> ParseResult<Vec<DecodedGlyph>> {
+        let mut glyphs = Vec::new();
+        let mut position = 0;
+        while position < bytes.len() {
+            let code_len = match &self.code_encoding {
+                CodeEncoding::Simple => 1,
+                CodeEncoding::Identity | CodeEncoding::Composite(CidEncoding::Utf16Be) => 2,
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)) => {
+                    cmap.code_len_at(bytes, position)
+                }
+            };
+            if position + code_len > bytes.len() {
+                return Err(syntax("truncated character code"));
+            }
+            let code = bytes[position..position + code_len].to_vec();
+            position += code_len;
+            let cid = match &self.code_encoding {
+                CodeEncoding::Simple => None,
+                CodeEncoding::Identity | CodeEncoding::Composite(CidEncoding::Utf16Be) => {
+                    Some(be_code(&code)?)
+                }
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)) => cmap
+                    .map_code_to_cid(&code)
+                    .or_else(|| cmap.map_notdef(&code))
+                    .map(u32::from),
+            };
+            let gid = cid.and_then(|cid| self.gid_for(cid));
+            let unicode = self.unicode_for(&code);
+            let advance = match &self.cid_widths {
+                Some(widths) => cid.map_or(widths.default, |cid| widths.width(cid)),
+                None => self.simple_width(be_code(&code)?),
+            };
+            glyphs.push(DecodedGlyph {
+                source_code: code,
+                cid,
+                gid,
+                unicode,
+                advance,
+            });
+        }
+        Ok(glyphs)
+    }
+
+    fn gid_for(&self, cid: u32) -> Option<u16> {
+        match self.cid_to_gid.as_ref()? {
+            CidToGid::Identity => u16::try_from(cid).ok(),
+            CidToGid::Table(table) => table.get(cid as usize).copied(),
+        }
+    }
+
+    fn unicode_for(&self, code: &[u8]) -> Option<String> {
+        if let Some(cmap) = &self.to_unicode {
+            if let Some(mapped) = cmap.map(code) {
+                return cmap.to_unicode(&mapped);
+            }
+        }
+        if matches!(
+            self.code_encoding,
+            CodeEncoding::Composite(CidEncoding::Utf16Be)
+        ) {
+            return Some(decode_utf16be(code));
+        }
+        if matches!(self.code_encoding, CodeEncoding::Simple) {
+            let value = code[0];
+            if let Some(name) = self.differences.get(&value) {
+                return glyph_name_to_unicode(name).map(str::to_owned);
+            }
+            if self.symbolic {
+                return symbol_code_to_unicode(value).map(str::to_owned);
+            }
+            let decoder = match self.encoding.as_deref() {
+                Some("WinAnsiEncoding") => TextEncoding::WinAnsiEncoding,
+                Some("MacRomanEncoding") => TextEncoding::MacRomanEncoding,
+                _ => TextEncoding::StandardEncoding,
+            };
+            return Some(decoder.decode(&[value]));
+        }
+        None
+    }
+
+    fn simple_width(&self, code: u32) -> f64 {
+        code.checked_sub(self.first_char)
+            .and_then(|offset| self.simple_widths.get(offset as usize))
+            .copied()
+            .unwrap_or(self.missing_width)
+    }
+}
+
+fn resolve_encoding<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+    composite: bool,
+) -> ParseResult<(
+    Option<String>,
+    BTreeMap<u8, String>,
+    CodeEncoding,
+    WritingMode,
+)> {
+    let Some(object) = object else {
+        if composite {
+            return Err(syntax("Type0 font is missing its Encoding"));
+        }
+        return Ok((
+            None,
+            BTreeMap::new(),
+            CodeEncoding::Simple,
+            WritingMode::Horizontal,
+        ));
+    };
+    let resolved = document.resolve(object)?;
+    match resolved {
+        PdfObject::Name(name) if composite => {
+            let vertical = name.0.ends_with("-V");
+            let code_encoding =
+                if matches!(name.0.as_str(), "Identity-H" | "Identity-V") {
+                    CodeEncoding::Identity
+                } else {
+                    CodeEncoding::Composite(resolve_predefined(&name.0).ok_or_else(|| {
+                        syntax(&format!("unsupported predefined CMap /{}", name.0))
+                    })?)
+                };
+            Ok((
+                Some(name.0),
+                BTreeMap::new(),
+                code_encoding,
+                if vertical {
+                    WritingMode::Vertical
+                } else {
+                    WritingMode::Horizontal
+                },
+            ))
+        }
+        PdfObject::Name(name) => Ok((
+            Some(name.0),
+            BTreeMap::new(),
+            CodeEncoding::Simple,
+            WritingMode::Horizontal,
+        )),
+        PdfObject::Dictionary(dict) if !composite => {
+            let base = dict
+                .get("BaseEncoding")
+                .and_then(PdfObject::as_name)
+                .map(|name| name.0.clone());
+            Ok((
+                base,
+                parse_differences(&dict)?,
+                CodeEncoding::Simple,
+                WritingMode::Horizontal,
+            ))
+        }
+        PdfObject::Stream(stream) if composite => {
+            let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+            let cmap = EncodingCMap::parse(&data)?;
+            let mode = if cmap.wmode == 1 {
+                WritingMode::Vertical
+            } else {
+                WritingMode::Horizontal
+            };
+            Ok((
+                None,
+                BTreeMap::new(),
+                CodeEncoding::Composite(CidEncoding::Cmap(cmap)),
+                mode,
+            ))
+        }
+        _ => Err(syntax("invalid font Encoding")),
+    }
+}
+
+fn resolve_cmap<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<CMap>> {
+    let Some(object) = object else {
+        return Ok(None);
+    };
+    let resolved = document.resolve(object)?;
+    let stream = resolved
+        .as_stream()
+        .ok_or_else(|| syntax("ToUnicode must be a stream"))?;
+    let data = stream.decode_with_limit(&document.options(), MAX_CMAP_STREAM_SIZE)?;
+    CMap::parse(&data).map(Some)
+}
+
+fn resolve_cid_to_gid<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<CidToGid>> {
+    let Some(object) = object else {
+        return Ok(Some(CidToGid::Identity));
+    };
+    let resolved = document.resolve(object)?;
+    match resolved {
+        PdfObject::Name(name) if name.0 == "Identity" => Ok(Some(CidToGid::Identity)),
+        PdfObject::Stream(stream) => {
+            let data = stream.decode_with_limit(&document.options(), MAX_CID_TO_GID_MAP_SIZE)?;
+            if data.len() % 2 != 0 {
+                return Err(syntax("CIDToGIDMap stream has odd length"));
+            }
+            Ok(Some(CidToGid::Table(
+                data.chunks_exact(2)
+                    .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+                    .collect(),
+            )))
+        }
+        _ => Err(syntax("CIDToGIDMap must be /Identity or a stream")),
+    }
+}
+
+fn parse_cid_widths<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+) -> ParseResult<CidWidths> {
+    let default = dict
+        .get("DW")
+        .and_then(PdfObject::as_real)
+        .unwrap_or(1000.0);
+    let entries = resolve_number_or_array_object(document, dict.get("W"))?;
+    let Some(entries) = entries.and_then(|object| object.as_array().cloned()) else {
+        return Ok(CidWidths {
+            explicit: HashMap::new(),
+            ranges: Vec::new(),
+            default,
+        });
+    };
+    let mut explicit = HashMap::new();
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    while index < entries.0.len() {
+        let first = entries.0[index]
+            .as_integer()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| syntax("invalid first CID in W"))?;
+        match entries.0.get(index + 1) {
+            Some(PdfObject::Array(widths)) => {
+                for (offset, width) in widths.0.iter().enumerate() {
+                    let cid = first
+                        .checked_add(u32::try_from(offset).map_err(|_| syntax("W range overflow"))?)
+                        .ok_or_else(|| syntax("W range overflow"))?;
+                    explicit.insert(
+                        cid,
+                        width.as_real().ok_or_else(|| syntax("invalid W width"))?,
+                    );
+                }
+                index += 2;
+            }
+            Some(last) => {
+                let last = last
+                    .as_integer()
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| syntax("invalid last CID in W"))?;
+                let width = entries
+                    .0
+                    .get(index + 2)
+                    .and_then(PdfObject::as_real)
+                    .ok_or_else(|| syntax("missing W range width"))?;
+                if last < first {
+                    return Err(syntax("reversed CID width range"));
+                }
+                ranges.push((first, last, width));
+                index += 3;
+            }
+            None => return Err(syntax("truncated W array")),
+        }
+    }
+    Ok(CidWidths {
+        explicit,
+        ranges,
+        default,
+    })
+}
+
+fn resolve_embedded_font<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    descriptor: &PdfDictionary,
+) -> ParseResult<Option<EmbeddedFont>> {
+    for (key, default_format) in [
+        ("FontFile", EmbeddedFontFormat::Type1),
+        ("FontFile2", EmbeddedFontFormat::TrueType),
+        ("FontFile3", EmbeddedFontFormat::Type1C),
+    ] {
+        let Some(object) = descriptor.get(key) else {
+            continue;
+        };
+        let resolved = document.resolve(object)?;
+        let stream = resolved
+            .as_stream()
+            .ok_or_else(|| syntax(&format!("{key} must be a stream")))?;
+        let format = if key == "FontFile3" {
+            match stream
+                .dict
+                .get("Subtype")
+                .and_then(PdfObject::as_name)
+                .map(|n| n.0.as_str())
+            {
+                Some("Type1C") => EmbeddedFontFormat::Type1C,
+                Some("CIDFontType0C") => EmbeddedFontFormat::CidFontType0C,
+                Some("OpenType") => EmbeddedFontFormat::OpenType,
+                _ => return Err(syntax("FontFile3 has unsupported or missing Subtype")),
+            }
+        } else {
+            default_format
+        };
+        let data = stream.decode_with_limit(&document.options(), MAX_FONT_STREAM_SIZE)?;
+        return Ok(Some(EmbeddedFont { format, data }));
+    }
+    Ok(None)
+}
+
+fn parse_differences(dict: &PdfDictionary) -> ParseResult<BTreeMap<u8, String>> {
+    let mut result = BTreeMap::new();
+    let Some(array) = dict.get("Differences").and_then(PdfObject::as_array) else {
+        return Ok(result);
+    };
+    let mut code = None;
+    for object in &array.0 {
+        if let Some(value) = object.as_integer() {
+            code =
+                Some(u8::try_from(value).map_err(|_| syntax("Differences code outside 0..=255"))?);
+        } else if let Some(name) = object.as_name() {
+            let current = code.ok_or_else(|| syntax("Differences name without a code"))?;
+            result.insert(current, name.0.clone());
+            code = current.checked_add(1);
+        } else {
+            return Err(syntax("invalid Differences entry"));
+        }
+    }
+    Ok(result)
+}
+
+fn resolve_number_array<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Vec<f64>> {
+    let Some(object) = resolve_number_or_array_object(document, object)? else {
+        return Ok(Vec::new());
+    };
+    let array = object
+        .as_array()
+        .ok_or_else(|| syntax("Widths must be an array"))?;
+    array
+        .0
+        .iter()
+        .map(|value| {
+            value
+                .as_real()
+                .ok_or_else(|| syntax("Widths must be numeric"))
+        })
+        .collect()
+}
+
+fn resolve_number_or_array_object<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<PdfObject>> {
+    object.map(|value| document.resolve(value)).transpose()
+}
+
+fn resolve_optional_dict<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    object: Option<&PdfObject>,
+) -> ParseResult<Option<PdfDictionary>> {
+    let Some(object) = object else {
+        return Ok(None);
+    };
+    let resolved = document.resolve(object)?;
+    resolved
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| syntax("FontDescriptor must be a dictionary"))
+        .map(Some)
+}
+
+fn resolve_required<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+    key: &str,
+) -> ParseResult<PdfObject> {
+    document.resolve(dict.get(key).ok_or_else(|| missing(key))?)
+}
+
+fn expect_dict<'a>(object: &'a PdfObject, description: &str) -> ParseResult<&'a PdfDictionary> {
+    object
+        .as_dict()
+        .ok_or_else(|| syntax(&format!("{description} must be a dictionary")))
+}
+
+fn required_name<'a>(dict: &'a PdfDictionary, key: &str) -> ParseResult<&'a str> {
+    dict.get(key)
+        .and_then(PdfObject::as_name)
+        .map(|name| name.0.as_str())
+        .ok_or_else(|| missing(key))
+}
+
+fn be_code(code: &[u8]) -> ParseResult<u32> {
+    if code.len() > 4 {
+        return Err(syntax("character code exceeds four bytes"));
+    }
+    Ok(code
+        .iter()
+        .fold(0u32, |value, byte| (value << 8) | u32::from(*byte)))
+}
+
+fn glyph_name_to_unicode(name: &str) -> Option<&'static str> {
+    match name {
+        "bullet" => Some("•"),
+        "space" => Some(" "),
+        "hyphen" => Some("-"),
+        "minus" => Some("−"),
+        "checkmark" => Some("✓"),
+        _ => None,
+    }
+}
+
+fn symbol_code_to_unicode(code: u8) -> Option<&'static str> {
+    match code {
+        0xB7 => Some("•"),
+        b'x' => Some("ξ"),
+        _ => None,
+    }
+}
+
+fn missing(key: &str) -> ParseError {
+    ParseError::MissingKey(key.into())
+}
+
+fn syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.into(),
+    }
+}

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -103,8 +103,8 @@ impl Type3Font {
             let stream = proc_object
                 .as_stream()
                 .ok_or_else(|| syntax("Type 3 CharProc must be a stream"))?;
-            let data = stream
-                .decode_with_limit(&document.options(), MAX_TYPE3_GLYPH_STREAM_SIZE)
+            let data = document
+                .decode_stream_with_limit(stream, MAX_TYPE3_GLYPH_STREAM_SIZE)
                 .map_err(|error| {
                     syntax(&format!(
                         "failed to decode Type 3 CharProc /{name} (code {code}): {error}"

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -37,7 +37,9 @@ pub struct Type3Glyph {
     pub procedure_width: (f64, f64),
     /// Glyph bounding box declared by `d1`, when present.
     pub bbox: Option<[f64; 4]>,
-    /// Parsed, renderer-neutral glyph operations, including `d0`/`d1`.
+    /// Parsed, renderer-neutral glyph drawing operations. The leading `d0` or
+    /// `d1` operator is represented by [`Self::procedure_width`] and
+    /// [`Self::bbox`] rather than duplicated here.
     pub operations: Vec<ContentOperation>,
 }
 

--- a/oxidize-pdf-core/src/fonts/type3.rs
+++ b/oxidize-pdf-core/src/fonts/type3.rs
@@ -1,0 +1,754 @@
+//! Renderer-neutral resolution of embedded Type 3 glyph programs.
+
+use crate::parser::content::{ContentOperation, ContentParser};
+use crate::parser::document::PdfDocument;
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::{ParseError, ParseResult};
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Read, Seek};
+
+/// Maximum decoded size accepted for one glyph program.
+pub const MAX_TYPE3_GLYPH_STREAM_SIZE: usize = 8 * 1024 * 1024;
+
+/// A resolved Type 3 font suitable for use by a downstream renderer.
+#[derive(Debug, Clone)]
+pub struct Type3Font {
+    /// Optional PDF font name (`/Name` or `/BaseFont`).
+    pub name: Option<String>,
+    /// Glyph-space to text-space transformation.
+    pub font_matrix: [f64; 6],
+    /// Font bounding box in glyph space.
+    pub font_bbox: [f64; 4],
+    /// Resolved private resources used by glyph programs.
+    pub resources: Option<PdfDictionary>,
+    glyphs: BTreeMap<u8, Type3Glyph>,
+}
+
+/// One resolved Type 3 character procedure.
+#[derive(Debug, Clone)]
+pub struct Type3Glyph {
+    /// Character code used by page text-showing operators.
+    pub code: u8,
+    /// Name selected through the font encoding.
+    pub name: String,
+    /// Advance declared by `/Widths` (glyph-space units).
+    pub width: f64,
+    /// Displacement declared by the `d0` or `d1` operator.
+    pub procedure_width: (f64, f64),
+    /// Glyph bounding box declared by `d1`, when present.
+    pub bbox: Option<[f64; 4]>,
+    /// Parsed, renderer-neutral glyph operations, including `d0`/`d1`.
+    pub operations: Vec<ContentOperation>,
+}
+
+impl Type3Font {
+    /// Resolve a direct or indirect Type 3 font dictionary and its character
+    /// procedures. Glyph names are not interpreted as Unicode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid Type 3 dictionary, unsupported encoding,
+    /// malformed or oversized character procedure, or an unresolved required
+    /// indirect object. Codes without a name or `CharProc` are omitted so
+    /// [`Self::glyph`] returns `None` and downstream fallback remains possible.
+    pub fn resolve<R: Read + Seek>(
+        font_object: &PdfObject,
+        document: &PdfDocument<R>,
+    ) -> ParseResult<Self> {
+        let font_object = document.resolve(font_object)?;
+        let font = expect_dict(&font_object, "Type 3 font")?;
+        if font
+            .get("Subtype")
+            .and_then(PdfObject::as_name)
+            .map(|n| n.0.as_str())
+            != Some("Type3")
+        {
+            return Err(syntax("font subtype is not Type3"));
+        }
+
+        let font_matrix = number_array::<6>(font, "FontMatrix")?;
+        let font_bbox = number_array::<4>(font, "FontBBox")?;
+        let first = integer(font, "FirstChar")?;
+        let last = integer(font, "LastChar")?;
+        if !(0..=255).contains(&first) || !(0..=255).contains(&last) || first > last {
+            return Err(syntax("invalid Type 3 FirstChar/LastChar range"));
+        }
+
+        let widths_object = resolve_required(document, font, "Widths")?;
+        let widths = widths_object
+            .as_array()
+            .ok_or_else(|| syntax("Type 3 Widths must be an array"))?;
+        let expected = (last - first + 1) as usize;
+        if widths.0.len() < expected {
+            return Err(syntax("Type 3 Widths is shorter than the character range"));
+        }
+
+        let encoding_object = resolve_required(document, font, "Encoding")?;
+        let names = encoding_names(&encoding_object)?;
+        let charprocs_object = resolve_required(document, font, "CharProcs")?;
+        let charprocs = expect_dict(&charprocs_object, "Type 3 CharProcs")?;
+
+        let mut glyphs = BTreeMap::new();
+        for code in first..=last {
+            let code = code as u8;
+            let Some(name) = names.get(&code) else {
+                continue;
+            };
+            let Some(proc_object) = charprocs.get(name) else {
+                continue;
+            };
+            let proc_object = document.resolve(proc_object)?;
+            let stream = proc_object
+                .as_stream()
+                .ok_or_else(|| syntax("Type 3 CharProc must be a stream"))?;
+            let data = stream
+                .decode_with_limit(&document.options(), MAX_TYPE3_GLYPH_STREAM_SIZE)
+                .map_err(|error| {
+                    syntax(&format!(
+                        "failed to decode Type 3 CharProc /{name} (code {code}): {error}"
+                    ))
+                })?;
+            let parsed = ContentParser::parse_type3_charproc(&data).map_err(|error| {
+                syntax(&format!(
+                    "invalid Type 3 CharProc /{name} (code {code}): {error}"
+                ))
+            })?;
+            let width = widths.0[(i64::from(code) - first) as usize]
+                .as_real()
+                .ok_or_else(|| syntax("Type 3 width must be numeric"))?;
+            glyphs.insert(
+                code,
+                Type3Glyph {
+                    code,
+                    name: name.clone(),
+                    width,
+                    procedure_width: parsed.width,
+                    bbox: parsed.bbox,
+                    operations: parsed.operations,
+                },
+            );
+        }
+
+        let resources = match font.get("Resources") {
+            Some(value) => {
+                Some(expect_dict(&document.resolve(value)?, "Type 3 Resources")?.clone())
+            }
+            None => None,
+        };
+        let name = font
+            .get("Name")
+            .or_else(|| font.get("BaseFont"))
+            .and_then(PdfObject::as_name)
+            .map(|value| value.0.clone());
+        Ok(Self {
+            name,
+            font_matrix,
+            font_bbox,
+            resources,
+            glyphs,
+        })
+    }
+
+    /// Return the resolved glyph for a character code, or `None` when its
+    /// encoding is undefined or the font provides no corresponding `CharProc`.
+    pub fn glyph(&self, code: u8) -> Option<&Type3Glyph> {
+        self.glyphs.get(&code)
+    }
+
+    /// Iterate over all resolved glyphs.
+    pub fn glyphs(&self) -> impl Iterator<Item = &Type3Glyph> {
+        self.glyphs.values()
+    }
+
+    /// Resolve one entry from the font's private resource dictionary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the category is not a dictionary or an indirect
+    /// resource cannot be resolved.
+    pub fn resolve_resource<R: Read + Seek>(
+        &self,
+        category: &str,
+        name: &str,
+        document: &PdfDocument<R>,
+    ) -> ParseResult<Option<PdfObject>> {
+        let Some(resources) = &self.resources else {
+            return Ok(None);
+        };
+        let Some(category_object) = resources.get(category) else {
+            return Ok(None);
+        };
+        let category_object = document.resolve(category_object)?;
+        let category_dict = expect_dict(&category_object, "Type 3 resource category")?;
+        category_dict
+            .get(name)
+            .map(|value| document.resolve(value))
+            .transpose()
+    }
+}
+
+fn resolve_required<R: Read + Seek>(
+    document: &PdfDocument<R>,
+    dict: &PdfDictionary,
+    key: &str,
+) -> ParseResult<PdfObject> {
+    document.resolve(
+        dict.get(key)
+            .ok_or_else(|| ParseError::MissingKey(key.into()))?,
+    )
+}
+
+fn expect_dict<'a>(object: &'a PdfObject, description: &str) -> ParseResult<&'a PdfDictionary> {
+    object
+        .as_dict()
+        .ok_or_else(|| syntax(&format!("{description} must be a dictionary")))
+}
+
+fn integer(dict: &PdfDictionary, key: &str) -> ParseResult<i64> {
+    dict.get(key)
+        .and_then(PdfObject::as_integer)
+        .ok_or_else(|| ParseError::MissingKey(key.into()))
+}
+
+fn number_array<const N: usize>(dict: &PdfDictionary, key: &str) -> ParseResult<[f64; N]> {
+    let array = dict
+        .get(key)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| ParseError::MissingKey(key.into()))?;
+    if array.0.len() != N {
+        return Err(syntax(&format!("{key} must contain {N} numbers")));
+    }
+    let mut result = [0.0; N];
+    for (target, object) in result.iter_mut().zip(&array.0) {
+        *target = object
+            .as_real()
+            .ok_or_else(|| syntax(&format!("{key} must contain only numbers")))?;
+    }
+    Ok(result)
+}
+
+fn encoding_names(encoding: &PdfObject) -> ParseResult<HashMap<u8, String>> {
+    match encoding {
+        PdfObject::Name(name) => predefined_encoding(name.as_str()),
+        PdfObject::Dictionary(dict) => {
+            let mut names = match dict.get("BaseEncoding").and_then(PdfObject::as_name) {
+                Some(name) => predefined_encoding(name.as_str())?,
+                None => predefined_encoding("StandardEncoding")?,
+            };
+            apply_encoding_differences(dict, &mut names)?;
+            Ok(names)
+        }
+        _ => Err(syntax("Type 3 Encoding must be a name or dictionary")),
+    }
+}
+
+fn apply_encoding_differences(
+    encoding: &PdfDictionary,
+    result: &mut HashMap<u8, String>,
+) -> ParseResult<()> {
+    let Some(differences) = encoding.get("Differences").and_then(PdfObject::as_array) else {
+        return Ok(());
+    };
+    let mut code: Option<i64> = None;
+    for object in &differences.0 {
+        if let Some(value) = object.as_integer() {
+            if !(0..=255).contains(&value) {
+                return Err(syntax("Encoding Differences code is outside 0..=255"));
+            }
+            code = Some(value);
+        } else if let Some(name) = object.as_name() {
+            let value =
+                code.ok_or_else(|| syntax("Encoding Differences name has no starting code"))?;
+            result.insert(value as u8, name.0.clone());
+            code = value.checked_add(1);
+        } else {
+            return Err(syntax("invalid object in Encoding Differences"));
+        }
+    }
+    Ok(())
+}
+
+fn predefined_encoding(name: &str) -> ParseResult<HashMap<u8, String>> {
+    if !matches!(
+        name,
+        "StandardEncoding" | "WinAnsiEncoding" | "MacRomanEncoding"
+    ) {
+        return Err(syntax(&format!("unsupported Type 3 encoding /{name}")));
+    }
+    let mut names = HashMap::new();
+    for code in 32u8..=126 {
+        names.insert(code, ascii_glyph_name(code).to_string());
+    }
+    match name {
+        "StandardEncoding" => {
+            names.insert(39, "quoteright".into());
+            names.insert(96, "quoteleft".into());
+            for &(code, glyph) in STANDARD_ENCODING_EXTENDED {
+                names.insert(code, glyph.into());
+            }
+        }
+        "WinAnsiEncoding" => {
+            for &(code, glyph) in WIN_ANSI_EXTENDED {
+                names.insert(code, glyph.into());
+            }
+        }
+        "MacRomanEncoding" => {
+            for (offset, glyph) in MAC_ROMAN_EXTENDED.iter().enumerate() {
+                names.insert(0x80 + offset as u8, (*glyph).into());
+            }
+        }
+        _ => unreachable!(),
+    }
+    Ok(names)
+}
+
+const STANDARD_ENCODING_EXTENDED: &[(u8, &str)] = &[
+    (161, "exclamdown"),
+    (162, "cent"),
+    (163, "sterling"),
+    (164, "fraction"),
+    (165, "yen"),
+    (166, "florin"),
+    (167, "section"),
+    (168, "currency"),
+    (169, "quotesingle"),
+    (170, "quotedblleft"),
+    (171, "guillemotleft"),
+    (172, "guilsinglleft"),
+    (173, "guilsinglright"),
+    (174, "fi"),
+    (175, "fl"),
+    (177, "endash"),
+    (178, "dagger"),
+    (179, "daggerdbl"),
+    (180, "periodcentered"),
+    (182, "paragraph"),
+    (183, "bullet"),
+    (184, "quotesinglbase"),
+    (185, "quotedblbase"),
+    (186, "quotedblright"),
+    (187, "guillemotright"),
+    (188, "ellipsis"),
+    (189, "perthousand"),
+    (191, "questiondown"),
+    (193, "grave"),
+    (194, "acute"),
+    (195, "circumflex"),
+    (196, "tilde"),
+    (197, "macron"),
+    (198, "breve"),
+    (199, "dotaccent"),
+    (200, "dieresis"),
+    (202, "ring"),
+    (203, "cedilla"),
+    (205, "hungarumlaut"),
+    (206, "ogonek"),
+    (207, "caron"),
+    (208, "emdash"),
+    (225, "AE"),
+    (227, "ordfeminine"),
+    (232, "Lslash"),
+    (233, "Oslash"),
+    (234, "OE"),
+    (235, "ordmasculine"),
+    (241, "ae"),
+    (245, "dotlessi"),
+    (248, "lslash"),
+    (249, "oslash"),
+    (250, "oe"),
+    (251, "germandbls"),
+];
+
+const WIN_ANSI_EXTENDED: &[(u8, &str)] = &[
+    (128, "Euro"),
+    (130, "quotesinglbase"),
+    (131, "florin"),
+    (132, "quotedblbase"),
+    (133, "ellipsis"),
+    (134, "dagger"),
+    (135, "daggerdbl"),
+    (136, "circumflex"),
+    (137, "perthousand"),
+    (138, "Scaron"),
+    (139, "guilsinglleft"),
+    (140, "OE"),
+    (142, "Zcaron"),
+    (145, "quoteleft"),
+    (146, "quoteright"),
+    (147, "quotedblleft"),
+    (148, "quotedblright"),
+    (149, "bullet"),
+    (150, "endash"),
+    (151, "emdash"),
+    (152, "tilde"),
+    (153, "trademark"),
+    (154, "scaron"),
+    (155, "guilsinglright"),
+    (156, "oe"),
+    (158, "zcaron"),
+    (159, "Ydieresis"),
+    (160, "space"),
+    (161, "exclamdown"),
+    (162, "cent"),
+    (163, "sterling"),
+    (164, "currency"),
+    (165, "yen"),
+    (166, "brokenbar"),
+    (167, "section"),
+    (168, "dieresis"),
+    (169, "copyright"),
+    (170, "ordfeminine"),
+    (171, "guillemotleft"),
+    (172, "logicalnot"),
+    (173, "hyphen"),
+    (174, "registered"),
+    (175, "macron"),
+    (176, "degree"),
+    (177, "plusminus"),
+    (178, "twosuperior"),
+    (179, "threesuperior"),
+    (180, "acute"),
+    (181, "mu"),
+    (182, "paragraph"),
+    (183, "periodcentered"),
+    (184, "cedilla"),
+    (185, "onesuperior"),
+    (186, "ordmasculine"),
+    (187, "guillemotright"),
+    (188, "onequarter"),
+    (189, "onehalf"),
+    (190, "threequarters"),
+    (191, "questiondown"),
+    (192, "Agrave"),
+    (193, "Aacute"),
+    (194, "Acircumflex"),
+    (195, "Atilde"),
+    (196, "Adieresis"),
+    (197, "Aring"),
+    (198, "AE"),
+    (199, "Ccedilla"),
+    (200, "Egrave"),
+    (201, "Eacute"),
+    (202, "Ecircumflex"),
+    (203, "Edieresis"),
+    (204, "Igrave"),
+    (205, "Iacute"),
+    (206, "Icircumflex"),
+    (207, "Idieresis"),
+    (208, "Eth"),
+    (209, "Ntilde"),
+    (210, "Ograve"),
+    (211, "Oacute"),
+    (212, "Ocircumflex"),
+    (213, "Otilde"),
+    (214, "Odieresis"),
+    (215, "multiply"),
+    (216, "Oslash"),
+    (217, "Ugrave"),
+    (218, "Uacute"),
+    (219, "Ucircumflex"),
+    (220, "Udieresis"),
+    (221, "Yacute"),
+    (222, "Thorn"),
+    (223, "germandbls"),
+    (224, "agrave"),
+    (225, "aacute"),
+    (226, "acircumflex"),
+    (227, "atilde"),
+    (228, "adieresis"),
+    (229, "aring"),
+    (230, "ae"),
+    (231, "ccedilla"),
+    (232, "egrave"),
+    (233, "eacute"),
+    (234, "ecircumflex"),
+    (235, "edieresis"),
+    (236, "igrave"),
+    (237, "iacute"),
+    (238, "icircumflex"),
+    (239, "idieresis"),
+    (240, "eth"),
+    (241, "ntilde"),
+    (242, "ograve"),
+    (243, "oacute"),
+    (244, "ocircumflex"),
+    (245, "otilde"),
+    (246, "odieresis"),
+    (247, "divide"),
+    (248, "oslash"),
+    (249, "ugrave"),
+    (250, "uacute"),
+    (251, "ucircumflex"),
+    (252, "udieresis"),
+    (253, "yacute"),
+    (254, "thorn"),
+    (255, "ydieresis"),
+];
+
+const MAC_ROMAN_EXTENDED: [&str; 128] = [
+    "Adieresis",
+    "Aring",
+    "Ccedilla",
+    "Eacute",
+    "Ntilde",
+    "Odieresis",
+    "Udieresis",
+    "aacute",
+    "agrave",
+    "acircumflex",
+    "adieresis",
+    "atilde",
+    "aring",
+    "ccedilla",
+    "eacute",
+    "egrave",
+    "ecircumflex",
+    "edieresis",
+    "iacute",
+    "igrave",
+    "icircumflex",
+    "idieresis",
+    "ntilde",
+    "oacute",
+    "ograve",
+    "ocircumflex",
+    "odieresis",
+    "otilde",
+    "uacute",
+    "ugrave",
+    "ucircumflex",
+    "udieresis",
+    "dagger",
+    "degree",
+    "cent",
+    "sterling",
+    "section",
+    "bullet",
+    "paragraph",
+    "germandbls",
+    "registered",
+    "copyright",
+    "trademark",
+    "acute",
+    "dieresis",
+    "notequal",
+    "AE",
+    "Oslash",
+    "infinity",
+    "plusminus",
+    "lessequal",
+    "greaterequal",
+    "yen",
+    "mu",
+    "partialdiff",
+    "summation",
+    "product",
+    "pi",
+    "integral",
+    "ordfeminine",
+    "ordmasculine",
+    "Omega",
+    "ae",
+    "oslash",
+    "questiondown",
+    "exclamdown",
+    "logicalnot",
+    "radical",
+    "florin",
+    "approxequal",
+    "Delta",
+    "guillemotleft",
+    "guillemotright",
+    "ellipsis",
+    "space",
+    "Agrave",
+    "Atilde",
+    "Otilde",
+    "OE",
+    "oe",
+    "endash",
+    "emdash",
+    "quotedblleft",
+    "quotedblright",
+    "quoteleft",
+    "quoteright",
+    "divide",
+    "lozenge",
+    "ydieresis",
+    "Ydieresis",
+    "fraction",
+    "currency",
+    "guilsinglleft",
+    "guilsinglright",
+    "fi",
+    "fl",
+    "daggerdbl",
+    "periodcentered",
+    "quotesinglbase",
+    "quotedblbase",
+    "perthousand",
+    "Acircumflex",
+    "Ecircumflex",
+    "Aacute",
+    "Edieresis",
+    "Egrave",
+    "Iacute",
+    "Icircumflex",
+    "Idieresis",
+    "Igrave",
+    "Oacute",
+    "Ocircumflex",
+    "apple",
+    "Ograve",
+    "Uacute",
+    "Ucircumflex",
+    "Ugrave",
+    "dotlessi",
+    "circumflex",
+    "tilde",
+    "macron",
+    "breve",
+    "dotaccent",
+    "ring",
+    "cedilla",
+    "hungarumlaut",
+    "ogonek",
+    "caron",
+];
+
+fn ascii_glyph_name(code: u8) -> &'static str {
+    const DIGITS: [&str; 10] = [
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+    ];
+    match code {
+        b'A'..=b'Z' | b'a'..=b'z' => match code {
+            b'A' => "A",
+            b'B' => "B",
+            b'C' => "C",
+            b'D' => "D",
+            b'E' => "E",
+            b'F' => "F",
+            b'G' => "G",
+            b'H' => "H",
+            b'I' => "I",
+            b'J' => "J",
+            b'K' => "K",
+            b'L' => "L",
+            b'M' => "M",
+            b'N' => "N",
+            b'O' => "O",
+            b'P' => "P",
+            b'Q' => "Q",
+            b'R' => "R",
+            b'S' => "S",
+            b'T' => "T",
+            b'U' => "U",
+            b'V' => "V",
+            b'W' => "W",
+            b'X' => "X",
+            b'Y' => "Y",
+            b'Z' => "Z",
+            b'a' => "a",
+            b'b' => "b",
+            b'c' => "c",
+            b'd' => "d",
+            b'e' => "e",
+            b'f' => "f",
+            b'g' => "g",
+            b'h' => "h",
+            b'i' => "i",
+            b'j' => "j",
+            b'k' => "k",
+            b'l' => "l",
+            b'm' => "m",
+            b'n' => "n",
+            b'o' => "o",
+            b'p' => "p",
+            b'q' => "q",
+            b'r' => "r",
+            b's' => "s",
+            b't' => "t",
+            b'u' => "u",
+            b'v' => "v",
+            b'w' => "w",
+            b'x' => "x",
+            b'y' => "y",
+            _ => "z",
+        },
+        b'0'..=b'9' => DIGITS[(code - b'0') as usize],
+        b' ' => "space",
+        b'!' => "exclam",
+        b'\"' => "quotedbl",
+        b'#' => "numbersign",
+        b'$' => "dollar",
+        b'%' => "percent",
+        b'&' => "ampersand",
+        b'\'' => "quotesingle",
+        b'(' => "parenleft",
+        b')' => "parenright",
+        b'*' => "asterisk",
+        b'+' => "plus",
+        b',' => "comma",
+        b'-' => "hyphen",
+        b'.' => "period",
+        b'/' => "slash",
+        b':' => "colon",
+        b';' => "semicolon",
+        b'<' => "less",
+        b'=' => "equal",
+        b'>' => "greater",
+        b'?' => "question",
+        b'@' => "at",
+        b'[' => "bracketleft",
+        b'\\' => "backslash",
+        b']' => "bracketright",
+        b'^' => "asciicircum",
+        b'_' => "underscore",
+        b'`' => "grave",
+        b'{' => "braceleft",
+        b'|' => "bar",
+        b'}' => "braceright",
+        b'~' => "asciitilde",
+        _ => ".notdef",
+    }
+}
+
+fn syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::objects::{PdfArray, PdfName};
+
+    #[test]
+    fn named_standard_encoding_maps_ascii_glyph_names() {
+        let names = encoding_names(&PdfObject::Name(PdfName("StandardEncoding".into())))
+            .expect("known encoding");
+        assert_eq!(names.get(&65).map(String::as_str), Some("A"));
+        assert_eq!(names.get(&48).map(String::as_str), Some("zero"));
+    }
+
+    #[test]
+    fn differences_override_base_encoding() {
+        let mut encoding = PdfDictionary::new();
+        encoding.insert(
+            "BaseEncoding".into(),
+            PdfObject::Name(PdfName("WinAnsiEncoding".into())),
+        );
+        encoding.insert(
+            "Differences".into(),
+            PdfObject::Array(PdfArray(vec![
+                PdfObject::Integer(65),
+                PdfObject::Name(PdfName("OpaqueA".into())),
+            ])),
+        );
+        let names = encoding_names(&PdfObject::Dictionary(encoding)).expect("valid encoding");
+        assert_eq!(names.get(&65).map(String::as_str), Some("OpaqueA"));
+        assert_eq!(names.get(&66).map(String::as_str), Some("B"));
+    }
+}

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -304,8 +304,9 @@ pub use parser::{
 pub use operations::{
     extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page, overlay_pdf,
     reorder_pdf_pages, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
-    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionLimits,
-    ImageExtractor, OverlayOptions, OverlayPosition, ReorderOptions,
+    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
+    ImageExtractionLimits, ImageExtractionResult, ImageExtractor, OverlayOptions, OverlayPosition,
+    ReorderOptions,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -304,8 +304,8 @@ pub use parser::{
 pub use operations::{
     extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page, overlay_pdf,
     reorder_pdf_pages, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
-    ExtractImagesOptions, ExtractedImage, ImageExtractor, OverlayOptions, OverlayPosition,
-    ReorderOptions,
+    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionLimits,
+    ImageExtractor, OverlayOptions, OverlayPosition, ReorderOptions,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/operations/extract_images.rs
+++ b/oxidize-pdf-core/src/operations/extract_images.rs
@@ -181,6 +181,37 @@ impl Default for ImageExtractionLimits {
     }
 }
 
+/// Errors produced by bounded in-memory image extraction.
+#[derive(Debug, thiserror::Error)]
+pub enum ImageExtractionError {
+    /// An existing PDF operation or image-processing step failed.
+    #[error(transparent)]
+    Operation(#[from] OperationError),
+    /// A configured extraction bound would be exceeded.
+    #[error(
+        "Image extraction limit exceeded for {limit}: maximum {maximum}, attempted {attempted}"
+    )]
+    LimitExceeded {
+        limit: &'static str,
+        maximum: u64,
+        attempted: u64,
+    },
+}
+
+/// Result type for bounded in-memory image extraction.
+pub type ImageExtractionResult<T> = Result<T, ImageExtractionError>;
+
+impl ImageExtractionError {
+    fn into_operation_error(self) -> OperationError {
+        match self {
+            Self::Operation(error) => error,
+            error @ Self::LimitExceeded { .. } => {
+                OperationError::ProcessingError(error.to_string())
+            }
+        }
+    }
+}
+
 struct ImageExtractionBudget {
     limits: ImageExtractionLimits,
     images: usize,
@@ -196,10 +227,10 @@ impl ImageExtractionBudget {
         }
     }
 
-    fn check_pixels(&self, width: u32, height: u32) -> OperationResult<()> {
+    fn check_pixels(&self, width: u32, height: u32) -> ImageExtractionResult<()> {
         let pixels = u64::from(width) * u64::from(height);
         if pixels > self.limits.max_decoded_pixels_per_image {
-            return Err(OperationError::ImageExtractionLimitExceeded {
+            return Err(ImageExtractionError::LimitExceeded {
                 limit: "decoded pixels per image",
                 maximum: self.limits.max_decoded_pixels_per_image,
                 attempted: pixels,
@@ -208,10 +239,10 @@ impl ImageExtractionBudget {
         Ok(())
     }
 
-    fn check_image_slot(&self) -> OperationResult<()> {
+    fn check_image_slot(&self) -> ImageExtractionResult<()> {
         let attempted = self.images.checked_add(1).unwrap_or(usize::MAX);
         if attempted > self.limits.max_images {
-            return Err(OperationError::ImageExtractionLimitExceeded {
+            return Err(ImageExtractionError::LimitExceeded {
                 limit: "image count",
                 maximum: self.limits.max_images as u64,
                 attempted: attempted as u64,
@@ -220,9 +251,9 @@ impl ImageExtractionBudget {
         Ok(())
     }
 
-    fn consume(&mut self, bytes: usize) -> OperationResult<()> {
+    fn consume(&mut self, bytes: usize) -> ImageExtractionResult<()> {
         if bytes > self.limits.max_encoded_bytes_per_image {
-            return Err(OperationError::ImageExtractionLimitExceeded {
+            return Err(ImageExtractionError::LimitExceeded {
                 limit: "encoded bytes per image",
                 maximum: self.limits.max_encoded_bytes_per_image as u64,
                 attempted: bytes as u64,
@@ -230,15 +261,16 @@ impl ImageExtractionBudget {
         }
         self.check_image_slot()?;
         let next_images = self.images + 1;
-        let next_bytes = self.encoded_bytes.checked_add(bytes).ok_or(
-            OperationError::ImageExtractionLimitExceeded {
-                limit: "total encoded bytes",
-                maximum: self.limits.max_total_encoded_bytes as u64,
-                attempted: u64::MAX,
-            },
-        )?;
+        let next_bytes =
+            self.encoded_bytes
+                .checked_add(bytes)
+                .ok_or(ImageExtractionError::LimitExceeded {
+                    limit: "total encoded bytes",
+                    maximum: self.limits.max_total_encoded_bytes as u64,
+                    attempted: u64::MAX,
+                })?;
         if next_bytes > self.limits.max_total_encoded_bytes {
-            return Err(OperationError::ImageExtractionLimitExceeded {
+            return Err(ImageExtractionError::LimitExceeded {
                 limit: "total encoded bytes",
                 maximum: self.limits.max_total_encoded_bytes as u64,
                 attempted: next_bytes as u64,
@@ -278,9 +310,9 @@ impl<R: Read + Seek> ImageExtractor<R> {
         &mut self,
         limits: ImageExtractionLimits,
         mut visitor: F,
-    ) -> OperationResult<()>
+    ) -> ImageExtractionResult<()>
     where
-        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+        F: FnMut(ExtractedImageData) -> ImageExtractionResult<()>,
     {
         let page_count = self
             .document
@@ -302,7 +334,7 @@ impl<R: Read + Seek> ImageExtractor<R> {
     pub fn extract_all_in_memory(
         &mut self,
         limits: ImageExtractionLimits,
-    ) -> OperationResult<Vec<ExtractedImageData>> {
+    ) -> ImageExtractionResult<Vec<ExtractedImageData>> {
         let mut images = Vec::new();
         self.visit_images(limits, |image| {
             images.push(image);
@@ -321,7 +353,7 @@ impl<R: Read + Seek> ImageExtractor<R> {
         &mut self,
         page_number: usize,
         limits: ImageExtractionLimits,
-    ) -> OperationResult<Vec<ExtractedImageData>> {
+    ) -> ImageExtractionResult<Vec<ExtractedImageData>> {
         let mut images = Vec::new();
         let mut budget = ImageExtractionBudget::new(limits);
         self.visit_page_images(page_number, &mut budget, &mut |image| {
@@ -336,9 +368,9 @@ impl<R: Read + Seek> ImageExtractor<R> {
         page_number: usize,
         budget: &mut ImageExtractionBudget,
         visitor: &mut F,
-    ) -> OperationResult<()>
+    ) -> ImageExtractionResult<()>
     where
-        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+        F: FnMut(ExtractedImageData) -> ImageExtractionResult<()>,
     {
         let page = self
             .document
@@ -400,7 +432,7 @@ impl<R: Read + Seek> ImageExtractor<R> {
         page_number: usize,
         image_index: usize,
         budget: &ImageExtractionBudget,
-    ) -> OperationResult<Option<ExtractedImageData>> {
+    ) -> ImageExtractionResult<Option<ExtractedImageData>> {
         let Some(PdfObject::Integer(width @ 1..)) = stream.dict.get("Width") else {
             return Ok(None);
         };
@@ -480,9 +512,9 @@ impl<R: Read + Seek> ImageExtractor<R> {
         image_index: &mut usize,
         budget: &mut ImageExtractionBudget,
         visitor: &mut F,
-    ) -> OperationResult<()>
+    ) -> ImageExtractionResult<()>
     where
-        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+        F: FnMut(ExtractedImageData) -> ImageExtractionResult<()>,
     {
         let mut position = 0;
         while let Some(begin) = Self::find_bytes(stream_data, b"BI", position) {
@@ -536,7 +568,7 @@ impl<R: Read + Seek> ImageExtractor<R> {
             Ok(())
         });
         self.processed_images = cache;
-        result?;
+        result.map_err(ImageExtractionError::into_operation_error)?;
         Ok(images)
     }
 
@@ -557,7 +589,7 @@ impl<R: Read + Seek> ImageExtractor<R> {
             Ok(())
         });
         self.processed_images = cache;
-        result?;
+        result.map_err(ImageExtractionError::into_operation_error)?;
         Ok(images)
     }
 

--- a/oxidize-pdf-core/src/operations/extract_images.rs
+++ b/oxidize-pdf-core/src/operations/extract_images.rs
@@ -29,6 +29,7 @@ pub struct TransformMatrix {
 }
 
 impl TransformMatrix {
+    #[allow(dead_code)]
     fn new(a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) -> Self {
         Self { a, b, c, d, e, f }
     }
@@ -139,6 +140,116 @@ pub struct ExtractedImage {
     pub format: ImageFormat,
 }
 
+/// An extracted image whose encoded bytes remain in memory.
+#[derive(Debug, Clone)]
+pub struct ExtractedImageData {
+    /// Zero-based page containing the image.
+    pub page_number: usize,
+    /// Zero-based image index within the page.
+    pub image_index: usize,
+    /// Image width in pixels.
+    pub width: u32,
+    /// Image height in pixels.
+    pub height: u32,
+    /// Encoding of `data`.
+    pub format: ImageFormat,
+    /// Encoded image bytes after optional preprocessing.
+    pub data: Vec<u8>,
+}
+
+/// Resource bounds applied while extracting images in memory.
+#[derive(Debug, Clone, Copy)]
+pub struct ImageExtractionLimits {
+    /// Maximum number of images delivered to the consumer.
+    pub max_images: usize,
+    /// Maximum encoded size of one delivered image.
+    pub max_encoded_bytes_per_image: usize,
+    /// Maximum total encoded size delivered during the operation.
+    pub max_total_encoded_bytes: usize,
+    /// Maximum width multiplied by height for one image.
+    pub max_decoded_pixels_per_image: u64,
+}
+
+impl Default for ImageExtractionLimits {
+    fn default() -> Self {
+        Self {
+            max_images: usize::MAX,
+            max_encoded_bytes_per_image: usize::MAX,
+            max_total_encoded_bytes: usize::MAX,
+            max_decoded_pixels_per_image: u64::MAX,
+        }
+    }
+}
+
+struct ImageExtractionBudget {
+    limits: ImageExtractionLimits,
+    images: usize,
+    encoded_bytes: usize,
+}
+
+impl ImageExtractionBudget {
+    fn new(limits: ImageExtractionLimits) -> Self {
+        Self {
+            limits,
+            images: 0,
+            encoded_bytes: 0,
+        }
+    }
+
+    fn check_pixels(&self, width: u32, height: u32) -> OperationResult<()> {
+        let pixels = u64::from(width) * u64::from(height);
+        if pixels > self.limits.max_decoded_pixels_per_image {
+            return Err(OperationError::ImageExtractionLimitExceeded {
+                limit: "decoded pixels per image",
+                maximum: self.limits.max_decoded_pixels_per_image,
+                attempted: pixels,
+            });
+        }
+        Ok(())
+    }
+
+    fn check_image_slot(&self) -> OperationResult<()> {
+        let attempted = self.images.checked_add(1).unwrap_or(usize::MAX);
+        if attempted > self.limits.max_images {
+            return Err(OperationError::ImageExtractionLimitExceeded {
+                limit: "image count",
+                maximum: self.limits.max_images as u64,
+                attempted: attempted as u64,
+            });
+        }
+        Ok(())
+    }
+
+    fn consume(&mut self, bytes: usize) -> OperationResult<()> {
+        if bytes > self.limits.max_encoded_bytes_per_image {
+            return Err(OperationError::ImageExtractionLimitExceeded {
+                limit: "encoded bytes per image",
+                maximum: self.limits.max_encoded_bytes_per_image as u64,
+                attempted: bytes as u64,
+            });
+        }
+        self.check_image_slot()?;
+        let next_images = self.images + 1;
+        let next_bytes = self.encoded_bytes.checked_add(bytes).ok_or(
+            OperationError::ImageExtractionLimitExceeded {
+                limit: "total encoded bytes",
+                maximum: self.limits.max_total_encoded_bytes as u64,
+                attempted: u64::MAX,
+            },
+        )?;
+        if next_bytes > self.limits.max_total_encoded_bytes {
+            return Err(OperationError::ImageExtractionLimitExceeded {
+                limit: "total encoded bytes",
+                maximum: self.limits.max_total_encoded_bytes as u64,
+                attempted: next_bytes as u64,
+            });
+        }
+        self.images = next_images;
+        self.encoded_bytes = next_bytes;
+        Ok(())
+    }
+}
+
 /// Image extractor
 pub struct ImageExtractor<R: Read + Seek> {
     document: PdfDocument<R>,
@@ -157,25 +268,276 @@ impl<R: Read + Seek> ImageExtractor<R> {
         }
     }
 
-    /// Extract all images from the document
-    pub fn extract_all(&mut self) -> OperationResult<Vec<ExtractedImage>> {
-        // Create output directory if needed
-        if self.options.create_dir && !self.options.output_dir.exists() {
-            fs::create_dir_all(&self.options.output_dir)?;
-        }
-
-        let mut extracted_images = Vec::new();
+    /// Visit every extracted image without writing to the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the document cannot be parsed, a configured limit
+    /// would be exceeded, image processing fails, or the visitor returns an error.
+    pub fn visit_images<F>(
+        &mut self,
+        limits: ImageExtractionLimits,
+        mut visitor: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+    {
         let page_count = self
             .document
             .page_count()
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
+            .map_err(|error| OperationError::ParseError(error.to_string()))?;
+        let mut budget = ImageExtractionBudget::new(limits);
+        for page_number in 0..page_count as usize {
+            self.visit_page_images(page_number, &mut budget, &mut visitor)?;
+        }
+        Ok(())
+    }
 
-        for page_idx in 0..page_count {
-            let page_images = self.extract_from_page(page_idx as usize)?;
-            extracted_images.extend(page_images);
+    /// Extract every image as encoded bytes without filesystem writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing or image processing fails, or when a
+    /// configured extraction limit would be exceeded.
+    pub fn extract_all_in_memory(
+        &mut self,
+        limits: ImageExtractionLimits,
+    ) -> OperationResult<Vec<ExtractedImageData>> {
+        let mut images = Vec::new();
+        self.visit_images(limits, |image| {
+            images.push(image);
+            Ok(())
+        })?;
+        Ok(images)
+    }
+
+    /// Extract one page's images as encoded bytes without filesystem writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the page cannot be read, image processing fails,
+    /// or a configured extraction limit would be exceeded.
+    pub fn extract_from_page_in_memory(
+        &mut self,
+        page_number: usize,
+        limits: ImageExtractionLimits,
+    ) -> OperationResult<Vec<ExtractedImageData>> {
+        let mut images = Vec::new();
+        let mut budget = ImageExtractionBudget::new(limits);
+        self.visit_page_images(page_number, &mut budget, &mut |image| {
+            images.push(image);
+            Ok(())
+        })?;
+        Ok(images)
+    }
+
+    fn visit_page_images<F>(
+        &mut self,
+        page_number: usize,
+        budget: &mut ImageExtractionBudget,
+        visitor: &mut F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+    {
+        let page = self
+            .document
+            .get_page(page_number as u32)
+            .map_err(|error| OperationError::ParseError(error.to_string()))?;
+        let resources = self
+            .document
+            .get_page_resources(&page)
+            .map_err(|error| OperationError::ParseError(error.to_string()))?;
+        let mut references = Vec::new();
+        if let Some(resources) = resources {
+            if let Some(PdfObject::Dictionary(xobjects)) = resources.get("XObject") {
+                for object in xobjects.0.values() {
+                    if let PdfObject::Reference(number, generation) = object {
+                        references.push((*number, *generation));
+                    }
+                }
+            }
         }
 
-        Ok(extracted_images)
+        let mut image_index = 0;
+        for (number, generation) in references {
+            let object = self
+                .document
+                .get_object(number, generation)
+                .map_err(|error| OperationError::ParseError(error.to_string()))?;
+            let PdfObject::Stream(stream) = object else {
+                continue;
+            };
+            if !matches!(stream.dict.get("Subtype"), Some(PdfObject::Name(name)) if name.0 == "Image")
+            {
+                continue;
+            }
+            budget.check_image_slot()?;
+            if let Some(image) =
+                self.prepare_image_data(&stream, page_number, image_index, budget)?
+            {
+                budget.consume(image.data.len())?;
+                visitor(image)?;
+                image_index += 1;
+            }
+        }
+
+        if self.options.extract_inline {
+            for content in self
+                .document
+                .get_page_content_streams(&page)
+                .map_err(|error| OperationError::ParseError(error.to_string()))?
+            {
+                self.visit_inline_images(&content, page_number, &mut image_index, budget, visitor)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn prepare_image_data(
+        &self,
+        stream: &PdfStream,
+        page_number: usize,
+        image_index: usize,
+        budget: &ImageExtractionBudget,
+    ) -> OperationResult<Option<ExtractedImageData>> {
+        let Some(PdfObject::Integer(width @ 1..)) = stream.dict.get("Width") else {
+            return Ok(None);
+        };
+        let Some(PdfObject::Integer(height @ 1..)) = stream.dict.get("Height") else {
+            return Ok(None);
+        };
+        let (Ok(width), Ok(height)) = (u32::try_from(*width), u32::try_from(*height)) else {
+            return Ok(None);
+        };
+        if self
+            .options
+            .min_size
+            .is_some_and(|minimum| width < minimum || height < minimum)
+        {
+            return Ok(None);
+        }
+        budget.check_pixels(width, height)?;
+        let color_space = stream.dict.get("ColorSpace");
+        let bits = match stream.dict.get("BitsPerComponent") {
+            Some(PdfObject::Integer(bits)) => *bits as u8,
+            _ => 8,
+        };
+        let smask = self.extract_smask_alpha(&stream.dict, width, height);
+        let first_filter = match stream.dict.get("Filter") {
+            Some(PdfObject::Name(name)) => Some(name.0.as_str()),
+            Some(PdfObject::Array(filters)) => filters.0.first().and_then(|filter| match filter {
+                PdfObject::Name(name) => Some(name.0.as_str()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let (data, format) = match first_filter {
+            Some("DCTDecode") => (stream.data.clone(), ImageFormat::Jpeg),
+            Some("FlateDecode" | "LZWDecode") | None => {
+                let decoded = self.decode_image_stream(stream)?;
+                (
+                    self.convert_raw_image_data_to_png(
+                        &decoded,
+                        width,
+                        height,
+                        color_space,
+                        bits,
+                        smask.as_deref(),
+                    )?,
+                    ImageFormat::Png,
+                )
+            }
+            Some("CCITTFaxDecode") => {
+                let decoded = self.decode_image_stream(stream)?;
+                (
+                    self.convert_ccitt_to_png(&decoded, width, height)?,
+                    ImageFormat::Png,
+                )
+            }
+            Some(_) => return Ok(None),
+        };
+        #[cfg(feature = "external-images")]
+        let data = if self.should_preprocess() {
+            self.preprocess_image_data(&data, width, height, format)?
+        } else {
+            data
+        };
+        Ok(Some(ExtractedImageData {
+            page_number,
+            image_index,
+            width,
+            height,
+            format,
+            data,
+        }))
+    }
+
+    fn visit_inline_images<F>(
+        &self,
+        stream_data: &[u8],
+        page_number: usize,
+        image_index: &mut usize,
+        budget: &mut ImageExtractionBudget,
+        visitor: &mut F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(ExtractedImageData) -> OperationResult<()>,
+    {
+        let mut position = 0;
+        while let Some(begin) = Self::find_bytes(stream_data, b"BI", position) {
+            let Some(id) = Self::find_bytes(stream_data, b"ID", begin + 2) else {
+                break;
+            };
+            let Some(end) = Self::find_bytes(stream_data, b"EI", id + 2) else {
+                break;
+            };
+            budget.check_image_slot()?;
+            let dictionary = String::from_utf8_lossy(&stream_data[begin + 2..id]);
+            let (width, height) = self.parse_inline_image_dict(dictionary.trim());
+            budget.check_pixels(width, height)?;
+            let data = stream_data[id + 2..end].to_vec();
+            budget.consume(data.len())?;
+            let format = self
+                .detect_image_format_from_data(&data)
+                .unwrap_or(ImageFormat::Raw);
+            visitor(ExtractedImageData {
+                page_number,
+                image_index: *image_index,
+                width,
+                height,
+                format,
+                data,
+            })?;
+            *image_index += 1;
+            position = end + 2;
+        }
+        Ok(())
+    }
+
+    fn find_bytes(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+        haystack
+            .get(start..)?
+            .windows(needle.len())
+            .position(|window| window == needle)
+            .map(|position| start + position)
+    }
+
+    /// Extract all images from the document
+    pub fn extract_all(&mut self) -> OperationResult<Vec<ExtractedImage>> {
+        if self.options.create_dir && !self.options.output_dir.exists() {
+            fs::create_dir_all(&self.options.output_dir)?;
+        }
+        let options = self.options.clone();
+        let mut cache = std::mem::take(&mut self.processed_images);
+        let mut images = Vec::new();
+        let result = self.visit_images(ImageExtractionLimits::default(), |image| {
+            images.push(Self::persist_image_data(&options, &mut cache, image)?);
+            Ok(())
+        });
+        self.processed_images = cache;
+        result?;
+        Ok(images)
     }
 
     /// Extract images from a specific page
@@ -183,326 +545,57 @@ impl<R: Read + Seek> ImageExtractor<R> {
         &mut self,
         page_number: usize,
     ) -> OperationResult<Vec<ExtractedImage>> {
-        let mut extracted = Vec::new();
-
-        // Get the page
-        let page = self
-            .document
-            .get_page(page_number as u32)
-            .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-        // Get page resources and collect XObject references
-        let xobject_refs: Vec<(String, u32, u16)> = {
-            let resources = self
-                .document
-                .get_page_resources(&page)
-                .map_err(|e| OperationError::ParseError(e.to_string()))?;
-
-            let mut refs = Vec::new();
-
-            if let Some(resources) = resources {
-                if let Some(PdfObject::Dictionary(xobjects)) =
-                    resources.0.get(&PdfName("XObject".to_string()))
-                {
-                    for (name, obj_ref) in &xobjects.0 {
-                        if let PdfObject::Reference(obj_num, gen_num) = obj_ref {
-                            refs.push((name.0.clone(), *obj_num, *gen_num));
-                        }
-                    }
-                }
-            }
-
-            refs
-        };
-
-        // Process each XObject reference
-        let mut image_index = 0;
-        for (name, obj_num, gen_num) in xobject_refs {
-            if let Ok(xobject) = self.document.get_object(obj_num, gen_num) {
-                if let Some(extracted_image) =
-                    self.process_xobject(&xobject, page_number, image_index, &name)?
-                {
-                    extracted.push(extracted_image);
-                    image_index += 1;
-                }
-            }
+        if self.options.create_dir && !self.options.output_dir.exists() {
+            fs::create_dir_all(&self.options.output_dir)?;
         }
-
-        // If no XObjects found via resources, try alternative method
-        if extracted.is_empty() {
-            // Analyze content streams for image references
-            if let Ok(content_streams) = self.document.get_page_content_streams(&page) {
-                for stream_data in &content_streams {
-                    let referenced_images = self.extract_referenced_images_from_content(
-                        stream_data,
-                        page_number,
-                        &mut image_index,
-                    )?;
-                    extracted.extend(referenced_images);
-                }
-            }
-        }
-
-        // Extract inline images from content stream if requested
-        if self.options.extract_inline {
-            if let Ok(parsed_page) = self.document.get_page(page_number as u32) {
-                if let Ok(content_streams) = self.document.get_page_content_streams(&parsed_page) {
-                    for stream_data in &content_streams {
-                        let inline_images = self.extract_inline_images_from_stream(
-                            stream_data,
-                            page_number,
-                            &mut image_index,
-                        )?;
-                        extracted.extend(inline_images);
-                    }
-                }
-            }
-        }
-
-        Ok(extracted)
+        let options = self.options.clone();
+        let mut cache = std::mem::take(&mut self.processed_images);
+        let mut images = Vec::new();
+        let mut budget = ImageExtractionBudget::new(ImageExtractionLimits::default());
+        let result = self.visit_page_images(page_number, &mut budget, &mut |image| {
+            images.push(Self::persist_image_data(&options, &mut cache, image)?);
+            Ok(())
+        });
+        self.processed_images = cache;
+        result?;
+        Ok(images)
     }
 
-    /// Process an XObject to see if it's an image
-    fn process_xobject(
-        &mut self,
-        xobject: &PdfObject,
-        page_number: usize,
-        image_index: usize,
-        _name: &str,
-    ) -> OperationResult<Option<ExtractedImage>> {
-        if let PdfObject::Stream(stream) = xobject {
-            // Check if it's an image XObject
-            if let Some(PdfObject::Name(subtype)) =
-                stream.dict.0.get(&PdfName("Subtype".to_string()))
-            {
-                if subtype.0 == "Image" {
-                    return self.extract_image_xobject(stream, page_number, image_index);
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    /// Extract an image XObject
-    fn extract_image_xobject(
-        &mut self,
-        stream: &PdfStream,
-        page_number: usize,
-        image_index: usize,
-    ) -> OperationResult<Option<ExtractedImage>> {
-        // Get image properties
-        let width = match stream.dict.0.get(&PdfName("Width".to_string())) {
-            Some(PdfObject::Integer(w)) => *w as u32,
-            _ => return Ok(None),
-        };
-
-        let height = match stream.dict.0.get(&PdfName("Height".to_string())) {
-            Some(PdfObject::Integer(h)) => *h as u32,
-            _ => return Ok(None),
-        };
-
-        // Check minimum size
-        if let Some(min_size) = self.options.min_size {
-            if width < min_size || height < min_size {
-                return Ok(None);
-            }
-        }
-
-        // Get color space information
-        let color_space = stream.dict.0.get(&PdfName("ColorSpace".to_string()));
-        let bits_per_component = match stream.dict.0.get(&PdfName("BitsPerComponent".to_string())) {
-            Some(PdfObject::Integer(bits)) => *bits as u8,
-            _ => 8, // Default to 8 bits per component
-        };
-
-        // Get the decoded image data (resolving an indirect /DecodeParms so
-        // predictors are applied — issue #286).
-        let mut data = self.decode_image_stream(stream)?;
-
-        // Soft mask (/SMask): a grayscale image whose samples are the per-pixel
-        // alpha of this image. Decoded once here (resized to this image's
-        // dimensions) and composited into an RGBA PNG by the raw→PNG paths below
-        // (issue #286: images whose visible shape lives entirely in the SMask
-        // otherwise extract as opaque, often near-black, rectangles).
-        let smask_alpha = self.extract_smask_alpha(&stream.dict, width, height);
-
-        // Determine format from filter and process data accordingly
-        let format = match stream.dict.0.get(&PdfName("Filter".to_string())) {
-            Some(PdfObject::Name(filter)) => match filter.0.as_str() {
-                "DCTDecode" => {
-                    // JPEG data is already in correct format - use raw stream data
-                    // DCTDecode streams contain complete JPEG data, don't decode
-                    if smask_alpha.is_some() {
-                        tracing::debug!(
-                            "image has an /SMask but is DCT-encoded; alpha not composited into JPEG output"
-                        );
-                    }
-                    data = stream.data.clone();
-                    ImageFormat::Jpeg
-                }
-                "FlateDecode" => {
-                    // FlateDecode contains raw pixel data - need to convert to image format
-                    data = self.convert_raw_image_data_to_png(
-                        &data,
-                        width,
-                        height,
-                        color_space,
-                        bits_per_component,
-                        smask_alpha.as_deref(),
-                    )?;
-                    ImageFormat::Png
-                }
-                "CCITTFaxDecode" => {
-                    // CCITT data for scanned documents - convert to PNG
-                    data = self.convert_ccitt_to_png(&data, width, height)?;
-                    ImageFormat::Png
-                }
-                "LZWDecode" => {
-                    // LZW compressed raw data - convert to PNG
-                    data = self.convert_raw_image_data_to_png(
-                        &data,
-                        width,
-                        height,
-                        color_space,
-                        bits_per_component,
-                        smask_alpha.as_deref(),
-                    )?;
-                    ImageFormat::Png
-                }
-                _ => {
-                    tracing::debug!("Unsupported image filter: {}", filter.0);
-                    return Ok(None);
-                }
-            },
-            Some(PdfObject::Array(filters)) => {
-                // Handle filter arrays - use the first filter
-                if let Some(PdfObject::Name(filter)) = filters.0.first() {
-                    match filter.0.as_str() {
-                        "DCTDecode" => {
-                            // JPEG data is already in correct format - use raw stream data
-                            if smask_alpha.is_some() {
-                                tracing::debug!(
-                                    "image has an /SMask but is DCT-encoded; alpha not composited into JPEG output"
-                                );
-                            }
-                            data = stream.data.clone();
-                            ImageFormat::Jpeg
-                        }
-                        "FlateDecode" => {
-                            data = self.convert_raw_image_data_to_png(
-                                &data,
-                                width,
-                                height,
-                                color_space,
-                                bits_per_component,
-                                smask_alpha.as_deref(),
-                            )?;
-                            ImageFormat::Png
-                        }
-                        "CCITTFaxDecode" => {
-                            data = self.convert_ccitt_to_png(&data, width, height)?;
-                            ImageFormat::Png
-                        }
-                        "LZWDecode" => {
-                            data = self.convert_raw_image_data_to_png(
-                                &data,
-                                width,
-                                height,
-                                color_space,
-                                bits_per_component,
-                                smask_alpha.as_deref(),
-                            )?;
-                            ImageFormat::Png
-                        }
-                        _ => {
-                            tracing::debug!("Unsupported image filter: {}", filter.0);
-                            return Ok(None);
-                        }
-                    }
-                } else {
-                    return Ok(None);
-                }
-            }
-            _ => {
-                // No filter - raw image data
-                data = self.convert_raw_image_data_to_png(
-                    &data,
-                    width,
-                    height,
-                    color_space,
-                    bits_per_component,
-                    smask_alpha.as_deref(),
-                )?;
-                ImageFormat::Png
-            }
-        };
-
-        // Generate unique key for this image data
-        let image_key = format!("{:x}", md5::compute(&data));
-
-        // For scanned PDFs where all pages reference the same image object,
-        // we need to create separate files per page for OCR processing
-        // Don't deduplicate if we're extracting for OCR purposes
-        let allow_deduplication = !self.options.name_pattern.contains("{page}");
-
-        // Check if we've already extracted this image (only if deduplication is allowed)
-        if allow_deduplication {
-            if let Some(existing_path) = self.processed_images.get(&image_key) {
-                // Return reference to already extracted image
-                return Ok(Some(ExtractedImage {
-                    page_number,
-                    image_index,
-                    file_path: existing_path.clone(),
-                    width,
-                    height,
-                    format,
-                }));
-            }
-        }
-
-        // Generate output filename
-        let extension = match format {
+    fn persist_image_data(
+        options: &ExtractImagesOptions,
+        cache: &mut HashMap<String, PathBuf>,
+        image: ExtractedImageData,
+    ) -> OperationResult<ExtractedImage> {
+        let key = format!("{:x}", md5::compute(&image.data));
+        let allow_deduplication = !options.name_pattern.contains("{page}");
+        let extension = match image.format {
             ImageFormat::Jpeg => "jpg",
             ImageFormat::Png => "png",
             ImageFormat::Tiff => "tiff",
             ImageFormat::Raw => "rgb",
         };
-
-        let filename = self
-            .options
+        let filename = options
             .name_pattern
-            .replace("{page}", &(page_number + 1).to_string())
-            .replace("{index}", &(image_index + 1).to_string())
+            .replace("{page}", &(image.page_number + 1).to_string())
+            .replace("{index}", &(image.image_index + 1).to_string())
             .replace("{format}", extension);
-
-        let output_path = self.options.output_dir.join(filename);
-
-        // Apply preprocessing if enabled
-        #[cfg(feature = "external-images")]
-        let processed_data = if self.should_preprocess() {
-            self.preprocess_image_data(&data, width, height, format)?
-        } else {
-            data
-        };
-
-        #[cfg(not(feature = "external-images"))]
-        let processed_data = data;
-
-        // Write image data
-        let mut file = File::create(&output_path)?;
-        file.write_all(&processed_data)?;
-
-        // Cache the path
-        self.processed_images.insert(image_key, output_path.clone());
-
-        Ok(Some(ExtractedImage {
-            page_number,
-            image_index,
-            file_path: output_path,
-            width,
-            height,
-            format,
-        }))
+        let existing = allow_deduplication
+            .then(|| cache.get(&key).cloned())
+            .flatten();
+        let path = existing.unwrap_or_else(|| options.output_dir.join(filename));
+        if !allow_deduplication || !cache.contains_key(&key) {
+            let mut file = File::create(&path)?;
+            file.write_all(&image.data)?;
+            cache.insert(key, path.clone());
+        }
+        Ok(ExtractedImage {
+            page_number: image.page_number,
+            image_index: image.image_index,
+            file_path: path,
+            width: image.width,
+            height: image.height,
+            format: image.format,
+        })
     }
 
     /// Detect image format from raw data by examining magic bytes
@@ -543,292 +636,6 @@ impl<R: Read + Seek> ImageExtractor<R> {
         // Default to PNG for FlateDecode if no other format detected
         // This is a fallback since FlateDecode is commonly used for PNG in PDFs
         Ok(ImageFormat::Png)
-    }
-
-    /// Extract inline images from a content stream
-    fn extract_inline_images_from_stream(
-        &mut self,
-        stream_data: &[u8],
-        page_number: usize,
-        image_index: &mut usize,
-    ) -> OperationResult<Vec<ExtractedImage>> {
-        let mut inline_images = Vec::new();
-
-        // Convert bytes to string for parsing
-        let stream_str = String::from_utf8_lossy(stream_data);
-
-        // Find inline image operators: BI (Begin Image), ID (Image Data), EI (End Image)
-        let mut pos = 0;
-        while let Some(bi_pos) = stream_str[pos..].find("BI") {
-            let absolute_bi_pos = pos + bi_pos;
-
-            // Find the ID operator after BI
-            if let Some(relative_id_pos) = stream_str[absolute_bi_pos..].find("ID") {
-                let absolute_id_pos = absolute_bi_pos + relative_id_pos;
-
-                // Find the EI operator after ID
-                if let Some(relative_ei_pos) = stream_str[absolute_id_pos..].find("EI") {
-                    let absolute_ei_pos = absolute_id_pos + relative_ei_pos;
-
-                    // Extract image dictionary (between BI and ID)
-                    let dict_section = &stream_str[absolute_bi_pos + 2..absolute_id_pos].trim();
-
-                    // Extract image data (between ID and EI)
-                    let data_start = absolute_id_pos + 2;
-                    let data_end = absolute_ei_pos;
-
-                    if data_start < data_end && data_end <= stream_data.len() {
-                        let image_data = &stream_data[data_start..data_end];
-
-                        // Parse basic image properties from dictionary
-                        let (width, height) = self.parse_inline_image_dict(dict_section);
-
-                        // Create extracted image
-                        if let Ok(extracted_image) = self.save_inline_image(
-                            image_data,
-                            page_number,
-                            *image_index,
-                            width,
-                            height,
-                        ) {
-                            inline_images.push(extracted_image);
-                            *image_index += 1;
-                        }
-                    }
-
-                    // Continue searching after this EI
-                    pos = absolute_ei_pos + 2;
-                } else {
-                    break; // No matching EI found
-                }
-            } else {
-                break; // No matching ID found
-            }
-        }
-
-        Ok(inline_images)
-    }
-
-    /// Extract images referenced in content streams when resources are not available
-    fn extract_referenced_images_from_content(
-        &mut self,
-        stream_data: &[u8],
-        page_number: usize,
-        image_index: &mut usize,
-    ) -> OperationResult<Vec<ExtractedImage>> {
-        let mut extracted = Vec::new();
-
-        // Convert to string for parsing
-        let content = String::from_utf8_lossy(stream_data);
-
-        tracing::debug!("       Content: {}", content);
-
-        // Parse transformation matrices and image references together
-        // Pattern: look for cm matrices followed by Do operators
-        let image_with_transform = self.parse_images_with_transformations(&content)?;
-
-        for (image_name, transform_matrix) in image_with_transform {
-            // Try to find this object by scanning all objects in the document
-            if let Some(mut extracted_image) =
-                self.find_and_extract_xobject_by_name(&image_name, page_number, *image_index)?
-            {
-                // Apply transformation if one was found
-                if let Some(matrix) = transform_matrix {
-                    extracted_image =
-                        self.apply_transformation_to_image(extracted_image, &matrix)?;
-                }
-
-                extracted.push(extracted_image);
-                *image_index += 1;
-            }
-        }
-
-        Ok(extracted)
-    }
-
-    /// Find an XObject by name by scanning through the document
-    fn find_and_extract_xobject_by_name(
-        &mut self,
-        name: &str,
-        page_number: usize,
-        image_index: usize,
-    ) -> OperationResult<Option<ExtractedImage>> {
-        // This is a brute force approach - scan through objects looking for image streams
-        // In a real implementation, we would have better object mapping, but for now
-        // this should work for common landscape-in-portrait cases
-
-        // Try some common object numbers that might contain images
-        // We'll scan a range and look for stream objects that look like images
-        for obj_num in 1..1000 {
-            if let Ok(obj) = self.document.get_object(obj_num, 0) {
-                if let Some(extracted) =
-                    self.try_extract_image_from_object(&obj, page_number, image_index, name)?
-                {
-                    return Ok(Some(extracted));
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Try to extract an image from any PDF object
-    fn try_extract_image_from_object(
-        &mut self,
-        obj: &PdfObject,
-        page_number: usize,
-        image_index: usize,
-        _expected_name: &str,
-    ) -> OperationResult<Option<ExtractedImage>> {
-        if let PdfObject::Stream(stream) = obj {
-            // Check if this stream looks like an image
-            if let Some(PdfObject::Name(subtype)) =
-                stream.dict.0.get(&PdfName("Subtype".to_string()))
-            {
-                if subtype.0 == "Image" {
-                    return self.extract_image_xobject(stream, page_number, image_index);
-                }
-            }
-
-            // Also check for streams that might be images but don't have proper Subtype
-            if let Some(PdfObject::Integer(_width)) =
-                stream.dict.0.get(&PdfName("Width".to_string()))
-            {
-                if let Some(PdfObject::Integer(_height)) =
-                    stream.dict.0.get(&PdfName("Height".to_string()))
-                {
-                    return self.extract_image_xobject(stream, page_number, image_index);
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Parse content stream to find images with their transformation matrices
-    fn parse_images_with_transformations(
-        &self,
-        content: &str,
-    ) -> OperationResult<Vec<(String, Option<TransformMatrix>)>> {
-        let mut results = Vec::new();
-        let lines: Vec<&str> = content.lines().collect();
-
-        let mut current_matrix: Option<TransformMatrix> = None;
-
-        for line in lines {
-            let line = line.trim();
-
-            // Look for transformation matrices: "a b c d e f cm"
-            if line.ends_with(" cm") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() == 7 && parts[6] == "cm" {
-                    // Parse the 6 matrix values
-                    if let (Ok(a), Ok(b), Ok(c), Ok(d), Ok(e), Ok(f)) = (
-                        parts[0].parse::<f64>(),
-                        parts[1].parse::<f64>(),
-                        parts[2].parse::<f64>(),
-                        parts[3].parse::<f64>(),
-                        parts[4].parse::<f64>(),
-                        parts[5].parse::<f64>(),
-                    ) {
-                        current_matrix = Some(TransformMatrix::new(a, b, c, d, e, f));
-                    }
-                }
-            }
-
-            // Look for image draw commands: "/ImageName Do"
-            if line.contains(" Do") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                for part in parts {
-                    if part.starts_with('/') && !part.contains("Do") {
-                        let image_name = part[1..].to_string(); // Remove the '/'
-                        results.push((image_name, current_matrix.clone()));
-                    }
-                }
-            }
-
-            // Reset matrix on graphics state restore
-            if line.trim() == "Q" {
-                current_matrix = None;
-            }
-        }
-
-        Ok(results)
-    }
-
-    /// Apply transformation matrix to an extracted image
-    #[allow(unused_mut)]
-    fn apply_transformation_to_image(
-        &self,
-        mut extracted_image: ExtractedImage,
-        _matrix: &TransformMatrix,
-    ) -> OperationResult<ExtractedImage> {
-        #[cfg(feature = "external-images")]
-        {
-            // Read the extracted image file
-            let image_data = std::fs::read(&extracted_image.file_path)?;
-
-            // Load with image crate
-            let img = image::load_from_memory(&image_data).map_err(|e| {
-                OperationError::ParseError(format!("Failed to load image for transformation: {e}"))
-            })?;
-
-            // IGNORE TRANSFORMATION FOR NOW - FOCUS ON STRIDE PROBLEM
-            let transformed_img =
-                self.fix_stride_problem(img, extracted_image.width, extracted_image.height)?;
-
-            // Save the transformed image
-            let output_filename = extracted_image
-                .file_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| OperationError::InvalidPath {
-                    reason: format!(
-                        "Image path has no valid filename: {:?}",
-                        extracted_image.file_path
-                    ),
-                })?;
-            let output_extension = extracted_image
-                .file_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| OperationError::InvalidPath {
-                    reason: format!(
-                        "Image path has no valid extension: {:?}",
-                        extracted_image.file_path
-                    ),
-                })?;
-
-            let parent_dir =
-                extracted_image
-                    .file_path
-                    .parent()
-                    .ok_or_else(|| OperationError::InvalidPath {
-                        reason: format!(
-                            "Image path has no parent directory: {:?}",
-                            extracted_image.file_path
-                        ),
-                    })?;
-            let transformed_path = parent_dir.join(format!(
-                "{}_transformed.{}",
-                output_filename, output_extension
-            ));
-
-            transformed_img.save(&transformed_path).map_err(|e| {
-                OperationError::ParseError(format!("Failed to save transformed image: {e}"))
-            })?;
-
-            // Update the extracted image info
-            let (new_width, new_height) = transformed_img.dimensions();
-            extracted_image.file_path = transformed_path;
-            extracted_image.width = new_width;
-            extracted_image.height = new_height;
-        }
-
-        #[cfg(not(feature = "external-images"))]
-        {}
-
-        Ok(extracted_image)
     }
 
     /// Apply rotation transformation
@@ -875,69 +682,6 @@ impl<R: Read + Seek> ImageExtractor<R> {
         }
     }
 
-    /// Fix stride/row alignment problems in image data
-    #[cfg(feature = "external-images")]
-    fn fix_stride_problem(
-        &self,
-        img: DynamicImage,
-        original_width: u32,
-        original_height: u32,
-    ) -> OperationResult<DynamicImage> {
-        // Convert to raw grayscale data
-        let gray_img = img.to_luma8();
-        let pixel_data = gray_img.as_raw();
-
-        // Try different row strides to fix misalignment
-        let bytes_per_row = original_width as usize;
-        let min_bytes_per_row = bytes_per_row;
-
-        // Possible stride alignments
-        let possible_strides = [
-            min_bytes_per_row,              // No padding
-            (min_bytes_per_row + 1) & !1,   // 2-byte aligned
-            (min_bytes_per_row + 3) & !3,   // 4-byte aligned
-            (min_bytes_per_row + 7) & !7,   // 8-byte aligned
-            (min_bytes_per_row + 15) & !15, // 16-byte aligned
-            min_bytes_per_row + 1,          // +1 padding
-            min_bytes_per_row + 2,          // +2 padding
-            min_bytes_per_row + 4,          // +4 padding
-        ];
-
-        for (_i, &stride) in possible_strides.iter().enumerate() {
-            let expected_total = stride * original_height as usize;
-
-            if expected_total <= pixel_data.len() {
-                // Extract using this stride
-                let mut corrected_data = Vec::new();
-                for row in 0..original_height {
-                    let row_start = row as usize * stride;
-                    let row_end = row_start + bytes_per_row;
-
-                    if row_end <= pixel_data.len() {
-                        corrected_data.extend_from_slice(&pixel_data[row_start..row_end]);
-                    } else {
-                        // Fill with white if we run out of data
-                        corrected_data.resize(corrected_data.len() + bytes_per_row, 255);
-                    }
-                }
-
-                // Create corrected image
-                if corrected_data.len() == (original_width * original_height) as usize {
-                    if let Some(corrected_img) = ImageBuffer::<Luma<u8>, Vec<u8>>::from_raw(
-                        original_width,
-                        original_height,
-                        corrected_data,
-                    ) {
-                        return Ok(DynamicImage::ImageLuma8(corrected_img));
-                    }
-                }
-            } else {
-            }
-        }
-
-        Ok(img)
-    }
-
     /// Parse inline image dictionary to extract width and height
     fn parse_inline_image_dict(&self, dict_str: &str) -> (u32, u32) {
         let mut width = 100; // Default width
@@ -967,71 +711,6 @@ impl<R: Read + Seek> ImageExtractor<R> {
         }
 
         (width, height)
-    }
-
-    /// Save an inline image to disk
-    fn save_inline_image(
-        &mut self,
-        data: &[u8],
-        page_number: usize,
-        image_index: usize,
-        width: u32,
-        height: u32,
-    ) -> OperationResult<ExtractedImage> {
-        // Generate unique key for deduplication
-        let image_key = format!("{:x}", md5::compute(data));
-
-        // Don't deduplicate if we're extracting for OCR purposes (pattern contains {page})
-        let allow_deduplication = !self.options.name_pattern.contains("{page}");
-
-        // Check if we've already extracted this image (only if deduplication is allowed)
-        if allow_deduplication {
-            if let Some(existing_path) = self.processed_images.get(&image_key) {
-                return Ok(ExtractedImage {
-                    page_number,
-                    image_index,
-                    file_path: existing_path.clone(),
-                    width,
-                    height,
-                    format: ImageFormat::Raw, // Inline images are often raw
-                });
-            }
-        }
-
-        // Determine format and extension
-        let format = self
-            .detect_image_format_from_data(data)
-            .unwrap_or(ImageFormat::Raw);
-        let extension = match format {
-            ImageFormat::Jpeg => "jpg",
-            ImageFormat::Png => "png",
-            ImageFormat::Tiff => "tif",
-            ImageFormat::Raw => "raw",
-        };
-
-        // Generate filename
-        let filename = format!(
-            "inline_page_{}_{:03}.{}",
-            page_number + 1,
-            image_index + 1,
-            extension
-        );
-        let file_path = self.options.output_dir.join(filename);
-
-        // Write image data to file
-        fs::write(&file_path, data)?;
-
-        // Cache the extracted image
-        self.processed_images.insert(image_key, file_path.clone());
-
-        Ok(ExtractedImage {
-            page_number,
-            image_index,
-            file_path,
-            width,
-            height,
-            format,
-        })
     }
 
     /// Decode an image stream, resolving an indirect `/DecodeParms` (or `/DP`)

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -19,7 +19,7 @@ pub mod split;
 pub use chunk_page_mapper::ChunkPageMapper;
 pub use extract_images::{
     extract_images_from_pages, extract_images_from_pdf, ExtractImagesOptions, ExtractedImage,
-    ImageExtractor, ImagePreprocessingOptions,
+    ExtractedImageData, ImageExtractionLimits, ImageExtractor, ImagePreprocessingOptions,
 };
 pub use merge::{merge_pdf_files, merge_pdfs, MergeInput, MergeOptions, PdfMerger};
 pub use overlay::{overlay_pdf, OverlayOptions, OverlayPosition, PdfOverlay};
@@ -83,6 +83,16 @@ pub enum OperationError {
     /// IO error
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// A configured image extraction bound would be exceeded.
+    #[error(
+        "Image extraction limit exceeded for {limit}: maximum {maximum}, attempted {attempted}"
+    )]
+    ImageExtractionLimitExceeded {
+        limit: &'static str,
+        maximum: u64,
+        attempted: u64,
+    },
 
     /// Core PDF error
     #[error("PDF error: {0}")]

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -19,7 +19,8 @@ pub mod split;
 pub use chunk_page_mapper::ChunkPageMapper;
 pub use extract_images::{
     extract_images_from_pages, extract_images_from_pdf, ExtractImagesOptions, ExtractedImage,
-    ExtractedImageData, ImageExtractionLimits, ImageExtractor, ImagePreprocessingOptions,
+    ExtractedImageData, ImageExtractionError, ImageExtractionLimits, ImageExtractionResult,
+    ImageExtractor, ImagePreprocessingOptions,
 };
 pub use merge::{merge_pdf_files, merge_pdfs, MergeInput, MergeOptions, PdfMerger};
 pub use overlay::{overlay_pdf, OverlayOptions, OverlayPosition, PdfOverlay};
@@ -83,16 +84,6 @@ pub enum OperationError {
     /// IO error
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
-
-    /// A configured image extraction bound would be exceeded.
-    #[error(
-        "Image extraction limit exceeded for {limit}: maximum {maximum}, attempted {attempted}"
-    )]
-    ImageExtractionLimitExceeded {
-        limit: &'static str,
-        maximum: u64,
-        attempted: u64,
-    },
 
     /// Core PDF error
     #[error("PDF error: {0}")]

--- a/oxidize-pdf-core/src/parser/content.rs
+++ b/oxidize-pdf-core/src/parser/content.rs
@@ -888,6 +888,12 @@ pub struct ContentParser {
     position: usize,
 }
 
+pub(crate) struct ParsedType3CharProc {
+    pub(crate) width: (f64, f64),
+    pub(crate) bbox: Option<[f64; 4]>,
+    pub(crate) operations: Vec<ContentOperation>,
+}
+
 impl ContentParser {
     /// Create a new content parser
     pub fn new(_content: &[u8]) -> Self {
@@ -932,6 +938,111 @@ impl ContentParser {
     /// ```
     pub fn parse(content: &[u8]) -> ParseResult<Vec<ContentOperation>> {
         Self::parse_content(content)
+    }
+
+    /// Parse a content stream without best-effort recovery.
+    ///
+    /// Unlike [`Self::parse`], malformed or unknown operators are returned to
+    /// the caller. This is intended for self-contained programs such as Type 3
+    /// character procedures, where silently dropping an operation could alter
+    /// the rendered glyph.
+    pub fn parse_strict(content: &[u8]) -> ParseResult<Vec<ContentOperation>> {
+        let mut tokenizer = ContentTokenizer::new(content);
+        let mut tokens = Vec::new();
+        while let Some(token) = tokenizer.next_token()? {
+            tokens.push(token);
+        }
+        Self {
+            tokens,
+            position: 0,
+        }
+        .parse_operators_strict()
+    }
+
+    pub(crate) fn parse_type3_charproc(content: &[u8]) -> ParseResult<ParsedType3CharProc> {
+        let mut tokenizer = ContentTokenizer::new(content);
+        let mut tokens = Vec::new();
+        while let Some(token) = tokenizer.next_token()? {
+            tokens.push(token);
+        }
+        let mut parser = Self {
+            tokens,
+            position: 0,
+        };
+        let mut operations = Vec::new();
+        let mut operands = Vec::new();
+        let mut metrics = None;
+        while parser.position < parser.tokens.len() {
+            let token = parser.tokens[parser.position].clone();
+            parser.position += 1;
+            match token {
+                Token::Operator(op) if op == "d0" => {
+                    if metrics.is_some() || !operations.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0/d1 must be the first Type 3 CharProc operator".into(),
+                        });
+                    }
+                    let wy = parser.pop_number(&mut operands)?;
+                    let wx = parser.pop_number(&mut operands)?;
+                    if !operands.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0 has extra operands".into(),
+                        });
+                    }
+                    metrics = Some(((f64::from(wx), f64::from(wy)), None));
+                }
+                Token::Operator(op) if op == "d1" => {
+                    if metrics.is_some() || !operations.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d0/d1 must be the first Type 3 CharProc operator".into(),
+                        });
+                    }
+                    let ury = parser.pop_number(&mut operands)?;
+                    let urx = parser.pop_number(&mut operands)?;
+                    let lly = parser.pop_number(&mut operands)?;
+                    let llx = parser.pop_number(&mut operands)?;
+                    let wy = parser.pop_number(&mut operands)?;
+                    let wx = parser.pop_number(&mut operands)?;
+                    if !operands.is_empty() {
+                        return Err(ParseError::SyntaxError {
+                            position: parser.position,
+                            message: "d1 has extra operands".into(),
+                        });
+                    }
+                    metrics = Some((
+                        (f64::from(wx), f64::from(wy)),
+                        Some([
+                            f64::from(llx),
+                            f64::from(lly),
+                            f64::from(urx),
+                            f64::from(ury),
+                        ]),
+                    ));
+                }
+                Token::Operator(op) => {
+                    operations.push(parser.parse_operator(&op, &mut operands)?);
+                }
+                operand => operands.push(operand),
+            }
+        }
+        if !operands.is_empty() {
+            return Err(ParseError::SyntaxError {
+                position: parser.position,
+                message: "trailing operands without an operator".into(),
+            });
+        }
+        let (width, bbox) = metrics.ok_or_else(|| ParseError::SyntaxError {
+            position: 0,
+            message: "Type 3 CharProc must begin with d0 or d1".into(),
+        })?;
+        Ok(ParsedType3CharProc {
+            width,
+            bbox,
+            operations,
+        })
     }
 
     /// Parse a content stream into a vector of operators.
@@ -1002,6 +1113,29 @@ impl ContentParser {
         }
 
         Ok(operators)
+    }
+
+    fn parse_operators_strict(&mut self) -> ParseResult<Vec<ContentOperation>> {
+        let mut operators = Vec::new();
+        let mut operand_stack = Vec::new();
+        while self.position < self.tokens.len() {
+            let token = self.tokens[self.position].clone();
+            self.position += 1;
+            match token {
+                Token::Operator(op) => {
+                    operators.push(self.parse_operator(&op, &mut operand_stack)?);
+                }
+                operand => operand_stack.push(operand),
+            }
+        }
+        if operand_stack.is_empty() {
+            Ok(operators)
+        } else {
+            Err(ParseError::SyntaxError {
+                position: self.position,
+                message: "trailing operands without an operator".to_string(),
+            })
+        }
     }
 
     fn parse_operator(

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -259,6 +259,11 @@ impl<R: Read + Seek> PdfDocument<R> {
         Ok(self.reader.borrow().version().to_string())
     }
 
+    /// Return an owned catalog for crate-internal document-level consumers.
+    pub(crate) fn catalog_dictionary(&self) -> ParseResult<PdfDictionary> {
+        self.reader.borrow_mut().catalog().cloned()
+    }
+
     /// Get the parse options
     pub fn options(&self) -> ParseOptions {
         self.reader.borrow().options().clone()

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -51,12 +51,12 @@
 
 #[cfg(test)]
 use super::objects::{PdfArray, PdfName};
-use super::objects::{PdfDictionary, PdfObject};
+use super::objects::{PdfDictionary, PdfObject, PdfStream};
 use super::page_tree::{PageTree, ParsedPage};
 use super::reader::PdfReader;
 use super::{ParseError, ParseOptions, ParseResult};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::path::Path;
@@ -969,6 +969,98 @@ impl<R: Read + Seek> PdfDocument<R> {
         }
     }
 
+    /// Decode a stream after resolving document-owned `/DecodeParms` references.
+    ///
+    /// This is the document-aware counterpart to [`PdfStream::decode`]. Use it
+    /// when a stream dictionary may contain indirect filter parameter objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a parameter reference is missing, circular, has an
+    /// invalid type, or when the underlying filter decoder fails.
+    pub fn decode_stream(&self, stream: &PdfStream) -> ParseResult<Vec<u8>> {
+        let dict = self.stream_dict_with_resolved_decode_parms(&stream.dict)?;
+        super::filters::decode_stream(&stream.data, &dict, &self.options())
+    }
+
+    /// Decode a stream with resolved `/DecodeParms` and a maximum output size.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::decode_stream`], plus an error when a
+    /// filter would exceed `max_bytes` or has no bounded decoder.
+    pub fn decode_stream_with_limit(
+        &self,
+        stream: &PdfStream,
+        max_bytes: usize,
+    ) -> ParseResult<Vec<u8>> {
+        let dict = self.stream_dict_with_resolved_decode_parms(&stream.dict)?;
+        super::filters::decode_stream_with_limit(&stream.data, &dict, &self.options(), max_bytes)
+    }
+
+    fn stream_dict_with_resolved_decode_parms(
+        &self,
+        dict: &PdfDictionary,
+    ) -> ParseResult<PdfDictionary> {
+        let Some(decode_parms) = dict.get("DecodeParms") else {
+            return Ok(dict.clone());
+        };
+        let mut resolved_dict = dict.clone();
+        let resolved = match decode_parms {
+            PdfObject::Array(array) => PdfObject::Array(super::objects::PdfArray(
+                array
+                    .0
+                    .iter()
+                    .map(|entry| self.resolve_decode_parms_entry(entry, true))
+                    .collect::<ParseResult<Vec<_>>>()?,
+            )),
+            other => self.resolve_decode_parms_entry(other, false)?,
+        };
+        resolved_dict.insert("DecodeParms".into(), resolved);
+        Ok(resolved_dict)
+    }
+
+    fn resolve_decode_parms_entry(
+        &self,
+        object: &PdfObject,
+        array_entry: bool,
+    ) -> ParseResult<PdfObject> {
+        let mut current = object.clone();
+        let mut visited = HashSet::new();
+        let mut resolved_reference = false;
+        while let PdfObject::Reference(object_number, generation) = current {
+            resolved_reference = true;
+            if !visited.insert((object_number, generation)) {
+                return Err(ParseError::CircularReference);
+            }
+            if visited.len() > super::stack_safe::MAX_RECURSION_DEPTH {
+                return Err(ParseError::SyntaxError {
+                    position: 0,
+                    message: "DecodeParms reference chain exceeds maximum depth".into(),
+                });
+            }
+            current = self.get_object(object_number, generation)?;
+        }
+        match current {
+            PdfObject::Dictionary(_) => Ok(current),
+            PdfObject::Null if !resolved_reference => Ok(current),
+            PdfObject::Array(array) if !array_entry => {
+                Ok(PdfObject::Array(super::objects::PdfArray(
+                    array
+                        .0
+                        .iter()
+                        .map(|entry| self.resolve_decode_parms_entry(entry, true))
+                        .collect::<ParseResult<Vec<_>>>()?,
+                )))
+            }
+            _ => Err(ParseError::SyntaxError {
+                position: 0,
+                message: "DecodeParms must resolve to a dictionary, null, or an array of those"
+                    .into(),
+            }),
+        }
+    }
+
     /// Get content streams for a specific page.
     ///
     /// This method handles both single streams and arrays of streams,
@@ -1042,20 +1134,19 @@ impl<R: Read + Seek> PdfDocument<R> {
 
     pub fn get_page_content_streams(&self, page: &ParsedPage) -> ParseResult<Vec<Vec<u8>>> {
         let mut streams = Vec::new();
-        let options = self.options();
 
         if let Some(contents) = page.dict.get("Contents") {
             let resolved_contents = self.resolve(contents)?;
 
             match &resolved_contents {
                 PdfObject::Stream(stream) => {
-                    streams.push(stream.decode(&options)?);
+                    streams.push(self.decode_stream(stream)?);
                 }
                 PdfObject::Array(array) => {
                     for item in &array.0 {
                         let resolved = self.resolve(item)?;
                         if let PdfObject::Stream(stream) = resolved {
-                            streams.push(stream.decode(&options)?);
+                            streams.push(self.decode_stream(&stream)?);
                         }
                     }
                 }

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -1847,8 +1847,17 @@ fn apply_png_predictor_advanced(
     // Calculate bytes per pixel
     let bytes_per_pixel = (bpc * colors).div_ceil(8);
 
-    // Calculate row size (columns + 1 for predictor byte)
-    let row_size = columns + 1;
+    // Each PNG row contains the full sample payload plus one filter byte.
+    // `/Columns` counts pixels, not bytes, for multi-component images.
+    let row_bytes = columns
+        .checked_mul(colors)
+        .and_then(|samples| samples.checked_mul(bpc))
+        .and_then(|bits| bits.checked_add(7))
+        .map(|bits| bits / 8)
+        .ok_or_else(|| ParseError::StreamDecodeError("PNG predictor row size overflow".into()))?;
+    let row_size = row_bytes
+        .checked_add(1)
+        .ok_or_else(|| ParseError::StreamDecodeError("PNG predictor row size overflow".into()))?;
 
     if data.len() % row_size != 0 {
         return Err(ParseError::StreamDecodeError(
@@ -1857,7 +1866,7 @@ fn apply_png_predictor_advanced(
     }
 
     let num_rows = data.len() / row_size;
-    let mut result = Vec::with_capacity(columns * num_rows);
+    let mut result = Vec::with_capacity(row_bytes * num_rows);
 
     for row in 0..num_rows {
         let row_start = row * row_size;
@@ -1877,7 +1886,7 @@ fn apply_png_predictor_advanced(
             2 => {
                 // Up filter - each byte is prediction from byte above
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };
@@ -1886,7 +1895,7 @@ fn apply_png_predictor_advanced(
             3 => {
                 // Average filter
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };
@@ -1895,7 +1904,7 @@ fn apply_png_predictor_advanced(
             4 => {
                 // Paeth filter
                 let prev_row = if row > 0 {
-                    Some(&result[(row - 1) * columns..row * columns])
+                    Some(&result[(row - 1) * row_bytes..row * row_bytes])
                 } else {
                     None
                 };

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -224,6 +224,80 @@ pub fn decode_stream(
     Ok(result)
 }
 
+/// Decode stream data while enforcing a caller-provided output bound.
+///
+/// The bound is applied before copying unfiltered data, incrementally while
+/// inflating Flate data, and after every filter in a filter chain.
+pub fn decode_stream_with_limit(
+    data: &[u8],
+    dict: &PdfDictionary,
+    _options: &ParseOptions,
+    max_bytes: usize,
+) -> ParseResult<Vec<u8>> {
+    let filters = match dict.get("Filter") {
+        Some(PdfObject::Name(name)) => vec![name.as_str()],
+        Some(PdfObject::Array(array)) => array
+            .0
+            .iter()
+            .map(|object| {
+                object
+                    .as_name()
+                    .map(|name| name.as_str())
+                    .ok_or_else(|| bounded_decode_syntax("Invalid filter in array"))
+            })
+            .collect::<ParseResult<Vec<_>>>()?,
+        None => return copy_with_limit(data, max_bytes),
+        _ => return Err(bounded_decode_syntax("Invalid Filter type")),
+    };
+    let decode_params = dict.get("DecodeParms");
+    let mut result = copy_with_limit(data, max_bytes)?;
+    for (index, filter_name) in filters.iter().enumerate() {
+        let filter = Filter::from_name(filter_name)
+            .ok_or_else(|| bounded_decode_syntax(&format!("Unknown filter: {filter_name}")))?;
+        let params = get_filter_params(decode_params, index);
+        result = match filter {
+            Filter::FlateDecode => {
+                let decoded = decode_flate_with_limit(&result, max_bytes)?;
+                if let Some(params) = params {
+                    if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer)
+                    {
+                        apply_predictor(&decoded, predictor as u32, params).unwrap_or(decoded)
+                    } else {
+                        decoded
+                    }
+                } else {
+                    decoded
+                }
+            }
+            Filter::LZWDecode => decode_lzw_with_limit(&result, params, max_bytes)?,
+            Filter::RunLengthDecode => decode_run_length_with_limit(&result, max_bytes)?,
+            other => apply_filter_with_params(&result, other, params)?,
+        };
+        if result.len() > max_bytes {
+            return Err(ParseError::StreamDecodeError(format!(
+                "decoded stream exceeds limit of {max_bytes} bytes"
+            )));
+        }
+    }
+    Ok(result)
+}
+
+fn copy_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
+    if data.len() > max_bytes {
+        return Err(ParseError::StreamDecodeError(format!(
+            "stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    Ok(data.to_vec())
+}
+
+fn bounded_decode_syntax(message: &str) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: message.to_string(),
+    }
+}
+
 /// Apply a single filter to data (legacy function, use apply_filter_with_params)
 #[allow(dead_code)]
 pub(crate) fn apply_filter(data: &[u8], filter: Filter) -> ParseResult<Vec<u8>> {
@@ -311,6 +385,21 @@ fn decode_flate(data: &[u8]) -> ParseResult<Vec<u8>> {
     // Strategy 8: Last resort - return empty data instead of garbage
     tracing::debug!("Warning: All FlateDecode strategies failed, returning empty data");
     Ok(Vec::new())
+}
+
+#[cfg(feature = "compression")]
+fn decode_flate_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
+    let mut decoder = ZlibDecoder::new(data);
+    read_to_end_limited(&mut decoder, max_bytes).map_err(|error| {
+        ParseError::StreamDecodeError(format!("bounded FlateDecode failed: {error}"))
+    })
+}
+
+#[cfg(not(feature = "compression"))]
+fn decode_flate_with_limit(_data: &[u8], _max_bytes: usize) -> ParseResult<Vec<u8>> {
+    Err(ParseError::StreamDecodeError(
+        "FlateDecode requires the compression feature".to_string(),
+    ))
 }
 
 #[cfg(feature = "compression")]
@@ -1887,6 +1976,14 @@ fn paeth_predictor(left: u8, up: u8, up_left: u8) -> u8 {
 /// Section 3.3.3. The PDF variant of LZW uses variable-length codes starting at
 /// 9 bits and growing up to 12 bits.
 fn decode_lzw(data: &[u8], params: Option<&PdfDictionary>) -> ParseResult<Vec<u8>> {
+    decode_lzw_with_limit(data, params, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_lzw_with_limit(
+    data: &[u8],
+    params: Option<&PdfDictionary>,
+    max_bytes: usize,
+) -> ParseResult<Vec<u8>> {
     // Get parameters
     let early_change = params
         .and_then(|p| p.get("EarlyChange"))
@@ -1951,10 +2048,9 @@ fn decode_lzw(data: &[u8], params: Option<&PdfDictionary>) -> ParseResult<Vec<u8
             result.extend_from_slice(&string);
 
             // Decompression bomb check
-            if result.len() > MAX_DECOMPRESSED_SIZE {
+            if result.len() > max_bytes {
                 return Err(ParseError::StreamDecodeError(format!(
-                    "LZW decompressed size exceeds {} MB limit",
-                    MAX_DECOMPRESSED_SIZE / (1024 * 1024)
+                    "LZW decompressed size exceeds {max_bytes} byte limit"
                 )));
             }
 
@@ -2055,6 +2151,10 @@ impl<'a> LzwBitReader<'a> {
 /// Implements the Run Length Encoding decompression as specified in PDF Reference 1.7
 /// Section 3.3.4. Run-length encoding compresses sequences of identical bytes.
 fn decode_run_length(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_run_length_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_run_length_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut i = 0;
 
@@ -2091,10 +2191,9 @@ fn decode_run_length(data: &[u8]) -> ParseResult<Vec<u8>> {
         }
 
         // Decompression bomb check
-        if result.len() > MAX_DECOMPRESSED_SIZE {
+        if result.len() > max_bytes {
             return Err(ParseError::StreamDecodeError(format!(
-                "RunLength decompressed size exceeds {} MB limit",
-                MAX_DECOMPRESSED_SIZE / (1024 * 1024)
+                "RunLength decompressed size exceeds {max_bytes} byte limit"
             )));
         }
     }

--- a/oxidize-pdf-core/src/parser/filters.rs
+++ b/oxidize-pdf-core/src/parser/filters.rs
@@ -226,8 +226,9 @@ pub fn decode_stream(
 
 /// Decode stream data while enforcing a caller-provided output bound.
 ///
-/// The bound is applied before copying unfiltered data, incrementally while
-/// inflating Flate data, and after every filter in a filter chain.
+/// Unfiltered data is copied only when it fits. Expanding filters enforce the
+/// bound while producing output; filters without a bounded implementation are
+/// rejected rather than allocating an unchecked intermediate buffer.
 pub fn decode_stream_with_limit(
     data: &[u8],
     dict: &PdfDictionary,
@@ -250,36 +251,40 @@ pub fn decode_stream_with_limit(
         _ => return Err(bounded_decode_syntax("Invalid Filter type")),
     };
     let decode_params = dict.get("DecodeParms");
-    let mut result = copy_with_limit(data, max_bytes)?;
+    let mut result: Option<Vec<u8>> = None;
     for (index, filter_name) in filters.iter().enumerate() {
         let filter = Filter::from_name(filter_name)
             .ok_or_else(|| bounded_decode_syntax(&format!("Unknown filter: {filter_name}")))?;
         let params = get_filter_params(decode_params, index);
-        result = match filter {
-            Filter::FlateDecode => {
-                let decoded = decode_flate_with_limit(&result, max_bytes)?;
-                if let Some(params) = params {
-                    if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer)
-                    {
-                        apply_predictor(&decoded, predictor as u32, params).unwrap_or(decoded)
-                    } else {
-                        decoded
-                    }
-                } else {
-                    decoded
+        let input = result.as_deref().unwrap_or(data);
+        let applies_predictor = matches!(filter, Filter::FlateDecode | Filter::LZWDecode);
+        let mut decoded = match filter {
+            Filter::FlateDecode => decode_flate_with_limit(input, max_bytes)?,
+            Filter::ASCIIHexDecode => decode_ascii_hex_with_limit(input, max_bytes)?,
+            Filter::ASCII85Decode => decode_ascii85_with_limit(input, max_bytes)?,
+            Filter::LZWDecode => decode_lzw_with_limit(input, params, max_bytes)?,
+            Filter::RunLengthDecode => decode_run_length_with_limit(input, max_bytes)?,
+            other => {
+                return Err(ParseError::StreamDecodeError(format!(
+                    "filter {other:?} has no bounded decoder"
+                )))
+            }
+        };
+        if applies_predictor {
+            if let Some(params) = params {
+                if let Some(predictor) = params.get("Predictor").and_then(PdfObject::as_integer) {
+                    decoded = apply_predictor(&decoded, predictor as u32, params)?;
                 }
             }
-            Filter::LZWDecode => decode_lzw_with_limit(&result, params, max_bytes)?,
-            Filter::RunLengthDecode => decode_run_length_with_limit(&result, max_bytes)?,
-            other => apply_filter_with_params(&result, other, params)?,
-        };
-        if result.len() > max_bytes {
+        }
+        if decoded.len() > max_bytes {
             return Err(ParseError::StreamDecodeError(format!(
                 "decoded stream exceeds limit of {max_bytes} bytes"
             )));
         }
+        result = Some(decoded);
     }
-    Ok(result)
+    Ok(result.unwrap_or_default())
 }
 
 fn copy_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
@@ -586,6 +591,10 @@ fn decode_flate(_data: &[u8]) -> ParseResult<Vec<u8>> {
 
 /// Decode ASCIIHexDecode data
 fn decode_ascii_hex(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_ascii_hex_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_ascii_hex_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut chars = data.iter().filter(|&&b| !b.is_ascii_whitespace());
 
@@ -612,7 +621,7 @@ fn decode_ascii_hex(data: &[u8]) -> ParseResult<Vec<u8>> {
             ParseError::StreamDecodeError(format!("Invalid hex digit: {}", low as char))
         })?;
 
-        result.push((high_val << 4) | low_val);
+        push_bounded(&mut result, (high_val << 4) | low_val, max_bytes)?;
 
         if low == b'>' {
             break;
@@ -634,6 +643,10 @@ fn hex_digit_value(ch: u8) -> Option<u8> {
 
 /// Decode ASCII85Decode data
 fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
+    decode_ascii85_with_limit(data, MAX_DECOMPRESSED_SIZE)
+}
+
+fn decode_ascii85_with_limit(data: &[u8], max_bytes: usize) -> ParseResult<Vec<u8>> {
     let mut result = Vec::new();
     let mut chars = data.iter().filter(|&&b| !b.is_ascii_whitespace());
     let mut group = Vec::with_capacity(5);
@@ -666,7 +679,7 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
             }
             b'z' if group.is_empty() => {
                 // Special case: 'z' represents four zero bytes
-                result.extend_from_slice(&[0, 0, 0, 0]);
+                extend_bounded(&mut result, &[0, 0, 0, 0], max_bytes)?;
             }
             b'!'..=b'u' => {
                 group.push(c);
@@ -678,10 +691,16 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
                         .map(|(i, &ch)| (ch - b'!') as u32 * 85u32.pow(4 - i as u32))
                         .sum::<u32>();
 
-                    result.push((value >> 24) as u8);
-                    result.push((value >> 16) as u8);
-                    result.push((value >> 8) as u8);
-                    result.push(value as u8);
+                    extend_bounded(
+                        &mut result,
+                        &[
+                            (value >> 24) as u8,
+                            (value >> 16) as u8,
+                            (value >> 8) as u8,
+                            value as u8,
+                        ],
+                        max_bytes,
+                    )?;
 
                     group.clear();
                 }
@@ -715,11 +734,31 @@ fn decode_ascii85(data: &[u8]) -> ParseResult<Vec<u8>> {
         // Only output the number of bytes that were actually encoded
         let output_bytes = original_len - 1;
         for i in 0..output_bytes {
-            result.push((value >> (24 - 8 * i)) as u8);
+            push_bounded(&mut result, (value >> (24 - 8 * i)) as u8, max_bytes)?;
         }
     }
 
     Ok(result)
+}
+
+fn push_bounded(result: &mut Vec<u8>, byte: u8, max_bytes: usize) -> ParseResult<()> {
+    if result.len() >= max_bytes {
+        return Err(ParseError::StreamDecodeError(format!(
+            "decoded stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    result.push(byte);
+    Ok(())
+}
+
+fn extend_bounded(result: &mut Vec<u8>, bytes: &[u8], max_bytes: usize) -> ParseResult<()> {
+    if bytes.len() > max_bytes.saturating_sub(result.len()) {
+        return Err(ParseError::StreamDecodeError(format!(
+            "decoded stream exceeds limit of {max_bytes} bytes"
+        )));
+    }
+    result.extend_from_slice(bytes);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1753,14 +1792,10 @@ pub(crate) fn apply_filter_with_params(
 }
 
 /// Get filter parameters for a specific filter index
-fn get_filter_params(decode_params: Option<&PdfObject>, _index: usize) -> Option<&PdfDictionary> {
+fn get_filter_params(decode_params: Option<&PdfObject>, index: usize) -> Option<&PdfDictionary> {
     match decode_params {
         Some(PdfObject::Dictionary(dict)) => Some(dict),
-        Some(PdfObject::Array(array)) => {
-            // For multiple filters, each can have its own decode params
-            // For now, use the first one
-            array.0.first().and_then(|obj| obj.as_dict())
-        }
+        Some(PdfObject::Array(array)) => array.0.get(index).and_then(PdfObject::as_dict),
         _ => None,
     }
 }

--- a/oxidize-pdf-core/src/parser/objects.rs
+++ b/oxidize-pdf-core/src/parser/objects.rs
@@ -232,6 +232,15 @@ impl PdfStream {
         super::filters::decode_stream(&self.data, &self.dict, options)
     }
 
+    /// Decode the stream with a caller-defined maximum output size.
+    pub fn decode_with_limit(
+        &self,
+        options: &ParseOptions,
+        max_bytes: usize,
+    ) -> ParseResult<Vec<u8>> {
+        super::filters::decode_stream_with_limit(&self.data, &self.dict, options, max_bytes)
+    }
+
     /// Get the raw (possibly compressed) stream data.
     ///
     /// Returns the stream data exactly as stored in the PDF file,

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -300,6 +300,47 @@ struct PendingActualText {
     populated: bool,
 }
 
+#[derive(Default)]
+struct StructureActualText {
+    owners: Vec<crate::parser::objects::PdfObject>,
+    cache: HashMap<u32, Option<String>>,
+}
+
+impl StructureActualText {
+    fn get<R: Read + Seek>(
+        &mut self,
+        mcid: u32,
+        document: &PdfDocument<R>,
+        max_bytes: Option<usize>,
+    ) -> Result<Option<String>, ()> {
+        if let Some(cached) = self.cache.get(&mcid) {
+            return Ok(cached.clone());
+        }
+        let Some(owner) = self.owners.get(mcid as usize) else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        let Ok(owner) = document.resolve(owner) else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        let Some(crate::parser::objects::PdfObject::String(value)) =
+            owner.as_dict().and_then(|dict| dict.get("ActualText"))
+        else {
+            self.cache.insert(mcid, None);
+            return Ok(None);
+        };
+        if max_bytes
+            .is_some_and(|limit| value.as_bytes().len() > limit.saturating_mul(4).saturating_add(2))
+        {
+            return Err(());
+        }
+        let decoded = decode_pdf_string(value.as_bytes());
+        self.cache.insert(mcid, Some(decoded.clone()));
+        Ok(Some(decoded))
+    }
+}
+
 /// Text extraction state
 struct TextState {
     /// Current text matrix
@@ -1010,6 +1051,9 @@ impl TextExtractor {
     ) -> ParseResult<ExtractedText> {
         // Get the page
         let page = document.get_page(page_index)?;
+        // Tagged-PDF metadata is advisory: malformed mappings fall back to
+        // visual text instead of failing otherwise valid page extraction.
+        let mut structure_actual_text = resolve_structure_actual_text(&page.dict, document);
 
         // Extract font resources first
         {
@@ -1091,6 +1135,7 @@ impl TextExtractor {
                 operations,
                 document,
                 page_resources.as_ref(),
+                &mut structure_actual_text,
                 run,
                 page_index,
                 0,
@@ -1245,6 +1290,7 @@ impl TextExtractor {
         operations: Vec<ContentOperation>,
         document: &PdfDocument<R>,
         resources: Option<&crate::parser::objects::PdfDictionary>,
+        structure_actual_text: &mut StructureActualText,
         run: OpRunState,
         page_index: u32,
         depth: u8,
@@ -1409,7 +1455,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1439,7 +1489,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1459,7 +1512,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -1589,7 +1646,11 @@ impl TextExtractor {
                                         let outcome = append_bounded(
                                             &mut extracted_text,
                                             separator,
-                                            &decoded,
+                                            if state.pending_actualtext.is_some() {
+                                                ""
+                                            } else {
+                                                &decoded
+                                            },
                                             self.options.max_extracted_bytes,
                                             &mut truncated,
                                             self.options.merge_hyphenated,
@@ -1615,7 +1676,9 @@ impl TextExtractor {
                                         )
                                     };
 
-                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    if self.options.preserve_layout
+                                        || self.options.reorder_columns
+                                        || state.pending_actualtext.is_some()
                                     {
                                         emit_text_fragment(
                                             &mut fragments,
@@ -1636,7 +1699,11 @@ impl TextExtractor {
                                                 &mut line_groups,
                                                 &mut cur_group,
                                                 extracted_text.len(),
-                                                decoded.len(),
+                                                if state.pending_actualtext.is_some() {
+                                                    0
+                                                } else {
+                                                    decoded.len()
+                                                },
                                                 sep,
                                                 x,
                                                 y,
@@ -1786,7 +1853,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1812,7 +1883,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1831,7 +1905,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -1882,7 +1960,11 @@ impl TextExtractor {
                             let outcome = append_bounded(
                                 &mut extracted_text,
                                 separator,
-                                &decoded,
+                                if state.pending_actualtext.is_some() {
+                                    ""
+                                } else {
+                                    &decoded
+                                },
                                 self.options.max_extracted_bytes,
                                 &mut truncated,
                                 self.options.merge_hyphenated,
@@ -1908,7 +1990,10 @@ impl TextExtractor {
                             )
                         };
 
-                        if self.options.preserve_layout || self.options.reorder_columns {
+                        if self.options.preserve_layout
+                            || self.options.reorder_columns
+                            || state.pending_actualtext.is_some()
+                        {
                             emit_text_fragment(
                                 &mut fragments,
                                 &decoded,
@@ -1927,7 +2012,11 @@ impl TextExtractor {
                                     &mut line_groups,
                                     &mut cur_group,
                                     extracted_text.len(),
-                                    decoded.len(),
+                                    if state.pending_actualtext.is_some() {
+                                        0
+                                    } else {
+                                        decoded.len()
+                                    },
                                     sep,
                                     x,
                                     y,
@@ -2034,7 +2123,24 @@ impl TextExtractor {
 
                 ContentOperation::BeginMarkedContentWithProps(tag, props) => {
                     let parent_artifact = state.mc_stack.last().is_some_and(|e| e.is_artifact);
-                    let (mcid, actual_text) = resolve_props(&props, page_properties);
+                    let (mcid, inline_actual_text) = resolve_props(&props, page_properties);
+                    let actual_text = if inline_actual_text.is_some() {
+                        inline_actual_text
+                    } else if let Some(id) = mcid {
+                        match structure_actual_text.get(
+                            id,
+                            document,
+                            self.options.max_extracted_bytes,
+                        ) {
+                            Ok(value) => value,
+                            Err(()) => {
+                                truncated = true;
+                                break;
+                            }
+                        }
+                    } else {
+                        None
+                    };
 
                     // If this scope declares ActualText, open a pending run that will be
                     // flushed on the matching EMC. Suppresses per-Tj emission inside the
@@ -2077,9 +2183,7 @@ impl TextExtractor {
                         // If we just closed the scope that opened the pending run, flush it.
                         if pending.stack_depth + 1 == popped_depth {
                             let run = state.pending_actualtext.take().unwrap();
-                            if run.populated
-                                && (self.options.preserve_layout || self.options.reorder_columns)
-                            {
+                            if run.populated {
                                 // The ActualText owner has just been popped, so
                                 // retain its structural identity explicitly
                                 // instead of accidentally inheriting the parent.
@@ -2099,11 +2203,10 @@ impl TextExtractor {
                                     // If it would overshoot, drop the fragment and
                                     // stop — a huge override must not escape the
                                     // cap while reporting `truncated = false`.
-                                    // Always `None` separator, never `\n` —
-                                    // hyphen-wrap fusion (issue #486) does not
-                                    // apply here. This site is also only reached
-                                    // under `preserve_layout`/`reorder_columns`
-                                    // (see the gate above), not the flat path.
+                                    // The flat path already emitted only the
+                                    // geometrical separator while this scope was
+                                    // pending, so the replacement itself needs no
+                                    // additional separator here.
                                     if !append_bounded(
                                         &mut extracted_text,
                                         None,
@@ -2116,21 +2219,29 @@ impl TextExtractor {
                                     {
                                         break;
                                     }
-                                    fragments.push(TextFragment {
-                                        text: run.text,
-                                        x: run.first_x,
-                                        y: run.first_y,
-                                        width: run.width,
-                                        height: run.font_size,
-                                        font_size: run.font_size,
-                                        font_name: run.font_name,
-                                        is_bold: run.is_bold,
-                                        is_italic: run.is_italic,
-                                        color: run.color,
-                                        space_decisions: Vec::new(),
-                                        mcid,
-                                        struct_tag,
-                                    });
+                                    if self.reading_order {
+                                        if let Some(group) = cur_group.as_mut() {
+                                            group.end = extracted_text.len();
+                                        }
+                                    }
+                                    if self.options.preserve_layout || self.options.reorder_columns
+                                    {
+                                        fragments.push(TextFragment {
+                                            text: run.text,
+                                            x: run.first_x,
+                                            y: run.first_y,
+                                            width: run.width,
+                                            height: run.font_size,
+                                            font_size: run.font_size,
+                                            font_name: run.font_name,
+                                            is_bold: run.is_bold,
+                                            is_italic: run.is_italic,
+                                            color: run.color,
+                                            space_decisions: Vec::new(),
+                                            mcid,
+                                            struct_tag,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -2146,9 +2257,11 @@ impl TextExtractor {
                     // is never extracted.
                     const MAX_XOBJECT_DEPTH: u8 = 12;
                     if depth < MAX_XOBJECT_DEPTH {
-                        if let Some((xobj_ops, xobj_res, matrix)) =
+                        if let Some((xobj_ops, xobj_res, matrix, xobj_dict)) =
                             self.load_form_xobject(resources, &name, document)
                         {
+                            let mut form_structure_actual_text =
+                                resolve_structure_actual_text(&xobj_dict, document);
                             // `Do` paints inside an IMPLICIT q/Q (§8.10.1),
                             // so the whole graphics state — text state included
                             // (issue #452) — comes back afterwards. Same
@@ -2205,6 +2318,7 @@ impl TextExtractor {
                                 xobj_ops,
                                 document,
                                 xobj_res.as_ref(),
+                                &mut form_structure_actual_text,
                                 sub,
                                 page_index,
                                 depth + 1,
@@ -2257,6 +2371,7 @@ impl TextExtractor {
         Vec<ContentOperation>,
         Option<crate::parser::objects::PdfDictionary>,
         Option<[f64; 6]>,
+        crate::parser::objects::PdfDictionary,
     )> {
         use crate::parser::objects::PdfObject;
         let res = resources?;
@@ -2307,7 +2422,7 @@ impl TextExtractor {
                     None
                 }
             });
-        Some((ops, xobj_res, matrix))
+        Some((ops, xobj_res, matrix, stream.dict.clone()))
     }
 
     /// Fuse a hyphen-ended fragment with its line-wrap continuation while
@@ -3520,6 +3635,110 @@ fn multiply_matrix(a: &[f64; 6], b: &[f64; 6]) -> [f64; 6] {
 /// typographic punctuation WinAnsi puts in `0x80..=0x9F`.
 fn decode_pdf_string(bytes: &[u8]) -> String {
     crate::parser::objects::decode_text_string(bytes)
+}
+
+/// Build the page-local MCID -> structure-element `/ActualText` map.
+///
+/// The parent tree is a PDF number tree, so it may store `/Nums` directly or
+/// split them across indirect `/Kids`. Every failure is deliberately reduced
+/// to an empty/partial map: structure metadata must not make text extraction
+/// fail. Depth, visited-reference, and node-count limits keep malformed trees
+/// from causing cycles or unbounded traversal.
+fn resolve_structure_actual_text<R: Read + Seek>(
+    container: &crate::parser::objects::PdfDictionary,
+    document: &PdfDocument<R>,
+) -> StructureActualText {
+    use crate::parser::objects::PdfObject;
+
+    const MAX_NUMBER_TREE_DEPTH: usize = 32;
+    const MAX_NUMBER_TREE_NODES: usize = 4096;
+
+    fn number_tree_value<R: Read + Seek>(
+        object: &PdfObject,
+        key: i64,
+        document: &PdfDocument<R>,
+        depth: usize,
+        visited: &mut std::collections::HashSet<(u32, u16)>,
+        nodes: &mut usize,
+    ) -> Option<PdfObject> {
+        if depth > MAX_NUMBER_TREE_DEPTH || *nodes >= MAX_NUMBER_TREE_NODES {
+            return None;
+        }
+        *nodes += 1;
+
+        let resolved = match object {
+            PdfObject::Reference(id, generation) => {
+                if !visited.insert((*id, *generation)) {
+                    return None;
+                }
+                document.get_object(*id, *generation).ok()?
+            }
+            other => other.clone(),
+        };
+        let dict = resolved.as_dict()?;
+
+        if let Some(PdfObject::Array(nums)) = dict.get("Nums") {
+            for pair in nums.0.chunks_exact(2) {
+                if pair[0] == PdfObject::Integer(key) {
+                    return Some(pair[1].clone());
+                }
+            }
+        }
+
+        let PdfObject::Array(kids) = dict.get("Kids")? else {
+            return None;
+        };
+        for kid in &kids.0 {
+            if let Some(value) = number_tree_value(kid, key, document, depth + 1, visited, nodes) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    let Some(PdfObject::Integer(struct_parent_key)) = container.get("StructParents") else {
+        return StructureActualText::default();
+    };
+    if *struct_parent_key < 0 {
+        return StructureActualText::default();
+    }
+
+    let Ok(catalog) = document.catalog_dictionary() else {
+        return StructureActualText::default();
+    };
+    let Some(struct_root_object) = catalog.get("StructTreeRoot") else {
+        return StructureActualText::default();
+    };
+    let Ok(struct_root_object) = document.resolve(struct_root_object) else {
+        return StructureActualText::default();
+    };
+    let Some(struct_root) = struct_root_object.as_dict() else {
+        return StructureActualText::default();
+    };
+    let Some(parent_tree) = struct_root.get("ParentTree") else {
+        return StructureActualText::default();
+    };
+
+    let Some(owner_array_object) = number_tree_value(
+        parent_tree,
+        *struct_parent_key,
+        document,
+        0,
+        &mut std::collections::HashSet::new(),
+        &mut 0,
+    ) else {
+        return StructureActualText::default();
+    };
+    let Ok(owner_array_object) = document.resolve(&owner_array_object) else {
+        return StructureActualText::default();
+    };
+    let PdfObject::Array(owners) = owner_array_object else {
+        return StructureActualText::default();
+    };
+    StructureActualText {
+        owners: owners.0,
+        cache: HashMap::new(),
+    }
 }
 
 /// Resolve a `MarkedContentProps` to `(mcid, actual_text)`.

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -876,8 +876,26 @@ impl TextExtractor {
         Some(width / 1000.0 * font_size.abs())
     }
 
+    /// `dx` (from [`pen_delta`]) is measured in *user space* — the pen's
+    /// `text_matrix × CTM` origin already folds in any scale the PDF puts in
+    /// `Tm`/CTM rather than `Tf`. `font_space_advance`/`type0_implicit_space_advance`
+    /// compute a *text-space* advance from the nominal `Tf` font size alone,
+    /// so a document that draws at `Tf 1` with its real point size baked into
+    /// `Tm` (a common generator technique) would otherwise compare a
+    /// Tm-scaled `dx` against an unscaled threshold, letting an ordinary
+    /// sub-point positioning residue between glyph runs cross the threshold
+    /// and insert a spurious mid-token space (issue #510). Scaling by the
+    /// same `combined_text_scale` x-factor `emit_text_fragment` already
+    /// applies to page-space widths brings both sides of the `dx >
+    /// threshold` comparison into the same unit space.
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
-        match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
+        let (x_scale, _) = combined_text_scale(state);
+        let x_scale = if x_scale.is_finite() && x_scale > 0.0 {
+            x_scale
+        } else {
+            1.0
+        };
+        let threshold = match self.font_space_advance(state.font_name.as_deref(), state.font_size) {
             Some(advance) if advance > 0.0 => 0.5 * advance,
             _ => {
                 let legacy = self.options.space_threshold * state.font_size.abs();
@@ -892,7 +910,8 @@ impl TextExtractor {
                     _ => legacy,
                 }
             }
-        }
+        };
+        threshold * x_scale
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -886,12 +886,18 @@ impl TextExtractor {
     /// sub-point positioning residue between glyph runs cross the threshold
     /// and insert a spurious mid-token space (issue #510). Scaling by the
     /// same `combined_text_scale` x-factor `emit_text_fragment` already
-    /// applies to page-space widths brings both sides of the `dx >
-    /// threshold` comparison into the same unit space.
+    /// applies to page-space widths, plus the horizontal text scaling (`Tz`)
+    /// used by [`advance_pen`], brings both sides of the `dx > threshold`
+    /// comparison into the same unit space.
     fn flat_space_gap_threshold(&self, state: &TextState) -> f64 {
         let (x_scale, _) = combined_text_scale(state);
-        let x_scale = if x_scale.is_finite() && x_scale > 0.0 {
+        let x_scale = if x_scale.is_finite() && x_scale > f64::EPSILON {
             x_scale
+        } else {
+            1.0
+        };
+        let horizontal_scale = if state.horizontal_scale.is_finite() {
+            state.horizontal_scale.abs() / 100.0
         } else {
             1.0
         };
@@ -911,7 +917,7 @@ impl TextExtractor {
                 }
             }
         };
-        threshold * x_scale
+        threshold * x_scale * horizontal_scale
     }
 
     /// Minimum inter-fragment x-gap that counts as a word space for `frag`.
@@ -4374,6 +4380,19 @@ mod tests {
         // Non-finite baseline: same fallback.
         let nan_state = state_with_ctm([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]);
         assert_eq!(pen_delta(&nan_state, (1.0, 2.0), (4.0, 6.0)), (3.0, 4.0));
+    }
+
+    #[test]
+    fn flat_space_threshold_uses_unscaled_fallback_for_tiny_baseline() {
+        let mut state = TextState::default();
+        state.font_size = 10.0;
+        state.text_matrix = [f64::EPSILON, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let extractor = TextExtractor::new();
+
+        assert_eq!(
+            extractor.flat_space_gap_threshold(&state),
+            extractor.options.space_threshold * state.font_size
+        );
     }
 
     // ── issue #382: per-page byte-budget helper ──────────────────────────────

--- a/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
+++ b/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
@@ -211,7 +211,7 @@ fn decode_png_rgb(png: &[u8]) -> (u32, u32, Vec<u8>) {
 /// single-index-per-pixel data through the palette into RGB. Returns the
 /// expected pixel bytes the extractor must reproduce.
 fn reconstruct_indexed_image_rgb(doc: &PdfDocument<File>) -> (u32, u32, Vec<u8>) {
-    use oxidize_pdf::parser::objects::{PdfName, PdfStream};
+    use oxidize_pdf::parser::objects::PdfName;
 
     let stream = match doc.get_object(10, 0).unwrap() {
         PdfObject::Stream(s) => s,
@@ -244,18 +244,7 @@ fn reconstruct_indexed_image_rgb(doc: &PdfDocument<File>) -> (u32, u32, Vec<u8>)
         other => panic!("unexpected lookup table {other:?}"),
     };
 
-    // Resolve the indirect /DecodeParms so decode() applies the predictor.
-    let mut resolved_dict = stream.dict.clone();
-    let dp = doc
-        .resolve(dict.get(&PdfName("DecodeParms".into())).unwrap())
-        .unwrap();
-    resolved_dict.0.insert(PdfName("DecodeParms".into()), dp);
-    let indices = PdfStream {
-        dict: resolved_dict,
-        data: stream.data.clone(),
-    }
-    .decode(&doc.options())
-    .unwrap();
+    let indices = doc.decode_stream(&stream).unwrap();
 
     let pixel_count = (width * height) as usize;
     assert_eq!(

--- a/oxidize-pdf-core/tests/issue_506_struct_actual_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_506_struct_actual_text_test.rs
@@ -1,0 +1,348 @@
+//! Regression tests for issue #506: text extraction must honor `/ActualText`
+//! on the structure element that owns a marked-content MCID.
+
+use std::io::Cursor;
+
+use oxidize_pdf::{
+    parser::{PdfDocument, PdfReader},
+    structure::{StandardStructureType, StructTree, StructureElement},
+    text::{ExtractionOptions, Font, TextExtractor},
+    Document, Page,
+};
+
+fn extract(mut document: Document, options: ExtractionOptions) -> oxidize_pdf::text::ExtractedText {
+    let bytes = document.to_bytes().expect("serialize tagged PDF");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse tagged PDF");
+    let parsed = PdfDocument::new(reader);
+    TextExtractor::with_options(options)
+        .extract_from_page(&parsed, 0)
+        .expect("extract tagged page")
+}
+
+fn raw_tagged_pdf(parent_tree: &str, extra_objects: &[String], mcid: u32) -> Vec<u8> {
+    let content =
+        format!("BT /F1 12 Tf 1 0 0 1 72 720 Tm /Span << /MCID {mcid} >> BDC (VISUAL) Tj EMC ET");
+    let mut objects = vec![
+        "<< /Type /Catalog /Pages 3 0 R /StructTreeRoot 6 0 R >>".to_string(),
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] /StructParents 0 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len()),
+        "<< /Type /StructTreeRoot /ParentTree 7 0 R >>".to_string(),
+        parent_tree.to_string(),
+    ];
+    objects.extend(extra_objects.iter().cloned());
+
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (index, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn extract_raw(pdf: Vec<u8>) -> String {
+    let reader = PdfReader::new(Cursor::new(pdf)).expect("parse raw tagged PDF");
+    let parsed = PdfDocument::new(reader);
+    TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    })
+    .extract_from_page(&parsed, 0)
+    .expect("malformed structure metadata must not fail extraction")
+    .text
+}
+
+fn tagged_form_pdf() -> Vec<u8> {
+    let page_content = "/Fm Do";
+    let form_content =
+        "BT /F1 12 Tf 1 0 0 1 0 0 Tm /Span << /MCID 0 >> BDC (VISUAL_FORM) Tj EMC ET";
+    let objects = vec![
+        "<< /Type /Catalog /Pages 3 0 R /StructTreeRoot 7 0 R >>".to_string(),
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] /StructParents 0 /Resources << /Font << /F1 4 0 R >> /XObject << /Fm 6 0 R >> >> /Contents 5 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [2 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{page_content}\nendstream", page_content.len()),
+        format!("<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /StructParents 1 /Resources << /Font << /F1 4 0 R >> >> /Length {} >>\nstream\n{form_content}\nendstream", form_content.len()),
+        "<< /Type /StructTreeRoot /ParentTree 8 0 R >>".to_string(),
+        "<< /Nums [0 [9 0 R] 1 [10 0 R]] >>".to_string(),
+        "<< /Type /StructElem /ActualText (PAGE_WRONG) >>".to_string(),
+        "<< /Type /StructElem /ActualText (FORM_RIGHT) >>".to_string(),
+    ];
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = Vec::new();
+    for (index, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn resolves_inline_and_structure_actualtext_with_inline_precedence() {
+    let mut page = Page::a4();
+
+    let inline_only = page
+        .begin_marked_content_with_actual_text("Span", "INLINE_ONLY")
+        .expect("begin inline-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("VISUAL_A")
+        .expect("write first visual run");
+    page.end_marked_content().expect("end inline-only run");
+
+    let structure_only = page
+        .begin_marked_content("Span")
+        .expect("begin structure-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 700.0)
+        .write("VISUAL_B")
+        .expect("write second visual run");
+    page.end_marked_content().expect("end structure-only run");
+
+    let conflicting = page
+        .begin_marked_content_with_actual_text("Span", "INLINE_WINS")
+        .expect("begin conflicting run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 680.0)
+        .write("VISUAL_C")
+        .expect("write third visual run");
+    page.end_marked_content().expect("end conflicting run");
+
+    let unicode = page
+        .begin_marked_content("Span")
+        .expect("begin unicode structure run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 660.0)
+        .write("VISUAL_D")
+        .expect("write fourth visual run");
+    page.end_marked_content()
+        .expect("end unicode structure run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    for (mcid, actual_text) in [
+        (inline_only, None),
+        (structure_only, Some("STRUCT_ONLY")),
+        (conflicting, Some("STRUCT_LOSES")),
+        (unicode, Some("2⁴⁰ E = mc² Aⁿ⁺¹B")),
+    ] {
+        let mut span = StructureElement::new(StandardStructureType::Span);
+        if let Some(actual_text) = actual_text {
+            span = span.with_actual_text(actual_text);
+        }
+        span.add_mcid(0, mcid);
+        tree.add_child(root, span).expect("attach structure span");
+    }
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let extracted = extract(
+        document,
+        ExtractionOptions {
+            preserve_layout: true,
+            ..Default::default()
+        },
+    );
+    let text_for = |mcid| {
+        extracted
+            .fragments
+            .iter()
+            .find(|fragment| fragment.mcid == Some(mcid))
+            .map(|fragment| fragment.text.as_str())
+    };
+
+    assert_eq!(text_for(inline_only), Some("INLINE_ONLY"));
+    assert_eq!(text_for(structure_only), Some("STRUCT_ONLY"));
+    assert_eq!(text_for(conflicting), Some("INLINE_WINS"));
+    assert_eq!(text_for(unicode), Some("2⁴⁰ E = mc² Aⁿ⁺¹B"));
+    assert!(!extracted.text.contains("VISUAL_"), "{}", extracted.text);
+    assert!(
+        !extracted.text.contains("STRUCT_LOSES"),
+        "{}",
+        extracted.text
+    );
+}
+
+#[test]
+fn structure_actualtext_replaces_visual_text_in_flat_extraction() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("Span").expect("begin span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("VISUAL")
+        .expect("write visual run");
+    page.end_marked_content().expect("end span");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 700.0)
+        .write("TAIL")
+        .expect("write following flat run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span).with_actual_text("STRUCT");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach span");
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+
+    let bytes = document.to_bytes().expect("serialize flat fixture");
+    let reader = PdfReader::new(Cursor::new(bytes)).expect("parse flat fixture");
+    let parsed = PdfDocument::new(reader);
+    let extracted = TextExtractor::with_options(ExtractionOptions::default())
+        .with_reading_order(true)
+        .extract_from_page(&parsed, 0)
+        .expect("extract flat fixture");
+    assert_eq!(extracted.text, "STRUCT\nTAIL");
+    assert!(extracted.fragments.is_empty());
+}
+
+#[test]
+fn structure_actualtext_cannot_bypass_the_page_byte_budget() {
+    let mut page = Page::a4();
+    let mcid = page
+        .begin_marked_content("Span")
+        .expect("begin structure-only run");
+    page.text()
+        .set_font(Font::Helvetica, 12.0)
+        .at(72.0, 720.0)
+        .write("x")
+        .expect("write visual run");
+    page.end_marked_content().expect("end structure-only run");
+
+    let mut tree = StructTree::new();
+    let root = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut span = StructureElement::new(StandardStructureType::Span)
+        .with_actual_text("STRUCT_REPLACEMENT_IS_TOO_LONG");
+    span.add_mcid(0, mcid);
+    tree.add_child(root, span).expect("attach structure span");
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let extracted = extract(
+        document,
+        ExtractionOptions {
+            preserve_layout: true,
+            max_extracted_bytes: Some(10),
+            ..Default::default()
+        },
+    );
+
+    assert!(extracted.truncated);
+    assert!(extracted.text.len() <= 10, "{}", extracted.text.len());
+    assert!(!extracted.text.contains("STRUCT_REPLACEMENT"));
+}
+
+#[test]
+fn resolves_parent_tree_kids_and_indirect_owner() {
+    let pdf = raw_tagged_pdf(
+        "<< /Kids [9 0 R] >>",
+        &[
+            "<< /Type /StructElem /ActualText <FEFF005300540052005500430054> >>".to_string(),
+            "<< /Nums [0 [8 0 R]] >>".to_string(),
+        ],
+        0,
+    );
+    assert_eq!(extract_raw(pdf), "STRUCT");
+}
+
+#[test]
+fn malformed_parent_tree_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf("<< /Nums [0 /NotAnOwnerArray] >>", &[], 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn invalid_mcid_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf(
+        "<< /Nums [0 [8 0 R]] >>",
+        &["<< /Type /StructElem /ActualText (STRUCT) >>".to_string()],
+        7,
+    );
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn cyclic_parent_tree_falls_back_to_visual_text() {
+    let pdf = raw_tagged_pdf("<< /Kids [7 0 R] >>", &[], 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn overdeep_parent_tree_falls_back_to_visual_text() {
+    let depth = 34usize;
+    let owner_id = 8 + depth;
+    let mut nodes = Vec::new();
+    for index in 0..depth {
+        let object_id = 8 + index;
+        let body = if index + 1 == depth {
+            format!("<< /Nums [0 [{owner_id} 0 R]] >>")
+        } else {
+            format!("<< /Kids [{} 0 R] >>", object_id + 1)
+        };
+        nodes.push(body);
+    }
+    nodes.push("<< /Type /StructElem /ActualText (STRUCT) >>".to_string());
+    let pdf = raw_tagged_pdf("<< /Kids [8 0 R] >>", &nodes, 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn oversized_parent_tree_stops_at_the_node_limit() {
+    const CHILDREN: usize = 4097;
+    let owner_id = 8 + CHILDREN;
+    let kids = (8..8 + CHILDREN)
+        .map(|id| format!("{id} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut nodes = vec!["<< >>".to_string(); CHILDREN];
+    nodes[CHILDREN - 1] = format!("<< /Nums [0 [{owner_id} 0 R]] >>");
+    nodes.push("<< /Type /StructElem /ActualText (STRUCT) >>".to_string());
+
+    let pdf = raw_tagged_pdf(&format!("<< /Kids [{kids}] >>"), &nodes, 0);
+    assert_eq!(extract_raw(pdf), "VISUAL");
+}
+
+#[test]
+fn form_xobject_uses_its_own_structparents_context() {
+    assert_eq!(extract_raw(tagged_form_pdf()), "FORM_RIGHT");
+}

--- a/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
+++ b/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
@@ -1,0 +1,132 @@
+//! Issue #509 — downstream renderers need resolved Type 3 glyph programs.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::fonts::Type3Font;
+use oxidize_pdf::parser::content::ContentOperation;
+use oxidize_pdf::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfStream};
+use oxidize_pdf::parser::ParseOptions;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use std::io::Cursor;
+use std::io::Write;
+
+fn build_pdf() -> Vec<u8> {
+    build_pdf_with_glyph(b"500 0 0 0 8 1 d1 0 0 8 1 re f BI /W 8 /H 1 /BPC 1 /IM true ID \xAA EI")
+}
+
+fn build_pdf_with_glyph(glyph: &[u8]) -> Vec<u8> {
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b"BT /F1 12 Tf <10> Tj ET"),
+        b"<< /Type /Font /Subtype /Type3 /Name /OpaquePdfTeX /FontBBox [0 0 8 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 16 /LastChar 16 /Widths 7 0 R /Encoding << /Differences [16 /a16] >> /CharProcs 6 0 R /Resources << /XObject << /Dot 9 0 R >> >> >>".to_vec(),
+        b"<< /a16 8 0 R >>".to_vec(),
+        b"[500]".to_vec(),
+        stream_obj("", glyph),
+        b"<< /Subtype /Form /BBox [0 0 1 1] >>".to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_opaque_control_code_to_parsed_charproc() {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(build_pdf())).unwrap());
+    let page = document.get_page(0).unwrap();
+    let resources = document.get_page_resources(&page).unwrap().unwrap();
+    let fonts = document.resolve(resources.get("Font").unwrap()).unwrap();
+    let font_ref = fonts.as_dict().unwrap().get("F1").unwrap();
+
+    let font = Type3Font::resolve(font_ref, &document).unwrap();
+    let direct_font_object = document.get_object(5, 0).unwrap();
+    assert!(Type3Font::resolve(&direct_font_object, &document)
+        .unwrap()
+        .glyph(0x10)
+        .is_some());
+    assert_eq!(font.name.as_deref(), Some("OpaquePdfTeX"));
+    assert_eq!(font.font_matrix, [0.001, 0.0, 0.0, 0.001, 0.0, 0.0]);
+
+    let glyph = font
+        .glyph(0x10)
+        .expect("code 0x10 must resolve through Differences");
+    assert_eq!(glyph.name, "a16");
+    assert_eq!(glyph.width, 500.0);
+    assert_eq!(glyph.procedure_width, (500.0, 0.0));
+    assert_eq!(glyph.bbox, Some([0.0, 0.0, 8.0, 1.0]));
+    assert!(glyph
+        .operations
+        .iter()
+        .any(|op| matches!(op, ContentOperation::InlineImage { .. })));
+    assert!(font
+        .resolve_resource("XObject", "Dot", &document)
+        .unwrap()
+        .unwrap()
+        .as_dict()
+        .is_some());
+    assert_eq!(
+        font.glyphs().map(|glyph| glyph.code).collect::<Vec<_>>(),
+        vec![0x10]
+    );
+}
+
+#[test]
+fn non_type3_font_is_rejected() {
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 1 1] >>".to_vec(),
+        b"<< >>".to_vec(),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+    ];
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(assemble_pdf(&objects))).unwrap());
+    assert!(
+        Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document).is_err()
+    );
+}
+
+#[test]
+fn d0_metrics_are_exposed_without_changing_content_operation() {
+    let document = PdfDocument::new(
+        PdfReader::new(Cursor::new(build_pdf_with_glyph(b"600 0 d0 0 0 m"))).unwrap(),
+    );
+    let font =
+        Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document).unwrap();
+    let glyph = font.glyph(0x10).unwrap();
+    assert_eq!(glyph.procedure_width, (600.0, 0.0));
+    assert_eq!(glyph.bbox, None);
+}
+
+#[test]
+fn malformed_charproc_is_rejected_with_glyph_context() {
+    let document = PdfDocument::new(
+        PdfReader::new(Cursor::new(build_pdf_with_glyph(b"500 d1 0 0 m"))).unwrap(),
+    );
+    let error = Type3Font::resolve(&oxidize_pdf::parser::PdfObject::Reference(5, 0), &document)
+        .expect_err("malformed d1 must not be silently skipped");
+    let message = error.to_string();
+    assert!(message.contains("/a16"), "missing glyph name: {message}");
+    assert!(message.contains("code 16"), "missing glyph code: {message}");
+}
+
+#[test]
+fn bounded_decode_stops_flate_expansion_at_the_local_limit() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&vec![b'x'; 4096]).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("FlateDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: compressed,
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 1024)
+        .expect_err("the decoder must stop before allocating the full output");
+    assert!(error.to_string().contains("1024"));
+}

--- a/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
+++ b/oxidize-pdf-core/tests/issue_509_type3_charprocs_test.rs
@@ -130,3 +130,59 @@ fn bounded_decode_stops_flate_expansion_at_the_local_limit() {
         .expect_err("the decoder must stop before allocating the full output");
     assert!(error.to_string().contains("1024"));
 }
+
+#[test]
+fn bounded_decode_limits_output_not_ascii_encoded_input() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("ASCIIHexDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: b"00>".to_vec(),
+    };
+
+    assert_eq!(
+        stream
+            .decode_with_limit(&ParseOptions::default(), 1)
+            .expect("one decoded byte is within the output limit"),
+        vec![0]
+    );
+}
+
+#[test]
+fn bounded_decode_stops_ascii85_expansion_during_output() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("ASCII85Decode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: b"z".to_vec(),
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 3)
+        .expect_err("z expands to four bytes and must stop at the limit");
+    assert!(error.to_string().contains("3"));
+}
+
+#[test]
+fn bounded_decode_rejects_filters_without_a_bounded_decoder() {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Filter".into(),
+        PdfObject::Name(PdfName("CCITTFaxDecode".into())),
+    );
+    let stream = PdfStream {
+        dict,
+        data: Vec::new(),
+    };
+
+    let error = stream
+        .decode_with_limit(&ParseOptions::default(), 1024)
+        .expect_err("an unbounded codec must not run behind the bounded API");
+    assert!(error.to_string().contains("no bounded decoder"));
+}

--- a/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
+++ b/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
@@ -1,0 +1,109 @@
+//! Repro for a flat-path spurious mid-token space regression introduced by
+//! the `flat_space_gap_threshold` font-derived tightening (commit ce79992,
+//! part of PR #499 / issue #496's follow-up hardening; released in 4.5.0).
+//!
+//! `flat_space_gap_threshold` replaced the old flat `0.3 * font_size` cutoff
+//! with `0.5 * real_space_advance` (the font's actual `/Widths` entry for
+//! code 32, in text-space units) whenever available. `real_space_advance` is
+//! computed from the nominal `Tf` font size alone, but the inter-run gap
+//! (`dx`) it is compared against is measured in *user space*, i.e. already
+//! scaled by `Tm`/CTM. When a PDF generator bakes its real rendering scale
+//! into `Tm` rather than `Tf` (drawing at `Tf 1` with e.g. `9 0 0 9 x y Tm`
+//! -- a common technique, seen here on a real Brazilian financial-prospectus
+//! template), the two sides of the comparison are off by that scale factor:
+//! the threshold ends up far smaller, relative to `dx`, than the old flat
+//! threshold was. A hyphenated phone number like "3030-7160" split across
+//! separate `Tj` runs (or even separate `BT`/`ET` text objects) with a
+//! perfectly ordinary few-hundredths-of-a-unit forward positioning residue
+//! between runs -- well under the old threshold -- now crosses the new one
+//! and gets a spurious space inserted, corrupting "3030-7160" into
+//! "3030- 7160".
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::TextExtractor;
+use std::io::Cursor;
+
+/// A simple WinAnsi TrueType font, `FirstChar 32`, real Verdana-ish widths:
+/// space (32) = 278, `-` (45) = 333, digits 0-9 (48-57) = 556 each --
+/// approximate real Verdana metrics.
+fn widths_array() -> String {
+    // widths[i] corresponds to code (32+i), for codes 32..=64 inclusive.
+    let mut widths = vec![500u32; 64 - 32 + 1];
+    widths[0] = 278; // space (32)
+    widths[45 - 32] = 333; // '-'
+    for digit_code in 48..=57 {
+        widths[digit_code - 32] = 556; // '0'..'9'
+    }
+    format!(
+        "[{}]",
+        widths
+            .iter()
+            .map(|w| w.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
+}
+
+fn build_pdf() -> Vec<u8> {
+    // font_size = 1, with the real 9pt rendering scale baked into `Tm`
+    // (a=d=9). An absolute `Tm` before each run precisely controls each
+    // run's user-space start x, avoiding any ambiguity from `Td`'s
+    // line-matrix-relative (not pen-relative) semantics.
+    //
+    // Natural advances at font_size 1, Tm x-scale 9 (from `widths_array`):
+    // "3030" = 4*556/1000*9 = 20.016 user-space units; "-" = 333/1000*9 =
+    // 2.997. The "-" run starts 0.05 units *short* of the natural pen
+    // position after "3030" (an ordinary small residue, either sign is
+    // harmless), and "7160" starts 0.15 units *past* the natural pen
+    // position after "-".
+    //
+    // The threshold is computed at the nominal font_size (1), unscaled by
+    // Tm: `0.5 * 278/1000 * 1 = 0.139` (new, font-derived) vs.
+    // `0.3 * font_size(1) = 0.3` (old, flat). `dx` is measured in
+    // Tm-scaled user-space units, so 0.15 clears the new threshold but not
+    // the old one -- the mismatch between an unscaled threshold and a
+    // Tm-scaled `dx` is exactly the bug.
+    let content = b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+9 0 0 9 119.966 700 Tm\n(-)Tj\n\
+9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n";
+    let widths = widths_array();
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", content),
+        format!(
+            "<< /Type /Font /Subtype /TrueType /BaseFont /Verdana \
+             /Encoding /WinAnsiEncoding /FirstChar 32 /LastChar 64 \
+             /Widths {widths} /FontDescriptor 6 0 R >>"
+        )
+        .into_bytes(),
+        b"<< /Type /FontDescriptor /FontName /Verdana /Flags 32 \
+          /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 \
+          /CapHeight 700 /StemV 80 >>"
+            .to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn small_forward_residue_between_simple_font_runs_at_font_size_1_is_not_a_space() {
+    let pdf = build_pdf();
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(
+        text, "3030-7160",
+        "small positive Td residue between simple-font runs at font_size=1 \
+         (well below the old flat 0.3*font_size threshold) must not be \
+         promoted to a word space by the font-derived threshold, got: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
+++ b/oxidize-pdf-core/tests/issue_510_tm_scaled_space_threshold_test.rs
@@ -65,9 +65,14 @@ fn build_pdf() -> Vec<u8> {
     // Tm-scaled user-space units, so 0.15 clears the new threshold but not
     // the old one -- the mismatch between an unscaled threshold and a
     // Tm-scaled `dx` is exactly the bug.
-    let content = b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+    build_pdf_with_content(
+        b"BT\n/F1 1 Tf\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
 9 0 0 9 119.966 700 Tm\n(-)Tj\n\
-9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n";
+9 0 0 9 123.113 700 Tm\n(7160)Tj\nET\n",
+    )
+}
+
+fn build_pdf_with_content(content: &[u8]) -> Vec<u8> {
     let widths = widths_array();
     let objects: Vec<Vec<u8>> = vec![
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
@@ -102,8 +107,42 @@ fn small_forward_residue_between_simple_font_runs_at_font_size_1_is_not_a_space(
         .text;
     assert_eq!(
         text, "3030-7160",
-        "small positive Td residue between simple-font runs at font_size=1 \
+        "small positive Tm residue between simple-font runs at font_size=1 \
          (well below the old flat 0.3*font_size threshold) must not be \
          promoted to a word space by the font-derived threshold, got: {text:?}"
     );
+}
+
+#[test]
+fn horizontal_text_scaling_is_included_in_the_space_threshold() {
+    let pdf = build_pdf_with_content(
+        b"BT\n/F1 1 Tf\n200 Tz\n9 0 0 9 100 700 Tm\n(3030)Tj\n\
+9 0 0 9 140 700 Tm\n(-)Tj\n\
+9 0 0 9 147.994 700 Tm\n(7160)Tj\nET\n",
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(text, "3030-7160");
+}
+
+#[test]
+fn ctm_only_scaling_is_included_in_the_space_threshold() {
+    let pdf = build_pdf_with_content(
+        b"q\n9 0 0 9 0 0 cm\nBT\n/F1 1 Tf\n1 0 0 1 11.111111 77.777778 Tm\n(3030)Tj\n\
+1 0 0 1 13.329556 77.777778 Tm\n(-)Tj\n\
+1 0 0 1 13.679222 77.777778 Tm\n(7160)Tj\nET\nQ\n",
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let text = TextExtractor::new()
+        .extract_from_page(&doc, 0)
+        .expect("extraction should succeed")
+        .text;
+    assert_eq!(text, "3030-7160");
 }

--- a/oxidize-pdf-core/tests/issue_513_resolved_parser_fonts_test.rs
+++ b/oxidize-pdf-core/tests/issue_513_resolved_parser_fonts_test.rs
@@ -1,0 +1,296 @@
+//! Issue #513 — coherent parser-side font resources for renderers.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::fonts::{EmbeddedFontFormat, FontSubtype, ResolvedFontResource, WritingMode};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use std::io::Cursor;
+use std::io::Write;
+
+fn identity_type2_pdf() -> Vec<u8> {
+    let to_unicode = b"/CIDInit /ProcSet findresource begin\n\
+12 dict begin begincmap\n\
+1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+1 beginbfchar <0001> <00E1> endbfchar\n\
+endcmap end end";
+    let objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 /Resources << /Font << /F1 5 0 R >> >> >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b"BT /F1 12 Tf <00010002> Tj ET"),
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Demo /Encoding /Identity-H /DescendantFonts [6 0 R] /ToUnicode 9 0 R >>".to_vec(),
+        b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Demo /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /W [1 [600 700]] /DW 1000 /CIDToGIDMap 8 0 R >>".to_vec(),
+        b"<< /Type /FontDescriptor /FontName /Demo /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile2 10 0 R >>".to_vec(),
+        stream_obj("", &[0, 0, 0, 5, 0, 9]),
+        stream_obj("", to_unicode),
+        stream_obj("", b"\0\x01\0\0fake-ttf"),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_inherited_identity_type2_into_renderer_glyphs() {
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(identity_type2_pdf())).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.base_font.as_deref(), Some("Demo"));
+    assert_eq!(font.subtype, FontSubtype::CidFontType2);
+    assert_eq!(font.writing_mode, WritingMode::Horizontal);
+    let embedded = font.embedded_font.as_ref().expect("FontFile2 resolved");
+    assert_eq!(embedded.format, EmbeddedFontFormat::TrueType);
+    assert_eq!(embedded.data, b"\0\x01\0\0fake-ttf");
+
+    let glyphs = font.decode_glyphs(&[0, 1, 0, 2]).unwrap();
+    assert_eq!(glyphs.len(), 2);
+    assert_eq!(glyphs[0].source_code, vec![0, 1]);
+    assert_eq!(glyphs[0].cid, Some(1));
+    assert_eq!(glyphs[0].gid, Some(5));
+    assert_eq!(glyphs[0].unicode.as_deref(), Some("á"));
+    assert_eq!(glyphs[0].advance, 600.0);
+    assert_eq!(glyphs[1].cid, Some(2));
+    assert_eq!(glyphs[1].gid, Some(9));
+    assert_eq!(glyphs[1].unicode, None);
+    assert_eq!(glyphs[1].advance, 700.0);
+}
+
+fn one_font_pdf(font: Vec<u8>, extra: Vec<Vec<u8>>) -> Vec<u8> {
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R /MediaBox [0 0 100 100] >>".to_vec(),
+        stream_obj("", b""),
+        font,
+    ];
+    objects.extend(extra);
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn resolves_cidfont_type0_open_type_program_and_vertical_mode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /CffDemo /Encoding /Identity-V /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CffDemo /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /DW 880 >>".to_vec(),
+            b"<< /Type /FontDescriptor /FontName /CffDemo /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile3 8 0 R >>".to_vec(),
+            stream_obj("/Subtype /OpenType", b"OTTOcff-data"),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.subtype, FontSubtype::CidFontType0);
+    assert_eq!(font.writing_mode, WritingMode::Vertical);
+    assert_eq!(
+        font.embedded_font.as_ref().unwrap().format,
+        EmbeddedFontFormat::OpenType
+    );
+    let glyph = font.decode_glyphs(&[0, 7]).unwrap().remove(0);
+    assert_eq!(glyph.cid, Some(7));
+    assert_eq!(glyph.gid, None);
+    assert_eq!(glyph.advance, 880.0);
+}
+
+#[test]
+fn resolves_symbol_difference_as_a_bullet_not_latin_x() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Symbol /FirstChar 120 /LastChar 120 /Widths [500] /Encoding << /Differences [120 /bullet] >> /FontDescriptor 6 0 R >>".to_vec(),
+        vec![b"<< /Type /FontDescriptor /FontName /Symbol /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"x").unwrap().remove(0);
+
+    assert_eq!(
+        font.differences.get(&120).map(String::as_str),
+        Some("bullet")
+    );
+    assert_eq!(glyph.source_code, b"x");
+    assert_eq!(glyph.unicode.as_deref(), Some("•"));
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.advance, 500.0);
+}
+
+#[test]
+fn resolves_non_identity_encoding_cmap_and_default_identity_gid() {
+    let encoding = b"begincmap /WMode 0 def 1 begincodespacerange <00> <FF> endcodespacerange 1 begincidchar <41> 5 endcidchar endcmap";
+    let to_unicode = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange 1 beginbfchar <41> <0041> endbfchar endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Mapped /Encoding 7 0 R /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Mapped /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /W [5 [444]] >>".to_vec(),
+            stream_obj("", encoding),
+            stream_obj("", to_unicode),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"A").unwrap().remove(0);
+
+    assert_eq!(glyph.source_code, b"A");
+    assert_eq!(glyph.cid, Some(5));
+    assert_eq!(glyph.gid, Some(5));
+    assert_eq!(glyph.unicode.as_deref(), Some("A"));
+    assert_eq!(glyph.advance, 444.0);
+}
+
+#[test]
+fn utf16_encoding_preserves_unicode_without_tounicode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /UnicodeCid /Encoding /UniJIS-UTF16-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /UnicodeCid /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /W [225 [555]] >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(&[0, 0xE1]).unwrap().remove(0);
+
+    assert_eq!(glyph.cid, Some(0xE1));
+    assert_eq!(glyph.gid, Some(0xE1));
+    assert_eq!(glyph.unicode.as_deref(), Some("á"));
+    assert_eq!(glyph.advance, 555.0);
+}
+
+#[test]
+fn decodes_win_ansi_without_confusing_code_and_unicode() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /TrueType /BaseFont /Arial /FirstChar 149 /LastChar 149 /Widths [350] /Encoding /WinAnsiEncoding >>".to_vec(),
+        vec![],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(&[0x95]).unwrap().remove(0);
+
+    assert_eq!(glyph.source_code, vec![0x95]);
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.unicode.as_deref(), Some("•"));
+    assert_eq!(glyph.advance, 350.0);
+}
+
+#[test]
+fn exposes_type3_through_the_coherent_resource_model() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type3 /Name /Painted /FontBBox [0 0 1 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 65 /LastChar 65 /Widths [500] /Encoding << /Differences [65 /A] >> /CharProcs << /A 6 0 R >> >>".to_vec(),
+        vec![stream_obj("", b"500 0 d0")],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(font.subtype, FontSubtype::Type3);
+    assert_eq!(font.type3.as_ref().unwrap().glyph(65).unwrap().width, 500.0);
+    assert_eq!(font.decode_glyphs(b"A").unwrap()[0].advance, 500.0);
+}
+
+#[test]
+fn type3_uses_tounicode_when_decoding_glyphs() {
+    let to_unicode = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange 1 beginbfchar <41> <03A9> endbfchar endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type3 /Name /Painted /FontBBox [0 0 1 1] /FontMatrix [0.001 0 0 0.001 0 0] /FirstChar 65 /LastChar 65 /Widths [500] /Encoding << /Differences [65 /A] >> /CharProcs << /A 6 0 R >> /ToUnicode 7 0 R >>".to_vec(),
+        vec![stream_obj("", b"500 0 d0"), stream_obj("", to_unicode)],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+
+    assert_eq!(
+        font.decode_glyphs(b"A").unwrap()[0].unicode.as_deref(),
+        Some("Ω")
+    );
+}
+
+#[test]
+fn unmapped_composite_code_uses_default_cid_width() {
+    let encoding = b"begincmap 1 begincodespacerange <00> <FF> endcodespacerange endcmap";
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Mapped /Encoding 7 0 R /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Mapped /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /DW 777 >>".to_vec(),
+            stream_obj("", encoding),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let font = ResolvedFontResource::from_page(&document, 0, "F1").unwrap();
+    let glyph = font.decode_glyphs(b"A").unwrap().remove(0);
+
+    assert_eq!(glyph.cid, None);
+    assert_eq!(glyph.advance, 777.0);
+}
+
+#[test]
+fn rejects_non_cid_descendant_in_type0_font() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /TrueType /BaseFont /Bad >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+
+    assert!(error.to_string().contains("Type0 descendant"));
+}
+
+#[test]
+fn rejects_odd_cid_to_gid_map_without_panicking() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Bad /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /CIDToGIDMap 7 0 R >>".to_vec(),
+            stream_obj("", &[0]),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("odd length"));
+}
+
+#[test]
+fn rejects_type0_font_without_required_encoding() {
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Bad /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>".to_vec()],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("missing its Encoding"));
+}
+
+#[test]
+fn rejects_oversized_cid_to_gid_map_after_bounded_decompression() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&vec![0; (u16::MAX as usize + 1) * 2 + 1])
+        .unwrap();
+    let compressed = encoder.finish().unwrap();
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /Type0 /BaseFont /Huge /Encoding /Identity-H /DescendantFonts [6 0 R] >>".to_vec(),
+        vec![
+            b"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Huge /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /CIDToGIDMap 7 0 R >>".to_vec(),
+            stream_obj("/Filter /FlateDecode", &compressed),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}
+
+#[test]
+fn rejects_circular_font_resource_without_panicking() {
+    let pdf = one_font_pdf(b"6 0 R".to_vec(), vec![b"5 0 R".to_vec()]);
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    assert!(ResolvedFontResource::from_page(&document, 0, "F1").is_err());
+}
+
+#[test]
+fn rejects_oversized_embedded_font_after_bounded_decompression() {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&vec![0; 10 * 1024 * 1024 + 1]).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let pdf = one_font_pdf(
+        b"<< /Type /Font /Subtype /TrueType /BaseFont /Huge /FirstChar 0 /LastChar 0 /Widths [500] /FontDescriptor 6 0 R >>".to_vec(),
+        vec![
+            b"<< /Type /FontDescriptor /FontName /Huge /Flags 32 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 /FontFile2 7 0 R >>".to_vec(),
+            stream_obj("/Filter /FlateDecode", &compressed),
+        ],
+    );
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+    let error = ResolvedFontResource::from_page(&document, 0, "F1").unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}

--- a/oxidize-pdf-core/tests/issue_514_indirect_decode_parms_test.rs
+++ b/oxidize-pdf-core/tests/issue_514_indirect_decode_parms_test.rs
@@ -1,0 +1,124 @@
+//! Issue #514 — resolve indirect DecodeParms through PdfDocument.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use flate2::{write::ZlibEncoder, Compression};
+use oxidize_pdf::parser::{objects::PdfObject, PdfDocument, PdfReader};
+use std::io::{Cursor, Write};
+
+const PIXELS: &[u8] = &[10, 20, 30, 40, 50, 60];
+
+fn compressed_predictor_row() -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&[0]).unwrap();
+    encoder.write_all(PIXELS).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn document_with_stream(
+    stream_dict: &str,
+    decode_parms_object: Vec<u8>,
+) -> PdfDocument<Cursor<Vec<u8>>> {
+    let compressed = compressed_predictor_row();
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b""),
+        stream_obj(stream_dict, &compressed),
+        decode_parms_object,
+    ]);
+    PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap())
+}
+
+fn image_stream(
+    document: &PdfDocument<Cursor<Vec<u8>>>,
+) -> oxidize_pdf::parser::objects::PdfStream {
+    match document.get_object(5, 0).unwrap() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("object 5 must be a stream, got {other:?}"),
+    }
+}
+
+#[test]
+fn indirect_decode_parms_matches_inline_predictor_output() {
+    let indirect = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+    let inline = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms << /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>",
+        b"null".to_vec(),
+    );
+
+    let indirect_bytes = indirect.decode_stream(&image_stream(&indirect)).unwrap();
+    let inline_bytes = inline.decode_stream(&image_stream(&inline)).unwrap();
+
+    assert_eq!(indirect_bytes, PIXELS);
+    assert_eq!(indirect_bytes, inline_bytes);
+}
+
+#[test]
+fn filter_array_resolves_its_indirect_parameter_entry() {
+    let document = document_with_stream(
+        "/Filter [/FlateDecode] /DecodeParms [6 0 R]",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+
+    assert_eq!(
+        document.decode_stream(&image_stream(&document)).unwrap(),
+        PIXELS
+    );
+}
+
+#[test]
+fn bounded_decode_keeps_the_existing_output_limit() {
+    let document = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"<< /Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8 >>".to_vec(),
+    );
+
+    let error = document
+        .decode_stream_with_limit(&image_stream(&document), PIXELS.len() - 1)
+        .unwrap_err();
+    assert!(error.to_string().contains("limit"));
+}
+
+#[test]
+fn missing_indirect_decode_parms_is_an_error() {
+    let document =
+        document_with_stream("/Filter /FlateDecode /DecodeParms 99 0 R", b"null".to_vec());
+
+    assert!(document.decode_stream(&image_stream(&document)).is_err());
+}
+
+#[test]
+fn circular_indirect_decode_parms_is_an_error() {
+    let compressed = compressed_predictor_row();
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b""),
+        stream_obj("/Filter /FlateDecode /DecodeParms 6 0 R", &compressed),
+        b"7 0 R".to_vec(),
+        b"6 0 R".to_vec(),
+    ]);
+    let document = PdfDocument::new(PdfReader::new(Cursor::new(pdf)).unwrap());
+
+    assert!(document.decode_stream(&image_stream(&document)).is_err());
+}
+
+#[test]
+fn non_dictionary_decode_parms_is_an_error() {
+    let document = document_with_stream(
+        "/Filter /FlateDecode /DecodeParms 6 0 R",
+        b"(not a dictionary)".to_vec(),
+    );
+
+    let error = document
+        .decode_stream(&image_stream(&document))
+        .unwrap_err();
+    assert!(error.to_string().contains("DecodeParms"));
+}

--- a/oxidize-pdf-core/tests/issue_516_in_memory_image_extraction_test.rs
+++ b/oxidize-pdf-core/tests/issue_516_in_memory_image_extraction_test.rs
@@ -4,8 +4,8 @@ mod common;
 
 use common::pdf_assembler::{assemble_pdf, stream_obj};
 use oxidize_pdf::operations::{
-    ExtractImagesOptions, ImageExtractionLimits, ImageExtractor, ImagePreprocessingOptions,
-    OperationError,
+    ExtractImagesOptions, ImageExtractionError, ImageExtractionLimits, ImageExtractor,
+    ImagePreprocessingOptions, OperationError,
 };
 use oxidize_pdf::parser::{PdfDocument, PdfReader};
 use std::io::Cursor;
@@ -102,7 +102,7 @@ fn visitor_error_stops_extraction_immediately() {
     let error = extractor
         .visit_images(ImageExtractionLimits::default(), |_| {
             calls += 1;
-            Err(OperationError::ParseError("visitor stopped".into()))
+            Err(OperationError::ParseError("visitor stopped".into()).into())
         })
         .unwrap_err();
 
@@ -127,7 +127,7 @@ fn rejects_pixel_limit_before_decoding_image_data() {
 
     assert!(matches!(
         extractor.extract_all_in_memory(limits),
-        Err(OperationError::ImageExtractionLimitExceeded {
+        Err(ImageExtractionError::LimitExceeded {
             limit: "decoded pixels per image",
             ..
         })
@@ -144,7 +144,7 @@ fn enforces_per_image_and_total_encoded_byte_limits() {
     };
     assert!(matches!(
         per_image.extract_all_in_memory(per_image_limits),
-        Err(OperationError::ImageExtractionLimitExceeded {
+        Err(ImageExtractionError::LimitExceeded {
             limit: "encoded bytes per image",
             ..
         })
@@ -157,7 +157,7 @@ fn enforces_per_image_and_total_encoded_byte_limits() {
     };
     assert!(matches!(
         total.extract_all_in_memory(total_limits),
-        Err(OperationError::ImageExtractionLimitExceeded {
+        Err(ImageExtractionError::LimitExceeded {
             limit: "total encoded bytes",
             ..
         })
@@ -181,7 +181,7 @@ fn enforces_the_image_count_limit_before_visiting() {
 
     assert!(matches!(
         result,
-        Err(OperationError::ImageExtractionLimitExceeded {
+        Err(ImageExtractionError::LimitExceeded {
             limit: "image count",
             ..
         })

--- a/oxidize-pdf-core/tests/issue_516_in_memory_image_extraction_test.rs
+++ b/oxidize-pdf-core/tests/issue_516_in_memory_image_extraction_test.rs
@@ -1,0 +1,228 @@
+//! Issue #516 — bounded image extraction without filesystem writes.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::operations::{
+    ExtractImagesOptions, ImageExtractionLimits, ImageExtractor, ImagePreprocessingOptions,
+    OperationError,
+};
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use std::io::Cursor;
+
+const JPEG_BYTES: &[u8] = b"\xff\xd8issue-516-jpeg\xff\xd9";
+
+fn image_document(image_body: &[u8], width: u32, height: u32) -> PdfDocument<Cursor<Vec<u8>>> {
+    let image_dict = format!(
+        "/Type /XObject /Subtype /Image /Width {width} /Height {height} \
+         /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode"
+    );
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b"q /Im0 Do Q"),
+        stream_obj(&image_dict, image_body),
+    ]);
+    PdfDocument::new(PdfReader::new(Cursor::new(pdf)).expect("fixture must parse"))
+}
+
+fn inline_image_document() -> PdfDocument<Cursor<Vec<u8>>> {
+    let pdf = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Contents 4 0 R >>".to_vec(),
+        stream_obj("", b"BI\n/W 1\n/H 1\nID\n\xff\x00\nEI"),
+    ]);
+    PdfDocument::new(PdfReader::new(Cursor::new(pdf)).expect("fixture must parse"))
+}
+
+fn extractor(output_dir: &std::path::Path) -> ImageExtractor<Cursor<Vec<u8>>> {
+    let options = ExtractImagesOptions {
+        output_dir: output_dir.to_path_buf(),
+        create_dir: true,
+        min_size: None,
+        preprocessing: disabled_preprocessing(),
+        ..ExtractImagesOptions::default()
+    };
+    ImageExtractor::new(image_document(JPEG_BYTES, 2, 3), options)
+}
+
+fn disabled_preprocessing() -> ImagePreprocessingOptions {
+    ImagePreprocessingOptions {
+        auto_correct_rotation: false,
+        enhance_contrast: false,
+        denoise: false,
+        upscale_small_images: false,
+        upscale_threshold: 300,
+        upscale_factor: 2,
+        force_grayscale: false,
+    }
+}
+
+#[test]
+fn extracts_image_bytes_without_touching_the_filesystem() {
+    let temp = tempfile::tempdir().unwrap();
+    let absent_output = temp.path().join("must-not-exist");
+    let mut extractor = extractor(&absent_output);
+
+    let images = extractor
+        .extract_all_in_memory(ImageExtractionLimits::default())
+        .unwrap();
+
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].data, JPEG_BYTES);
+    assert_eq!((images[0].width, images[0].height), (2, 3));
+    assert!(
+        !absent_output.exists(),
+        "in-memory extraction wrote to disk"
+    );
+}
+
+#[test]
+fn extracts_one_page_in_memory() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut extractor = extractor(&temp.path().join("unused"));
+
+    let images = extractor
+        .extract_from_page_in_memory(0, ImageExtractionLimits::default())
+        .unwrap();
+
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].page_number, 0);
+    assert_eq!(images[0].image_index, 0);
+}
+
+#[test]
+fn visitor_error_stops_extraction_immediately() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut extractor = extractor(&temp.path().join("unused"));
+    let mut calls = 0;
+
+    let error = extractor
+        .visit_images(ImageExtractionLimits::default(), |_| {
+            calls += 1;
+            Err(OperationError::ParseError("visitor stopped".into()))
+        })
+        .unwrap_err();
+
+    assert_eq!(calls, 1);
+    assert!(error.to_string().contains("visitor stopped"));
+}
+
+#[test]
+fn rejects_pixel_limit_before_decoding_image_data() {
+    let temp = tempfile::tempdir().unwrap();
+    let options = ExtractImagesOptions {
+        output_dir: temp.path().join("unused"),
+        min_size: None,
+        preprocessing: disabled_preprocessing(),
+        ..ExtractImagesOptions::default()
+    };
+    let mut extractor = ImageExtractor::new(image_document(b"not-a-jpeg", 100, 100), options);
+    let limits = ImageExtractionLimits {
+        max_decoded_pixels_per_image: 9_999,
+        ..ImageExtractionLimits::default()
+    };
+
+    assert!(matches!(
+        extractor.extract_all_in_memory(limits),
+        Err(OperationError::ImageExtractionLimitExceeded {
+            limit: "decoded pixels per image",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn enforces_per_image_and_total_encoded_byte_limits() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut per_image = extractor(&temp.path().join("unused-a"));
+    let per_image_limits = ImageExtractionLimits {
+        max_encoded_bytes_per_image: JPEG_BYTES.len() - 1,
+        ..ImageExtractionLimits::default()
+    };
+    assert!(matches!(
+        per_image.extract_all_in_memory(per_image_limits),
+        Err(OperationError::ImageExtractionLimitExceeded {
+            limit: "encoded bytes per image",
+            ..
+        })
+    ));
+
+    let mut total = extractor(&temp.path().join("unused-b"));
+    let total_limits = ImageExtractionLimits {
+        max_total_encoded_bytes: JPEG_BYTES.len() - 1,
+        ..ImageExtractionLimits::default()
+    };
+    assert!(matches!(
+        total.extract_all_in_memory(total_limits),
+        Err(OperationError::ImageExtractionLimitExceeded {
+            limit: "total encoded bytes",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn enforces_the_image_count_limit_before_visiting() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut extractor = extractor(&temp.path().join("unused"));
+    let limits = ImageExtractionLimits {
+        max_images: 0,
+        ..ImageExtractionLimits::default()
+    };
+    let mut calls = 0;
+
+    let result = extractor.visit_images(limits, |_| {
+        calls += 1;
+        Ok(())
+    });
+
+    assert!(matches!(
+        result,
+        Err(OperationError::ImageExtractionLimitExceeded {
+            limit: "image count",
+            ..
+        })
+    ));
+    assert_eq!(calls, 0);
+}
+
+#[test]
+fn inline_binary_offsets_are_applied_to_the_original_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let options = ExtractImagesOptions {
+        output_dir: temp.path().join("unused"),
+        min_size: None,
+        preprocessing: disabled_preprocessing(),
+        ..ExtractImagesOptions::default()
+    };
+    let mut extractor = ImageExtractor::new(inline_image_document(), options);
+
+    let images = extractor
+        .extract_all_in_memory(ImageExtractionLimits::default())
+        .unwrap();
+
+    assert_eq!(images.len(), 1);
+    assert!(images[0].data.contains(&0xff));
+}
+
+#[test]
+fn file_api_persists_the_same_bytes_produced_by_the_memory_core() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = temp.path().join("images");
+    let mut memory = extractor(&temp.path().join("unused"));
+    let expected = memory
+        .extract_all_in_memory(ImageExtractionLimits::default())
+        .unwrap();
+    let mut files = extractor(&output);
+
+    let persisted = files.extract_all().unwrap();
+
+    assert_eq!(persisted.len(), expected.len());
+    assert_eq!(
+        std::fs::read(&persisted[0].file_path).unwrap(),
+        expected[0].data
+    );
+}


### PR DESCRIPTION
## Summary

- expose bounded Type 3 CharProc glyph resolution (#509)
- align flat-path spacing thresholds with the full text transform (#510)
- expose resolved parser font resources for downstream renderers (#513)
- resolve indirect `/DecodeParms` before applying predictors (#514)
- add bounded in-memory image extraction APIs (#516)
- bump the workspace package to 4.6.0 and finalize the changelog

## Local validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `./scripts/verify-examples.sh --run`
- `cargo package -p oxidize-pdf --allow-dirty --locked --no-verify`

All completed successfully. The package step reported the existing yanked `spin 0.9.8` lockfile warning.