### PR TITLE
feat: preserve document semantics when adding OCR layers

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -47,6 +47,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_highlight_revisions
           -- --ignored --exact
 
+      - name: Validate incremental OCR layers
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_542_incremental_ocr_test
+          qpdf_accepts_classic_and_xref_stream_ocr_revisions
+          -- --ignored --exact
+
       - name: Validate AES-256 R5 interoperability
         run: >
           cargo test -p oxidize-pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Lossless incremental OCR text layers** (#542). Positioned, invisible
+  Unicode text can now be appended to existing pages without rebuilding the
+  document graph or changing the source-byte prefix. The editor exposes a
+  policy-aware dry run, isolated streams and font resources, language,
+  confidence, source-region and reading-order metadata, duplicate-layer
+  detection, deterministic output, xref-table and xref-stream support, and
+  validated atomic publication through `PdfOcrConverter`. Encrypted inputs and
+  every DocMDP certification level fail closed because OCR changes page
+  content.
 - **Lossless incremental page reordering** (#531). The new
   `reorder_pdf_pages_lossless` API preserves the source bytes, indirect page
   identities, inherited page attributes, and unrelated document objects while

--- a/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
+++ b/oxidize-pdf-core/src/operations/pdf_ocr_converter.rs
@@ -38,12 +38,12 @@
 //! ```
 
 use crate::error::{PdfError, Result};
-use crate::graphics::Color;
 use crate::operations::page_analysis::{AnalysisOptions, PageContentAnalyzer};
 use crate::parser::{ParseOptions, PdfDocument, PdfReader};
 use crate::text::{FragmentType, OcrOptions, OcrProvider};
-use crate::{Document, Font, Page};
+use crate::writer::{IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage, OcrLayerPlan};
 use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 use std::time::Instant;
 
@@ -55,11 +55,11 @@ pub struct ConversionOptions {
     pub min_confidence: f64,
     /// Whether to skip pages that already contain text
     pub skip_text_pages: bool,
-    /// Font size for invisible text layer (should match expected text size)
+    /// Legacy preferred font size; positioned incremental layers use each OCR region's height.
     pub text_layer_font_size: f64,
     /// DPI for image processing
     pub dpi: u32,
-    /// Whether to preserve original page structure
+    /// Legacy compatibility flag; incremental conversion always preserves page structure.
     pub preserve_structure: bool,
     /// Progress callback function
     pub progress_callback: Option<Box<dyn Fn(usize, usize) + Send + Sync>>,
@@ -149,8 +149,8 @@ impl PdfOcrConverter {
     ) -> Result<ConversionResult> {
         let start_time = Instant::now();
 
-        // Open input PDF
-        let file = File::open(input_path.as_ref()).map_err(|e| PdfError::Io(e))?;
+        let base_bytes = std::fs::read(input_path.as_ref()).map_err(PdfError::Io)?;
+        let file = File::open(input_path.as_ref()).map_err(PdfError::Io)?;
 
         let reader = PdfReader::new_with_options(file, ParseOptions::tolerant())?;
         let document = PdfDocument::new(reader);
@@ -159,10 +159,9 @@ impl PdfOcrConverter {
         // Initialize analyzer
         let analyzer = PageContentAnalyzer::with_options(document, self.analysis_options.clone());
 
-        // Create new output document
-        let mut output_doc = Document::new();
-
         let mut stats = ConversionStats::new();
+        let mut layers = Vec::new();
+        let mut accepted_results = Vec::new();
 
         // Process each page
         for page_num in 0..page_count {
@@ -170,20 +169,61 @@ impl PdfOcrConverter {
                 callback(page_num as usize, page_count as usize);
             }
 
-            let processed_page = self.process_page(
-                &analyzer,
-                page_num as usize,
-                ocr_provider,
-                options,
-                &mut stats,
-            )?;
-
-            output_doc.add_page(processed_page);
+            stats.pages_processed += 1;
+            let analysis = analyzer
+                .analyze_page(page_num as usize)
+                .map_err(|error| PdfError::ParseError(error.to_string()))?;
+            if analysis.is_scanned() && (!options.skip_text_pages || analysis.character_count < 50)
+            {
+                let image_data = analyzer
+                    .extract_page_image_data(page_num as usize)
+                    .map_err(|error| {
+                        PdfError::ParseError(format!(
+                            "Failed to extract image from page {page_num}: {error}"
+                        ))
+                    })?;
+                let result = ocr_provider
+                    .process_image(&image_data, &options.ocr_options)
+                    .map_err(|error| {
+                        PdfError::InvalidStructure(format!(
+                            "OCR failed for page {page_num}: {error}"
+                        ))
+                    })?;
+                if result.confidence >= options.min_confidence {
+                    let fragments = result
+                        .fragments
+                        .iter()
+                        .filter(|fragment| fragment.fragment_type == FragmentType::Word)
+                        .enumerate()
+                        .map(|(reading_order, fragment)| OcrLayerFragment {
+                            text: fragment.text.clone(),
+                            region: [fragment.x, fragment.y, fragment.width, fragment.height],
+                            confidence: fragment.confidence,
+                            reading_order: reading_order as u32,
+                        })
+                        .collect();
+                    layers.push(OcrLayerPage {
+                        page_index: page_num,
+                        language: result.language.clone(),
+                        fragments,
+                    });
+                    accepted_results.push((page_num, result.confidence, result.text.len()));
+                }
+            } else if options.skip_text_pages {
+                stats.pages_skipped += 1;
+            }
         }
-
-        // Save output document
-        let pdf_bytes = output_doc.to_bytes()?;
-        std::fs::write(output_path.as_ref(), pdf_bytes).map_err(|e| PdfError::Io(e))?;
+        let update = IncrementalOcrLayerEditor::new(&base_bytes).apply(&layers)?;
+        stats.pages_ocr_processed = update.plan.pages.len();
+        for (_, confidence, characters) in accepted_results
+            .iter()
+            .filter(|(page, _, _)| update.plan.pages.binary_search(page).is_ok())
+        {
+            stats.total_confidence += confidence;
+            stats.total_characters += characters;
+        }
+        stats.pages_skipped += update.plan.pages_skipped_existing_ocr.len();
+        atomic_write(output_path.as_ref(), &update.pdf_bytes)?;
 
         let processing_time = start_time.elapsed();
 
@@ -197,144 +237,18 @@ impl PdfOcrConverter {
         })
     }
 
-    /// Process a single page, applying OCR if needed
-    fn process_page<P: OcrProvider>(
+    /// Validate positioned OCR results without modifying or publishing a PDF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed, encrypted, or DocMDP-certified input,
+    /// invalid page requests, or unsupported page content/resource layouts.
+    pub fn plan_incremental_layers(
         &self,
-        analyzer: &PageContentAnalyzer,
-        page_num: usize,
-        ocr_provider: &P,
-        options: &ConversionOptions,
-        stats: &mut ConversionStats,
-    ) -> Result<Page> {
-        stats.pages_processed += 1;
-
-        // Analyze page content
-        let analysis = analyzer
-            .analyze_page(page_num)
-            .map_err(|e| PdfError::ParseError(e.to_string()))?;
-
-        // Create base page
-        // Enhancement: Get actual page dimensions from source PDF
-        // Priority: MEDIUM - Currently defaults to A4 for all pages
-        // Would require passing page info from analyzer
-        let mut page = Page::a4();
-
-        if analysis.is_scanned() && (!options.skip_text_pages || analysis.character_count < 50) {
-            // Page needs OCR processing
-            self.process_scanned_page(analyzer, page_num, ocr_provider, options, stats, &mut page)?;
-        } else {
-            // Copy existing page content (vector text, graphics, etc.)
-            self.copy_page_content(analyzer, page_num, &mut page)?;
-            if options.skip_text_pages {
-                stats.pages_skipped += 1;
-            }
-        }
-
-        Ok(page)
-    }
-
-    /// Process a scanned page with OCR
-    fn process_scanned_page<P: OcrProvider>(
-        &self,
-        analyzer: &PageContentAnalyzer,
-        page_num: usize,
-        ocr_provider: &P,
-        options: &ConversionOptions,
-        stats: &mut ConversionStats,
-        page: &mut Page,
-    ) -> Result<()> {
-        // Extract image data from the page
-        let image_data = analyzer.extract_page_image_data(page_num).map_err(|e| {
-            PdfError::ParseError(format!(
-                "Failed to extract image from page {}: {}",
-                page_num, e
-            ))
-        })?;
-
-        // Apply OCR to extract text
-        let ocr_result = ocr_provider
-            .process_image(&image_data, &options.ocr_options)
-            .map_err(|e| {
-                PdfError::InvalidStructure(format!("OCR failed for page {}: {}", page_num, e))
-            })?;
-
-        if ocr_result.confidence >= options.min_confidence {
-            // Add the original image to the page (visible layer)
-            self.add_image_to_page(page, &image_data)?;
-
-            // Add invisible text layer
-            self.add_invisible_text_layer(page, &ocr_result, options)?;
-
-            stats.pages_ocr_processed += 1;
-            stats.total_confidence += ocr_result.confidence;
-            stats.total_characters += ocr_result.text.len();
-        } else {
-            // Low confidence, just add the image without text layer
-            self.add_image_to_page(page, &image_data)?;
-            tracing::debug!(
-                "Warning: Low OCR confidence ({:.1}%) for page {}, skipping text layer",
-                ocr_result.confidence * 100.0,
-                page_num
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Add an image to a page
-    fn add_image_to_page(&self, page: &mut Page, _image_data: &[u8]) -> Result<()> {
-        // TODO: Implement image embedding
-        // For now, we'll create a placeholder
-        page.graphics()
-            .save_state()
-            .set_fill_color(Color::rgb(240.0, 240.0, 240.0))
-            .rect(50.0, 50.0, 500.0, 700.0)
-            .fill()
-            .restore_state();
-
-        Ok(())
-    }
-
-    /// Add an invisible text layer over the image
-    fn add_invisible_text_layer(
-        &self,
-        page: &mut Page,
-        ocr_result: &crate::text::OcrProcessingResult,
-        options: &ConversionOptions,
-    ) -> Result<()> {
-        // Add invisible text at detected positions
-        let text_context = page.text();
-
-        for fragment in &ocr_result.fragments {
-            if fragment.fragment_type == FragmentType::Word {
-                // Position text at the detected coordinates
-                // Make text invisible by setting rendering mode to invisible
-                text_context
-                    .set_font(Font::Helvetica, options.text_layer_font_size)
-                    .at(fragment.x as f64, fragment.y as f64)
-                    .set_rendering_mode(crate::text::TextRenderingMode::Invisible)
-                    .write(&fragment.text)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Copy existing page content (for pages that already have text)
-    fn copy_page_content(
-        &self,
-        _analyzer: &PageContentAnalyzer,
-        _page_num: usize,
-        page: &mut Page,
-    ) -> Result<()> {
-        // TODO: Implement page content copying
-        // For now, create a placeholder indicating this is a text page
-        page.text()
-            .set_font(Font::Helvetica, 12.0)
-            .at(50.0, 750.0)
-            .write("This page already contains text content")?;
-
-        Ok(())
+        pdf_bytes: &[u8],
+        pages: &[OcrLayerPage],
+    ) -> Result<OcrLayerPlan> {
+        IncrementalOcrLayerEditor::new(pdf_bytes).plan(pages)
     }
 
     /// Batch process multiple PDF files
@@ -375,6 +289,21 @@ impl PdfOcrConverter {
 
         Ok(results)
     }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(PdfError::Io)?;
+    temporary.write_all(bytes).map_err(PdfError::Io)?;
+    temporary.flush().map_err(PdfError::Io)?;
+    temporary.as_file().sync_all().map_err(PdfError::Io)?;
+    temporary
+        .persist(path)
+        .map_err(|error| PdfError::Io(error.error))?;
+    Ok(())
 }
 
 /// Internal statistics tracking
@@ -490,5 +419,14 @@ mod tests {
         stats.pages_ocr_processed = 2;
         stats.total_confidence = 1.6;
         assert_eq!(stats.calculate_average_confidence(), 0.8);
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = directory.path().join("output.pdf");
+        std::fs::write(&output, b"old").unwrap();
+        atomic_write(&output, b"new").unwrap();
+        assert_eq!(std::fs::read(output).unwrap(), b"new");
     }
 }

--- a/oxidize-pdf-core/src/signatures/permissions.rs
+++ b/oxidize-pdf-core/src/signatures/permissions.rs
@@ -12,6 +12,7 @@ pub(crate) enum IncrementalModification {
     FormFill,
     AddSignature,
     AddAnnotation,
+    OcrTextLayer,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -322,9 +323,12 @@ fn enforce_permission(
             modification,
             IncrementalModification::FormFill | IncrementalModification::AddSignature
         ),
-        DocMdpPermission::FormFillSignAndAnnotate => {
-            !matches!(modification, IncrementalModification::PageTreeReorder)
-        }
+        DocMdpPermission::FormFillSignAndAnnotate => matches!(
+            modification,
+            IncrementalModification::FormFill
+                | IncrementalModification::AddSignature
+                | IncrementalModification::AddAnnotation
+        ),
     };
     if allowed {
         return Ok(());
@@ -334,6 +338,7 @@ fn enforce_permission(
         IncrementalModification::FormFill => "form filling",
         IncrementalModification::AddSignature => "adding signatures",
         IncrementalModification::AddAnnotation => "adding annotations",
+        IncrementalModification::OcrTextLayer => "adding an OCR text layer",
     };
     Err(PdfError::PermissionDenied(format!(
         "DocMDP {description} does not permit {edit}"
@@ -387,6 +392,17 @@ mod tests {
             assert!(
                 enforce_permission(IncrementalModification::PageTreeReorder, permission).is_err()
             );
+        }
+    }
+
+    #[test]
+    fn ocr_page_content_is_forbidden_at_every_permission_level() {
+        for permission in [
+            DocMdpPermission::NoChanges,
+            DocMdpPermission::FormFillAndSign,
+            DocMdpPermission::FormFillSignAndAnnotate,
+        ] {
+            assert!(enforce_permission(IncrementalModification::OcrTextLayer, permission).is_err());
         }
     }
 }

--- a/oxidize-pdf-core/src/writer/incremental_ocr_layer.rs
+++ b/oxidize-pdf-core/src/writer/incremental_ocr_layer.rs
@@ -1,0 +1,624 @@
+//! Lossless incremental OCR text layers for existing PDFs.
+
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream};
+use crate::parser::{PdfDocument, PdfReader};
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use std::collections::HashSet;
+use std::io::Cursor;
+
+const OCR_FONT_NAME: &str = "OxidizeOCR";
+
+/// One OCR word in PDF user-space coordinates.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OcrLayerFragment {
+    /// Recognized Unicode text.
+    pub text: String,
+    /// Source-image region `[x, y, width, height]` mapped to page coordinates.
+    pub region: [f64; 4],
+    /// Recognition confidence in the inclusive range 0–1.
+    pub confidence: f64,
+    /// Zero-based logical reading-order index.
+    pub reading_order: u32,
+}
+
+/// OCR text to append to one existing page.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OcrLayerPage {
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// BCP 47 language tag associated with the recognized text.
+    pub language: String,
+    /// Positioned fragments in deterministic logical order.
+    pub fragments: Vec<OcrLayerFragment>,
+}
+
+/// Dry-run description of an incremental OCR update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OcrLayerPlan {
+    /// Pages whose dictionaries will be replaced in the new revision.
+    pub pages: Vec<u32>,
+    /// Number of new content streams.
+    pub streams_added: usize,
+    /// Number of isolated font resources added.
+    pub resources_added: usize,
+    /// Pages skipped because an oxidize-pdf OCR layer already exists.
+    pub pages_skipped_existing_ocr: Vec<u32>,
+}
+
+/// Result of one validated incremental OCR update.
+#[derive(Debug, Clone)]
+pub struct OcrLayerUpdate {
+    /// Complete PDF bytes; the input is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// The plan that was applied.
+    pub plan: OcrLayerPlan,
+}
+
+/// Plans and applies isolated OCR layers without rebuilding the document graph.
+pub struct IncrementalOcrLayerEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalOcrLayerEditor<'a> {
+    /// Create an editor over complete existing PDF bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Validate the request and report the exact pages and object classes changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF or request is invalid, encrypted, certified
+    /// against page-content edits, or uses an unsupported resource layout.
+    pub fn plan(&self, pages: &[OcrLayerPage]) -> Result<OcrLayerPlan> {
+        validate_policy(self.base_bytes)?;
+        let document = parse_document(self.base_bytes)?;
+        validate_request(&document, pages)?;
+        build_plan(&document, pages)
+    }
+
+    /// Append exactly one incremental revision and reopen it for validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for any planning failure or when the incremental output
+    /// cannot be serialized and reopened with every requested layer present.
+    pub fn apply(&self, pages: &[OcrLayerPage]) -> Result<OcrLayerUpdate> {
+        validate_policy(self.base_bytes)?;
+
+        let document = parse_document(self.base_bytes)?;
+        validate_request(&document, pages)?;
+        let plan = build_plan(&document, pages)?;
+        if plan.pages.is_empty() {
+            return Ok(OcrLayerUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                plan,
+            });
+        }
+
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        for page_index in &plan.pages {
+            let requested = pages
+                .iter()
+                .find(|page| page.page_index == *page_index)
+                .ok_or_else(|| invalid("OCR plan references an absent page request"))?;
+            let parsed_page = document
+                .get_page(requested.page_index)
+                .map_err(|error| invalid(format!("read page {}: {error}", requested.page_index)))?;
+            let font_id = update.allocate_id()?;
+            update.replace(font_id, PdfObject::Dictionary(ocr_font_dictionary()))?;
+            let stream_id = update.allocate_id()?;
+            let stream = PdfStream {
+                dict: ocr_stream_dictionary(&requested.language),
+                data: build_ocr_content(requested)?,
+            };
+            update.replace(stream_id, PdfObject::Stream(stream))?;
+
+            let mut page_dictionary = parsed_page.dict.clone();
+            let resources = merged_resources(&parsed_page, &document, font_id)?;
+            page_dictionary.insert("Resources".to_string(), PdfObject::Dictionary(resources));
+            page_dictionary.insert(
+                "Contents".to_string(),
+                append_content_reference(parsed_page.get_contents(), stream_id)?,
+            );
+            update.replace(parsed_page.obj_ref, PdfObject::Dictionary(page_dictionary))?;
+        }
+
+        let pdf_bytes = update.finish()?;
+        validate_output(self.base_bytes, &pdf_bytes, &plan)?;
+        Ok(OcrLayerUpdate { pdf_bytes, plan })
+    }
+}
+
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| invalid(format!("parse base PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "incremental OCR is not supported on encrypted PDFs".to_string(),
+        ));
+    }
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid(format!("read catalog: {error}")))?
+        .clone();
+    ensure_modification_allowed(&mut reader, &catalog, IncrementalModification::OcrTextLayer)
+}
+
+fn parse_document(bytes: &[u8]) -> Result<PdfDocument<Cursor<&[u8]>>> {
+    let reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| invalid(format!("parse base PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "incremental OCR is not supported on encrypted PDFs".to_string(),
+        ));
+    }
+    Ok(PdfDocument::new(reader))
+}
+
+fn validate_request(document: &PdfDocument<Cursor<&[u8]>>, pages: &[OcrLayerPage]) -> Result<()> {
+    let page_count = document
+        .page_count()
+        .map_err(|error| invalid(format!("read page tree: {error}")))?;
+    let mut seen = HashSet::new();
+    for page in pages {
+        if page.page_index >= page_count {
+            return Err(invalid(format!(
+                "OCR page {} is outside the document",
+                page.page_index
+            )));
+        }
+        if !seen.insert(page.page_index) {
+            return Err(invalid(format!(
+                "OCR page {} is requested more than once",
+                page.page_index
+            )));
+        }
+        if page.language.trim().is_empty() || !page.language.is_ascii() {
+            return Err(invalid("OCR language must be a non-empty ASCII BCP 47 tag"));
+        }
+        let mut previous_order = None;
+        for fragment in &page.fragments {
+            if fragment.text.is_empty()
+                || !fragment.confidence.is_finite()
+                || !(0.0..=1.0).contains(&fragment.confidence)
+                || fragment.region.iter().any(|value| !value.is_finite())
+                || fragment.region[2] <= 0.0
+                || fragment.region[3] <= 0.0
+            {
+                return Err(invalid(
+                    "OCR fragment contains invalid text, confidence, or region",
+                ));
+            }
+            if previous_order.is_some_and(|value| fragment.reading_order <= value) {
+                return Err(invalid(
+                    "OCR fragments must have strictly increasing logical reading order",
+                ));
+            }
+            previous_order = Some(fragment.reading_order);
+        }
+    }
+    Ok(())
+}
+
+fn build_plan(
+    document: &PdfDocument<Cursor<&[u8]>>,
+    pages: &[OcrLayerPage],
+) -> Result<OcrLayerPlan> {
+    let mut changed = Vec::new();
+    let mut skipped = Vec::new();
+    for requested in pages {
+        let page = document
+            .get_page(requested.page_index)
+            .map_err(|error| invalid(format!("read page {}: {error}", requested.page_index)))?;
+        if has_existing_ocr_layer(&page, document)? {
+            skipped.push(requested.page_index);
+        } else if !requested.fragments.is_empty() {
+            merged_resources(&page, document, (u32::MAX, 0))?;
+            append_content_reference(page.get_contents(), (u32::MAX, 0))?;
+            changed.push(requested.page_index);
+        }
+    }
+    changed.sort_unstable();
+    skipped.sort_unstable();
+    Ok(OcrLayerPlan {
+        streams_added: changed.len(),
+        resources_added: changed.len(),
+        pages: changed,
+        pages_skipped_existing_ocr: skipped,
+    })
+}
+
+fn has_existing_ocr_layer(
+    page: &crate::parser::page_tree::ParsedPage,
+    document: &PdfDocument<Cursor<&[u8]>>,
+) -> Result<bool> {
+    let Some(contents) = page.get_contents() else {
+        return Ok(false);
+    };
+    let values: Vec<&PdfObject> = match contents {
+        PdfObject::Array(array) => array.0.iter().collect(),
+        value => vec![value],
+    };
+    for value in values {
+        let object =
+            match value {
+                PdfObject::Reference(number, generation) => document
+                    .get_object(*number, *generation)
+                    .map_err(|error| invalid(format!("resolve page content: {error}")))?,
+                object => object.clone(),
+            };
+        if object
+            .as_stream()
+            .and_then(|stream| stream.dict.get("OxidizeOCR"))
+            == Some(&PdfObject::Boolean(true))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn merged_resources(
+    page: &crate::parser::page_tree::ParsedPage,
+    document: &PdfDocument<Cursor<&[u8]>>,
+    font_id: (u32, u16),
+) -> Result<PdfDictionary> {
+    let mut resources = page.get_resources().cloned().unwrap_or_default();
+    let mut fonts = match resources.get("Font") {
+        None => PdfDictionary::new(),
+        Some(PdfObject::Dictionary(fonts)) => fonts.clone(),
+        Some(PdfObject::Reference(number, generation)) => document
+            .get_object(*number, *generation)
+            .map_err(|error| invalid(format!("resolve page fonts: {error}")))?
+            .as_dict()
+            .cloned()
+            .ok_or_else(|| invalid("page /Font resource is not a dictionary"))?,
+        Some(_) => return Err(invalid("page /Font resource is not a dictionary")),
+    };
+    if fonts.get(OCR_FONT_NAME).is_some() {
+        return Err(invalid("page already reserves the /OxidizeOCR font name"));
+    }
+    fonts.insert(
+        OCR_FONT_NAME.to_string(),
+        PdfObject::Reference(font_id.0, font_id.1),
+    );
+    resources.insert("Font".to_string(), PdfObject::Dictionary(fonts));
+    Ok(resources)
+}
+
+fn append_content_reference(
+    contents: Option<&PdfObject>,
+    stream_id: (u32, u16),
+) -> Result<PdfObject> {
+    let new_stream = PdfObject::Reference(stream_id.0, stream_id.1);
+    match contents {
+        None => Ok(new_stream),
+        Some(PdfObject::Reference(number, generation)) => Ok(PdfObject::Array(PdfArray(vec![
+            PdfObject::Reference(*number, *generation),
+            new_stream,
+        ]))),
+        Some(PdfObject::Array(array))
+            if array
+                .0
+                .iter()
+                .all(|value| matches!(value, PdfObject::Reference(_, _))) =>
+        {
+            let mut values = array.0.clone();
+            values.push(new_stream);
+            Ok(PdfObject::Array(PdfArray(values)))
+        }
+        Some(_) => Err(invalid(
+            "incremental OCR requires indirect page content streams",
+        )),
+    }
+}
+
+fn ocr_font_dictionary() -> PdfDictionary {
+    let mut font = PdfDictionary::new();
+    font.insert("Type".to_string(), name("Font"));
+    font.insert("Subtype".to_string(), name("Type1"));
+    font.insert("BaseFont".to_string(), name("Helvetica"));
+    font.insert("Encoding".to_string(), name("WinAnsiEncoding"));
+    font
+}
+
+fn ocr_stream_dictionary(language: &str) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("OxidizeOCR".to_string(), PdfObject::Boolean(true));
+    dictionary.insert(
+        "Lang".to_string(),
+        PdfObject::String(crate::parser::objects::PdfString(
+            language.as_bytes().to_vec(),
+        )),
+    );
+    dictionary
+}
+
+fn build_ocr_content(page: &OcrLayerPage) -> Result<Vec<u8>> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"q\nBT\n/OxidizeOCR 1 Tf\n3 Tr\n");
+    for (index, fragment) in page.fragments.iter().enumerate() {
+        let [x, y, width, height] = fragment.region;
+        let separator = (index + 1 < page.fragments.len())
+            .then_some(" ")
+            .unwrap_or("");
+        let logical_text = format!("{}{separator}", fragment.text);
+        let actual_text = encode_actual_text(&logical_text);
+        let glyphs = encode_invisible_glyphs(&logical_text);
+        let escaped_glyphs = escape_literal(&glyphs);
+        let estimated_width = (fragment.text.chars().count().max(1) as f64) * 0.5;
+        let horizontal_scale = (width / estimated_width * 100.0).clamp(1.0, 1000.0);
+        content.extend_from_slice(
+            format!(
+                "/OCR << /ActualText {} /Lang ({}) /OxidizeConfidence {:.6} /OxidizeRegion [{:.6} {:.6} {:.6} {:.6}] /OxidizeReadingOrder {} >> BDC\n/OxidizeOCR {:.6} Tf\n{:.6} Tz\n1 0 0 1 {:.6} {:.6} Tm\n({}) Tj\nEMC\n",
+                actual_text,
+                escape_literal(page.language.as_bytes()),
+                fragment.confidence,
+                x,
+                y,
+                width,
+                height,
+                fragment.reading_order,
+                height,
+                horizontal_scale,
+                x,
+                y,
+                escaped_glyphs,
+            )
+            .as_bytes(),
+        );
+    }
+    content.extend_from_slice(b"ET\nQ\n");
+    Ok(content)
+}
+
+fn encode_actual_text(text: &str) -> String {
+    let mut output = String::from("<FEFF");
+    for unit in text.encode_utf16() {
+        output.push_str(&format!("{unit:04X}"));
+    }
+    output.push('>');
+    output
+}
+
+fn encode_invisible_glyphs(text: &str) -> Vec<u8> {
+    text.chars()
+        .map(|character| {
+            if character.is_ascii() {
+                character as u8
+            } else {
+                b'?'
+            }
+        })
+        .collect()
+}
+
+fn escape_literal(bytes: &[u8]) -> String {
+    let mut output = String::new();
+    for byte in bytes {
+        match byte {
+            b'(' | b')' | b'\\' => {
+                output.push('\\');
+                output.push(*byte as char);
+            }
+            b'\n' => output.push_str("\\n"),
+            b'\r' => output.push_str("\\r"),
+            byte => output.push(*byte as char),
+        }
+    }
+    output
+}
+
+fn validate_output(base: &[u8], output: &[u8], plan: &OcrLayerPlan) -> Result<()> {
+    if !output.starts_with(base) {
+        return Err(invalid(
+            "incremental OCR output does not preserve the input prefix",
+        ));
+    }
+    let document = parse_document(output)?;
+    for page_index in &plan.pages {
+        let page = document
+            .get_page(*page_index)
+            .map_err(|error| invalid(format!("reopen page {page_index}: {error}")))?;
+        if !has_existing_ocr_layer(&page, &document)? {
+            return Err(invalid(format!(
+                "reopened page {page_index} has no validated OCR layer"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName(value.to_string()))
+}
+
+fn invalid(message: impl Into<String>) -> PdfError {
+    PdfError::InvalidStructure(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::TextAnnotation;
+    use crate::geometry::Point;
+    use crate::text::{ExtractionOptions, TextExtractor};
+    use crate::{Document, Font, Page};
+
+    fn base_pdf() -> Vec<u8> {
+        let mut document = Document::new();
+        document.set_title("preserved metadata");
+        let mut page = Page::a4();
+        page.set_rotation(90);
+        page.text()
+            .set_font(Font::Helvetica, 12.0)
+            .at(20.0, 800.0)
+            .write("visible original")
+            .unwrap();
+        page.add_annotation(
+            TextAnnotation::new(Point::new(40.0, 760.0))
+                .with_contents("preserved annotation")
+                .to_annotation(),
+        );
+        document.add_page(page);
+        document.to_bytes().unwrap()
+    }
+
+    fn xref_stream_base_pdf() -> Vec<u8> {
+        let mut document = Document::new();
+        document.enable_xref_streams(true);
+        document.set_title("xref metadata");
+        document.add_page(Page::a4());
+        document.to_bytes().unwrap()
+    }
+
+    fn layer() -> OcrLayerPage {
+        OcrLayerPage {
+            page_index: 0,
+            language: "en-US".to_string(),
+            fragments: vec![OcrLayerFragment {
+                text: "searchable".to_string(),
+                region: [50.0, 700.0, 80.0, 12.0],
+                confidence: 0.98,
+                reading_order: 0,
+            }],
+        }
+    }
+
+    #[test]
+    fn dry_run_reports_only_incremental_ocr_objects() {
+        let base = base_pdf();
+        let plan = IncrementalOcrLayerEditor::new(&base)
+            .plan(&[layer()])
+            .unwrap();
+        assert_eq!(plan.pages, vec![0]);
+        assert_eq!(plan.streams_added, 1);
+        assert_eq!(plan.resources_added, 1);
+        assert!(plan.pages_skipped_existing_ocr.is_empty());
+    }
+
+    #[test]
+    fn update_preserves_base_as_exact_prefix_and_reopens() {
+        let base = base_pdf();
+        let update = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[layer()])
+            .unwrap();
+        assert!(update.pdf_bytes.starts_with(&base));
+        assert!(update.pdf_bytes.len() > base.len());
+        let document = parse_document(&update.pdf_bytes).unwrap();
+        assert_eq!(document.page_count().unwrap(), 1);
+        let page = document.get_page(0).unwrap();
+        assert_eq!(page.rotation, 90);
+        assert!(page.has_annotations());
+        assert_eq!(
+            document.metadata().unwrap().title.as_deref(),
+            Some("preserved metadata")
+        );
+        let extracted = TextExtractor::with_options(ExtractionOptions::default())
+            .extract_from_page(&document, 0)
+            .unwrap();
+        assert!(extracted.text.contains("visible original"));
+        assert!(extracted.text.contains("searchable"));
+    }
+
+    #[test]
+    fn second_application_detects_existing_ocr_layer() {
+        let base = base_pdf();
+        let first = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[layer()])
+            .unwrap();
+        let second = IncrementalOcrLayerEditor::new(&first.pdf_bytes)
+            .apply(&[layer()])
+            .unwrap();
+        assert_eq!(second.pdf_bytes, first.pdf_bytes);
+        assert_eq!(second.plan.pages_skipped_existing_ocr, vec![0]);
+    }
+
+    #[test]
+    fn supports_xref_stream_sources() {
+        let base = xref_stream_base_pdf();
+        assert!(base
+            .windows(b"/Type /XRef".len())
+            .any(|bytes| bytes == b"/Type /XRef"));
+        let update = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[layer()])
+            .unwrap();
+        assert!(update.pdf_bytes.starts_with(&base));
+        let reopened = parse_document(&update.pdf_bytes).unwrap();
+        assert_eq!(reopened.page_count().unwrap(), 1);
+        assert_eq!(
+            reopened.metadata().unwrap().title.as_deref(),
+            Some("xref metadata")
+        );
+    }
+
+    #[test]
+    fn unicode_actual_text_and_logical_order_are_extractable() {
+        let base = base_pdf();
+        let mut requested = layer();
+        requested.fragments = vec![
+            OcrLayerFragment {
+                text: "café".to_string(),
+                region: [50.0, 700.0, 40.0, 12.0],
+                confidence: 0.99,
+                reading_order: 0,
+            },
+            OcrLayerFragment {
+                text: "世界".to_string(),
+                region: [95.0, 700.0, 30.0, 12.0],
+                confidence: 0.97,
+                reading_order: 1,
+            },
+        ];
+        let update = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[requested])
+            .unwrap();
+        let document = parse_document(&update.pdf_bytes).unwrap();
+        let extracted = TextExtractor::with_options(ExtractionOptions::default())
+            .extract_from_page(&document, 0)
+            .unwrap();
+        let first = extracted.text.find("café").unwrap();
+        let second = extracted.text.find("世界").unwrap();
+        assert!(first < second, "{}", extracted.text);
+    }
+
+    #[test]
+    fn docmdp_certification_rejects_ocr_page_content_changes() {
+        let base = include_bytes!("../../tests/fixtures/signatures/docmdp_p2_rsa.pdf");
+        let error = IncrementalOcrLayerEditor::new(base)
+            .apply(&[layer()])
+            .unwrap_err();
+        assert!(matches!(error, PdfError::PermissionDenied(message) if message.contains("DocMDP")));
+    }
+
+    #[test]
+    fn dry_run_also_rejects_forbidden_docmdp_changes() {
+        let base = include_bytes!("../../tests/fixtures/signatures/docmdp_p2_rsa.pdf");
+        let error = IncrementalOcrLayerEditor::new(base)
+            .plan(&[layer()])
+            .unwrap_err();
+        assert!(matches!(error, PdfError::PermissionDenied(message) if message.contains("DocMDP")));
+    }
+
+    #[test]
+    fn page_request_order_does_not_change_output() {
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.add_page(Page::a4());
+        let base = document.to_bytes().unwrap();
+        let first = layer();
+        let mut second = layer();
+        second.page_index = 1;
+        let forward = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[first.clone(), second.clone()])
+            .unwrap();
+        let reverse = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[second, first])
+            .unwrap();
+        assert_eq!(forward.pdf_bytes, reverse.pdf_bytes);
+    }
+}

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -9,6 +9,7 @@ pub(crate) struct IncrementalUpdate<'a> {
     base: &'a [u8],
     previous_xref: u64,
     root: (u32, u16),
+    info: Option<(u32, u16)>,
     original_size: u32,
     next_id: u32,
     first_id: Option<Vec<u8>>,
@@ -46,6 +47,7 @@ impl<'a> IncrementalUpdate<'a> {
             base,
             previous_xref: trailer.xref_offset,
             root,
+            info: trailer.info(),
             original_size: size,
             next_id: size,
             first_id,
@@ -129,6 +131,7 @@ impl<'a> IncrementalUpdate<'a> {
                 &changed,
                 self.previous_xref,
                 self.root,
+                self.info,
                 size,
                 id_pair,
             )?,
@@ -138,6 +141,7 @@ impl<'a> IncrementalUpdate<'a> {
                     &mut out,
                     self.previous_xref,
                     self.root,
+                    self.info,
                     size,
                     xref_position,
                     id_pair,
@@ -201,10 +205,16 @@ pub(super) fn write_object(out: &mut Vec<u8>, object: &PdfObject) -> Result<()> 
             out.push(b']');
         }
         PdfObject::Dictionary(dictionary) => write_dictionary(out, dictionary)?,
-        PdfObject::Stream(_) => {
-            return Err(PdfError::InvalidStructure(
-                "generic incremental object writer does not accept streams".to_string(),
-            ))
+        PdfObject::Stream(stream) => {
+            let mut dictionary = stream.dict.clone();
+            dictionary.insert(
+                "Length".to_string(),
+                PdfObject::Integer(stream.data.len() as i64),
+            );
+            write_dictionary(out, &dictionary)?;
+            out.extend_from_slice(b"\nstream\n");
+            out.extend_from_slice(&stream.data);
+            out.extend_from_slice(b"\nendstream");
         }
     }
     Ok(())
@@ -318,6 +328,7 @@ fn write_xref_stream(
     changed: &[(u32, u16, u64)],
     previous_xref: u64,
     root: (u32, u16),
+    info: Option<(u32, u16)>,
     size: u32,
     id_pair: Option<(Vec<u8>, Vec<u8>)>,
 ) -> Result<()> {
@@ -338,6 +349,9 @@ fn write_xref_stream(
     );
     dictionary.insert("Size".to_string(), PdfObject::Integer(i64::from(size)));
     dictionary.insert("Root".to_string(), PdfObject::Reference(root.0, root.1));
+    if let Some((number, generation)) = info {
+        dictionary.insert("Info".to_string(), PdfObject::Reference(number, generation));
+    }
     dictionary.insert(
         "Prev".to_string(),
         PdfObject::Integer(i64::try_from(previous_xref).map_err(|_| {
@@ -416,6 +430,7 @@ fn write_trailer(
     out: &mut Vec<u8>,
     previous_xref: u64,
     root: (u32, u16),
+    info: Option<(u32, u16)>,
     size: u32,
     xref_position: u64,
     id_pair: Option<(Vec<u8>, Vec<u8>)>,
@@ -427,6 +442,9 @@ fn write_trailer(
         )
         .as_bytes(),
     );
+    if let Some((number, generation)) = info {
+        out.extend_from_slice(format!("/Info {number} {generation} R ").as_bytes());
+    }
     if let Some((first, second)) = id_pair {
         let hex = |bytes: &[u8]| {
             bytes

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -4,6 +4,7 @@ mod content_stream_utils;
 mod incremental_annotations;
 mod incremental_form_fill;
 mod incremental_highlights;
+mod incremental_ocr_layer;
 mod incremental_text_notes;
 mod incremental_update;
 mod object_streams;
@@ -19,6 +20,9 @@ pub use incremental_form_fill::IncrementalFormFiller;
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
     HighlightUpdate, IncrementalHighlightEditor,
+};
+pub use incremental_ocr_layer::{
+    IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage, OcrLayerPlan, OcrLayerUpdate,
 };
 pub use incremental_text_notes::{
     IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,

--- a/oxidize-pdf-core/tests/issue_542_incremental_ocr_test.rs
+++ b/oxidize-pdf-core/tests/issue_542_incremental_ocr_test.rs
@@ -1,0 +1,49 @@
+use oxidize_pdf::writer::{IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage};
+use oxidize_pdf::{Document, Page};
+use std::process::Command;
+
+fn base_pdf(xref_stream: bool) -> Vec<u8> {
+    let mut document = Document::new();
+    document.enable_xref_streams(xref_stream);
+    document.add_page(Page::a4());
+    document.to_bytes().unwrap()
+}
+
+fn layer() -> OcrLayerPage {
+    OcrLayerPage {
+        page_index: 0,
+        language: "es".to_string(),
+        fragments: vec![OcrLayerFragment {
+            text: "búsqueda".to_string(),
+            region: [50.0, 700.0, 70.0, 12.0],
+            confidence: 0.99,
+            reading_order: 0,
+        }],
+    }
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_ocr_revisions() {
+    for (name, base) in [
+        ("classic", base_pdf(false)),
+        ("xref-stream", base_pdf(true)),
+    ] {
+        let update = IncrementalOcrLayerEditor::new(&base)
+            .apply(&[layer()])
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- append positioned invisible Unicode OCR text as a validated incremental revision
- preserve the complete source byte prefix, page resources/content, metadata, annotations, rotation, and unrelated document semantics
- expose dry-run planning plus language, confidence, source-region, and logical reading-order metadata
- skip existing oxidize-pdf OCR layers and emit deterministic isolated streams/resources
- reject encrypted and DocMDP-certified inputs, reopen outputs before atomic publication
- support classic xref tables and xref streams with qpdf CI validation

## Validation
- cargo test -p oxidize-pdf --lib (6716 passed)
- cargo test -p oxidize-pdf --test issue_532_docmdp_permissions_test
- cargo test -p oxidize-pdf --test issue_525_incremental_highlights_test --test issue_531_lossless_page_reorder_test
- cargo test -p oxidize-pdf --test issue_542_incremental_ocr_test qpdf_accepts_classic_and_xref_stream_ocr_revisions -- --ignored --exact
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- Kripteia test quality: 100/100; security: no issues

Closes #542