### PR TITLE
feat(writer): incremental highlight editing

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -40,6 +40,13 @@ jobs:
           qpdf_accepts_incremental_text_note_revision
           -- --ignored --exact
 
+      - name: Validate incremental highlights
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_525_incremental_highlights_test
+          qpdf_accepts_classic_and_xref_stream_highlight_revisions
+          -- --ignored --exact
+
       - name: Validate AES-256 R5 interoperability
         run: >
           cargo test -p oxidize-pdf

--- a/oxidize-pdf-core/src/writer/incremental_annotations.rs
+++ b/oxidize-pdf-core/src/writer/incremental_annotations.rs
@@ -1,0 +1,144 @@
+//! Shared page and annotation discovery for incremental annotation editors.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::{PdfDocument, PdfReader};
+use std::collections::HashMap;
+use std::io::Cursor;
+
+#[derive(Clone)]
+pub(super) struct PageState {
+    pub(super) reference: (u32, u16),
+    pub(super) dictionary: PdfDictionary,
+    pub(super) bounds: [f64; 4],
+    pub(super) container: AnnotationContainer,
+    pub(super) annotations: Vec<PdfObject>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum AnnotationContainer {
+    Page,
+    Indirect((u32, u16)),
+}
+
+pub(super) struct AnnotationState {
+    pub(super) page_index: u32,
+    pub(super) dictionary: PdfDictionary,
+}
+
+pub(super) struct AnnotationSnapshot {
+    pub(super) pages: Vec<PageState>,
+    pub(super) annotations: HashMap<(u32, u16), AnnotationState>,
+}
+
+impl AnnotationSnapshot {
+    pub(super) fn parse(bytes: &[u8], target_subtype: &str, feature: &str) -> Result<Self> {
+        let reader = PdfReader::new(Cursor::new(bytes))
+            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
+        if reader.is_encrypted() {
+            return Err(PdfError::PermissionDenied(format!(
+                "incremental {feature} editing is not supported on encrypted PDFs"
+            )));
+        }
+        let document = PdfDocument::new(reader);
+        let page_count = document
+            .page_count()
+            .map_err(|e| PdfError::InvalidStructure(format!("read page tree: {e}")))?;
+        let mut pages = Vec::with_capacity(page_count as usize);
+        let mut annotations = HashMap::new();
+        let mut indirect_annots_pages = HashMap::new();
+
+        for page_index in 0..page_count {
+            let page = document
+                .get_page(page_index)
+                .map_err(|e| PdfError::InvalidStructure(format!("read page {page_index}: {e}")))?;
+            let bounds = page.crop_box.unwrap_or(page.media_box);
+            let (container, values) = match page.dict.get("Annots") {
+                None => (AnnotationContainer::Page, Vec::new()),
+                Some(PdfObject::Array(array)) => (AnnotationContainer::Page, array.0.clone()),
+                Some(PdfObject::Reference(number, generation)) => {
+                    if let Some(first_page) =
+                        indirect_annots_pages.insert((*number, *generation), page_index)
+                    {
+                        return Err(PdfError::InvalidStructure(format!(
+                            "page /Annots array {number} {generation} is shared by multiple pages ({first_page} and {page_index})"
+                        )));
+                    }
+                    let object = document.get_object(*number, *generation).map_err(|e| {
+                        PdfError::InvalidStructure(format!("resolve page /Annots: {e}"))
+                    })?;
+                    let array = object.as_array().ok_or_else(|| {
+                        PdfError::InvalidStructure("indirect /Annots is not an array".to_string())
+                    })?;
+                    (
+                        AnnotationContainer::Indirect((*number, *generation)),
+                        array.0.clone(),
+                    )
+                }
+                Some(_) => {
+                    return Err(PdfError::InvalidStructure(
+                        "page /Annots must be an array or indirect array".to_string(),
+                    ))
+                }
+            };
+
+            for value in &values {
+                match value {
+                    PdfObject::Reference(number, generation) => {
+                        let object = document.get_object(*number, *generation).map_err(|e| {
+                            PdfError::InvalidStructure(format!(
+                                "resolve annotation {number} {generation}: {e}"
+                            ))
+                        })?;
+                        let dictionary = object.as_dict().cloned().ok_or_else(|| {
+                            PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is not a dictionary"
+                            ))
+                        })?;
+                        let id = (*number, *generation);
+                        if annotations
+                            .get(&id)
+                            .is_some_and(|existing: &AnnotationState| {
+                                existing.page_index != page_index
+                            })
+                        {
+                            return Err(PdfError::InvalidStructure(format!(
+                                "annotation {number} {generation} is referenced from multiple pages"
+                            )));
+                        }
+                        annotations.insert(
+                            id,
+                            AnnotationState {
+                                page_index,
+                                dictionary,
+                            },
+                        );
+                    }
+                    PdfObject::Dictionary(dictionary)
+                        if subtype(dictionary) == Some(target_subtype) =>
+                    {
+                        return Err(PdfError::InvalidStructure(format!(
+                            "inline /{target_subtype} annotations have no stable object identity"
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+            pages.push(PageState {
+                reference: page.obj_ref,
+                dictionary: page.dict,
+                bounds,
+                container,
+                annotations: values,
+            });
+        }
+        Ok(Self { pages, annotations })
+    }
+}
+
+pub(super) fn subtype(dictionary: &PdfDictionary) -> Option<&str> {
+    dictionary
+        .get("Subtype")
+        .and_then(PdfObject::as_name)
+        .map(|name| name.0.as_str())
+}

--- a/oxidize-pdf-core/src/writer/incremental_highlights.rs
+++ b/oxidize-pdf-core/src/writer/incremental_highlights.rs
@@ -1,0 +1,532 @@
+//! Incremental editing of standard `/Highlight` annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use std::collections::{HashMap, HashSet};
+
+/// Stable indirect-object identity of a highlight annotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HighlightId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+/// A validated highlight quadrilateral in PDF `/QuadPoints` order.
+///
+/// The points are the start and end of the first edge followed by the start
+/// and end of the opposite edge. They must describe a convex, non-degenerate
+/// quadrilateral.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HighlightQuad([Point; 4]);
+
+impl HighlightQuad {
+    /// Validate and construct a highlight quadrilateral.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] for non-finite, repeated,
+    /// degenerate, crossed, or concave points.
+    pub fn new(points: [Point; 4]) -> Result<Self> {
+        validate_quad_shape(&points)?;
+        Ok(Self(points))
+    }
+
+    /// Return the points in PDF `/QuadPoints` order.
+    pub const fn points(&self) -> &[Point; 4] {
+        &self.0
+    }
+}
+
+/// A validated DeviceRGB color for a highlight annotation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HighlightColor([f64; 3]);
+
+impl HighlightColor {
+    /// Construct an RGB color whose components are in the inclusive range 0–1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] for non-finite or out-of-range components.
+    pub fn new(components: [f64; 3]) -> Result<Self> {
+        validate_unit_values(&components, "highlight RGB color")?;
+        Ok(Self(components))
+    }
+
+    /// Return the RGB components.
+    pub const fn components(self) -> [f64; 3] {
+        self.0
+    }
+}
+
+/// A validated highlight opacity (`/CA`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HighlightOpacity(f64);
+
+impl HighlightOpacity {
+    /// Construct an opacity in the inclusive range 0–1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidStructure`] for a non-finite or out-of-range value.
+    pub fn new(value: f64) -> Result<Self> {
+        validate_unit_values(&[value], "highlight opacity")?;
+        Ok(Self(value))
+    }
+
+    /// Return the opacity value.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl HighlightId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// A standard PDF highlight annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Highlight {
+    /// Stable indirect-object identity.
+    pub id: HighlightId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Annotation bounding rectangle `[left, bottom, right, top]`.
+    pub rect: [f64; 4],
+    /// One or more quadrilaterals, each in PDF `/QuadPoints` order.
+    pub quadrilaterals: Vec<HighlightQuad>,
+    /// RGB color components in the inclusive range 0–1.
+    pub color: HighlightColor,
+    /// Optional constant opacity (`/CA`) in the inclusive range 0–1.
+    pub opacity: Option<HighlightOpacity>,
+    /// Optional annotation contents.
+    pub contents: Option<String>,
+}
+
+/// A requested change to the document's highlights.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HighlightMutation {
+    /// Add a highlight to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Non-empty validated highlight geometry.
+        quadrilaterals: Vec<HighlightQuad>,
+        /// DeviceRGB highlight color.
+        color: HighlightColor,
+        /// Optional constant opacity.
+        opacity: Option<HighlightOpacity>,
+        /// Optional annotation contents.
+        contents: Option<String>,
+    },
+    /// Remove an existing highlight reference from its page.
+    Remove {
+        /// Stable identity of the highlight to remove.
+        id: HighlightId,
+    },
+}
+
+/// Result of one atomic incremental highlight update.
+#[derive(Debug, Clone)]
+pub struct HighlightUpdate {
+    /// Complete PDF bytes. The original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Complete current highlight set after the update.
+    pub highlights: Vec<Highlight>,
+}
+
+/// Reads and atomically edits standard highlights in an existing PDF.
+pub struct IncrementalHighlightEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalHighlightEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/Highlight` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF is malformed or encrypted, or when a
+    /// highlight has no stable identity or contains invalid properties.
+    pub fn highlights(&self) -> Result<Vec<Highlight>> {
+        let snapshot = AnnotationSnapshot::parse(self.base_bytes, "Highlight", "highlight")?;
+        read_highlights(&snapshot)
+    }
+
+    /// Validate and apply a batch as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed or encrypted PDFs, invalid pages or
+    /// identities, conflicting mutations, invalid geometry, and exhausted
+    /// indirect-object numbers.
+    pub fn apply(&self, mutations: &[HighlightMutation]) -> Result<HighlightUpdate> {
+        let mut snapshot = AnnotationSnapshot::parse(self.base_bytes, "Highlight", "highlight")?;
+        let existing = read_highlights(&snapshot)?;
+        if mutations.is_empty() {
+            return Ok(HighlightUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                highlights: existing,
+            });
+        }
+        let existing_pages = validate_batch(&snapshot, &existing, mutations)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+
+        for mutation in mutations {
+            match mutation {
+                HighlightMutation::Add {
+                    page_index,
+                    quadrilaterals,
+                    color,
+                    opacity,
+                    contents,
+                } => {
+                    let id = update.allocate_id()?;
+                    update.replace(
+                        id,
+                        PdfObject::Dictionary(new_dictionary(
+                            quadrilaterals,
+                            *color,
+                            *opacity,
+                            contents.as_deref(),
+                        )),
+                    )?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    changed_pages.insert(*page_index);
+                }
+                HighlightMutation::Remove { id } => {
+                    let page_index = *existing_pages.get(id).ok_or_else(|| {
+                        invalid(&format!(
+                            "highlight {} {} does not exist",
+                            id.object_number, id.generation_number
+                        ))
+                    })?;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+
+        for page_index in changed_pages {
+            let page = &mut snapshot.pages[page_index as usize];
+            match page.container {
+                AnnotationContainer::Page => {
+                    page.dictionary.insert(
+                        "Annots".to_string(),
+                        PdfObject::Array(PdfArray(page.annotations.clone())),
+                    );
+                    update.replace(
+                        page.reference,
+                        PdfObject::Dictionary(page.dictionary.clone()),
+                    )?;
+                }
+                AnnotationContainer::Indirect(id) => {
+                    update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?;
+                }
+            }
+        }
+        let pdf_bytes = update.finish()?;
+        let highlights = IncrementalHighlightEditor::new(&pdf_bytes).highlights()?;
+        Ok(HighlightUpdate {
+            pdf_bytes,
+            highlights,
+        })
+    }
+}
+
+fn read_highlights(snapshot: &AnnotationSnapshot) -> Result<Vec<Highlight>> {
+    let mut result = Vec::new();
+    for (&(number, generation), state) in &snapshot.annotations {
+        if subtype(&state.dictionary) != Some("Highlight") {
+            continue;
+        }
+        result.push(parse_highlight(
+            HighlightId::new(number, generation),
+            state.page_index,
+            &state.dictionary,
+        )?);
+    }
+    result.sort_by_key(|item| {
+        (
+            item.page_index,
+            item.id.object_number,
+            item.id.generation_number,
+        )
+    });
+    Ok(result)
+}
+
+fn parse_highlight(id: HighlightId, page_index: u32, dict: &PdfDictionary) -> Result<Highlight> {
+    let rect_values = numeric_array(dict, "Rect", Some(4))?;
+    let rect = [
+        rect_values[0],
+        rect_values[1],
+        rect_values[2],
+        rect_values[3],
+    ];
+    if rect[2] <= rect[0] || rect[3] <= rect[1] {
+        return Err(invalid(
+            "/Highlight /Rect must have positive width and height",
+        ));
+    }
+    let values = numeric_array(dict, "QuadPoints", None)?;
+    if values.is_empty() || values.len() % 8 != 0 {
+        return Err(invalid(
+            "/Highlight /QuadPoints must contain one or more groups of eight numbers",
+        ));
+    }
+    let quadrilaterals = values
+        .chunks_exact(8)
+        .map(|v| {
+            HighlightQuad::new([
+                Point::new(v[0], v[1]),
+                Point::new(v[2], v[3]),
+                Point::new(v[4], v[5]),
+                Point::new(v[6], v[7]),
+            ])
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let color_values = numeric_array(dict, "C", Some(3))?;
+    let color = HighlightColor::new([color_values[0], color_values[1], color_values[2]])?;
+    let opacity = match dict.get("CA") {
+        None => None,
+        Some(value) => {
+            Some(HighlightOpacity::new(number(value).ok_or_else(|| {
+                invalid("/Highlight /CA must be a finite number")
+            })?)?)
+        }
+    };
+    let contents = match dict.get("Contents") {
+        None => None,
+        Some(value) => Some(
+            value
+                .as_string()
+                .ok_or_else(|| invalid("/Highlight /Contents must be a string"))?
+                .to_text(),
+        ),
+    };
+    Ok(Highlight {
+        id,
+        page_index,
+        rect,
+        quadrilaterals,
+        color,
+        opacity,
+        contents,
+    })
+}
+
+fn validate_batch(
+    snapshot: &AnnotationSnapshot,
+    existing: &[Highlight],
+    mutations: &[HighlightMutation],
+) -> Result<HashMap<HighlightId, u32>> {
+    let existing_pages: HashMap<_, _> = existing
+        .iter()
+        .map(|item| (item.id, item.page_index))
+        .collect();
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            HighlightMutation::Add {
+                page_index,
+                quadrilaterals,
+                color,
+                opacity,
+                ..
+            } => {
+                let page = snapshot
+                    .pages
+                    .get(*page_index as usize)
+                    .ok_or_else(|| invalid(&format!("page {page_index} does not exist")))?;
+                validate_quads(quadrilaterals, page.bounds)?;
+                let _ = (color, opacity);
+            }
+            HighlightMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("highlight is targeted more than once"));
+                }
+                if !existing_pages.contains_key(id) {
+                    return Err(invalid(&format!(
+                        "highlight {} {} does not exist",
+                        id.object_number, id.generation_number
+                    )));
+                }
+            }
+        }
+    }
+    Ok(existing_pages)
+}
+
+fn validate_quads(quads: &[HighlightQuad], bounds: [f64; 4]) -> Result<()> {
+    if quads.is_empty() {
+        return Err(invalid("highlight must contain at least one quadrilateral"));
+    }
+    for point in quads.iter().flat_map(|quad| quad.points()) {
+        if point.x < bounds[0] || point.x > bounds[2] || point.y < bounds[1] || point.y > bounds[3]
+        {
+            return Err(invalid("highlight coordinates are outside the page bounds"));
+        }
+    }
+    Ok(())
+}
+
+fn new_dictionary(
+    quads: &[HighlightQuad],
+    color: HighlightColor,
+    opacity: Option<HighlightOpacity>,
+    contents: Option<&str>,
+) -> PdfDictionary {
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Annot".to_string())),
+    );
+    dict.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("Highlight".to_string())),
+    );
+    let rect = quad_bounds(quads);
+    dict.insert("Rect".to_string(), numbers(&rect));
+    let flat: Vec<f64> = quads
+        .iter()
+        .flat_map(|quad| quad.points().iter().flat_map(|p| [p.x, p.y]))
+        .collect();
+    dict.insert("QuadPoints".to_string(), numbers(&flat));
+    dict.insert("C".to_string(), numbers(&color.components()));
+    if let Some(value) = opacity {
+        dict.insert("CA".to_string(), PdfObject::Real(value.value()));
+    }
+    if let Some(value) = contents {
+        dict.insert("Contents".to_string(), pdf_text(value));
+    }
+    dict
+}
+
+fn quad_bounds(quads: &[HighlightQuad]) -> [f64; 4] {
+    let mut left = f64::INFINITY;
+    let mut bottom = f64::INFINITY;
+    let mut right = f64::NEG_INFINITY;
+    let mut top = f64::NEG_INFINITY;
+    for point in quads.iter().flat_map(|quad| quad.points()) {
+        left = left.min(point.x);
+        bottom = bottom.min(point.y);
+        right = right.max(point.x);
+        top = top.max(point.y);
+    }
+    [left, bottom, right, top]
+}
+
+fn validate_quad_shape(points: &[Point; 4]) -> Result<()> {
+    if points
+        .iter()
+        .any(|point| !point.x.is_finite() || !point.y.is_finite())
+    {
+        return Err(invalid("highlight coordinates must be finite"));
+    }
+    let boundary = [points[0], points[1], points[3], points[2]];
+    let mut sign = 0.0;
+    for index in 0..4 {
+        let a = boundary[index];
+        let b = boundary[(index + 1) % 4];
+        let c = boundary[(index + 2) % 4];
+        let cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
+        if cross.abs() <= f64::EPSILON {
+            return Err(invalid(
+                "highlight quadrilateral must have four non-collinear corners",
+            ));
+        }
+        if sign == 0.0 {
+            sign = cross.signum();
+        } else if cross.signum() != sign {
+            return Err(invalid(
+                "highlight quadrilateral must be convex and not crossed",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn numeric_array(dict: &PdfDictionary, key: &str, length: Option<usize>) -> Result<Vec<f64>> {
+    let array = dict
+        .get(key)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid(&format!("/Highlight /{key} is missing or is not an array")))?;
+    if length.is_some_and(|expected| array.0.len() != expected) {
+        return Err(invalid(&format!(
+            "/Highlight /{key} has the wrong number of values"
+        )));
+    }
+    array
+        .0
+        .iter()
+        .map(|value| {
+            number(value).ok_or_else(|| {
+                invalid(&format!(
+                    "/Highlight /{key} contains a non-finite or non-numeric value"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn number(value: &PdfObject) -> Option<f64> {
+    match value {
+        PdfObject::Integer(v) => Some(*v as f64),
+        PdfObject::Real(v) if v.is_finite() => Some(*v),
+        _ => None,
+    }
+}
+
+fn validate_unit_values(values: &[f64], label: &str) -> Result<()> {
+    if values
+        .iter()
+        .any(|value| !value.is_finite() || !(0.0..=1.0).contains(value))
+    {
+        return Err(invalid(&format!(
+            "{label} components must be finite and between 0 and 1"
+        )));
+    }
+    Ok(())
+}
+
+fn numbers(values: &[f64]) -> PdfObject {
+    PdfObject::Array(PdfArray(
+        values.iter().copied().map(PdfObject::Real).collect(),
+    ))
+}
+
+fn pdf_text(contents: &str) -> PdfObject {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in contents.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    PdfObject::String(PdfString(bytes))
+}
+
+fn invalid(message: &str) -> PdfError {
+    PdfError::InvalidStructure(message.to_string())
+}

--- a/oxidize-pdf-core/src/writer/incremental_highlights.rs
+++ b/oxidize-pdf-core/src/writer/incremental_highlights.rs
@@ -354,8 +354,6 @@ fn validate_batch(
             HighlightMutation::Add {
                 page_index,
                 quadrilaterals,
-                color,
-                opacity,
                 ..
             } => {
                 let page = snapshot
@@ -363,7 +361,6 @@ fn validate_batch(
                     .get(*page_index as usize)
                     .ok_or_else(|| invalid(&format!("page {page_index} does not exist")))?;
                 validate_quads(quadrilaterals, page.bounds)?;
-                let _ = (color, opacity);
             }
             HighlightMutation::Remove { id } => {
                 if !targeted.insert(*id) {

--- a/oxidize-pdf-core/src/writer/incremental_text_notes.rs
+++ b/oxidize-pdf-core/src/writer/incremental_text_notes.rs
@@ -1,12 +1,11 @@
 //! Incremental editing of standard `/Text` annotations in existing PDFs.
 
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot, PageState};
 use super::incremental_update::IncrementalUpdate;
 use crate::error::{PdfError, Result};
 use crate::geometry::Point;
 use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
-use crate::parser::{PdfDocument, PdfReader};
 use std::collections::{HashMap, HashSet};
-use std::io::Cursor;
 
 const NOTE_SIZE: f64 = 20.0;
 
@@ -212,21 +211,6 @@ impl<'a> IncrementalTextNoteEditor<'a> {
     }
 }
 
-#[derive(Clone)]
-struct PageState {
-    reference: (u32, u16),
-    dictionary: PdfDictionary,
-    bounds: [f64; 4],
-    container: AnnotationContainer,
-    annotations: Vec<PdfObject>,
-}
-
-#[derive(Clone, Copy)]
-enum AnnotationContainer {
-    Page,
-    Indirect((u32, u16)),
-}
-
 struct AnnotationState {
     page_index: u32,
     dictionary: PdfDictionary,
@@ -253,118 +237,36 @@ struct Snapshot {
 
 impl Snapshot {
     fn parse(bytes: &[u8]) -> Result<Self> {
-        let reader = PdfReader::new(Cursor::new(bytes))
-            .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
-        if reader.is_encrypted() {
-            return Err(PdfError::PermissionDenied(
-                "incremental text-note editing is not supported on encrypted PDFs".to_string(),
-            ));
-        }
-        let document = PdfDocument::new(reader);
-        let page_count = document
-            .page_count()
-            .map_err(|e| PdfError::InvalidStructure(format!("read page tree: {e}")))?;
-        let mut pages = Vec::with_capacity(page_count as usize);
+        let shared = AnnotationSnapshot::parse(bytes, "Text", "text-note")?;
         let mut annotations = HashMap::new();
-        let mut indirect_annots_pages = HashMap::new();
-
-        for page_index in 0..page_count {
-            let page = document
-                .get_page(page_index)
-                .map_err(|e| PdfError::InvalidStructure(format!("read page {page_index}: {e}")))?;
-            let bounds = page.crop_box.unwrap_or(page.media_box);
-            let (container, values) = match page.dict.get("Annots") {
-                None => (AnnotationContainer::Page, Vec::new()),
-                Some(PdfObject::Array(array)) => (AnnotationContainer::Page, array.0.clone()),
-                Some(PdfObject::Reference(number, generation)) => {
-                    if let Some(first_page) =
-                        indirect_annots_pages.insert((*number, *generation), page_index)
-                    {
-                        return Err(PdfError::InvalidStructure(format!(
-                            "page /Annots array {number} {generation} is shared by multiple pages ({first_page} and {page_index})"
-                        )));
-                    }
-                    let object = document.get_object(*number, *generation).map_err(|e| {
-                        PdfError::InvalidStructure(format!("resolve page /Annots: {e}"))
-                    })?;
-                    let array = object.as_array().ok_or_else(|| {
-                        PdfError::InvalidStructure("indirect /Annots is not an array".to_string())
-                    })?;
-                    (
-                        AnnotationContainer::Indirect((*number, *generation)),
-                        array.0.clone(),
-                    )
-                }
-                Some(_) => {
-                    return Err(PdfError::InvalidStructure(
-                        "page /Annots must be an array or indirect array".to_string(),
-                    ))
-                }
+        for ((number, generation), state) in shared.annotations {
+            let is_text = subtype(&state.dictionary) == Some("Text");
+            let rect = if is_text {
+                parse_rectangle(&state.dictionary)?
+            } else {
+                [0.0; 4]
             };
-
-            for value in &values {
-                match value {
-                    PdfObject::Reference(number, generation) => {
-                        let object = document.get_object(*number, *generation).map_err(|e| {
-                            PdfError::InvalidStructure(format!(
-                                "resolve annotation {number} {generation}: {e}"
-                            ))
-                        })?;
-                        let dictionary = object.as_dict().cloned().ok_or_else(|| {
-                            PdfError::InvalidStructure(format!(
-                                "annotation {number} {generation} is not a dictionary"
-                            ))
-                        })?;
-                        let is_text = subtype(&dictionary) == Some("Text");
-                        let rect = if is_text {
-                            parse_rectangle(&dictionary)?
-                        } else {
-                            [0.0; 4]
-                        };
-                        let contents = dictionary
-                            .get("Contents")
-                            .and_then(PdfObject::as_string)
-                            .map(PdfString::to_text)
-                            .unwrap_or_default();
-                        let id = TextNoteId::new(*number, *generation);
-                        if annotations
-                            .get(&id)
-                            .is_some_and(|existing: &AnnotationState| {
-                                existing.page_index != page_index
-                            })
-                        {
-                            return Err(PdfError::InvalidStructure(format!(
-                                "annotation {number} {generation} is referenced from multiple pages"
-                            )));
-                        }
-                        annotations.insert(
-                            id,
-                            AnnotationState {
-                                page_index,
-                                dictionary,
-                                rect,
-                                contents,
-                                is_text,
-                            },
-                        );
-                    }
-                    PdfObject::Dictionary(dictionary) if subtype(dictionary) == Some("Text") => {
-                        return Err(PdfError::InvalidStructure(
-                            "inline /Text annotations have no stable object identity".to_string(),
-                        ));
-                    }
-                    _ => {}
-                }
-            }
-            pages.push(PageState {
-                reference: page.obj_ref,
-                dictionary: page.dict,
-                bounds,
-                container,
-                annotations: values,
-            });
+            let contents = state
+                .dictionary
+                .get("Contents")
+                .and_then(PdfObject::as_string)
+                .map(PdfString::to_text)
+                .unwrap_or_default();
+            annotations.insert(
+                TextNoteId::new(number, generation),
+                AnnotationState {
+                    page_index: state.page_index,
+                    dictionary: state.dictionary,
+                    rect,
+                    contents,
+                    is_text,
+                },
+            );
         }
-        Ok(Self { pages, annotations })
+        Ok(Self {
+            pages: shared.pages,
+            annotations,
+        })
     }
 }
 
@@ -464,13 +366,6 @@ fn validate_position(position: Point, width: f64, height: f64, bounds: [f64; 4])
         ));
     }
     Ok(())
-}
-
-fn subtype(dictionary: &PdfDictionary) -> Option<&str> {
-    dictionary
-        .get("Subtype")
-        .and_then(PdfObject::as_name)
-        .map(|name| name.0.as_str())
 }
 
 fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -13,6 +13,13 @@ pub(super) struct IncrementalUpdate<'a> {
     next_id: u32,
     first_id: Option<Vec<u8>>,
     replacements: Vec<(u32, u16, PdfObject)>,
+    xref_kind: XrefKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum XrefKind {
+    Table,
+    Stream,
 }
 
 impl<'a> IncrementalUpdate<'a> {
@@ -43,6 +50,7 @@ impl<'a> IncrementalUpdate<'a> {
             next_id: size,
             first_id,
             replacements: Vec::new(),
+            xref_kind: detect_xref_kind(base, trailer.xref_offset)?,
         })
     }
 
@@ -97,7 +105,16 @@ impl<'a> IncrementalUpdate<'a> {
         }
 
         let xref_position = out.len() as u64;
-        out.extend_from_slice(&partial_xref(&changed));
+        let xref_stream_id = if self.xref_kind == XrefKind::Stream {
+            let id = self.next_id;
+            self.next_id = self.next_id.checked_add(1).ok_or_else(|| {
+                PdfError::InvalidStructure("PDF object number space is exhausted".to_string())
+            })?;
+            changed.push((id, 0, xref_position));
+            Some(id)
+        } else {
+            None
+        };
         let size = self.next_id.max(self.original_size);
         let id_pair = self.first_id.map(|first| {
             let mut material = first.clone();
@@ -105,16 +122,49 @@ impl<'a> IncrementalUpdate<'a> {
             material.extend_from_slice(&xref_position.to_le_bytes());
             (first, md5::compute(material).0.to_vec())
         });
-        write_trailer(
-            &mut out,
-            self.previous_xref,
-            self.root,
-            size,
-            xref_position,
-            id_pair,
-        );
+        match xref_stream_id {
+            Some(id) => write_xref_stream(
+                &mut out,
+                id,
+                &changed,
+                self.previous_xref,
+                self.root,
+                size,
+                id_pair,
+            )?,
+            None => {
+                out.extend_from_slice(&partial_xref(&changed));
+                write_trailer(
+                    &mut out,
+                    self.previous_xref,
+                    self.root,
+                    size,
+                    xref_position,
+                    id_pair,
+                );
+            }
+        }
         Ok(out)
     }
+}
+
+fn detect_xref_kind(base: &[u8], offset: u64) -> Result<XrefKind> {
+    let start = usize::try_from(offset).map_err(|_| {
+        PdfError::InvalidStructure("cross-reference offset does not fit in memory".to_string())
+    })?;
+    let tail = base.get(start..).ok_or_else(|| {
+        PdfError::InvalidStructure("cross-reference offset is outside the PDF".to_string())
+    })?;
+    let tail = tail
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .and_then(|index| tail.get(index..))
+        .ok_or_else(|| PdfError::InvalidStructure("empty cross-reference section".to_string()))?;
+    Ok(if tail.starts_with(b"xref") {
+        XrefKind::Table
+    } else {
+        XrefKind::Stream
+    })
 }
 
 fn write_indirect_object(
@@ -260,6 +310,106 @@ fn partial_xref(changed: &[(u32, u16, u64)]) -> Vec<u8> {
         index = end + 1;
     }
     out
+}
+
+fn write_xref_stream(
+    out: &mut Vec<u8>,
+    object_number: u32,
+    changed: &[(u32, u16, u64)],
+    previous_xref: u64,
+    root: (u32, u16),
+    size: u32,
+    id_pair: Option<(Vec<u8>, Vec<u8>)>,
+) -> Result<()> {
+    let mut sorted = changed.to_vec();
+    sorted.sort_by_key(|entry| entry.0);
+    let ranges = xref_ranges(&sorted);
+    let mut data = Vec::with_capacity(sorted.len() * 11);
+    for (_, generation, offset) in &sorted {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&generation.to_be_bytes());
+    }
+
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("XRef".to_string())),
+    );
+    dictionary.insert("Size".to_string(), PdfObject::Integer(i64::from(size)));
+    dictionary.insert("Root".to_string(), PdfObject::Reference(root.0, root.1));
+    dictionary.insert(
+        "Prev".to_string(),
+        PdfObject::Integer(i64::try_from(previous_xref).map_err(|_| {
+            PdfError::InvalidStructure("previous xref offset exceeds PDF integer range".to_string())
+        })?),
+    );
+    dictionary.insert(
+        "W".to_string(),
+        PdfObject::Array(crate::parser::objects::PdfArray(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(8),
+            PdfObject::Integer(2),
+        ])),
+    );
+    dictionary.insert(
+        "Index".to_string(),
+        PdfObject::Array(crate::parser::objects::PdfArray(
+            ranges
+                .iter()
+                .flat_map(|(first, count)| {
+                    [
+                        PdfObject::Integer(i64::from(*first)),
+                        PdfObject::Integer(i64::from(*count)),
+                    ]
+                })
+                .collect(),
+        )),
+    );
+    dictionary.insert(
+        "Length".to_string(),
+        PdfObject::Integer(
+            i64::try_from(data.len())
+                .map_err(|_| PdfError::InvalidStructure("xref stream is too large".to_string()))?,
+        ),
+    );
+    if let Some((first, second)) = id_pair {
+        dictionary.insert(
+            "ID".to_string(),
+            PdfObject::Array(crate::parser::objects::PdfArray(vec![
+                PdfObject::String(PdfString(first)),
+                PdfObject::String(PdfString(second)),
+            ])),
+        );
+    }
+
+    out.extend_from_slice(format!("{object_number} 0 obj\n").as_bytes());
+    write_dictionary(out, &dictionary)?;
+    out.extend_from_slice(b"\nstream\n");
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    let xref_position = sorted
+        .iter()
+        .find(|entry| entry.0 == object_number)
+        .map(|entry| entry.2)
+        .ok_or_else(|| PdfError::InvalidStructure("xref stream has no self entry".to_string()))?;
+    out.extend_from_slice(format!("startxref\n{xref_position}\n%%EOF\n").as_bytes());
+    Ok(())
+}
+
+fn xref_ranges(changed: &[(u32, u16, u64)]) -> Vec<(u32, u32)> {
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    while index < changed.len() {
+        let first = changed[index].0;
+        let mut end = index;
+        while end + 1 < changed.len() && changed[end + 1].0 == changed[end].0 + 1 {
+            end += 1;
+        }
+        ranges.push((first, (end - index + 1) as u32));
+        index = end + 1;
+    }
+    ranges
 }
 
 fn write_trailer(

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -1,7 +1,9 @@
 //! PDF writing functionality
 
 mod content_stream_utils;
+mod incremental_annotations;
 mod incremental_form_fill;
+mod incremental_highlights;
 mod incremental_text_notes;
 mod incremental_update;
 mod object_streams;
@@ -14,6 +16,10 @@ pub(crate) use content_stream_utils::{
     apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
 };
 pub use incremental_form_fill::IncrementalFormFiller;
+pub use incremental_highlights::{
+    Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
+    HighlightUpdate, IncrementalHighlightEditor,
+};
 pub use incremental_text_notes::{
     IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,
 };

--- a/oxidize-pdf-core/tests/issue_525_incremental_highlights_test.rs
+++ b/oxidize-pdf-core/tests/issue_525_incremental_highlights_test.rs
@@ -12,10 +12,11 @@ fn classic_base() -> Vec<u8> {
     build_classic(&[
         (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
         (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
-        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R 6 0 R] /CustomPageKey 42 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R 6 0 R 7 0 R] /CustomPageKey 42 >>"),
         (4, b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 90 30] /QuadPoints [10 30 90 30 10 10 90 10] /C [1 1 0] /CA 0.5 /Contents (old) /CustomHighlightKey /Keep >>"),
         (5, b"<< /Type /Annot /Subtype /Link /Rect [0 0 5 5] /CustomLinkKey 99 >>"),
         (6, b"<< /Type /Annot /Subtype /Text /Rect [100 100 120 120] /Contents (note) >>"),
+        (7, b"<< /Type /Annot /Subtype /VendorMarkup /Rect [130 130 150 150] /VendorKey (preserve) >>"),
     ])
 }
 
@@ -176,6 +177,10 @@ fn reads_adds_multiline_and_removes_highlights_without_touching_other_annotation
         .0
         .iter()
         .any(|item| item.as_reference() == Some((6, 0))));
+    assert!(annots
+        .0
+        .iter()
+        .any(|item| item.as_reference() == Some((7, 0))));
     assert_eq!(
         document
             .get_object(5, 0)
@@ -184,6 +189,17 @@ fn reads_adds_multiline_and_removes_highlights_without_touching_other_annotation
             .unwrap()
             .get("CustomLinkKey"),
         Some(&PdfObject::Integer(99))
+    );
+    assert_eq!(
+        document
+            .get_object(7, 0)
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .get("VendorKey")
+            .and_then(PdfObject::as_string)
+            .map(|value| value.to_text()),
+        Some("preserve".to_string())
     );
 }
 
@@ -290,6 +306,38 @@ fn reads_all_pages_indirect_annots_and_nonzero_generations() {
         .unwrap();
     assert_eq!(update.highlights.len(), 1);
     assert_eq!(update.highlights[0].id, HighlightId::new(6, 2));
+
+    let added = IncrementalHighlightEditor::new(&base)
+        .apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(100.0, 100.0, 180.0, 120.0)],
+            color: color([1.0, 0.5, 0.0]),
+            opacity: None,
+            contents: Some("indirect array".to_string()),
+        }])
+        .unwrap();
+    let reader = PdfReader::new(Cursor::new(&added.pdf_bytes)).unwrap();
+    let document = PdfDocument::new(reader);
+    let page = document.get_page(0).unwrap();
+    assert_eq!(
+        page.dict.get("Annots").and_then(PdfObject::as_reference),
+        Some((7, 0))
+    );
+    let annots_object = document.get_object(7, 0).unwrap();
+    let annots = annots_object.as_array().unwrap();
+    assert!(annots
+        .0
+        .iter()
+        .any(|value| value.as_reference() == Some((5, 1))));
+    let new_id = added
+        .highlights
+        .iter()
+        .find(|highlight| highlight.contents.as_deref() == Some("indirect array"))
+        .unwrap()
+        .id;
+    assert!(annots.0.iter().any(|value| {
+        value.as_reference() == Some((new_id.object_number, new_id.generation_number))
+    }));
 }
 
 #[test]
@@ -380,6 +428,32 @@ fn rejects_malformed_inline_and_encrypted_documents() {
         IncrementalHighlightEditor::new(&malformed_contents).highlights(),
         "/Contents must be a string",
     );
+
+    for (body, expected) in [
+        (
+            b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 20] /QuadPoints [10 20 20 20 10 10 20 10] /C [1 1 0] >>".as_slice(),
+            "/Rect has the wrong number",
+        ),
+        (
+            b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 20 20] /QuadPoints [10 20 20 20 10 10 20 10] /C [1.5 1 0] >>".as_slice(),
+            "between 0 and 1",
+        ),
+        (
+            b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 20 20] /QuadPoints [10 20 20 20 10 10 20 10] /C [1 1 0] /CA -0.1 >>".as_slice(),
+            "between 0 and 1",
+        ),
+    ] {
+        let malformed_property = build_classic(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+            (4, body),
+        ]);
+        assert_invalid_contains(
+            IncrementalHighlightEditor::new(&malformed_property).highlights(),
+            expected,
+        );
+    }
 
     let inline = build_classic(&[
         (1, b"<< /Type /Catalog /Pages 2 0 R >>"),

--- a/oxidize-pdf-core/tests/issue_525_incremental_highlights_test.rs
+++ b/oxidize-pdf-core/tests/issue_525_incremental_highlights_test.rs
@@ -1,0 +1,433 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfDocument, PdfReader};
+use oxidize_pdf::writer::{
+    HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
+    IncrementalHighlightEditor,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn classic_base() -> Vec<u8> {
+    build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R 6 0 R] /CustomPageKey 42 >>"),
+        (4, b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 90 30] /QuadPoints [10 30 90 30 10 10 90 10] /C [1 1 0] /CA 0.5 /Contents (old) /CustomHighlightKey /Keep >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [0 0 5 5] /CustomLinkKey 99 >>"),
+        (6, b"<< /Type /Annot /Subtype /Text /Rect [100 100 120 120] /Contents (note) >>"),
+    ])
+}
+
+fn build_classic(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let with_generations: Vec<_> = objects
+        .iter()
+        .map(|(number, body)| (*number, 0, *body))
+        .collect();
+    build_classic_generations(&with_generations)
+}
+
+fn build_classic_generations(objects: &[(u32, u16, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[*number as usize] = Some((out.len(), *generation));
+        out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => out.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn assert_invalid_contains<T>(result: Result<T, PdfError>, expected: &str) {
+    match result {
+        Err(PdfError::InvalidStructure(message)) => assert!(
+            message.contains(expected),
+            "expected {expected:?} in {message:?}"
+        ),
+        Err(other) => panic!("expected InvalidStructure, got {other:?}"),
+        Ok(_) => panic!("expected InvalidStructure containing {expected:?}"),
+    }
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = Vec::new();
+    data.extend_from_slice(&[0, 0, 0, 0, 0, 0xFF, 0xFF]);
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn quad(left: f64, bottom: f64, right: f64, top: f64) -> HighlightQuad {
+    HighlightQuad::new([
+        Point::new(left, top),
+        Point::new(right, top),
+        Point::new(left, bottom),
+        Point::new(right, bottom),
+    ])
+    .unwrap()
+}
+
+fn color(components: [f64; 3]) -> HighlightColor {
+    HighlightColor::new(components).unwrap()
+}
+
+fn opacity(value: f64) -> HighlightOpacity {
+    HighlightOpacity::new(value).unwrap()
+}
+
+#[test]
+fn reads_adds_multiline_and_removes_highlights_without_touching_other_annotations() {
+    let base = classic_base();
+    let editor = IncrementalHighlightEditor::new(&base);
+    let existing = editor.highlights().unwrap();
+    assert_eq!(existing.len(), 1);
+    assert_eq!(existing[0].id, HighlightId::new(4, 0));
+    assert_eq!(existing[0].opacity, Some(opacity(0.5)));
+
+    let update = editor
+        .apply(&[
+            HighlightMutation::Remove {
+                id: HighlightId::new(4, 0),
+            },
+            HighlightMutation::Add {
+                page_index: 0,
+                quadrilaterals: vec![
+                    quad(20.0, 180.0, 120.0, 200.0),
+                    quad(20.0, 150.0, 80.0, 170.0),
+                ],
+                color: color([1.0, 0.8, 0.0]),
+                opacity: Some(opacity(0.75)),
+                contents: Some("two lines ✓".to_string()),
+            },
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert_eq!(update.highlights.len(), 1);
+    assert_eq!(update.highlights[0].quadrilaterals.len(), 2);
+    assert_eq!(
+        update.highlights[0].contents.as_deref(),
+        Some("two lines ✓")
+    );
+    let reopened = IncrementalHighlightEditor::new(&update.pdf_bytes)
+        .highlights()
+        .unwrap();
+    assert_eq!(reopened, update.highlights);
+    let reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let document = PdfDocument::new(reader);
+    let page = document.get_page(0).unwrap();
+    assert_eq!(
+        page.dict.get("CustomPageKey"),
+        Some(&PdfObject::Integer(42))
+    );
+    let annots = page
+        .dict
+        .get("Annots")
+        .and_then(PdfObject::as_array)
+        .unwrap();
+    assert!(annots
+        .0
+        .iter()
+        .any(|item| item.as_reference() == Some((5, 0))));
+    assert!(annots
+        .0
+        .iter()
+        .any(|item| item.as_reference() == Some((6, 0))));
+    assert_eq!(
+        document
+            .get_object(5, 0)
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .get("CustomLinkKey"),
+        Some(&PdfObject::Integer(99))
+    );
+}
+
+#[test]
+fn repeated_updates_preserve_xref_stream_revisions() {
+    let base = xref_stream_base();
+    let first = IncrementalHighlightEditor::new(&base)
+        .apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(10.0, 10.0, 100.0, 30.0)],
+            color: color([1.0, 1.0, 0.0]),
+            opacity: None,
+            contents: None,
+        }])
+        .unwrap();
+    let second = IncrementalHighlightEditor::new(&first.pdf_bytes)
+        .apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(10.0, 40.0, 100.0, 60.0)],
+            color: color([0.0, 1.0, 0.0]),
+            opacity: Some(opacity(0.4)),
+            contents: Some("second".to_string()),
+        }])
+        .unwrap();
+    assert!(first.pdf_bytes.starts_with(&base));
+    assert!(second.pdf_bytes.starts_with(&first.pdf_bytes));
+    assert_eq!(second.highlights.len(), 2);
+    assert_eq!(
+        second
+            .pdf_bytes
+            .windows(11)
+            .filter(|w| *w == b"/Type /XRef")
+            .count(),
+        3
+    );
+}
+
+#[test]
+fn repeated_updates_preserve_classic_xref_revisions() {
+    let base = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+        ),
+    ]);
+    let first = IncrementalHighlightEditor::new(&base)
+        .apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(10.0, 10.0, 80.0, 30.0)],
+            color: color([1.0, 1.0, 0.0]),
+            opacity: None,
+            contents: None,
+        }])
+        .unwrap();
+    let second = IncrementalHighlightEditor::new(&first.pdf_bytes)
+        .apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(10.0, 40.0, 80.0, 60.0)],
+            color: color([0.0, 1.0, 0.0]),
+            opacity: None,
+            contents: None,
+        }])
+        .unwrap();
+    assert_eq!(second.highlights.len(), 2);
+    assert_eq!(
+        second
+            .pdf_bytes
+            .windows(6)
+            .filter(|window| *window == b"\nxref\n")
+            .count(),
+        3
+    );
+    assert!(!second
+        .pdf_bytes
+        .windows(11)
+        .any(|window| window == b"/Type /XRef"));
+}
+
+#[test]
+fn reads_all_pages_indirect_annots_and_nonzero_generations() {
+    let base = build_classic_generations(&[
+        (1, 0, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, 0, b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>"),
+        (3, 0, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 7 0 R >>"),
+        (4, 0, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 8 0 R >>"),
+        (5, 1, b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 80 30] /QuadPoints [10 30 80 30 10 10 80 10] /C [1 1 0] >>"),
+        (6, 2, b"<< /Type /Annot /Subtype /Highlight /Rect [20 20 90 40] /QuadPoints [20 40 90 40 20 20 90 20] /C [0 1 0] >>"),
+        (7, 0, b"[5 1 R]"),
+        (8, 0, b"[6 2 R]"),
+    ]);
+    let highlights = IncrementalHighlightEditor::new(&base).highlights().unwrap();
+    assert_eq!(highlights.len(), 2);
+    assert_eq!(highlights[0].id, HighlightId::new(5, 1));
+    assert_eq!(highlights[0].page_index, 0);
+    assert_eq!(highlights[1].id, HighlightId::new(6, 2));
+    assert_eq!(highlights[1].page_index, 1);
+
+    let update = IncrementalHighlightEditor::new(&base)
+        .apply(&[HighlightMutation::Remove {
+            id: HighlightId::new(5, 1),
+        }])
+        .unwrap();
+    assert_eq!(update.highlights.len(), 1);
+    assert_eq!(update.highlights[0].id, HighlightId::new(6, 2));
+}
+
+#[test]
+fn rejects_invalid_geometry_color_page_and_identity_atomically() {
+    let base = classic_base();
+    let editor = IncrementalHighlightEditor::new(&base);
+    assert_invalid_contains(
+        editor.apply(&[HighlightMutation::Add {
+            page_index: 99,
+            quadrilaterals: vec![quad(1.0, 1.0, 2.0, 2.0)],
+            color: color([1.0; 3]),
+            opacity: None,
+            contents: None,
+        }]),
+        "page 99",
+    );
+    assert_invalid_contains(
+        editor.apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: Vec::new(),
+            color: color([1.0; 3]),
+            opacity: None,
+            contents: None,
+        }]),
+        "at least one",
+    );
+    assert_invalid_contains(
+        editor.apply(&[HighlightMutation::Add {
+            page_index: 0,
+            quadrilaterals: vec![quad(250.0, 250.0, 350.0, 280.0)],
+            color: color([1.0; 3]),
+            opacity: None,
+            contents: None,
+        }]),
+        "outside",
+    );
+    assert_invalid_contains(
+        editor.apply(&[HighlightMutation::Remove {
+            id: HighlightId::new(999, 0),
+        }]),
+        "does not exist",
+    );
+    assert_invalid_contains(
+        editor.apply(&[
+            HighlightMutation::Remove {
+                id: HighlightId::new(4, 0),
+            },
+            HighlightMutation::Remove {
+                id: HighlightId::new(4, 0),
+            },
+        ]),
+        "more than once",
+    );
+    assert!(HighlightColor::new([1.2, 0.0, 0.0]).is_err());
+    assert!(HighlightColor::new([f64::NAN, 0.0, 0.0]).is_err());
+    assert!(HighlightOpacity::new(-0.1).is_err());
+    assert!(HighlightQuad::new([Point::new(1.0, 1.0); 4]).is_err());
+}
+
+#[test]
+fn empty_batch_is_a_true_noop() {
+    let base = classic_base();
+    let update = IncrementalHighlightEditor::new(&base).apply(&[]).unwrap();
+    assert_eq!(update.pdf_bytes, base);
+    assert_eq!(update.highlights.len(), 1);
+}
+
+#[test]
+fn rejects_malformed_inline_and_encrypted_documents() {
+    let malformed = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 20 20] /QuadPoints [10 20] /C [1 1 0] >>"),
+    ]);
+    assert!(matches!(
+        IncrementalHighlightEditor::new(&malformed).highlights(),
+        Err(PdfError::InvalidStructure(_))
+    ));
+
+    let malformed_contents = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /Highlight /Rect [10 10 20 20] /QuadPoints [10 20 20 20 10 10 20 10] /C [1 1 0] /Contents 42 >>"),
+    ]);
+    assert_invalid_contains(
+        IncrementalHighlightEditor::new(&malformed_contents).highlights(),
+        "/Contents must be a string",
+    );
+
+    let inline = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /Highlight /Rect [10 10 20 20] /QuadPoints [10 20 20 20 10 10 20 10] /C [1 1 0] >>] >>"),
+    ]);
+    assert!(matches!(
+        IncrementalHighlightEditor::new(&inline).highlights(),
+        Err(PdfError::InvalidStructure(_))
+    ));
+
+    let mut encrypted = Document::new();
+    encrypted.add_page(Page::a4());
+    encrypted.encrypt_with_passwords("user", "owner");
+    let encrypted = encrypted.to_bytes().unwrap();
+    assert!(IncrementalHighlightEditor::new(&encrypted)
+        .highlights()
+        .is_err());
+    assert!(IncrementalHighlightEditor::new(&encrypted)
+        .apply(&[])
+        .is_err());
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_highlight_revisions() {
+    for (name, base) in [("classic", classic_base()), ("stream", xref_stream_base())] {
+        let update = IncrementalHighlightEditor::new(&base)
+            .apply(&[HighlightMutation::Add {
+                page_index: 0,
+                quadrilaterals: vec![quad(10.0, 40.0, 100.0, 60.0)],
+                color: color([1.0, 1.0, 0.0]),
+                opacity: Some(opacity(0.5)),
+                contents: Some("interop".to_string()),
+            }])
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, &update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add incremental reading, insertion, and removal of standard PDF highlight annotations
- preserve unrelated annotations, indirect annotation arrays, and classic/xref-stream revisions
- share annotation discovery with incremental text-note editing
- validate geometry, colors, opacity, identities, malformed inputs, and encrypted documents
- run qpdf interoperability coverage in CI

## Validation
- cargo fmt --all -- --check
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- cargo clippy -p oxidize-pdf --test issue_525_incremental_highlights_test -- -D warnings
- cargo test -p oxidize-pdf --test issue_525_incremental_highlights_test
- cargo test -p oxidize-pdf --test issue_525_incremental_highlights_test qpdf_accepts_classic_and_xref_stream_highlight_revisions -- --ignored --exact
- cargo test -p oxidize-pdf --test issue_493_incremental_text_notes_test
- cargo test -p oxidize-pdf --lib
- Kripteia test quality: 96/100
- Kripteia security: no findings

Closes #525