### PR TITLE
fix(text): tolerate floating-point residue when merging contiguous fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Fixed
+
+- **`merge_close_fragments` rejected a contiguous pair of same-line
+  fragments due to floating-point rounding noise in the merge-gap check**
+  (issue #521 follow-up). Two runs positioned back-to-back with no
+  repositioning operator between them (e.g. successive `Tj` calls) have a
+  gap that is mathematically zero, but the run's end position and the next
+  run's declared start position are computed via independent
+  floating-point paths that are not always bit-identical — a `-1e-13`-class
+  negative residue on an otherwise touching pair failed the `x_gap >= 0.0`
+  check and left the pair as two separate fragments instead of merging them
+  into one. The check now tolerates a small negative epsilon
+  (`x_gap >= -TOUCHING_EPS`) without loosening it enough to treat a real,
+  visible overlap as adjacent.
+
 ## [4.6.0] - 2026-08-20
 
 ### Added

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -15,6 +15,14 @@ use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
+/// Tolerance for treating a "touching" pair of same-line fragments (the next
+/// run starting exactly where the previous one's pen advance ended) as
+/// adjacent in [`TextExtractor::merge_close_fragments`], absorbing
+/// floating-point rounding noise between independently computed positions
+/// without loosening the check enough to treat a real, visible overlap as
+/// adjacent (issue #521 follow-up).
+const TOUCHING_EPS: f64 = 1e-6;
+
 /// Controls how carriage returns decoded from PDF text-showing strings are
 /// represented in extracted plain text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2950,8 +2958,19 @@ impl TextExtractor {
                 1.0
             };
 
+            // `x_gap >= 0.0` treats a "touching" pair (the next run starting
+            // exactly where the previous one's pen advance ended, e.g. two
+            // runs of the same word/sentence with no positioning operator
+            // between them) as mergeable. But `current.width` and
+            // `fragment.x` are usually derived from independent floating-point
+            // paths (accumulated per-glyph AFM/Widths sums vs. the text
+            // matrix's absolute origin) that are mathematically identical but
+            // not bit-identical, so a genuinely zero gap can land a few ULPs
+            // on either side of 0.0 (issue #521 follow-up). Tolerate that
+            // rounding noise (see `TOUCHING_EPS`) without loosening the check
+            // enough to treat a real, visible overlap as adjacent.
             let should_merge = y_diff < y_tol
-                && x_gap >= 0.0  // Fragment is to the right
+                && x_gap >= -TOUCHING_EPS  // Fragment is to the right (within FP rounding noise)
                 && x_gap < fragment.font_size * 0.5 // Gap less than 50% of font size
                 && current.mcid == fragment.mcid;
 

--- a/oxidize-pdf-core/src/text/extraction.rs
+++ b/oxidize-pdf-core/src/text/extraction.rs
@@ -15,14 +15,6 @@ use crate::text::graphics_state_stack::GraphicsStateStack;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
-/// Tolerance for treating a "touching" pair of same-line fragments (the next
-/// run starting exactly where the previous one's pen advance ended) as
-/// adjacent in [`TextExtractor::merge_close_fragments`], absorbing
-/// floating-point rounding noise between independently computed positions
-/// without loosening the check enough to treat a real, visible overlap as
-/// adjacent (issue #521 follow-up).
-const TOUCHING_EPS: f64 = 1e-6;
-
 /// Controls how carriage returns decoded from PDF text-showing strings are
 /// represented in extracted plain text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2967,10 +2959,10 @@ impl TextExtractor {
             // matrix's absolute origin) that are mathematically identical but
             // not bit-identical, so a genuinely zero gap can land a few ULPs
             // on either side of 0.0 (issue #521 follow-up). Tolerate that
-            // rounding noise (see `TOUCHING_EPS`) without loosening the check
+            // rounding noise (see `SAME_LINE_EPS`) without loosening the check
             // enough to treat a real, visible overlap as adjacent.
             let should_merge = y_diff < y_tol
-                && x_gap >= -TOUCHING_EPS  // Fragment is to the right (within FP rounding noise)
+                && x_gap >= -SAME_LINE_EPS  // Fragment is to the right (within FP rounding noise)
                 && x_gap < fragment.font_size * 0.5 // Gap less than 50% of font size
                 && current.mcid == fragment.mcid;
 

--- a/oxidize-pdf-core/tests/issue_521_merge_fp_residue_test.rs
+++ b/oxidize-pdf-core/tests/issue_521_merge_fp_residue_test.rs
@@ -1,0 +1,86 @@
+//! Regression test for a follow-up found in review of the fix for issue
+//! #521 (encoding-aware Standard-14 AFM widths, #523/#524).
+//!
+//! With real AFM-based pen advances, a run's end position and the next
+//! run's declared start position (its own `Tm`-derived origin) are computed
+//! through independent floating-point paths that are mathematically
+//! identical for a truly contiguous pair of runs, but not bit-identical --
+//! the difference can land a few ULPs on either side of zero.
+//! `merge_close_fragments` treated two same-line fragments as adjacent only
+//! when `x_gap >= 0.0`, so a `-1e-13`-class negative residue on an otherwise
+//! touching pair rejected the merge and left the pair as two separate
+//! `TextFragment`s instead of one.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::{ExtractionOptions, TextExtractor};
+use std::io::Cursor;
+
+/// A bare standard-14 Helvetica font: no `/Widths`, no `/FirstChar`/`/LastChar`
+/// -- valid per ISO 32000-1 §9.6.2.2 -- so the pen advance comes from the
+/// AFM-by-encoding resolver (#523), which is where the floating-point
+/// residue this test guards against originates.
+fn build_pdf_with_content(content: &[u8]) -> Vec<u8> {
+    let objects: Vec<Vec<u8>> = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> \
+          /Contents 4 0 R /MediaBox [0 0 595 842] >>"
+            .to_vec(),
+        stream_obj("", content),
+        b"<< /BaseFont /Helvetica /Encoding /WinAnsiEncoding /Subtype /Type1 /Type /Font >>"
+            .to_vec(),
+    ];
+    assemble_pdf(&objects)
+}
+
+#[test]
+fn contiguous_afm_positioned_runs_merge_despite_floating_point_residue() {
+    // Two bare `Tj` runs back-to-back with no repositioning `Tm`/`Td`
+    // between them: the second run starts exactly where the extractor's own
+    // pen advance placed the first run's end. Any gap between them is pure
+    // floating-point noise, not a real one, and must not produce either a
+    // spurious space or an extra fragment. Sixteen narrow "i" glyphs
+    // (Helvetica AFM width 222/1000 em) at a 1:1 text-space scale is a
+    // minimal reproduction of the residue: the extractor's pen-advance
+    // accumulation (`advance_pen`, one multiply per `Tj`) and the
+    // AFM-width-sum-based merge-gap check (`calculate_text_width_from_codes`,
+    // one multiply-and-sum) compute the same nominal position through
+    // different floating-point operation sequences.
+    let pdf = build_pdf_with_content(
+        b"BT\n/F1 12 Tf\n14 TL\n1 0 0 1 100 700 Tm\n\
+(iiiiiiiiiiiiiiii)Tj\n\
+(X)Tj\nET\n",
+    );
+    let doc = PdfReader::new(Cursor::new(pdf))
+        .expect("PDF should parse")
+        .into_document();
+    let extracted = TextExtractor::with_options(ExtractionOptions {
+        preserve_layout: true,
+        ..Default::default()
+    })
+    .extract_from_page(&doc, 0)
+    .expect("extraction should succeed");
+
+    assert_eq!(
+        extracted.fragments.len(),
+        1,
+        "the two contiguous AFM-positioned runs must merge into a single \
+         fragment, not be split apart by floating-point residue in the \
+         merge gap check; got {} fragments: {:?}",
+        extracted.fragments.len(),
+        extracted
+            .fragments
+            .iter()
+            .map(|f| &f.text)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        extracted.fragments[0].text, "iiiiiiiiiiiiiiiiX",
+        "a genuinely touching pair (no positioning gap) must not gain a \
+         spurious space either; got {:?}",
+        extracted.fragments[0].text
+    );
+}


### PR DESCRIPTION
Fixes #521.

## Summary

Follow-up to #523/#524. Consecutive text-showing runs can be mathematically contiguous while independently computed floating-point positions differ by a tiny negative residue. `merge_close_fragments` previously required `x_gap >= 0.0`, so that residue could leave a touching pair as separate fragments.

## Fix

- Accept a negative gap only within the existing `SAME_LINE_EPS` tolerance.
- Keep genuine visible overlaps excluded from adjacency merging.
- Reuse the shared same-line epsilon instead of introducing a duplicate tolerance.

## Testing

- Added `issue_521_merge_fp_residue_test.rs`, covering two contiguous AFM-positioned `Tj` runs.
- Verifies that the runs become one fragment without gaining a spurious space.
- Existing issue #235 fragment-emission regressions pass.
- `cargo fmt --all -- --check`, focused tests, and Clippy with `-D warnings` pass locally.
