### PR TITLE
feat(operations): add lossless incremental page reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+### Added
+
+- **Lossless incremental page reordering** (#531). The new
+  `reorder_pdf_pages_lossless` API preserves the source bytes, indirect page
+  identities, inherited page attributes, and unrelated document objects while
+  atomically applying an exact page permutation. Encrypted and signed inputs
+  fail closed pending DocMDP permission support in #532.
+
 ## [4.7.0] - 2026-08-25
 
 ### Added

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -303,8 +303,8 @@ pub use parser::{
 // Re-export operations
 pub use operations::{
     extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page, overlay_pdf,
-    reorder_pdf_pages, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
-    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
+    reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf,
+    swap_pdf_pages, ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
     ImageExtractionLimits, ImageExtractionResult, ImageExtractor, OverlayOptions, OverlayPosition,
     ReorderOptions,
 };

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -31,8 +31,8 @@ pub use page_extraction::{
 };
 pub use pdf_ocr_converter::{ConversionOptions, ConversionResult, PdfOcrConverter};
 pub use reorder::{
-    move_pdf_page, reorder_pdf_pages, reverse_pdf_pages, swap_pdf_pages, PageReorderer,
-    ReorderOptions,
+    move_pdf_page, reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages,
+    swap_pdf_pages, PageReorderer, ReorderOptions,
 };
 pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions, RotationAngle};
 pub use semantic_redactor::{

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -11,7 +11,7 @@ use crate::writer::IncrementalUpdate;
 use crate::{Document, Page};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 const INHERITABLE_PAGE_KEYS: [&str; 4] = ["Resources", "MediaBox", "CropBox", "Rotate"];
@@ -23,6 +23,13 @@ struct LosslessPage {
     reference: (u32, u16),
     dictionary: PdfDictionary,
     effective_inherited: HashMap<&'static str, PdfObject>,
+}
+
+#[derive(Debug)]
+struct LosslessValidation {
+    root_reference: (u32, u16),
+    catalog: PdfDictionary,
+    pages: Vec<((u32, u16), HashMap<&'static str, PdfObject>)>,
 }
 
 /// Options for page reordering
@@ -184,8 +191,8 @@ pub fn reorder_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
     page_order: &[usize],
 ) -> OperationResult<()> {
     let base = std::fs::read(input_path)?;
-    let (updated, expected_order) = reorder_pdf_bytes_lossless(&base, page_order)?;
-    validate_lossless_output(&base, &updated, &expected_order)?;
+    let (updated, expected) = reorder_pdf_bytes_lossless(&base, page_order)?;
+    validate_lossless_output(&base, &updated, &expected)?;
 
     let output_path = output_path.as_ref();
     let parent = output_path
@@ -196,9 +203,7 @@ pub fn reorder_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
     temporary.flush()?;
     temporary.as_file().sync_all()?;
 
-    let mut persisted_bytes = Vec::with_capacity(updated.len());
-    File::open(temporary.path())?.read_to_end(&mut persisted_bytes)?;
-    validate_lossless_output(&base, &persisted_bytes, &expected_order)?;
+    validate_lossless_file(&base, temporary.path(), &expected)?;
 
     temporary
         .persist(output_path)
@@ -209,7 +214,7 @@ pub fn reorder_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
 fn reorder_pdf_bytes_lossless(
     base: &[u8],
     page_order: &[usize],
-) -> Result<(Vec<u8>, Vec<(u32, u16)>), PdfError> {
+) -> Result<(Vec<u8>, LosslessValidation), PdfError> {
     let mut reader = PdfReader::new(Cursor::new(base))
         .map_err(|error| invalid_lossless(format!("parse source PDF: {error}")))?;
     if reader.is_encrypted() {
@@ -248,6 +253,7 @@ fn reorder_pdf_bytes_lossless(
         .iter()
         .map(|index| pages[*index].reference)
         .collect();
+    let root_inherited = inherited_values(&root_dictionary);
     let mut root_replacement = root_dictionary;
     root_replacement.insert(
         "Kids".to_string(),
@@ -262,19 +268,51 @@ fn reorder_pdf_bytes_lossless(
 
     let mut update = IncrementalUpdate::from_base(base)?;
     update.replace(root_reference, PdfObject::Dictionary(root_replacement))?;
+    let mut validation_pages = Vec::with_capacity(pages.len());
     for page in pages {
         let mut dictionary = page.dictionary;
-        dictionary.insert(
-            "Parent".to_string(),
-            PdfObject::Reference(root_reference.0, root_reference.1),
-        );
-        for (key, value) in page.effective_inherited {
-            dictionary.insert(key.to_string(), value);
+        let mut changed =
+            dictionary.get("Parent").and_then(PdfObject::as_reference) != Some(root_reference);
+        if changed {
+            dictionary.insert(
+                "Parent".to_string(),
+                PdfObject::Reference(root_reference.0, root_reference.1),
+            );
         }
-        update.replace(page.reference, PdfObject::Dictionary(dictionary))?;
+        for (key, value) in &page.effective_inherited {
+            if dictionary.contains_key(key) {
+                continue;
+            }
+            if root_inherited.get(key) != Some(value) {
+                dictionary.insert((*key).to_string(), value.clone());
+                changed = true;
+            }
+        }
+        validation_pages.push((page.reference, page.effective_inherited));
+        if changed {
+            update.replace(page.reference, PdfObject::Dictionary(dictionary))?;
+        }
     }
     let updated = update.finish()?;
-    Ok((updated, expected_order))
+    let ordered_pages = page_order
+        .iter()
+        .map(|index| validation_pages[*index].clone())
+        .collect();
+    Ok((
+        updated,
+        LosslessValidation {
+            root_reference,
+            catalog,
+            pages: ordered_pages,
+        },
+    ))
+}
+
+fn inherited_values(dictionary: &PdfDictionary) -> HashMap<&'static str, PdfObject> {
+    INHERITABLE_PAGE_KEYS
+        .into_iter()
+        .filter_map(|key| dictionary.get(key).cloned().map(|value| (key, value)))
+        .collect()
 }
 
 fn walk_page_tree<R: Read + std::io::Seek>(
@@ -532,36 +570,84 @@ fn object_contains_signature(object: &PdfObject, depth: usize) -> Result<bool, P
 fn validate_lossless_output(
     base: &[u8],
     updated: &[u8],
-    expected_order: &[(u32, u16)],
+    expected: &LosslessValidation,
 ) -> OperationResult<()> {
     if !updated.starts_with(base) {
         return Err(OperationError::ProcessingError(
             "incremental output does not preserve the source bytes as an exact prefix".to_string(),
         ));
     }
-    let document = PdfReader::new(Cursor::new(updated))
-        .map_err(|error| OperationError::ParseError(format!("reopen output PDF: {error}")))?
-        .into_document();
-    let count = document.page_count().map_err(|error| {
-        OperationError::ParseError(format!("validate output page tree: {error}"))
-    })? as usize;
-    if count != expected_order.len() {
+    let reader = PdfReader::new(Cursor::new(updated))
+        .map_err(|error| OperationError::ParseError(format!("reopen output PDF: {error}")))?;
+    validate_lossless_reader(reader, expected)
+}
+
+fn validate_lossless_file(
+    base: &[u8],
+    path: &Path,
+    expected: &LosslessValidation,
+) -> OperationResult<()> {
+    let mut file = File::open(path)?;
+    let mut chunk = [0u8; 64 * 1024];
+    for expected_chunk in base.chunks(chunk.len()) {
+        file.read_exact(&mut chunk[..expected_chunk.len()])?;
+        if &chunk[..expected_chunk.len()] != expected_chunk {
+            return Err(OperationError::ProcessingError(
+                "temporary output does not preserve the source bytes as an exact prefix"
+                    .to_string(),
+            ));
+        }
+    }
+    file.seek(SeekFrom::Start(0))?;
+    let reader = PdfReader::new(file)
+        .map_err(|error| OperationError::ParseError(format!("reopen temporary PDF: {error}")))?;
+    validate_lossless_reader(reader, expected)
+}
+
+fn validate_lossless_reader<R: Read + Seek>(
+    mut reader: PdfReader<R>,
+    expected: &LosslessValidation,
+) -> OperationResult<()> {
+    let catalog = reader
+        .catalog()
+        .map_err(|error| OperationError::ParseError(format!("validate output catalog: {error}")))?;
+    if catalog != &expected.catalog {
+        return Err(OperationError::ProcessingError(
+            "output catalog differs from the source catalog".to_string(),
+        ));
+    }
+
+    let mut actual_pages = Vec::new();
+    let mut visited = HashSet::new();
+    walk_page_tree(
+        &mut reader,
+        expected.root_reference,
+        None,
+        HashMap::new(),
+        &mut visited,
+        &mut actual_pages,
+        0,
+    )
+    .map_err(|error| OperationError::ParseError(format!("validate output page tree: {error}")))?;
+    if actual_pages.len() != expected.pages.len() {
         return Err(OperationError::ProcessingError(format!(
-            "output contains {count} pages, expected {}",
-            expected_order.len()
+            "output contains {} pages, expected {}",
+            actual_pages.len(),
+            expected.pages.len()
         )));
     }
-    for (index, expected) in expected_order.iter().enumerate() {
-        let actual = document
-            .get_page(index as u32)
-            .map_err(|error| {
-                OperationError::ParseError(format!("validate output page {index}: {error}"))
-            })?
-            .obj_ref;
-        if actual != *expected {
+    for (index, (actual, (expected_reference, expected_inherited))) in
+        actual_pages.iter().zip(&expected.pages).enumerate()
+    {
+        if actual.reference != *expected_reference {
             return Err(OperationError::ProcessingError(format!(
                 "output page {index} references {} {} R, expected {} {} R",
-                actual.0, actual.1, expected.0, expected.1
+                actual.reference.0, actual.reference.1, expected_reference.0, expected_reference.1
+            )));
+        }
+        if &actual.effective_inherited != expected_inherited {
+            return Err(OperationError::ProcessingError(format!(
+                "output page {index} does not preserve its effective inherited attributes"
             )));
         }
     }

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -3,11 +3,27 @@
 //! This module provides functionality to reorder pages within a PDF document.
 
 use super::{OperationError, OperationResult};
+use crate::error::PdfError;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfObject};
 use crate::parser::page_tree::ParsedPage;
 use crate::parser::{PdfDocument, PdfReader};
+use crate::writer::IncrementalUpdate;
 use crate::{Document, Page};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
+
+const INHERITABLE_PAGE_KEYS: [&str; 4] = ["Resources", "MediaBox", "CropBox", "Rotate"];
+const MAX_PAGE_TREE_DEPTH: usize = 256;
+const MAX_PAGE_COUNT: usize = 100_000;
+
+#[derive(Debug)]
+struct LosslessPage {
+    reference: (u32, u16),
+    dictionary: PdfDictionary,
+    effective_inherited: HashMap<&'static str, PdfObject>,
+}
 
 /// Options for page reordering
 #[derive(Debug, Clone)]
@@ -154,6 +170,406 @@ pub fn reorder_pdf_pages<P: AsRef<Path>, Q: AsRef<Path>>(
 
     let reorderer = PageReorderer::new(document, options);
     reorderer.reorder_to_file(output_path)
+}
+
+/// Reorder every page as one lossless incremental revision.
+///
+/// Unlike [`reorder_pdf_pages`], this API retains the original bytes and
+/// indirect page identities. The order must be an exact permutation of all
+/// source pages. Encrypted and signed inputs are rejected until their security
+/// policies can be enforced safely.
+pub fn reorder_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
+    input_path: P,
+    output_path: Q,
+    page_order: &[usize],
+) -> OperationResult<()> {
+    let base = std::fs::read(input_path)?;
+    let (updated, expected_order) = reorder_pdf_bytes_lossless(&base, page_order)?;
+    validate_lossless_output(&base, &updated, &expected_order)?;
+
+    let output_path = output_path.as_ref();
+    let parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty());
+    let mut temporary = tempfile::NamedTempFile::new_in(parent.unwrap_or_else(|| Path::new(".")))?;
+    temporary.write_all(&updated)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+
+    let mut persisted_bytes = Vec::with_capacity(updated.len());
+    File::open(temporary.path())?.read_to_end(&mut persisted_bytes)?;
+    validate_lossless_output(&base, &persisted_bytes, &expected_order)?;
+
+    temporary
+        .persist(output_path)
+        .map_err(|error| OperationError::Io(error.error))?;
+    Ok(())
+}
+
+fn reorder_pdf_bytes_lossless(
+    base: &[u8],
+    page_order: &[usize],
+) -> Result<(Vec<u8>, Vec<(u32, u16)>), PdfError> {
+    let mut reader = PdfReader::new(Cursor::new(base))
+        .map_err(|error| invalid_lossless(format!("parse source PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "lossless page reordering does not support encrypted PDFs".to_string(),
+        ));
+    }
+
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read document catalog: {error}")))?
+        .clone();
+    reject_signed_document(&mut reader, &catalog)?;
+
+    let root_reference = catalog
+        .get("Pages")
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid_lossless("catalog /Pages must be an indirect reference"))?;
+    let root_dictionary = object_dictionary(&mut reader, root_reference, "page-tree root")?;
+
+    let mut pages = Vec::new();
+    let mut visited = HashSet::new();
+    let inherited = HashMap::new();
+    walk_page_tree(
+        &mut reader,
+        root_reference,
+        None,
+        inherited,
+        &mut visited,
+        &mut pages,
+        0,
+    )?;
+    validate_exact_permutation(page_order, pages.len())?;
+
+    let expected_order: Vec<_> = page_order
+        .iter()
+        .map(|index| pages[*index].reference)
+        .collect();
+    let mut root_replacement = root_dictionary;
+    root_replacement.insert(
+        "Kids".to_string(),
+        PdfObject::Array(PdfArray(
+            expected_order
+                .iter()
+                .map(|(number, generation)| PdfObject::Reference(*number, *generation))
+                .collect(),
+        )),
+    );
+    root_replacement.insert("Count".to_string(), PdfObject::Integer(pages.len() as i64));
+
+    let mut update = IncrementalUpdate::from_base(base)?;
+    update.replace(root_reference, PdfObject::Dictionary(root_replacement))?;
+    for page in pages {
+        let mut dictionary = page.dictionary;
+        dictionary.insert(
+            "Parent".to_string(),
+            PdfObject::Reference(root_reference.0, root_reference.1),
+        );
+        for (key, value) in page.effective_inherited {
+            dictionary.insert(key.to_string(), value);
+        }
+        update.replace(page.reference, PdfObject::Dictionary(dictionary))?;
+    }
+    let updated = update.finish()?;
+    Ok((updated, expected_order))
+}
+
+fn walk_page_tree<R: Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+    node_reference: (u32, u16),
+    expected_parent: Option<(u32, u16)>,
+    inherited: HashMap<&'static str, PdfObject>,
+    visited: &mut HashSet<(u32, u16)>,
+    pages: &mut Vec<LosslessPage>,
+    depth: usize,
+) -> Result<usize, PdfError> {
+    if depth > MAX_PAGE_TREE_DEPTH {
+        return Err(invalid_lossless("page tree exceeds the supported depth"));
+    }
+    if !visited.insert(node_reference) {
+        return Err(invalid_lossless(format!(
+            "page tree contains a cycle or duplicate reference at {} {} R",
+            node_reference.0, node_reference.1
+        )));
+    }
+    let dictionary = object_dictionary(reader, node_reference, "page-tree node")?;
+    if let Some(parent) = expected_parent {
+        if dictionary.get("Parent").and_then(PdfObject::as_reference) != Some(parent) {
+            return Err(invalid_lossless(format!(
+                "page-tree node {} {} R has an inconsistent /Parent",
+                node_reference.0, node_reference.1
+            )));
+        }
+    } else if dictionary.contains_key("Parent") {
+        return Err(invalid_lossless(
+            "the root /Pages node must not have a /Parent",
+        ));
+    }
+
+    match dictionary.get_type() {
+        Some("Page") => {
+            if pages.len() >= MAX_PAGE_COUNT {
+                return Err(invalid_lossless(
+                    "page tree exceeds the supported page count",
+                ));
+            }
+            let mut effective_inherited = inherited;
+            for key in INHERITABLE_PAGE_KEYS {
+                if let Some(value) = dictionary.get(key) {
+                    effective_inherited.insert(key, value.clone());
+                }
+            }
+            if !effective_inherited.contains_key("MediaBox") {
+                return Err(invalid_lossless(format!(
+                    "page {} {} R has no effective /MediaBox",
+                    node_reference.0, node_reference.1
+                )));
+            }
+            pages.push(LosslessPage {
+                reference: node_reference,
+                dictionary,
+                effective_inherited,
+            });
+            Ok(1)
+        }
+        Some("Pages") => {
+            let mut child_inherited = inherited;
+            for key in INHERITABLE_PAGE_KEYS {
+                if let Some(value) = dictionary.get(key) {
+                    child_inherited.insert(key, value.clone());
+                }
+            }
+            let kids = resolve_reference_array(reader, dictionary.get("Kids"), "/Kids")?;
+            let declared_count = dictionary
+                .get("Count")
+                .and_then(PdfObject::as_integer)
+                .ok_or_else(|| invalid_lossless("every /Pages node must have an integer /Count"))?;
+            if declared_count < 0 {
+                return Err(invalid_lossless("a /Pages /Count cannot be negative"));
+            }
+            let mut actual_count = 0usize;
+            for child in kids {
+                actual_count = actual_count
+                    .checked_add(walk_page_tree(
+                        reader,
+                        child,
+                        Some(node_reference),
+                        child_inherited.clone(),
+                        visited,
+                        pages,
+                        depth + 1,
+                    )?)
+                    .ok_or_else(|| invalid_lossless("page count overflow"))?;
+            }
+            let declared_count = usize::try_from(declared_count)
+                .map_err(|_| invalid_lossless("a /Pages /Count does not fit in memory"))?;
+            if declared_count != actual_count {
+                return Err(invalid_lossless(format!(
+                    "/Pages node {} {} R declares /Count {} but contains {} pages",
+                    node_reference.0, node_reference.1, declared_count, actual_count
+                )));
+            }
+            Ok(actual_count)
+        }
+        other => Err(invalid_lossless(format!(
+            "page-tree node {} {} R has unsupported /Type {:?}",
+            node_reference.0, node_reference.1, other
+        ))),
+    }
+}
+
+fn object_dictionary<R: Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+    reference: (u32, u16),
+    role: &str,
+) -> Result<PdfDictionary, PdfError> {
+    reader
+        .get_object(reference.0, reference.1)
+        .map_err(|error| {
+            invalid_lossless(format!(
+                "resolve {role} {} {} R: {error}",
+                reference.0, reference.1
+            ))
+        })?
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| {
+            invalid_lossless(format!(
+                "{role} {} {} R must be a dictionary",
+                reference.0, reference.1
+            ))
+        })
+}
+
+fn resolve_reference_array<R: Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+    value: Option<&PdfObject>,
+    role: &str,
+) -> Result<Vec<(u32, u16)>, PdfError> {
+    let value = value.ok_or_else(|| invalid_lossless(format!("missing {role}")))?;
+    let resolved = match value {
+        PdfObject::Array(array) => PdfObject::Array(array.clone()),
+        PdfObject::Reference(number, generation) => reader
+            .get_object(*number, *generation)
+            .map_err(|error| invalid_lossless(format!("resolve indirect {role}: {error}")))?
+            .clone(),
+        _ => return Err(invalid_lossless(format!("{role} must be an array"))),
+    };
+    let array = match resolved {
+        PdfObject::Array(array) => array,
+        _ => {
+            return Err(invalid_lossless(format!(
+                "indirect {role} must resolve to an array"
+            )))
+        }
+    };
+    array
+        .0
+        .iter()
+        .map(|item| {
+            item.as_reference()
+                .ok_or_else(|| invalid_lossless(format!("{role} must contain only references")))
+        })
+        .collect()
+}
+
+fn validate_exact_permutation(page_order: &[usize], page_count: usize) -> Result<(), PdfError> {
+    if page_order.len() != page_count {
+        return Err(invalid_lossless(format!(
+            "page order must contain exactly {page_count} entries, got {}",
+            page_order.len()
+        )));
+    }
+    let mut seen = vec![false; page_count];
+    for &index in page_order {
+        if index >= page_count {
+            return Err(invalid_lossless(format!(
+                "page index {index} is out of bounds for {page_count} pages"
+            )));
+        }
+        if std::mem::replace(&mut seen[index], true) {
+            return Err(invalid_lossless(format!(
+                "page index {index} is duplicated"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn reject_signed_document<R: Read + std::io::Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+) -> Result<(), PdfError> {
+    if catalog.contains_key("Perms") {
+        return Err(PdfError::PermissionDenied(
+            "lossless page reordering does not support certified PDFs; see issue #532".to_string(),
+        ));
+    }
+    for reference in reader.object_references() {
+        let object = reader
+            .get_object(reference.0, reference.1)
+            .map_err(|error| {
+                invalid_lossless(format!(
+                    "inspect object {} {} R for signatures: {error}",
+                    reference.0, reference.1
+                ))
+            })?;
+        if object_contains_signature(object, 0)? {
+            return Err(PdfError::PermissionDenied(
+                "lossless page reordering does not support signed PDFs; see issue #532".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn object_contains_signature(object: &PdfObject, depth: usize) -> Result<bool, PdfError> {
+    if depth > 128 {
+        return Err(invalid_lossless(
+            "object nesting is too deep to inspect safely for signatures",
+        ));
+    }
+    match object {
+        PdfObject::Array(array) => {
+            for value in &array.0 {
+                if object_contains_signature(value, depth + 1)? {
+                    return Ok(true);
+                }
+            }
+        }
+        PdfObject::Dictionary(dictionary) => {
+            if dictionary.get_type() == Some("Sig")
+                || (dictionary.contains_key("ByteRange") && dictionary.contains_key("Contents"))
+            {
+                return Ok(true);
+            }
+            for value in dictionary.0.values() {
+                if object_contains_signature(value, depth + 1)? {
+                    return Ok(true);
+                }
+            }
+        }
+        PdfObject::Stream(stream) => {
+            if stream.dict.get_type() == Some("Sig")
+                || (stream.dict.contains_key("ByteRange") && stream.dict.contains_key("Contents"))
+            {
+                return Ok(true);
+            }
+            for value in stream.dict.0.values() {
+                if object_contains_signature(value, depth + 1)? {
+                    return Ok(true);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(false)
+}
+
+fn validate_lossless_output(
+    base: &[u8],
+    updated: &[u8],
+    expected_order: &[(u32, u16)],
+) -> OperationResult<()> {
+    if !updated.starts_with(base) {
+        return Err(OperationError::ProcessingError(
+            "incremental output does not preserve the source bytes as an exact prefix".to_string(),
+        ));
+    }
+    let document = PdfReader::new(Cursor::new(updated))
+        .map_err(|error| OperationError::ParseError(format!("reopen output PDF: {error}")))?
+        .into_document();
+    let count = document.page_count().map_err(|error| {
+        OperationError::ParseError(format!("validate output page tree: {error}"))
+    })? as usize;
+    if count != expected_order.len() {
+        return Err(OperationError::ProcessingError(format!(
+            "output contains {count} pages, expected {}",
+            expected_order.len()
+        )));
+    }
+    for (index, expected) in expected_order.iter().enumerate() {
+        let actual = document
+            .get_page(index as u32)
+            .map_err(|error| {
+                OperationError::ParseError(format!("validate output page {index}: {error}"))
+            })?
+            .obj_ref;
+        if actual != *expected {
+            return Err(OperationError::ProcessingError(format!(
+                "output page {index} references {} {} R, expected {} {} R",
+                actual.0, actual.1, expected.0, expected.1
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_lossless(message: impl Into<String>) -> PdfError {
+    PdfError::InvalidStructure(message.into())
 }
 
 /// Reverse all pages in a PDF

--- a/oxidize-pdf-core/src/parser/reader.rs
+++ b/oxidize-pdf-core/src/parser/reader.rs
@@ -163,6 +163,11 @@ impl<R: Read + Seek> PdfReader<R> {
         &self.trailer
     }
 
+    /// Return the latest in-use indirect-object references known to the xref.
+    pub(crate) fn object_references(&self) -> Vec<(u32, u16)> {
+        self.xref.in_use_references()
+    }
+
     /// Check if the PDF is unlocked (can read encrypted content)
     pub fn is_unlocked(&self) -> bool {
         match &self.encryption_handler {

--- a/oxidize-pdf-core/src/parser/xref.rs
+++ b/oxidize-pdf-core/src/parser/xref.rs
@@ -460,6 +460,26 @@ impl XRefTable {
         &self.entries
     }
 
+    /// Return every latest in-use object reference, including objects whose
+    /// current location is inside an object stream.
+    pub(crate) fn in_use_references(&self) -> Vec<(u32, u16)> {
+        let mut references: Vec<_> = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| entry.in_use)
+            .map(|(number, entry)| (*number, entry.generation))
+            .chain(
+                self.extended_entries
+                    .iter()
+                    .filter(|(_, entry)| entry.basic.in_use)
+                    .map(|(number, entry)| (*number, entry.basic.generation)),
+            )
+            .collect();
+        references.sort_unstable();
+        references.dedup();
+        references
+    }
+
     /// Parse xref table from a reader with fallback recovery
     pub fn parse<R: Read + Seek>(reader: &mut BufReader<R>) -> ParseResult<Self> {
         Self::parse_with_options(reader, &super::ParseOptions::default())
@@ -547,15 +567,29 @@ impl XRefTable {
             // Merge entries (newer entries override older ones)
             let _regular_count = table.entries.len();
             let _extended_count = table.extended_entries.len();
+            let current_compressed: std::collections::HashSet<u32> =
+                table.extended_entries.keys().copied().collect();
 
             for (obj_num, entry) in table.entries {
-                merged_table.entries.entry(obj_num).or_insert(entry);
+                // A newer uncompressed entry supersedes an older compressed
+                // entry for the same object number. Keep the two maps mutually
+                // exclusive so object resolution cannot accidentally prefer
+                // the stale object-stream location (issue #531).
+                if !current_compressed.contains(&obj_num)
+                    && !merged_table.extended_entries.contains_key(&obj_num)
+                {
+                    merged_table.entries.entry(obj_num).or_insert(entry);
+                }
             }
             for (obj_num, ext_entry) in table.extended_entries {
-                merged_table
-                    .extended_entries
-                    .entry(obj_num)
-                    .or_insert(ext_entry);
+                // Conversely, a newer compressed entry supersedes an older
+                // uncompressed one encountered later in the /Prev chain.
+                if !merged_table.entries.contains_key(&obj_num) {
+                    merged_table
+                        .extended_entries
+                        .entry(obj_num)
+                        .or_insert(ext_entry);
+                }
             }
 
             // Use the most recent trailer

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -5,7 +5,7 @@ use crate::parser::objects::{PdfDictionary, PdfName, PdfObject, PdfString};
 use crate::parser::PdfReader;
 use std::io::{Cursor, Read, Seek};
 
-pub(super) struct IncrementalUpdate<'a> {
+pub(crate) struct IncrementalUpdate<'a> {
     base: &'a [u8],
     previous_xref: u64,
     root: (u32, u16),
@@ -54,7 +54,7 @@ impl<'a> IncrementalUpdate<'a> {
         })
     }
 
-    pub(super) fn from_base(base: &'a [u8]) -> Result<Self> {
+    pub(crate) fn from_base(base: &'a [u8]) -> Result<Self> {
         let reader = PdfReader::new(Cursor::new(base))
             .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
         if reader.is_encrypted() {
@@ -73,7 +73,7 @@ impl<'a> IncrementalUpdate<'a> {
         Ok(id)
     }
 
-    pub(super) fn replace(&mut self, id: (u32, u16), object: PdfObject) -> Result<()> {
+    pub(crate) fn replace(&mut self, id: (u32, u16), object: PdfObject) -> Result<()> {
         if self
             .replacements
             .iter()
@@ -88,7 +88,7 @@ impl<'a> IncrementalUpdate<'a> {
         Ok(())
     }
 
-    pub(super) fn finish(mut self) -> Result<Vec<u8>> {
+    pub(crate) fn finish(mut self) -> Result<Vec<u8>> {
         self.replacements
             .sort_by_key(|(number, generation, _)| (*number, *generation));
         let mut out = Vec::with_capacity(self.base.len() + self.replacements.len() * 256 + 512);

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -23,6 +23,7 @@ pub use incremental_highlights::{
 pub use incremental_text_notes::{
     IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,
 };
+pub(crate) use incremental_update::IncrementalUpdate;
 pub use object_streams::{ObjectStream, ObjectStreamConfig, ObjectStreamStats, ObjectStreamWriter};
 pub use pdf_writer::{PdfWriter, WriterConfig};
 pub(crate) use signature::{Edition, PdfSignature};

--- a/oxidize-pdf-core/tests/issue_531_lossless_page_reorder_test.rs
+++ b/oxidize-pdf-core/tests/issue_531_lossless_page_reorder_test.rs
@@ -1,0 +1,256 @@
+//! Regression coverage for issue #531: page reordering must retain the source
+//! object graph and bytes instead of rebuilding pages through `Document`.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::operations::reorder_pdf_pages_lossless;
+use oxidize_pdf::parser::{PdfObject, PdfReader};
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Document, Page};
+use std::fs;
+use std::io::Cursor;
+use tempfile::TempDir;
+
+fn nested_page_tree_pdf(extra_object: Option<Vec<u8>>) -> Vec<u8> {
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R /Metadata 11 0 R /Outlines 12 0 R \
+          /Names 13 0 R /AcroForm 14 0 R /StructTreeRoot 15 0 R >>"
+            .to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>".to_vec(),
+        b"<< /Type /Pages /Parent 2 0 R /Kids [5 0 R] /Count 1 \
+          /Resources 7 0 R /MediaBox [0 0 300 400] >>"
+            .to_vec(),
+        b"<< /Type /Pages /Parent 2 0 R /Kids [6 0 R] /Count 1 \
+          /Resources 8 0 R /MediaBox [0 0 500 600] /Rotate 90 >>"
+            .to_vec(),
+        b"<< /Type /Page /Parent 3 0 R /Contents 9 0 R /Annots [16 0 R] \
+          /StructParents 0 >>"
+            .to_vec(),
+        b"<< /Type /Page /Parent 4 0 R /Contents 10 0 R >>".to_vec(),
+        b"<< /ProcSet [/PDF] /Marker (left) >>".to_vec(),
+        b"<< /ProcSet [/PDF] /Marker (right) >>".to_vec(),
+        stream_obj("", b""),
+        stream_obj("", b""),
+        stream_obj("/Type /Metadata /Subtype /XML", b"<keep-me/>"),
+        b"<< /Type /Outlines /Count 0 >>".to_vec(),
+        b"<< /Dests << /First [5 0 R /Fit] >> >>".to_vec(),
+        b"<< /Fields [] >>".to_vec(),
+        b"<< /Type /StructTreeRoot /K [] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Text /Rect [0 0 10 10] >>".to_vec(),
+    ];
+    if let Some(object) = extra_object {
+        objects.push(object);
+    }
+    assemble_pdf(&objects)
+}
+
+fn page_references(bytes: &[u8]) -> Vec<(u32, u16)> {
+    let document = PdfReader::new(Cursor::new(bytes))
+        .expect("PDF should parse")
+        .into_document();
+    (0..document.page_count().expect("page count"))
+        .map(|index| document.get_page(index).expect("page").obj_ref)
+        .collect()
+}
+
+#[test]
+fn nested_tree_reorder_preserves_prefix_ids_and_effective_inheritance() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = nested_page_tree_pdf(None);
+    fs::write(&input, &source).unwrap();
+
+    reorder_pdf_pages_lossless(&input, &output, &[1, 0]).expect("lossless reorder");
+    let reordered = fs::read(&output).unwrap();
+    assert!(
+        reordered.starts_with(&source),
+        "source must be an exact prefix"
+    );
+    assert_eq!(page_references(&reordered), vec![(6, 0), (5, 0)]);
+
+    let mut reader = PdfReader::new(Cursor::new(&reordered)).unwrap();
+    let page_6 = reader.get_object(6, 0).unwrap().as_dict().unwrap().clone();
+    assert_eq!(
+        page_6.get("Parent").and_then(PdfObject::as_reference),
+        Some((2, 0))
+    );
+    assert_eq!(
+        page_6.get("Resources").and_then(PdfObject::as_reference),
+        Some((8, 0))
+    );
+    assert_eq!(
+        page_6.get("Rotate").and_then(PdfObject::as_integer),
+        Some(90)
+    );
+    assert_eq!(
+        page_6.get("MediaBox"),
+        Some(&PdfObject::Array(oxidize_pdf::PdfArray(vec![
+            PdfObject::Integer(0),
+            PdfObject::Integer(0),
+            PdfObject::Integer(500),
+            PdfObject::Integer(600),
+        ])))
+    );
+
+    let page_5 = reader.get_object(5, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        page_5.get("Parent").and_then(PdfObject::as_reference),
+        Some((2, 0))
+    );
+    assert_eq!(
+        page_5.get("Resources").and_then(PdfObject::as_reference),
+        Some((7, 0))
+    );
+    assert_eq!(
+        page_5
+            .get("Annots")
+            .and_then(PdfObject::as_array)
+            .and_then(|array| array.0.first())
+            .and_then(PdfObject::as_reference),
+        Some((16, 0))
+    );
+    let catalog = reader.catalog().unwrap();
+    for (key, reference) in [
+        ("Metadata", (11, 0)),
+        ("Outlines", (12, 0)),
+        ("Names", (13, 0)),
+        ("AcroForm", (14, 0)),
+        ("StructTreeRoot", (15, 0)),
+    ] {
+        assert_eq!(
+            catalog.get(key).and_then(PdfObject::as_reference),
+            Some(reference)
+        );
+    }
+    assert!(reordered
+        .windows(b"<keep-me/>".len())
+        .any(|window| window == b"<keep-me/>"));
+}
+
+#[test]
+fn rejects_non_permutations_without_replacing_existing_destination() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(&input, nested_page_tree_pdf(None)).unwrap();
+    fs::write(&output, b"existing destination").unwrap();
+
+    for order in [&[0][..], &[0, 0][..], &[0, 2][..]] {
+        let error = reorder_pdf_pages_lossless(&input, &output, order)
+            .expect_err("invalid order must fail")
+            .to_string();
+        assert!(
+            error.contains("page order")
+                || error.contains("duplicated")
+                || error.contains("out of bounds")
+        );
+        assert_eq!(fs::read(&output).unwrap(), b"existing destination");
+    }
+}
+
+#[test]
+fn rejects_signed_documents_fail_closed() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("signed.pdf");
+    let output = directory.path().join("output.pdf");
+    let signature = b"<< /Type /Sig /ByteRange [0 1 2 3] /Contents <00> >>".to_vec();
+    fs::write(&input, nested_page_tree_pdf(Some(signature))).unwrap();
+
+    let error = reorder_pdf_pages_lossless(&input, &output, &[1, 0])
+        .expect_err("signed input must be rejected")
+        .to_string();
+    assert!(error.contains("signed PDFs"));
+    assert!(!output.exists());
+}
+
+#[test]
+fn supports_xref_stream_sources_and_emits_an_incremental_xref_stream() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("xref-stream.pdf");
+    let output = directory.path().join("output.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.add_page(Page::a4());
+    let source = document
+        .to_bytes_with_config(WriterConfig::modern())
+        .unwrap();
+    fs::write(&input, &source).unwrap();
+    let original_refs = page_references(&source);
+
+    reorder_pdf_pages_lossless(&input, &output, &[1, 0]).expect("xref-stream reorder");
+    let reordered = fs::read(&output).unwrap();
+    assert!(reordered.starts_with(&source));
+    assert_eq!(
+        page_references(&reordered),
+        vec![original_refs[1], original_refs[0]]
+    );
+    assert!(reordered
+        .windows(b"/Type /XRef".len())
+        .any(|window| window == b"/Type /XRef"));
+}
+
+#[test]
+fn atomically_replaces_the_input_when_paths_are_identical() {
+    let directory = TempDir::new().unwrap();
+    let path = directory.path().join("in-place.pdf");
+    let source = nested_page_tree_pdf(None);
+    fs::write(&path, &source).unwrap();
+
+    reorder_pdf_pages_lossless(&path, &path, &[1, 0]).expect("in-place reorder");
+    let reordered = fs::read(&path).unwrap();
+    assert!(reordered.starts_with(&source));
+    assert_eq!(page_references(&reordered), vec![(6, 0), (5, 0)]);
+}
+
+#[test]
+fn rejects_malformed_parent_links_and_page_counts() {
+    let directory = TempDir::new().unwrap();
+    let output = directory.path().join("output.pdf");
+
+    for (name, objects) in [
+        (
+            "bad-parent",
+            vec![
+                b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+                b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+                b"<< /Type /Page /Parent 99 0 R /MediaBox [0 0 10 10] >>".to_vec(),
+            ],
+        ),
+        (
+            "bad-count",
+            vec![
+                b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+                b"<< /Type /Pages /Kids [3 0 R] /Count 2 >>".to_vec(),
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>".to_vec(),
+            ],
+        ),
+    ] {
+        let input = directory.path().join(format!("{name}.pdf"));
+        fs::write(&input, assemble_pdf(&objects)).unwrap();
+        let error = reorder_pdf_pages_lossless(&input, &output, &[0])
+            .expect_err("malformed tree must fail")
+            .to_string();
+        assert!(error.contains("/Parent") || error.contains("/Count"));
+        assert!(!output.exists());
+    }
+}
+
+#[test]
+fn rejects_encrypted_documents() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("encrypted.pdf");
+    let output = directory.path().join("output.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    fs::write(&input, document.to_bytes().unwrap()).unwrap();
+
+    let error = reorder_pdf_pages_lossless(&input, &output, &[1, 0])
+        .expect_err("encrypted input must be rejected")
+        .to_string();
+    assert!(error.contains("encrypted PDFs"));
+    assert!(!output.exists());
+}

--- a/oxidize-pdf-core/tests/issue_531_lossless_page_reorder_test.rs
+++ b/oxidize-pdf-core/tests/issue_531_lossless_page_reorder_test.rs
@@ -19,12 +19,12 @@ fn nested_page_tree_pdf(extra_object: Option<Vec<u8>>) -> Vec<u8> {
             .to_vec(),
         b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>".to_vec(),
         b"<< /Type /Pages /Parent 2 0 R /Kids [5 0 R] /Count 1 \
-          /Resources 7 0 R /MediaBox [0 0 300 400] >>"
+          /Resources 7 0 R /MediaBox [0 0 300 400] /CropBox [10 20 290 380] >>"
             .to_vec(),
         b"<< /Type /Pages /Parent 2 0 R /Kids [6 0 R] /Count 1 \
           /Resources 8 0 R /MediaBox [0 0 500 600] /Rotate 90 >>"
             .to_vec(),
-        b"<< /Type /Page /Parent 3 0 R /Contents 9 0 R /Annots [16 0 R] \
+        b"<< /Type /Page /Parent 3 0 R /Contents 9 0 R /Annots [16 0 R 17 0 R] \
           /StructParents 0 >>"
             .to_vec(),
         b"<< /Type /Page /Parent 4 0 R /Contents 10 0 R >>".to_vec(),
@@ -34,10 +34,17 @@ fn nested_page_tree_pdf(extra_object: Option<Vec<u8>>) -> Vec<u8> {
         stream_obj("", b""),
         stream_obj("/Type /Metadata /Subtype /XML", b"<keep-me/>"),
         b"<< /Type /Outlines /Count 0 >>".to_vec(),
-        b"<< /Dests << /First [5 0 R /Fit] >> >>".to_vec(),
-        b"<< /Fields [] >>".to_vec(),
+        b"<< /Dests << /First [5 0 R /Fit] >> \
+          /EmbeddedFiles << /Names [(attachment.txt) 19 0 R] >> >>"
+            .to_vec(),
+        b"<< /Fields [17 0 R] >>".to_vec(),
         b"<< /Type /StructTreeRoot /K [] >>".to_vec(),
         b"<< /Type /Annot /Subtype /Text /Rect [0 0 10 10] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Widget /FT /Tx /T (field) /P 5 0 R \
+          /Rect [10 10 20 20] >>"
+            .to_vec(),
+        stream_obj("/Type /EmbeddedFile", b"attachment payload"),
+        b"<< /Type /Filespec /F (attachment.txt) /EF << /F 18 0 R >> >>".to_vec(),
     ];
     if let Some(object) = extra_object {
         objects.push(object);
@@ -104,6 +111,15 @@ fn nested_tree_reorder_preserves_prefix_ids_and_effective_inheritance() {
         Some((7, 0))
     );
     assert_eq!(
+        page_5.get("CropBox"),
+        Some(&PdfObject::Array(oxidize_pdf::PdfArray(vec![
+            PdfObject::Integer(10),
+            PdfObject::Integer(20),
+            PdfObject::Integer(290),
+            PdfObject::Integer(380),
+        ])))
+    );
+    assert_eq!(
         page_5
             .get("Annots")
             .and_then(PdfObject::as_array)
@@ -127,6 +143,71 @@ fn nested_tree_reorder_preserves_prefix_ids_and_effective_inheritance() {
     assert!(reordered
         .windows(b"<keep-me/>".len())
         .any(|window| window == b"<keep-me/>"));
+    let form = reader.get_object(14, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        form.get("Fields")
+            .and_then(PdfObject::as_array)
+            .and_then(|fields| fields.0.first())
+            .and_then(PdfObject::as_reference),
+        Some((17, 0))
+    );
+    let names = reader.get_object(13, 0).unwrap().as_dict().unwrap();
+    assert!(names.contains_key("EmbeddedFiles"));
+    assert!(
+        reader.get_object(17, 0).is_ok(),
+        "widget must remain reachable"
+    );
+    assert!(
+        reader.get_object(18, 0).is_ok(),
+        "attachment stream must remain reachable"
+    );
+    assert!(
+        reader.get_object(19, 0).is_ok(),
+        "file specification must remain reachable"
+    );
+}
+
+#[test]
+fn flat_tree_rewrites_only_the_page_tree_root() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("flat.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = assemble_pdf(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 \
+          /Resources 5 0 R /MediaBox [0 0 100 100] >>"
+            .to_vec(),
+        b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+        b"<< /ProcSet [/PDF] >>".to_vec(),
+    ]);
+    fs::write(&input, &source).unwrap();
+
+    reorder_pdf_pages_lossless(&input, &output, &[1, 0]).expect("flat reorder");
+    let reordered = fs::read(&output).unwrap();
+    let revision = &reordered[source.len()..];
+    assert!(revision.windows(7).any(|window| window == b"2 0 obj"));
+    assert!(!revision.windows(7).any(|window| window == b"3 0 obj"));
+    assert!(!revision.windows(7).any(|window| window == b"4 0 obj"));
+    assert_eq!(page_references(&reordered), vec![(4, 0), (3, 0)]);
+}
+
+#[test]
+fn accepts_a_source_with_an_existing_incremental_revision() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("second.pdf");
+    let source = nested_page_tree_pdf(None);
+    fs::write(&input, &source).unwrap();
+
+    reorder_pdf_pages_lossless(&input, &first, &[1, 0]).expect("first revision");
+    let first_revision = fs::read(&first).unwrap();
+    reorder_pdf_pages_lossless(&first, &second, &[1, 0]).expect("second revision");
+    let second_revision = fs::read(&second).unwrap();
+
+    assert!(second_revision.starts_with(&first_revision));
+    assert_eq!(page_references(&second_revision), vec![(5, 0), (6, 0)]);
 }
 
 #[test]
@@ -226,13 +307,21 @@ fn rejects_malformed_parent_links_and_page_counts() {
                 b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>".to_vec(),
             ],
         ),
+        (
+            "cycle",
+            vec![
+                b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+                b"<< /Type /Pages /Kids [3 0 R 3 0 R] /Count 2 >>".to_vec(),
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>".to_vec(),
+            ],
+        ),
     ] {
         let input = directory.path().join(format!("{name}.pdf"));
         fs::write(&input, assemble_pdf(&objects)).unwrap();
         let error = reorder_pdf_pages_lossless(&input, &output, &[0])
             .expect_err("malformed tree must fail")
             .to_string();
-        assert!(error.contains("/Parent") || error.contains("/Count"));
+        assert!(error.contains("/Parent") || error.contains("/Count") || error.contains("cycle"));
         assert!(!output.exists());
     }
 }


### PR DESCRIPTION
Closes #531.

## Summary

- Adds the public `reorder_pdf_pages_lossless` API for exact whole-document page permutations.
- Preserves the original bytes as an exact prefix and retains every indirect page identity.
- Normalizes nested page trees into a valid root while materializing effective inherited page attributes.
- Preserves annotations, forms, outlines, names, structure references, attachments, metadata, and unrelated objects.
- Supports classic xref tables, xref streams, object streams, and existing incremental revisions.
- Rejects encrypted, signed, certified, malformed, cyclic, incomplete, and duplicate-page inputs fail-closed.
- Validates the completed revision before atomically replacing the destination, including in-place operation.
- Fixes xref-chain precedence when a newer uncompressed object supersedes an older object-stream entry.

DocMDP permission evaluation remains explicitly out of scope and is tracked in #532.

## Validation

- `cargo test -p oxidize-pdf --test issue_531_lossless_page_reorder_test` — 7 passed.
- `cargo test -p oxidize-pdf --lib` — 6,705 passed, 3 ignored.
- Existing reorder tests — 10 passed.
- Xref unit tests — 71 passed.
- Clippy with `-D warnings` passes for the library and the new regression target.
- Formatting and `git diff --check` pass.