### PR TITLE
Merge release/4.6.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.6.0] - 2026-08-20
+
+### Added
+
+- **Type 3 font glyph resolution for downstream renderers** (#509). Parser
+  consumers can resolve bounded CharProc content streams together with the
+  glyph resources and metrics needed to render Type 3 fonts safely.
+- **Resolved parser font resources** (#513). The parser now exposes resolved
+  Type0, CID, simple, and Symbol font data through public, renderer-oriented
+  font resource types while retaining safe fallbacks for malformed PDFs.
+- **Bounded in-memory image extraction** (#516). New visitor and collection
+  APIs expose encoded image data without temporary files, with configurable
+  limits for image count, per-image and total encoded bytes, and decoded
+  pixels. Existing file-based extraction APIs remain compatible.
+
 ### Fixed
 
 - **Flat-path word-gap threshold compared a `Tm`-scaled pen delta against an
@@ -22,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   insert a spurious mid-token space. The threshold is now scaled by the same
   `Tm`/CTM x-factor already applied to page-space widths elsewhere in
   extraction, together with the horizontal text scaling selected by `Tz`.
+- **Indirect `/DecodeParms` references bypassed stream predictors** (#514).
+  Filter decoding now resolves indirect parameter dictionaries before
+  applying PNG and TIFF predictors, including parameters nested in filter
+  arrays, while rejecting cycles and invalid references safely.
 
 ## [4.5.1] - 2026-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.5.1"
+version = "4.6.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.5.1"
+version = "4.6.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]


### PR DESCRIPTION
Post-release synchronization after publishing v4.6.0.

This carries the 4.6.0 workspace version and finalized changelog back into `develop`.