### PR TITLE
chore(release): prepare v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.7.0] - 2026-08-25
+
+### Added
+
+- **Incremental editing for highlight annotations** (#525, #527). The new
+  `IncrementalHighlightEditor` API can enumerate, add, update, and remove
+  `/Highlight` annotations while preserving the original PDF bytes and
+  applying validated changes as incremental revisions.
+
 ### Fixed
 
-- **`merge_close_fragments` rejected a contiguous pair of same-line
-  fragments due to floating-point rounding noise in the merge-gap check**
-  (issue #521 follow-up). Two runs positioned back-to-back with no
-  repositioning operator between them (e.g. successive `Tj` calls) have a
-  gap that is mathematically zero, but the run's end position and the next
-  run's declared start position are computed via independent
-  floating-point paths that are not always bit-identical — a `-1e-13`-class
-  negative residue on an otherwise touching pair failed the `x_gap >= 0.0`
-  check and left the pair as two separate fragments instead of merging them
-  into one. The check now tolerates a small negative epsilon
-  (`x_gap >= -TOUCHING_EPS`) without loosening it enough to treat a real,
-  visible overlap as adjacent.
+- **Standard-14 fonts without explicit `/Widths` used inaccurate fallback
+  advances during text extraction** (#523, #524). Encoding-aware AFM metrics
+  now provide per-glyph widths for simple Standard-14 fonts, preventing
+  spurious spaces when text is split across consecutive showing operators.
+- **CMS signature verification could accept certificates without establishing
+  trust in the configured anchors** (#526, #528). Trust validation now fails
+  closed while preserving the existing public verification API.
+- **Floating-point residue could keep mathematically contiguous text fragments
+  separate** (#521, #522). Same-line merging now tolerates rounding noise
+  without treating visible overlaps as adjacent or inserting a spurious space.
 
 ## [4.6.0] - 2026-08-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.6.0"
+version = "4.7.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.6.0"
+version = "4.7.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]


### PR DESCRIPTION
## Release preparation

Reintegrates the v4.7.0 release metadata into develop after the release branch was cut.

- Bumps the workspace and lockfile version to 4.7.0.
- Moves the accumulated changes into the 4.7.0 CHANGELOG section.

This is the Git Flow release merge-back into develop.