### PR TITLE
feat: complete lossless tagged-PDF validation and editing

### DIFF
--- a/oxidize-pdf-core/src/signatures/permissions.rs
+++ b/oxidize-pdf-core/src/signatures/permissions.rs
@@ -13,6 +13,7 @@ pub(crate) enum IncrementalModification {
     AddSignature,
     AddAnnotation,
     OcrTextLayer,
+    TaggedStructure,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -339,6 +340,7 @@ fn enforce_permission(
         IncrementalModification::AddSignature => "adding signatures",
         IncrementalModification::AddAnnotation => "adding annotations",
         IncrementalModification::OcrTextLayer => "adding an OCR text layer",
+        IncrementalModification::TaggedStructure => "editing tagged-PDF structure",
     };
     Err(PdfError::PermissionDenied(format!(
         "DocMDP {description} does not permit {edit}"
@@ -403,6 +405,19 @@ mod tests {
             DocMdpPermission::FormFillSignAndAnnotate,
         ] {
             assert!(enforce_permission(IncrementalModification::OcrTextLayer, permission).is_err());
+        }
+    }
+
+    #[test]
+    fn tagged_structure_edits_are_forbidden_at_every_permission_level() {
+        for permission in [
+            DocMdpPermission::NoChanges,
+            DocMdpPermission::FormFillAndSign,
+            DocMdpPermission::FormFillSignAndAnnotate,
+        ] {
+            assert!(
+                enforce_permission(IncrementalModification::TaggedStructure, permission).is_err()
+            );
         }
     }
 }

--- a/oxidize-pdf-core/src/verification/mod.rs
+++ b/oxidize-pdf-core/src/verification/mod.rs
@@ -16,6 +16,7 @@ pub mod curated_matrix;
 pub mod iso_matrix;
 pub mod parser;
 pub mod semantic_comparison;
+pub mod tagged_pdf;
 pub mod validators;
 
 // Disabled vanity ISO compliance tests - these test PDF syntax rather than functionality

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -5,9 +5,12 @@
 //! before it can safely publish an incremental mutation.
 
 use crate::error::{PdfError, Result};
+use crate::parser::content::{
+    ContentOperation, ContentParser, MarkedContentProps, MarkedContentValue,
+};
 use crate::parser::objects::{PdfDictionary, PdfObject};
 use crate::parser::PdfReader;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{Cursor, Read, Seek};
 
 /// Hard limits for untrusted structure and number trees.
@@ -19,6 +22,8 @@ pub struct TaggedPdfLimits {
     pub max_depth: usize,
     /// Maximum total children and number-tree entries inspected.
     pub max_entries: usize,
+    /// Maximum total decoded page-content bytes inspected for MCIDs.
+    pub max_decoded_content_bytes: usize,
 }
 
 impl Default for TaggedPdfLimits {
@@ -27,6 +32,7 @@ impl Default for TaggedPdfLimits {
             max_objects: 100_000,
             max_depth: 256,
             max_entries: 1_000_000,
+            max_decoded_content_bytes: 256 * 1024 * 1024,
         }
     }
 }
@@ -53,17 +59,21 @@ pub enum TaggedPdfFindingCode {
     MissingStructureTree,
     InvalidStructureTreeRoot,
     InvalidStructureElement,
+    DirectStructureElement,
     MissingStructureType,
     BrokenParentLink,
     DuplicateStructureReference,
     StructureCycle,
     InvalidMarkedContentReference,
+    MissingMarkedContent,
+    InvalidObjectReference,
     MissingParentTree,
     InvalidParentTree,
     MissingStructParents,
     MissingParentTreeEntry,
     ParentTreeOwnerMismatch,
     UnmappedCustomRole,
+    InvalidRoleMap,
 }
 
 /// An indirect object reference exposed without leaking parser internals.
@@ -145,6 +155,9 @@ struct Validator<'a, R: Read + Seek> {
     role_map: BTreeMap<String, String>,
     class_names: Vec<String>,
     parent_tree: BTreeMap<i64, PdfObject>,
+    direct_mcid_counts: HashMap<TaggedPdfObjectRef, usize>,
+    page_mcids: HashMap<TaggedPdfObjectRef, HashSet<i64>>,
+    decoded_content_bytes: usize,
 }
 
 impl<'a, R: Read + Seek> Validator<'a, R> {
@@ -160,6 +173,9 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             role_map: BTreeMap::new(),
             class_names: Vec::new(),
             parent_tree: BTreeMap::new(),
+            direct_mcid_counts: HashMap::new(),
+            page_mcids: HashMap::new(),
+            decoded_content_bytes: 0,
         }
     }
 
@@ -197,6 +213,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         }
         self.read_name_map(root.get("RoleMap").cloned(), true)?;
         self.read_name_map(root.get("ClassMap").cloned(), false)?;
+        self.validate_role_map();
 
         if let Some(parent_tree) = root.get("ParentTree").cloned() {
             self.walk_number_tree(&parent_tree, 0)?;
@@ -275,6 +292,40 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         Ok(())
     }
 
+    fn validate_role_map(&mut self) {
+        let names: Vec<_> = self.role_map.keys().cloned().collect();
+        for name in names {
+            if let Err(message) = self.resolve_role(&name) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidRoleMap,
+                    format!("/StructTreeRoot/RoleMap/{name}"),
+                    message,
+                    None,
+                );
+            }
+        }
+    }
+
+    fn resolve_role(&self, name: &str) -> std::result::Result<String, String> {
+        let mut current = name;
+        let mut seen = HashSet::new();
+        loop {
+            if is_standard_structure_type(current) {
+                return Ok(current.to_string());
+            }
+            if !seen.insert(current.to_string()) {
+                return Err("RoleMap contains a cycle".to_string());
+            }
+            let Some(next) = self.role_map.get(current) else {
+                return Err(format!(
+                    "RoleMap chain does not resolve custom type /{current} to a standard type"
+                ));
+            };
+            current = next;
+        }
+    }
+
     fn walk_structure_value(
         &mut self,
         value: &PdfObject,
@@ -349,12 +400,28 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             return Ok(0);
         };
         let kind = dict.get_type();
-        if matches!(kind, Some("MCR") | Some("OBJR")) || dict.contains_key("MCID") {
+        if kind == Some("OBJR") {
+            self.validate_objr(&dict, expected_parent, inherited_page, path)?;
+            if let Some(reference) = object_ref {
+                self.active.remove(&reference);
+            }
+            return Ok(0);
+        }
+        if kind == Some("MCR") || dict.contains_key("MCID") {
             let marked = self.validate_mcr(&dict, expected_parent, inherited_page, path)?;
             if let Some(reference) = object_ref {
                 self.active.remove(&reference);
             }
             return Ok(usize::from(marked));
+        }
+        if object_ref.is_none() {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::DirectStructureElement,
+                path,
+                "structure elements must be indirect objects",
+                None,
+            );
         }
         let structure_type = dict
             .get("S")
@@ -369,7 +436,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 object_ref,
             );
         } else if let Some(name) = structure_type.as_deref() {
-            if !is_standard_structure_type(name) && !self.role_map.contains_key(name) {
+            if !is_standard_structure_type(name) && self.resolve_role(name).is_err() {
                 self.finding(
                     TaggedPdfFindingSeverity::Warning,
                     TaggedPdfFindingCode::UnmappedCustomRole,
@@ -397,7 +464,6 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .and_then(PdfObject::as_reference)
             .map(Into::into)
             .or(inherited_page);
-        let mut marked_content_count = 0;
         let child_count = dict
             .get("K")
             .map(|kids| match kids {
@@ -406,10 +472,10 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             })
             .unwrap_or(0);
         if let Some(kids) = dict.get("K") {
-            marked_content_count =
-                self.walk_structure_value(kids, object_ref, page, depth + 1, &format!("{path}/K"))?;
+            self.walk_structure_value(kids, object_ref, page, depth + 1, &format!("{path}/K"))?;
         }
         if let Some(reference) = object_ref {
+            let marked_content_count = self.direct_mcid_counts.remove(&reference).unwrap_or(0);
             self.elements.push(TaggedPdfStructureElement {
                 object: reference,
                 structure_type,
@@ -419,7 +485,78 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             });
             self.active.remove(&reference);
         }
-        Ok(marked_content_count)
+        Ok(0)
+    }
+
+    fn validate_objr(
+        &mut self,
+        dict: &PdfDictionary,
+        owner: Option<TaggedPdfObjectRef>,
+        inherited_page: Option<TaggedPdfObjectRef>,
+        path: &str,
+    ) -> Result<()> {
+        let Some(object) = dict
+            .get("Obj")
+            .and_then(PdfObject::as_reference)
+            .map(TaggedPdfObjectRef::from)
+        else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidObjectReference,
+                format!("{path}/Obj"),
+                "OBJR has no indirect /Obj reference",
+                owner,
+            );
+            return Ok(());
+        };
+        let referenced = self
+            .reader
+            .get_object(object.object_number, object.generation)?
+            .clone();
+        let Some(key) = referenced
+            .as_dict()
+            .or_else(|| referenced.as_stream().map(|stream| &stream.dict))
+            .and_then(|dict| dict.get("StructParent"))
+            .and_then(PdfObject::as_integer)
+        else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidObjectReference,
+                format!("{path}/Obj/StructParent"),
+                "object referenced by OBJR has no integer StructParent key",
+                Some(object),
+            );
+            return Ok(());
+        };
+        let actual = self
+            .parent_tree
+            .get(&key)
+            .and_then(PdfObject::as_reference)
+            .map(TaggedPdfObjectRef::from);
+        if actual != owner {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::ParentTreeOwnerMismatch,
+                format!("/StructTreeRoot/ParentTree/{key}"),
+                "ParentTree object-reference entry does not point back to its structure element",
+                owner,
+            );
+        }
+        let page = dict
+            .get("Pg")
+            .and_then(PdfObject::as_reference)
+            .map(Into::into)
+            .or(inherited_page);
+        if page.is_none() {
+            self.finding(
+                TaggedPdfFindingSeverity::Warning,
+                TaggedPdfFindingCode::InvalidObjectReference,
+                format!("{path}/Pg"),
+                "OBJR has no page association",
+                owner,
+            );
+        }
+        Ok(())
     }
 
     fn validate_mcr(
@@ -451,6 +588,9 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             );
             return Ok(false);
         }
+        if let Some(owner) = owner {
+            *self.direct_mcid_counts.entry(owner).or_default() += 1;
+        }
         let page = dict
             .get("Pg")
             .and_then(PdfObject::as_reference)
@@ -470,9 +610,22 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .reader
             .get_object(page.object_number, page.generation)?
             .clone();
-        let struct_parent = page_object
+        let context = dict
+            .get("Stm")
+            .and_then(PdfObject::as_reference)
+            .map(TaggedPdfObjectRef::from)
+            .unwrap_or(page);
+        let context_object = if context == page {
+            page_object
+        } else {
+            self.reader
+                .get_object(context.object_number, context.generation)?
+                .clone()
+        };
+        let struct_parent = context_object
             .as_dict()
-            .and_then(|page| page.get("StructParents"))
+            .or_else(|| context_object.as_stream().map(|stream| &stream.dict))
+            .and_then(|object| object.get("StructParents"))
             .and_then(PdfObject::as_integer);
         let Some(key) = struct_parent else {
             self.finding(
@@ -480,7 +633,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 TaggedPdfFindingCode::MissingStructParents,
                 &format!("{path}/Pg/StructParents"),
                 "page associated with MCID has no integer StructParents key",
-                Some(page),
+                Some(context),
             );
             return Ok(true);
         };
@@ -490,7 +643,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 TaggedPdfFindingCode::MissingParentTreeEntry,
                 &format!("/StructTreeRoot/ParentTree/{key}"),
                 "ParentTree has no entry for the page StructParents key",
-                Some(page),
+                Some(context),
             );
             return Ok(true);
         };
@@ -509,7 +662,134 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 owner,
             );
         }
+        let mcids = self.mcids_for_context(context, &context_object)?;
+        if !mcids.contains(&mcid) {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingMarkedContent,
+                format!("{path}/MCID"),
+                "MCID is referenced by the structure tree but absent from its content stream",
+                owner,
+            );
+        }
         Ok(true)
+    }
+
+    fn mcids_for_context(
+        &mut self,
+        context: TaggedPdfObjectRef,
+        object: &PdfObject,
+    ) -> Result<HashSet<i64>> {
+        if let Some(cached) = self.page_mcids.get(&context) {
+            return Ok(cached.clone());
+        }
+        let content = if let Some(stream) = object.as_stream() {
+            vec![stream.decode(self.reader.options())?]
+        } else if let Some(dict) = object.as_dict() {
+            match dict.get("Contents") {
+                Some(contents) => self.decode_content_objects(contents, 0)?,
+                None => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+        let resources = self.effective_resources(object, 0)?;
+        let mut mcids = HashSet::new();
+        for bytes in content {
+            self.decoded_content_bytes = self
+                .decoded_content_bytes
+                .checked_add(bytes.len())
+                .ok_or_else(|| self.limit_error("decoded content bytes", usize::MAX))?;
+            if self.decoded_content_bytes > self.limits.max_decoded_content_bytes {
+                return Err(self.limit_error(
+                    "decoded content bytes",
+                    self.limits.max_decoded_content_bytes,
+                ));
+            }
+            for operation in ContentParser::parse(&bytes)? {
+                if let ContentOperation::BeginMarkedContentWithProps(_, properties) = operation {
+                    if let Some(mcid) =
+                        self.mcid_from_properties(&properties, resources.as_ref())?
+                    {
+                        if mcid >= 0 {
+                            mcids.insert(mcid);
+                        }
+                    }
+                }
+            }
+        }
+        self.page_mcids.insert(context, mcids.clone());
+        Ok(mcids)
+    }
+
+    fn mcid_from_properties(
+        &mut self,
+        properties: &MarkedContentProps,
+        resources: Option<&PdfDictionary>,
+    ) -> Result<Option<i64>> {
+        match properties {
+            MarkedContentProps::Inline(properties) => {
+                Ok(properties.get("MCID").and_then(|value| match value {
+                    MarkedContentValue::Integer(mcid) => Some(*mcid),
+                    _ => None,
+                }))
+            }
+            MarkedContentProps::ResourceRef(name) => {
+                let Some(properties) = resources.and_then(|dict| dict.get("Properties")) else {
+                    return Ok(None);
+                };
+                let Some(properties) = self.resolve_dict(properties)? else {
+                    return Ok(None);
+                };
+                let Some(value) = properties.get(name) else {
+                    return Ok(None);
+                };
+                Ok(self
+                    .resolve_dict(value)?
+                    .and_then(|dict| dict.get("MCID").and_then(PdfObject::as_integer)))
+            }
+        }
+    }
+
+    fn effective_resources(
+        &mut self,
+        object: &PdfObject,
+        depth: usize,
+    ) -> Result<Option<PdfDictionary>> {
+        self.check_depth(depth)?;
+        let Some(dict) = object
+            .as_dict()
+            .or_else(|| object.as_stream().map(|stream| &stream.dict))
+        else {
+            return Ok(None);
+        };
+        if let Some(resources) = dict.get("Resources") {
+            return self.resolve_dict(resources);
+        }
+        let Some(parent) = dict.get("Parent") else {
+            return Ok(None);
+        };
+        let parent = self.resolve(parent)?;
+        self.effective_resources(&parent, depth + 1)
+    }
+
+    fn decode_content_objects(&mut self, value: &PdfObject, depth: usize) -> Result<Vec<Vec<u8>>> {
+        self.check_depth(depth)?;
+        let resolved = self.resolve(value)?;
+        if let Some(stream) = resolved.as_stream() {
+            return Ok(vec![stream.decode(self.reader.options())?]);
+        }
+        if let Some(array) = resolved.as_array() {
+            let mut streams = Vec::new();
+            for child in &array.0 {
+                self.bump_entry()?;
+                streams.extend(self.decode_content_objects(child, depth + 1)?);
+            }
+            return Ok(streams);
+        }
+        Err(PdfError::InvalidStructure(
+            "page /Contents is neither a stream nor an array of streams".to_string(),
+        ))
     }
 
     fn walk_number_tree(&mut self, value: &PdfObject, depth: usize) -> Result<()> {
@@ -540,6 +820,40 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             );
             return Ok(());
         };
+        if dict.contains_key("Nums") && dict.contains_key("Kids") {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidParentTree,
+                "/StructTreeRoot/ParentTree",
+                "number-tree node must not contain both Nums and Kids",
+                reference,
+            );
+        }
+        let declared_limits = if let Some(limits) = dict.get("Limits") {
+            let limits = self.resolve(limits)?;
+            let parsed = limits
+                .as_array()
+                .and_then(|array| match array.0.as_slice() {
+                    [PdfObject::Integer(first), PdfObject::Integer(last)]
+                        if *first >= 0 && first <= last =>
+                    {
+                        Some((*first, *last))
+                    }
+                    _ => None,
+                });
+            if parsed.is_none() {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree/Limits",
+                    "number-tree Limits must be two ordered non-negative integers",
+                    reference,
+                );
+            }
+            parsed
+        } else {
+            None
+        };
         if let Some(nums) = dict.get("Nums") {
             let nums = self.resolve(nums)?;
             let Some(array) = nums.as_array() else {
@@ -561,9 +875,43 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                     reference,
                 );
             }
+            let actual_limits = array
+                .0
+                .first()
+                .and_then(PdfObject::as_integer)
+                .zip(array.0.iter().rev().nth(1).and_then(PdfObject::as_integer));
+            if declared_limits.is_some() && declared_limits != actual_limits {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree/Limits",
+                    "number-tree Limits do not match the first and last Nums keys",
+                    reference,
+                );
+            }
+            let mut previous_key = None;
             for pair in array.0.chunks_exact(2) {
                 self.bump_entry()?;
                 if let Some(key) = pair[0].as_integer() {
+                    if key < 0 {
+                        self.finding(
+                            TaggedPdfFindingSeverity::Error,
+                            TaggedPdfFindingCode::InvalidParentTree,
+                            "/StructTreeRoot/ParentTree/Nums",
+                            "ParentTree keys must be non-negative integers",
+                            reference,
+                        );
+                    }
+                    if previous_key.is_some_and(|previous| key <= previous) {
+                        self.finding(
+                            TaggedPdfFindingSeverity::Error,
+                            TaggedPdfFindingCode::InvalidParentTree,
+                            "/StructTreeRoot/ParentTree/Nums",
+                            "number-tree keys must be strictly increasing",
+                            reference,
+                        );
+                    }
+                    previous_key = Some(key);
                     if self.parent_tree.insert(key, pair[1].clone()).is_some() {
                         self.finding(
                             TaggedPdfFindingSeverity::Error,
@@ -733,8 +1081,8 @@ mod tests {
         pdf(&[
             "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
-            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 >>",
-            "<< /Length 0 >>\nstream\n\nendstream",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R /RoleMap << /CustomP /P >> /ClassMap << /C1 << /O /Layout >> >> >>",
             "<< /Type /StructElem /S /CustomP /P 5 0 R /Pg 3 0 R /K [<< /Type /MCR /Pg 3 0 R /MCID 0 >>] >>",
             "<< /Nums [0 [6 0 R]] >>",
@@ -761,8 +1109,8 @@ mod tests {
         let bytes = pdf(&[
             "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
-            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 >>",
-            "null",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R >>",
             "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
             "<< /Nums [0 [5 0 R]] >>",
@@ -818,5 +1166,122 @@ mod tests {
         };
         let error = validate_tagged_pdf(&valid_tagged_pdf(), &options).unwrap_err();
         assert!(error.to_string().contains("nesting depth"));
+    }
+
+    #[test]
+    fn rejects_direct_structure_elements() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K << /Type /StructElem /S /P /P 4 0 R >> /ParentTree 5 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::DirectStructureElement));
+    }
+
+    #[test]
+    fn rejects_cyclic_role_maps() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R /RoleMap << /A /B /B /A >> >>",
+            "<< /Type /StructElem /S /A /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidRoleMap));
+    }
+
+    #[test]
+    fn rejects_an_mcid_absent_from_page_content() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 22 >>\nstream\n/P <</MCID 1>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Nums [0 [6 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::MissingMarkedContent));
+    }
+
+    #[test]
+    fn resolves_mcid_from_a_resource_property_list() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R /Resources << /Properties << /MC0 << /MCID 0 >> >> >> >>",
+            "<< /Length 15 >>\nstream\n/P /MC0 BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Nums [0 [6 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report.valid, "{:?}", report.findings);
+    }
+
+    #[test]
+    fn validates_objr_through_struct_parent() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
+            "<< /Type /StructElem /S /Annot /P 4 0 R /Pg 3 0 R /K << /Type /OBJR /Obj 7 0 R >> >>",
+            "<< /Nums [1 5 0 R] >>",
+            "<< /Type /Annot /Subtype /Link /StructParent 1 >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report.valid, "{:?}", report.findings);
+    }
+
+    #[test]
+    fn rejects_malformed_number_tree_order_and_limits() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [] /ParentTree 5 0 R >>",
+            "<< /Limits [1 0] /Nums [1 null 0 null] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| { finding.code == TaggedPdfFindingCode::InvalidParentTree })
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn enforces_decoded_content_limit() {
+        let options = TaggedPdfValidationOptions {
+            limits: TaggedPdfLimits {
+                max_decoded_content_bytes: 1,
+                ..Default::default()
+            },
+        };
+        let error = validate_tagged_pdf(&valid_tagged_pdf(), &options).unwrap_err();
+        assert!(error.to_string().contains("decoded content bytes"));
     }
 }

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -202,6 +202,7 @@ struct Validator<'a, R: Read + Seek> {
     current_content_context: Option<TaggedPdfObjectRef>,
     active_content: HashSet<TaggedPdfObjectRef>,
     last_mcid_by_owner: HashMap<TaggedPdfObjectRef, i64>,
+    last_mcid_by_context: HashMap<TaggedPdfObjectRef, i64>,
     objr_counts: HashMap<TaggedPdfObjectRef, usize>,
     decoded_content_bytes: usize,
     catalog_language: bool,
@@ -230,6 +231,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             current_content_context: None,
             active_content: HashSet::new(),
             last_mcid_by_owner: HashMap::new(),
+            last_mcid_by_context: HashMap::new(),
             objr_counts: HashMap::new(),
             decoded_content_bytes: 0,
             catalog_language: false,
@@ -526,7 +528,13 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         };
         let kind = dict.get_type();
         if kind == Some("OBJR") {
-            self.validate_objr(&dict, expected_parent, inherited_page, path)?;
+            self.validate_objr(
+                &dict,
+                expected_parent,
+                expected_parent_type,
+                inherited_page,
+                path,
+            )?;
             if let Some(reference) = object_ref {
                 self.active.remove(&reference);
             }
@@ -584,6 +592,9 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             path,
             object_ref,
         );
+        if matches!(resolved_type.as_deref(), Some("TH" | "TD")) {
+            self.validate_table_cell(&dict, resolved_type.as_deref().unwrap(), path, object_ref);
+        }
         if matches!(resolved_type.as_deref(), Some("Figure" | "Formula"))
             && alternate_text.is_none()
             && actual_text.is_none()
@@ -745,10 +756,59 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         }
     }
 
+    fn validate_table_cell(
+        &mut self,
+        dict: &PdfDictionary,
+        cell_type: &str,
+        path: &str,
+        object: Option<TaggedPdfObjectRef>,
+    ) {
+        for key in ["RowSpan", "ColSpan"] {
+            if table_attribute(dict, key)
+                .and_then(PdfObject::as_integer)
+                .is_some_and(|span| span < 1)
+            {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidTableStructure,
+                    format!("{path}/A/{key}"),
+                    format!("table-cell {key} must be a positive integer"),
+                    object,
+                );
+            }
+        }
+        if cell_type != "TH" {
+            return;
+        }
+        let scope = table_attribute(dict, "Scope").and_then(PdfObject::as_name);
+        if scope.is_some_and(|scope| !matches!(scope.as_str(), "Row" | "Column" | "Both")) {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidTableStructure,
+                format!("{path}/A/Scope"),
+                "TH Scope must be Row, Column, or Both",
+                object,
+            );
+        }
+        let has_headers = table_attribute(dict, "Headers")
+            .and_then(PdfObject::as_array)
+            .is_some_and(|headers| !headers.0.is_empty());
+        if scope.is_none() && !has_headers {
+            self.finding(
+                TaggedPdfFindingSeverity::Warning,
+                TaggedPdfFindingCode::InvalidTableStructure,
+                format!("{path}/A"),
+                "TH should define Scope or Headers so data cells can identify their headers",
+                object,
+            );
+        }
+    }
+
     fn validate_objr(
         &mut self,
         dict: &PdfDictionary,
         owner: Option<TaggedPdfObjectRef>,
+        owner_type: Option<&str>,
         inherited_page: Option<TaggedPdfObjectRef>,
         path: &str,
     ) -> Result<()> {
@@ -773,6 +833,34 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .reader
             .get_object(object.object_number, object.generation)?
             .clone();
+        if owner_type == Some("Link") {
+            let annotation = referenced
+                .as_dict()
+                .or_else(|| referenced.as_stream().map(|stream| &stream.dict));
+            if annotation
+                .and_then(|dictionary| dictionary.get("Subtype"))
+                .and_then(PdfObject::as_name)
+                .is_none_or(|subtype| subtype.as_str() != "Link")
+            {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidLinkStructure,
+                    format!("{path}/Obj/Subtype"),
+                    "OBJR child of Link must reference a Link annotation",
+                    owner,
+                );
+            } else if annotation.is_some_and(|dictionary| {
+                !dictionary.contains_key("A") && !dictionary.contains_key("Dest")
+            }) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidLinkStructure,
+                    format!("{path}/Obj"),
+                    "Link annotation has neither an action nor a destination",
+                    owner,
+                );
+            }
+        }
         let Some(key) = referenced
             .as_dict()
             .or_else(|| referenced.as_stream().map(|stream| &stream.dict))
@@ -898,6 +986,19 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .and_then(PdfObject::as_reference)
             .map(TaggedPdfObjectRef::from)
             .unwrap_or(page);
+        if self
+            .last_mcid_by_context
+            .insert(context, mcid)
+            .is_some_and(|previous| mcid <= previous)
+        {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidReadingOrder,
+                format!("{path}/MCID"),
+                "logical structure order does not follow marked-content order in its content context",
+                owner,
+            );
+        }
         let context_object = if context == page {
             page_object
         } else {
@@ -1508,6 +1609,17 @@ fn text_value(value: Option<&PdfObject>) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
+fn table_attribute<'a>(dictionary: &'a PdfDictionary, key: &str) -> Option<&'a PdfObject> {
+    dictionary.get(key).or_else(|| match dictionary.get("A") {
+        Some(PdfObject::Dictionary(attributes)) => attributes.get(key),
+        Some(PdfObject::Array(attributes)) => attributes
+            .0
+            .iter()
+            .find_map(|value| value.as_dict().and_then(|attributes| attributes.get(key))),
+        _ => None,
+    })
+}
+
 fn artifact_subtype(properties: &MarkedContentProps) -> Option<String> {
     match properties {
         MarkedContentProps::Inline(values) => values.get("Subtype").and_then(|value| match value {
@@ -2007,5 +2119,48 @@ mod tests {
             .findings
             .iter()
             .any(|finding| finding.code == TaggedPdfFindingCode::InvalidReadingOrder));
+    }
+
+    #[test]
+    fn rejects_logical_order_that_reverses_page_content() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 44 >>\nstream\n/P <</MCID 0>> BDC EMC /P <</MCID 1>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K [7 0 R 6 0 R] /ParentTree 8 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 1 >>",
+            "<< /Nums [0 [6 0 R 7 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report.findings.iter().any(|finding| {
+            finding.code == TaggedPdfFindingCode::InvalidReadingOrder
+                && finding.message.contains("logical structure order")
+        }));
+    }
+
+    #[test]
+    fn validates_table_header_attributes_and_link_annotation_semantics() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [5 0 R 6 0 R] /ParentTree 9 0 R >>",
+            "<< /Type /StructElem /S /TH /P 4 0 R /A << /O /Table /Scope /Invalid /RowSpan 0 >> >>",
+            "<< /Type /StructElem /S /Link /P 4 0 R /K << /Type /OBJR /Obj 7 0 R >> >>",
+            "<< /Type /Annot /Subtype /Text /StructParent 0 >>",
+            "null",
+            "<< /Nums [0 6 0 R] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report.findings.iter().any(|finding| {
+            finding.code == TaggedPdfFindingCode::InvalidTableStructure
+                && finding.path.ends_with("RowSpan")
+        }));
+        assert!(report.findings.iter().any(|finding| {
+            finding.code == TaggedPdfFindingCode::InvalidLinkStructure
+                && finding.path.ends_with("Subtype")
+        }));
     }
 }

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -74,6 +74,7 @@ pub enum TaggedPdfFindingCode {
     ParentTreeOwnerMismatch,
     UnmappedCustomRole,
     InvalidRoleMap,
+    InvalidClassMap,
     MissingDocumentLanguage,
     MissingAlternateText,
     InvalidHeadingOrder,
@@ -122,13 +123,15 @@ pub struct TaggedPdfStructureElement {
 }
 
 /// Machine-readable result of tagged-PDF inspection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TaggedPdfValidationReport {
     pub tagged: bool,
     pub valid: bool,
     pub structure_tree_root: Option<TaggedPdfObjectRef>,
     pub role_map: BTreeMap<String, String>,
     pub class_names: Vec<String>,
+    /// Lossless parsed ClassMap values, including unknown attributes and namespaces.
+    pub class_map: BTreeMap<String, PdfObject>,
     pub elements: Vec<TaggedPdfStructureElement>,
     pub parent_tree_entries: usize,
     pub findings: Vec<TaggedPdfFinding>,
@@ -137,9 +140,17 @@ pub struct TaggedPdfValidationReport {
 /// Inspect and validate the tagged structure of an existing PDF.
 ///
 /// The traversal validates structure-element parent links and the page
-/// `/StructParents` -> structure `/ParentTree` -> MCID owner association.  It
-/// does not claim full PDF/UA conformance: language, headings, tables, lists,
-/// links and alternate-text rules will build on this structural foundation.
+/// `/StructParents` -> structure `/ParentTree` -> MCID owner association. It
+/// also reports initial PDF/UA-oriented rules for catalog language, numbered
+/// heading order, and text alternatives for figures and formulas. It does not
+/// claim complete PDF/UA conformance; table, list, link, artifact, and complete
+/// reading-order rules are not yet implemented.
+///
+/// # Errors
+///
+/// Returns an error when the PDF cannot be parsed or decoded safely, is locked,
+/// or exceeds a configured traversal or decoded-content limit. Structural and
+/// PDF/UA findings are returned in the report rather than as function errors.
 pub fn validate_tagged_pdf(
     pdf: &[u8],
     options: &TaggedPdfValidationOptions,
@@ -163,12 +174,15 @@ struct Validator<'a, R: Read + Seek> {
     findings: Vec<TaggedPdfFinding>,
     role_map: BTreeMap<String, String>,
     class_names: Vec<String>,
+    class_map: BTreeMap<String, PdfObject>,
     parent_tree: BTreeMap<i64, PdfObject>,
     direct_mcid_counts: HashMap<TaggedPdfObjectRef, usize>,
     page_mcids: HashMap<TaggedPdfObjectRef, HashSet<i64>>,
     decoded_content_bytes: usize,
-    saw_language: bool,
+    catalog_language: bool,
     last_heading_level: Option<u8>,
+    saw_generic_heading: bool,
+    saw_numbered_heading: bool,
 }
 
 impl<'a, R: Read + Seek> Validator<'a, R> {
@@ -183,18 +197,21 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             findings: Vec::new(),
             role_map: BTreeMap::new(),
             class_names: Vec::new(),
+            class_map: BTreeMap::new(),
             parent_tree: BTreeMap::new(),
             direct_mcid_counts: HashMap::new(),
             page_mcids: HashMap::new(),
             decoded_content_bytes: 0,
-            saw_language: false,
+            catalog_language: false,
             last_heading_level: None,
+            saw_generic_heading: false,
+            saw_numbered_heading: false,
         }
     }
 
     fn run(mut self) -> Result<TaggedPdfValidationReport> {
         let catalog = self.reader.catalog()?.clone();
-        self.saw_language = text_value(catalog.get("Lang")).is_some();
+        self.catalog_language = text_value(catalog.get("Lang")).is_some();
         let Some(root_value) = catalog.get("StructTreeRoot").cloned() else {
             self.finding(
                 TaggedPdfFindingSeverity::Warning,
@@ -206,6 +223,15 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             return Ok(self.report(false, None));
         };
         let root_ref = root_value.as_reference().map(Into::into);
+        if root_ref.is_none() {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidStructureTreeRoot,
+                "/Catalog/StructTreeRoot",
+                "StructTreeRoot must be an indirect object",
+                None,
+            );
+        }
         let Some(root) = self.resolve_dict(&root_value)? else {
             self.finding(
                 TaggedPdfFindingSeverity::Error,
@@ -225,8 +251,8 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 root_ref,
             );
         }
-        self.read_name_map(root.get("RoleMap").cloned(), true)?;
-        self.read_name_map(root.get("ClassMap").cloned(), false)?;
+        self.read_role_map(root.get("RoleMap").cloned())?;
+        self.read_class_map(root.get("ClassMap").cloned())?;
         self.validate_role_map();
 
         if let Some(parent_tree) = root.get("ParentTree").cloned() {
@@ -244,12 +270,12 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         if let Some(kids) = root.get("K").cloned() {
             self.walk_structure_value(&kids, root_ref, None, 0, "/StructTreeRoot/K")?;
         }
-        if !self.saw_language {
+        if !self.catalog_language {
             self.finding(
                 TaggedPdfFindingSeverity::Error,
                 TaggedPdfFindingCode::MissingDocumentLanguage,
                 "/Catalog/Lang",
-                "tagged document has no language on the catalog or any structure element",
+                "tagged document catalog has no non-empty Lang entry",
                 root_ref,
             );
         }
@@ -276,6 +302,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             structure_tree_root: root,
             role_map: self.role_map,
             class_names: self.class_names,
+            class_map: self.class_map,
             elements: self.elements,
             parent_tree_entries: self.parent_tree.len(),
             findings: self.findings,
@@ -297,20 +324,50 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .or_else(|| object.as_stream().map(|stream| stream.dict.clone())))
     }
 
-    fn read_name_map(&mut self, value: Option<PdfObject>, role_map: bool) -> Result<()> {
+    fn read_role_map(&mut self, value: Option<PdfObject>) -> Result<()> {
         let Some(value) = value else { return Ok(()) };
         let Some(dict) = self.resolve_dict(&value)? else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidRoleMap,
+                "/StructTreeRoot/RoleMap",
+                "RoleMap must be a dictionary",
+                value.as_reference().map(Into::into),
+            );
             return Ok(());
         };
         for (name, value) in &dict.0 {
-            if role_map {
-                if let Some(target) = value.as_name() {
-                    self.role_map
-                        .insert(name.0.clone(), target.as_str().to_string());
-                }
+            if let Some(target) = value.as_name() {
+                self.role_map
+                    .insert(name.0.clone(), target.as_str().to_string());
             } else {
-                self.class_names.push(name.0.clone());
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidRoleMap,
+                    format!("/StructTreeRoot/RoleMap/{}", name.0),
+                    "RoleMap values must be names",
+                    None,
+                );
             }
+        }
+        Ok(())
+    }
+
+    fn read_class_map(&mut self, value: Option<PdfObject>) -> Result<()> {
+        let Some(value) = value else { return Ok(()) };
+        let Some(dict) = self.resolve_dict(&value)? else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidClassMap,
+                "/StructTreeRoot/ClassMap",
+                "ClassMap must be a dictionary",
+                value.as_reference().map(Into::into),
+            );
+            return Ok(());
+        };
+        for (name, value) in dict.0 {
+            self.class_names.push(name.0.clone());
+            self.class_map.insert(name.0, value);
         }
         Ok(())
     }
@@ -470,11 +527,13 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             }
         }
         let language = text_value(dict.get("Lang"));
-        self.saw_language |= language.is_some();
         let alternate_text = text_value(dict.get("Alt"));
         let actual_text = text_value(dict.get("ActualText"));
         let title = text_value(dict.get("T"));
-        if matches!(structure_type.as_deref(), Some("Figure" | "Formula"))
+        let resolved_type = structure_type
+            .as_deref()
+            .and_then(|name| self.resolve_role(name).ok());
+        if matches!(resolved_type.as_deref(), Some("Figure" | "Formula"))
             && alternate_text.is_none()
             && actual_text.is_none()
         {
@@ -486,16 +545,34 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 object_ref,
             );
         }
-        if let Some(level) = structure_type.as_deref().and_then(heading_level) {
-            if self
-                .last_heading_level
-                .is_some_and(|previous| level > previous + 1)
-            {
+        if resolved_type.as_deref() == Some("H") {
+            self.saw_generic_heading = true;
+            if self.saw_numbered_heading {
                 self.finding(
                     TaggedPdfFindingSeverity::Error,
                     TaggedPdfFindingCode::InvalidHeadingOrder,
                     format!("{path}/S"),
-                    "heading level skips an intermediate level in structure order",
+                    "generic H and numbered H1-H6 headings must not be mixed",
+                    object_ref,
+                );
+            }
+        } else if let Some(level) = resolved_type.as_deref().and_then(heading_level) {
+            self.saw_numbered_heading = true;
+            let invalid = if let Some(previous) = self.last_heading_level {
+                level > previous + 1
+            } else {
+                level != 1
+            };
+            if invalid || self.saw_generic_heading {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidHeadingOrder,
+                    format!("{path}/S"),
+                    if self.saw_generic_heading {
+                        "generic H and numbered H1-H6 headings must not be mixed"
+                    } else {
+                        "numbered headings must start at H1 and not skip levels"
+                    },
                     object_ref,
                 );
             }
@@ -672,6 +749,16 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .reader
             .get_object(page.object_number, page.generation)?
             .clone();
+        if dict.contains_key("Stm") && dict.get("Stm").and_then(PdfObject::as_reference).is_none() {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidMarkedContentReference,
+                format!("{path}/Stm"),
+                "MCR Stm must be an indirect stream reference",
+                owner,
+            );
+            return Ok(true);
+        }
         let context = dict
             .get("Stm")
             .and_then(PdfObject::as_reference)
@@ -745,43 +832,44 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         if let Some(cached) = self.page_mcids.get(&context) {
             return Ok(cached.clone());
         }
-        let content = if let Some(stream) = object.as_stream() {
-            vec![stream.decode(self.reader.options())?]
-        } else if let Some(dict) = object.as_dict() {
-            match dict.get("Contents") {
-                Some(contents) => self.decode_content_objects(contents, 0)?,
-                None => Vec::new(),
-            }
-        } else {
-            Vec::new()
-        };
         let resources = self.effective_resources(object, 0)?;
         let mut mcids = HashSet::new();
-        for bytes in content {
-            self.decoded_content_bytes = self
-                .decoded_content_bytes
-                .checked_add(bytes.len())
-                .ok_or_else(|| self.limit_error("decoded content bytes", usize::MAX))?;
-            if self.decoded_content_bytes > self.limits.max_decoded_content_bytes {
-                return Err(self.limit_error(
-                    "decoded content bytes",
-                    self.limits.max_decoded_content_bytes,
-                ));
-            }
-            for operation in ContentParser::parse(&bytes)? {
-                if let ContentOperation::BeginMarkedContentWithProps(_, properties) = operation {
-                    if let Some(mcid) =
-                        self.mcid_from_properties(&properties, resources.as_ref())?
-                    {
-                        if mcid >= 0 {
-                            mcids.insert(mcid);
-                        }
+        if let Some(stream) = object.as_stream() {
+            let bytes = stream.decode(self.reader.options())?;
+            self.process_content_bytes(&bytes, resources.as_ref(), &mut mcids)?;
+        } else if let Some(contents) = object.as_dict().and_then(|dict| dict.get("Contents")) {
+            self.process_content_objects(contents, resources.as_ref(), &mut mcids, 0)?;
+        }
+        self.page_mcids.insert(context, mcids.clone());
+        Ok(mcids)
+    }
+
+    fn process_content_bytes(
+        &mut self,
+        bytes: &[u8],
+        resources: Option<&PdfDictionary>,
+        mcids: &mut HashSet<i64>,
+    ) -> Result<()> {
+        self.decoded_content_bytes = self
+            .decoded_content_bytes
+            .checked_add(bytes.len())
+            .ok_or_else(|| self.limit_error("decoded content bytes", usize::MAX))?;
+        if self.decoded_content_bytes > self.limits.max_decoded_content_bytes {
+            return Err(self.limit_error(
+                "decoded content bytes",
+                self.limits.max_decoded_content_bytes,
+            ));
+        }
+        for operation in ContentParser::parse(bytes)? {
+            if let ContentOperation::BeginMarkedContentWithProps(_, properties) = operation {
+                if let Some(mcid) = self.mcid_from_properties(&properties, resources)? {
+                    if mcid >= 0 {
+                        mcids.insert(mcid);
                     }
                 }
             }
         }
-        self.page_mcids.insert(context, mcids.clone());
-        Ok(mcids)
+        Ok(())
     }
 
     fn mcid_from_properties(
@@ -835,26 +923,32 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         self.effective_resources(&parent, depth + 1)
     }
 
-    fn decode_content_objects(&mut self, value: &PdfObject, depth: usize) -> Result<Vec<Vec<u8>>> {
+    fn process_content_objects(
+        &mut self,
+        value: &PdfObject,
+        resources: Option<&PdfDictionary>,
+        mcids: &mut HashSet<i64>,
+        depth: usize,
+    ) -> Result<()> {
         self.check_depth(depth)?;
         let resolved = self.resolve(value)?;
         if let Some(stream) = resolved.as_stream() {
-            return Ok(vec![stream.decode(self.reader.options())?]);
+            let bytes = stream.decode(self.reader.options())?;
+            return self.process_content_bytes(&bytes, resources, mcids);
         }
         if let Some(array) = resolved.as_array() {
-            let mut streams = Vec::new();
             for child in &array.0 {
                 self.bump_entry()?;
-                streams.extend(self.decode_content_objects(child, depth + 1)?);
+                self.process_content_objects(child, resources, mcids, depth + 1)?;
             }
-            return Ok(streams);
+            return Ok(());
         }
         Err(PdfError::InvalidStructure(
             "page /Contents is neither a stream nor an array of streams".to_string(),
         ))
     }
 
-    fn walk_number_tree(&mut self, value: &PdfObject, depth: usize) -> Result<()> {
+    fn walk_number_tree(&mut self, value: &PdfObject, depth: usize) -> Result<Option<(i64, i64)>> {
         self.check_depth(depth)?;
         let reference = value.as_reference().map(TaggedPdfObjectRef::from);
         if let Some(reference) = reference {
@@ -866,7 +960,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                     "cycle or duplicate node in ParentTree",
                     Some(reference),
                 );
-                return Ok(());
+                return Ok(None);
             }
             if self.visited.len() > self.limits.max_objects {
                 return Err(self.limit_error("indirect objects", self.limits.max_objects));
@@ -880,7 +974,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 "ParentTree node is not a dictionary",
                 reference,
             );
-            return Ok(());
+            return Ok(None);
         };
         if dict.contains_key("Nums") && dict.contains_key("Kids") {
             self.finding(
@@ -916,6 +1010,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         } else {
             None
         };
+        let mut effective_limits = None;
         if let Some(nums) = dict.get("Nums") {
             let nums = self.resolve(nums)?;
             let Some(array) = nums.as_array() else {
@@ -926,7 +1021,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                     "number-tree Nums is not an array",
                     reference,
                 );
-                return Ok(());
+                return Ok(None);
             };
             if array.0.len() % 2 != 0 {
                 self.finding(
@@ -942,15 +1037,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 .first()
                 .and_then(PdfObject::as_integer)
                 .zip(array.0.iter().rev().nth(1).and_then(PdfObject::as_integer));
-            if declared_limits.is_some() && declared_limits != actual_limits {
-                self.finding(
-                    TaggedPdfFindingSeverity::Error,
-                    TaggedPdfFindingCode::InvalidParentTree,
-                    "/StructTreeRoot/ParentTree/Limits",
-                    "number-tree Limits do not match the first and last Nums keys",
-                    reference,
-                );
-            }
+            effective_limits = actual_limits;
             let mut previous_key = None;
             for pair in array.0.chunks_exact(2) {
                 self.bump_entry()?;
@@ -997,9 +1084,25 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         if let Some(kids) = dict.get("Kids") {
             let kids = self.resolve(kids)?;
             if let Some(array) = kids.as_array() {
+                let mut previous = None;
                 for kid in &array.0 {
                     self.bump_entry()?;
-                    self.walk_number_tree(kid, depth + 1)?;
+                    if let Some(range) = self.walk_number_tree(kid, depth + 1)? {
+                        if previous.is_some_and(|(_, last)| range.0 <= last) {
+                            self.finding(
+                                TaggedPdfFindingSeverity::Error,
+                                TaggedPdfFindingCode::InvalidParentTree,
+                                "/StructTreeRoot/ParentTree/Kids",
+                                "number-tree child ranges overlap or are out of order",
+                                reference,
+                            );
+                        }
+                        effective_limits = Some(match effective_limits {
+                            Some((first, _)) => (first, range.1),
+                            None => range,
+                        });
+                        previous = Some(range);
+                    }
                 }
             } else {
                 self.finding(
@@ -1011,7 +1114,16 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 );
             }
         }
-        Ok(())
+        if declared_limits.is_some() && declared_limits != effective_limits {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidParentTree,
+                "/StructTreeRoot/ParentTree/Limits",
+                "number-tree Limits do not match the effective subtree range",
+                reference,
+            );
+        }
+        Ok(effective_limits)
     }
 
     fn check_depth(&self, depth: usize) -> Result<()> {
@@ -1160,7 +1272,7 @@ mod tests {
 
     fn valid_tagged_pdf() -> Vec<u8> {
         pdf(&[
-            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
             "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
@@ -1183,12 +1295,16 @@ mod tests {
             Some("P")
         );
         assert_eq!(report.class_names, ["C1"]);
+        assert!(matches!(
+            report.class_map.get("C1"),
+            Some(PdfObject::Dictionary(_))
+        ));
     }
 
     #[test]
     fn reports_parent_tree_owner_mismatch() {
         let bytes = pdf(&[
-            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
             "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
@@ -1207,7 +1323,7 @@ mod tests {
     #[test]
     fn rejects_structure_cycles_without_recursing_forever() {
         let bytes = pdf(&[
-            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
             "<< /Type /Pages /Count 0 /Kids [] >>",
             "null",
             "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
@@ -1306,7 +1422,7 @@ mod tests {
     #[test]
     fn resolves_mcid_from_a_resource_property_list() {
         let bytes = pdf(&[
-            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R /Resources << /Properties << /MC0 << /MCID 0 >> >> >> >>",
             "<< /Length 15 >>\nstream\n/P /MC0 BDC EMC\nendstream",
@@ -1321,7 +1437,7 @@ mod tests {
     #[test]
     fn validates_objr_through_struct_parent() {
         let bytes = pdf(&[
-            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
             "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
@@ -1416,5 +1532,130 @@ mod tests {
             .findings
             .iter()
             .any(|finding| finding.code == TaggedPdfFindingCode::InvalidHeadingOrder));
+    }
+
+    #[test]
+    fn rejects_a_direct_structure_tree_root() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /Lang (en-US) /StructTreeRoot << /Type /StructTreeRoot /K [] /ParentTree << /Nums [] >> >> >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidStructureTreeRoot));
+    }
+
+    #[test]
+    fn reports_malformed_role_and_class_maps() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [] /ParentTree 5 0 R /RoleMap << /Custom 42 >> /ClassMap 7 >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidRoleMap));
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidClassMap));
+    }
+
+    #[test]
+    fn element_language_does_not_replace_catalog_language() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
+            "<< /Type /StructElem /S /Document /P 4 0 R /Lang (en-US) >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::MissingDocumentLanguage));
+    }
+
+    #[test]
+    fn applies_semantic_rules_after_role_mapping() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R /RoleMap << /Illustration /Figure >> >>",
+            "<< /Type /StructElem /S /Illustration /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::MissingAlternateText));
+    }
+
+    #[test]
+    fn numbered_headings_must_start_at_h1_and_not_mix_with_h() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [5 0 R 6 0 R] /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /H3 /P 4 0 R >>",
+            "<< /Type /StructElem /S /H /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| finding.code == TaggedPdfFindingCode::InvalidHeadingOrder)
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn rejects_overlapping_parent_tree_child_ranges() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [] /ParentTree 5 0 R >>",
+            "<< /Limits [0 2] /Kids [6 0 R 7 0 R] >>",
+            "<< /Limits [0 1] /Nums [0 null 1 null] >>",
+            "<< /Limits [1 2] /Nums [1 null 2 null] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report.findings.iter().any(|finding| {
+            finding.code == TaggedPdfFindingCode::InvalidParentTree
+                && finding.message.contains("overlap")
+        }));
+    }
+
+    #[test]
+    fn rejects_direct_mcr_stream_associations() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /K << /Type /MCR /Pg 3 0 R /Stm << /Length 0 >> /MCID 0 >> >>",
+            "<< /Nums [0 [6 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidMarkedContentReference));
     }
 }

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -75,6 +75,11 @@ pub enum TaggedPdfFindingCode {
     UnmappedCustomRole,
     InvalidRoleMap,
     InvalidClassMap,
+    InvalidReadingOrder,
+    InvalidTableStructure,
+    InvalidListStructure,
+    InvalidLinkStructure,
+    InvalidArtifact,
     MissingDocumentLanguage,
     MissingAlternateText,
     InvalidHeadingOrder,
@@ -107,7 +112,7 @@ pub struct TaggedPdfFinding {
 }
 
 /// Read-only summary of one indirect structure element.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TaggedPdfStructureElement {
     pub object: TaggedPdfObjectRef,
     pub structure_type: Option<String>,
@@ -120,6 +125,16 @@ pub struct TaggedPdfStructureElement {
     pub title: Option<String>,
     /// Every key present in the original dictionary, including unknown keys.
     pub dictionary_keys: Vec<String>,
+    /// Complete source dictionary, preserving unknown attributes and namespaces.
+    pub dictionary: PdfDictionary,
+}
+
+/// One `/Artifact` marked-content marker found in a page or form stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedPdfArtifact {
+    pub context: TaggedPdfObjectRef,
+    pub operation_index: usize,
+    pub subtype: Option<String>,
 }
 
 /// Machine-readable result of tagged-PDF inspection.
@@ -132,8 +147,13 @@ pub struct TaggedPdfValidationReport {
     pub class_names: Vec<String>,
     /// Lossless parsed ClassMap values, including unknown attributes and namespaces.
     pub class_map: BTreeMap<String, PdfObject>,
+    pub artifacts: Vec<TaggedPdfArtifact>,
     pub elements: Vec<TaggedPdfStructureElement>,
     pub parent_tree_entries: usize,
+    /// Lossless ParentTree values keyed by their integer number-tree key.
+    pub parent_tree: BTreeMap<i64, PdfObject>,
+    /// Every MCID found in each inspected page or form content context.
+    pub content_mcids: BTreeMap<TaggedPdfObjectRef, Vec<i64>>,
     pub findings: Vec<TaggedPdfFinding>,
 }
 
@@ -143,8 +163,8 @@ pub struct TaggedPdfValidationReport {
 /// `/StructParents` -> structure `/ParentTree` -> MCID owner association. It
 /// also reports initial PDF/UA-oriented rules for catalog language, numbered
 /// heading order, and text alternatives for figures and formulas. It does not
-/// claim complete PDF/UA conformance; table, list, link, artifact, and complete
-/// reading-order rules are not yet implemented.
+/// claim complete PDF/UA conformance; annotation semantics, complex table
+/// headers, and complete visual-vs-logical reading-order rules are not yet implemented.
 ///
 /// # Errors
 ///
@@ -178,6 +198,11 @@ struct Validator<'a, R: Read + Seek> {
     parent_tree: BTreeMap<i64, PdfObject>,
     direct_mcid_counts: HashMap<TaggedPdfObjectRef, usize>,
     page_mcids: HashMap<TaggedPdfObjectRef, HashSet<i64>>,
+    artifacts: Vec<TaggedPdfArtifact>,
+    current_content_context: Option<TaggedPdfObjectRef>,
+    active_content: HashSet<TaggedPdfObjectRef>,
+    last_mcid_by_owner: HashMap<TaggedPdfObjectRef, i64>,
+    objr_counts: HashMap<TaggedPdfObjectRef, usize>,
     decoded_content_bytes: usize,
     catalog_language: bool,
     last_heading_level: Option<u8>,
@@ -201,6 +226,11 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             parent_tree: BTreeMap::new(),
             direct_mcid_counts: HashMap::new(),
             page_mcids: HashMap::new(),
+            artifacts: Vec::new(),
+            current_content_context: None,
+            active_content: HashSet::new(),
+            last_mcid_by_owner: HashMap::new(),
+            objr_counts: HashMap::new(),
             decoded_content_bytes: 0,
             catalog_language: false,
             last_heading_level: None,
@@ -268,8 +298,9 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         }
 
         if let Some(kids) = root.get("K").cloned() {
-            self.walk_structure_value(&kids, root_ref, None, 0, "/StructTreeRoot/K")?;
+            self.walk_structure_value(&kids, root_ref, None, None, 0, "/StructTreeRoot/K")?;
         }
+        self.scan_all_pages()?;
         if !self.catalog_language {
             self.finding(
                 TaggedPdfFindingSeverity::Error,
@@ -296,6 +327,15 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             .findings
             .iter()
             .any(|finding| finding.severity == TaggedPdfFindingSeverity::Error);
+        let content_mcids = self
+            .page_mcids
+            .iter()
+            .map(|(context, values)| {
+                let mut values: Vec<_> = values.iter().copied().collect();
+                values.sort_unstable();
+                (*context, values)
+            })
+            .collect();
         TaggedPdfValidationReport {
             tagged,
             valid,
@@ -303,8 +343,11 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             role_map: self.role_map,
             class_names: self.class_names,
             class_map: self.class_map,
+            artifacts: self.artifacts,
             elements: self.elements,
             parent_tree_entries: self.parent_tree.len(),
+            parent_tree: self.parent_tree,
+            content_mcids,
             findings: self.findings,
         }
     }
@@ -410,6 +453,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         &mut self,
         value: &PdfObject,
         expected_parent: Option<TaggedPdfObjectRef>,
+        expected_parent_type: Option<&str>,
         inherited_page: Option<TaggedPdfObjectRef>,
         depth: usize,
         path: &str,
@@ -422,6 +466,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 marked += self.walk_structure_value(
                     child,
                     expected_parent,
+                    expected_parent_type,
                     inherited_page,
                     depth + 1,
                     &format!("{path}[{index}]"),
@@ -533,6 +578,12 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         let resolved_type = structure_type
             .as_deref()
             .and_then(|name| self.resolve_role(name).ok());
+        self.validate_parent_child(
+            expected_parent_type,
+            resolved_type.as_deref(),
+            path,
+            object_ref,
+        );
         if matches!(resolved_type.as_deref(), Some("Figure" | "Formula"))
             && alternate_text.is_none()
             && actual_text.is_none()
@@ -604,7 +655,28 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             })
             .unwrap_or(0);
         if let Some(kids) = dict.get("K") {
-            self.walk_structure_value(kids, object_ref, page, depth + 1, &format!("{path}/K"))?;
+            self.walk_structure_value(
+                kids,
+                object_ref,
+                resolved_type.as_deref(),
+                page,
+                depth + 1,
+                &format!("{path}/K"),
+            )?;
+        }
+        if resolved_type.as_deref() == Some("Link")
+            && object_ref
+                .and_then(|reference| self.objr_counts.get(&reference).copied())
+                .unwrap_or(0)
+                == 0
+        {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidLinkStructure,
+                format!("{path}/K"),
+                "Link structure element has no OBJR child",
+                object_ref,
+            );
         }
         if let Some(reference) = object_ref {
             let marked_content_count = self.direct_mcid_counts.remove(&reference).unwrap_or(0);
@@ -621,10 +693,56 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 actual_text,
                 title,
                 dictionary_keys,
+                dictionary: dict,
             });
             self.active.remove(&reference);
         }
         Ok(0)
+    }
+
+    fn validate_parent_child(
+        &mut self,
+        parent: Option<&str>,
+        child: Option<&str>,
+        path: &str,
+        object: Option<TaggedPdfObjectRef>,
+    ) {
+        let Some((parent, child)) = parent.zip(child) else {
+            return;
+        };
+        let violation = match parent {
+            "Table" => (!matches!(child, "Caption" | "THead" | "TBody" | "TFoot" | "TR"))
+                .then_some((
+                    TaggedPdfFindingCode::InvalidTableStructure,
+                    "Table children must be Caption, THead, TBody, TFoot, or TR",
+                )),
+            "THead" | "TBody" | "TFoot" => (child != "TR").then_some((
+                TaggedPdfFindingCode::InvalidTableStructure,
+                "table row groups may contain only TR elements",
+            )),
+            "TR" => (!matches!(child, "TH" | "TD")).then_some((
+                TaggedPdfFindingCode::InvalidTableStructure,
+                "TR elements may contain only TH or TD cells",
+            )),
+            "L" => (!matches!(child, "Caption" | "LI")).then_some((
+                TaggedPdfFindingCode::InvalidListStructure,
+                "L elements may contain only Caption or LI elements",
+            )),
+            "LI" => (!matches!(child, "Lbl" | "LBody")).then_some((
+                TaggedPdfFindingCode::InvalidListStructure,
+                "LI elements may contain only Lbl or LBody elements",
+            )),
+            _ => None,
+        };
+        if let Some((code, message)) = violation {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                code,
+                format!("{path}/S"),
+                message,
+                object,
+            );
+        }
     }
 
     fn validate_objr(
@@ -634,6 +752,9 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         inherited_page: Option<TaggedPdfObjectRef>,
         path: &str,
     ) -> Result<()> {
+        if let Some(owner) = owner {
+            *self.objr_counts.entry(owner).or_default() += 1;
+        }
         let Some(object) = dict
             .get("Obj")
             .and_then(PdfObject::as_reference)
@@ -729,6 +850,19 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         }
         if let Some(owner) = owner {
             *self.direct_mcid_counts.entry(owner).or_default() += 1;
+            if self
+                .last_mcid_by_owner
+                .insert(owner, mcid)
+                .is_some_and(|previous| mcid <= previous)
+            {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidReadingOrder,
+                    format!("{path}/MCID"),
+                    "MCIDs in one structure element must follow increasing content order",
+                    Some(owner),
+                );
+            }
         }
         let page = dict
             .get("Pg")
@@ -832,15 +966,21 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         if let Some(cached) = self.page_mcids.get(&context) {
             return Ok(cached.clone());
         }
+        if !self.active_content.insert(context) {
+            return Ok(HashSet::new());
+        }
         let resources = self.effective_resources(object, 0)?;
+        let previous_context = self.current_content_context.replace(context);
         let mut mcids = HashSet::new();
         if let Some(stream) = object.as_stream() {
-            let bytes = stream.decode(self.reader.options())?;
+            let bytes = self.decode_content_stream(stream)?;
             self.process_content_bytes(&bytes, resources.as_ref(), &mut mcids)?;
         } else if let Some(contents) = object.as_dict().and_then(|dict| dict.get("Contents")) {
             self.process_content_objects(contents, resources.as_ref(), &mut mcids, 0)?;
         }
         self.page_mcids.insert(context, mcids.clone());
+        self.active_content.remove(&context);
+        self.current_content_context = previous_context;
         Ok(mcids)
     }
 
@@ -860,12 +1000,151 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 self.limits.max_decoded_content_bytes,
             ));
         }
-        for operation in ContentParser::parse(bytes)? {
-            if let ContentOperation::BeginMarkedContentWithProps(_, properties) = operation {
-                if let Some(mcid) = self.mcid_from_properties(&properties, resources)? {
-                    if mcid >= 0 {
-                        mcids.insert(mcid);
+        for (operation_index, operation) in ContentParser::parse(bytes)?.into_iter().enumerate() {
+            match operation {
+                ContentOperation::BeginMarkedContent(tag) if tag == "Artifact" => {
+                    self.record_artifact(operation_index, None);
+                }
+                ContentOperation::BeginMarkedContentWithProps(tag, properties)
+                    if tag == "Artifact" =>
+                {
+                    if self.mcid_from_properties(&properties, resources)?.is_some() {
+                        self.finding(
+                            TaggedPdfFindingSeverity::Error,
+                            TaggedPdfFindingCode::InvalidArtifact,
+                            "/Contents/Artifact",
+                            "Artifact marked content must not carry an MCID",
+                            self.current_content_context,
+                        );
                     }
+                    self.record_artifact(operation_index, artifact_subtype(&properties));
+                }
+                ContentOperation::BeginMarkedContentWithProps(_, properties) => {
+                    if let Some(mcid) = self.mcid_from_properties(&properties, resources)? {
+                        if mcid >= 0 && !mcids.insert(mcid) {
+                            self.finding(
+                                TaggedPdfFindingSeverity::Error,
+                                TaggedPdfFindingCode::InvalidReadingOrder,
+                                "/Contents/MCID",
+                                "content context contains a duplicate MCID",
+                                self.current_content_context,
+                            );
+                        }
+                    }
+                }
+                ContentOperation::PaintXObject(name) => {
+                    self.scan_form_xobject(&name, resources)?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn decode_content_stream(&self, stream: &crate::parser::objects::PdfStream) -> Result<Vec<u8>> {
+        let remaining = self
+            .limits
+            .max_decoded_content_bytes
+            .saturating_sub(self.decoded_content_bytes);
+        stream
+            .decode_with_limit(self.reader.options(), remaining)
+            .map_err(|error| {
+                let message = error.to_string();
+                if message.contains("limit") || message.contains("exceeds") {
+                    self.limit_error(
+                        "decoded content bytes",
+                        self.limits.max_decoded_content_bytes,
+                    )
+                } else {
+                    error.into()
+                }
+            })
+    }
+
+    fn record_artifact(&mut self, operation_index: usize, subtype: Option<String>) {
+        if let Some(context) = self.current_content_context {
+            self.artifacts.push(TaggedPdfArtifact {
+                context,
+                operation_index,
+                subtype,
+            });
+        }
+    }
+
+    fn scan_form_xobject(&mut self, name: &str, resources: Option<&PdfDictionary>) -> Result<()> {
+        let Some(xobjects) = resources
+            .and_then(|resources| resources.get("XObject"))
+            .cloned()
+        else {
+            return Ok(());
+        };
+        let xobjects = self.resolve(&xobjects)?;
+        let Some(value) = xobjects.as_dict().and_then(|xobjects| xobjects.get(name)) else {
+            return Ok(());
+        };
+        let Some(reference) = value.as_reference().map(TaggedPdfObjectRef::from) else {
+            return Ok(());
+        };
+        let object = self
+            .reader
+            .get_object(reference.object_number, reference.generation)?
+            .clone();
+        if object
+            .as_stream()
+            .and_then(|stream| stream.dict.get("Subtype"))
+            .and_then(PdfObject::as_name)
+            .is_some_and(|subtype| subtype.0 == "Form")
+        {
+            self.mcids_for_context(reference, &object)?;
+        }
+        Ok(())
+    }
+
+    fn scan_all_pages(&mut self) -> Result<()> {
+        let pages = self.reader.catalog()?.get("Pages").cloned();
+        let mut references = Vec::new();
+        let mut seen = HashSet::new();
+        if let Some(pages) = pages {
+            self.collect_page_references(&pages, 0, &mut seen, &mut references)?;
+        }
+        for context in references {
+            if !self.page_mcids.contains_key(&context) {
+                let object = self
+                    .reader
+                    .get_object(context.object_number, context.generation)?
+                    .clone();
+                self.mcids_for_context(context, &object)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn collect_page_references(
+        &mut self,
+        value: &PdfObject,
+        depth: usize,
+        seen: &mut HashSet<TaggedPdfObjectRef>,
+        pages: &mut Vec<TaggedPdfObjectRef>,
+    ) -> Result<()> {
+        self.check_depth(depth)?;
+        let reference = value.as_reference().map(TaggedPdfObjectRef::from);
+        if reference.is_some_and(|reference| !seen.insert(reference)) {
+            return Ok(());
+        }
+        let Some(dictionary) = self.resolve_dict(value)? else {
+            return Ok(());
+        };
+        if dictionary.get_type() == Some("Page") {
+            if let Some(reference) = reference {
+                pages.push(reference);
+            }
+            return Ok(());
+        }
+        if let Some(kids) = dictionary.get("Kids") {
+            let kids = self.resolve(kids)?;
+            if let Some(array) = kids.as_array() {
+                for kid in &array.0 {
+                    self.collect_page_references(kid, depth + 1, seen, pages)?;
                 }
             }
         }
@@ -933,7 +1212,7 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         self.check_depth(depth)?;
         let resolved = self.resolve(value)?;
         if let Some(stream) = resolved.as_stream() {
-            let bytes = stream.decode(self.reader.options())?;
+            let bytes = self.decode_content_stream(stream)?;
             return self.process_content_bytes(&bytes, resources, mcids);
         }
         if let Some(array) = resolved.as_array() {
@@ -1227,6 +1506,16 @@ fn text_value(value: Option<&PdfObject>) -> Option<String> {
         .and_then(PdfObject::as_string)
         .map(|value| value.to_text())
         .filter(|value| !value.trim().is_empty())
+}
+
+fn artifact_subtype(properties: &MarkedContentProps) -> Option<String> {
+    match properties {
+        MarkedContentProps::Inline(values) => values.get("Subtype").and_then(|value| match value {
+            MarkedContentValue::Name(name) => Some(name.clone()),
+            _ => None,
+        }),
+        MarkedContentProps::ResourceRef(_) => None,
+    }
 }
 
 fn heading_level(name: &str) -> Option<u8> {
@@ -1657,5 +1946,66 @@ mod tests {
             .findings
             .iter()
             .any(|finding| finding.code == TaggedPdfFindingCode::InvalidMarkedContentReference));
+    }
+
+    #[test]
+    fn inventories_artifact_markers_and_subtypes() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>",
+            "<< /Length 47 >>\nstream\n/Artifact <</Subtype /Pagination>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K [] /ParentTree 6 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert_eq!(report.artifacts.len(), 1);
+        assert_eq!(report.artifacts[0].subtype.as_deref(), Some("Pagination"));
+    }
+
+    #[test]
+    fn validates_table_list_and_link_structure() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [5 0 R 7 0 R 9 0 R] /ParentTree 11 0 R >>",
+            "<< /Type /StructElem /S /Table /P 4 0 R /K 6 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R >>",
+            "<< /Type /StructElem /S /L /P 4 0 R /K 8 0 R >>",
+            "<< /Type /StructElem /S /P /P 7 0 R >>",
+            "<< /Type /StructElem /S /Link /P 4 0 R >>",
+            "null",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        for expected in [
+            TaggedPdfFindingCode::InvalidTableStructure,
+            TaggedPdfFindingCode::InvalidListStructure,
+            TaggedPdfFindingCode::InvalidLinkStructure,
+        ] {
+            assert!(report
+                .findings
+                .iter()
+                .any(|finding| finding.code == expected));
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_content_mcids() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 44 >>\nstream\n/P <</MCID 0>> BDC EMC /P <</MCID 0>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Nums [0 [6 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidReadingOrder));
     }
 }

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -74,6 +74,9 @@ pub enum TaggedPdfFindingCode {
     ParentTreeOwnerMismatch,
     UnmappedCustomRole,
     InvalidRoleMap,
+    MissingDocumentLanguage,
+    MissingAlternateText,
+    InvalidHeadingOrder,
 }
 
 /// An indirect object reference exposed without leaking parser internals.
@@ -110,6 +113,12 @@ pub struct TaggedPdfStructureElement {
     pub parent: Option<TaggedPdfObjectRef>,
     pub child_count: usize,
     pub marked_content_count: usize,
+    pub language: Option<String>,
+    pub alternate_text: Option<String>,
+    pub actual_text: Option<String>,
+    pub title: Option<String>,
+    /// Every key present in the original dictionary, including unknown keys.
+    pub dictionary_keys: Vec<String>,
 }
 
 /// Machine-readable result of tagged-PDF inspection.
@@ -158,6 +167,8 @@ struct Validator<'a, R: Read + Seek> {
     direct_mcid_counts: HashMap<TaggedPdfObjectRef, usize>,
     page_mcids: HashMap<TaggedPdfObjectRef, HashSet<i64>>,
     decoded_content_bytes: usize,
+    saw_language: bool,
+    last_heading_level: Option<u8>,
 }
 
 impl<'a, R: Read + Seek> Validator<'a, R> {
@@ -176,11 +187,14 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
             direct_mcid_counts: HashMap::new(),
             page_mcids: HashMap::new(),
             decoded_content_bytes: 0,
+            saw_language: false,
+            last_heading_level: None,
         }
     }
 
     fn run(mut self) -> Result<TaggedPdfValidationReport> {
         let catalog = self.reader.catalog()?.clone();
+        self.saw_language = text_value(catalog.get("Lang")).is_some();
         let Some(root_value) = catalog.get("StructTreeRoot").cloned() else {
             self.finding(
                 TaggedPdfFindingSeverity::Warning,
@@ -229,6 +243,15 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
 
         if let Some(kids) = root.get("K").cloned() {
             self.walk_structure_value(&kids, root_ref, None, 0, "/StructTreeRoot/K")?;
+        }
+        if !self.saw_language {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingDocumentLanguage,
+                "/Catalog/Lang",
+                "tagged document has no language on the catalog or any structure element",
+                root_ref,
+            );
         }
         self.elements.sort_by_key(|element| element.object);
         self.class_names.sort();
@@ -446,6 +469,38 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
                 );
             }
         }
+        let language = text_value(dict.get("Lang"));
+        self.saw_language |= language.is_some();
+        let alternate_text = text_value(dict.get("Alt"));
+        let actual_text = text_value(dict.get("ActualText"));
+        let title = text_value(dict.get("T"));
+        if matches!(structure_type.as_deref(), Some("Figure" | "Formula"))
+            && alternate_text.is_none()
+            && actual_text.is_none()
+        {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingAlternateText,
+                format!("{path}/Alt"),
+                "figure or formula has neither Alt nor ActualText",
+                object_ref,
+            );
+        }
+        if let Some(level) = structure_type.as_deref().and_then(heading_level) {
+            if self
+                .last_heading_level
+                .is_some_and(|previous| level > previous + 1)
+            {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidHeadingOrder,
+                    format!("{path}/S"),
+                    "heading level skips an intermediate level in structure order",
+                    object_ref,
+                );
+            }
+            self.last_heading_level = Some(level);
+        }
         let parent = dict
             .get("P")
             .and_then(PdfObject::as_reference)
@@ -476,12 +531,19 @@ impl<'a, R: Read + Seek> Validator<'a, R> {
         }
         if let Some(reference) = object_ref {
             let marked_content_count = self.direct_mcid_counts.remove(&reference).unwrap_or(0);
+            let mut dictionary_keys: Vec<_> = dict.0.keys().map(|key| key.0.clone()).collect();
+            dictionary_keys.sort();
             self.elements.push(TaggedPdfStructureElement {
                 object: reference,
                 structure_type,
                 parent,
                 child_count,
                 marked_content_count,
+                language,
+                alternate_text,
+                actual_text,
+                title,
+                dictionary_keys,
             });
             self.active.remove(&reference);
         }
@@ -1048,6 +1110,25 @@ fn is_standard_structure_type(name: &str) -> bool {
     )
 }
 
+fn text_value(value: Option<&PdfObject>) -> Option<String> {
+    value
+        .and_then(PdfObject::as_string)
+        .map(|value| value.to_text())
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn heading_level(name: &str) -> Option<u8> {
+    match name {
+        "H1" => Some(1),
+        "H2" => Some(2),
+        "H3" => Some(3),
+        "H4" => Some(4),
+        "H5" => Some(5),
+        "H6" => Some(6),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1084,7 +1165,7 @@ mod tests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
             "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R /RoleMap << /CustomP /P >> /ClassMap << /C1 << /O /Layout >> >> >>",
-            "<< /Type /StructElem /S /CustomP /P 5 0 R /Pg 3 0 R /K [<< /Type /MCR /Pg 3 0 R /MCID 0 >>] >>",
+            "<< /Type /StructElem /S /CustomP /P 5 0 R /Pg 3 0 R /Lang (en-US) /K [<< /Type /MCR /Pg 3 0 R /MCID 0 >>] >>",
             "<< /Nums [0 [6 0 R]] >>",
         ])
     }
@@ -1112,7 +1193,7 @@ mod tests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
             "<< /Length 22 >>\nstream\n/P <</MCID 0>> BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R >>",
-            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /Lang (en-US) /K 0 >>",
             "<< /Nums [0 [5 0 R]] >>",
         ]);
         let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
@@ -1211,7 +1292,7 @@ mod tests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R >>",
             "<< /Length 22 >>\nstream\n/P <</MCID 1>> BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
-            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /Lang (en-US) /K 0 >>",
             "<< /Nums [0 [6 0 R]] >>",
         ]);
         let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
@@ -1230,7 +1311,7 @@ mod tests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 /Contents 4 0 R /Resources << /Properties << /MC0 << /MCID 0 >> >> >> >>",
             "<< /Length 15 >>\nstream\n/P /MC0 BDC EMC\nendstream",
             "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
-            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /Lang (en-US) /K 0 >>",
             "<< /Nums [0 [6 0 R]] >>",
         ]);
         let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
@@ -1244,7 +1325,7 @@ mod tests {
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
             "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
-            "<< /Type /StructElem /S /Annot /P 4 0 R /Pg 3 0 R /K << /Type /OBJR /Obj 7 0 R >> >>",
+            "<< /Type /StructElem /S /Annot /P 4 0 R /Pg 3 0 R /Lang (en-US) /K << /Type /OBJR /Obj 7 0 R >> >>",
             "<< /Nums [1 5 0 R] >>",
             "<< /Type /Annot /Subtype /Link /StructParent 1 >>",
         ]);
@@ -1283,5 +1364,57 @@ mod tests {
         };
         let error = validate_tagged_pdf(&valid_tagged_pdf(), &options).unwrap_err();
         assert!(error.to_string().contains("decoded content bytes"));
+    }
+
+    #[test]
+    fn reports_missing_language_for_tagged_documents() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
+            "<< /Type /StructElem /S /Document /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| { finding.code == TaggedPdfFindingCode::MissingDocumentLanguage }));
+    }
+
+    #[test]
+    fn reports_figure_without_text_alternative() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
+            "<< /Type /StructElem /S /Figure /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::MissingAlternateText));
+    }
+
+    #[test]
+    fn reports_skipped_heading_levels_in_structure_order() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [5 0 R 6 0 R] /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /H1 /P 4 0 R >>",
+            "<< /Type /StructElem /S /H3 /P 4 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::InvalidHeadingOrder));
     }
 }

--- a/oxidize-pdf-core/src/verification/tagged_pdf.rs
+++ b/oxidize-pdf-core/src/verification/tagged_pdf.rs
@@ -1,0 +1,822 @@
+//! Bounded inspection and validation of tagged-PDF structure trees.
+//!
+//! This module intentionally starts with a read-only API.  A lossless editor
+//! needs a trustworthy inventory of the existing structure and stable findings
+//! before it can safely publish an incremental mutation.
+
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfDictionary, PdfObject};
+use crate::parser::PdfReader;
+use std::collections::{BTreeMap, HashSet};
+use std::io::{Cursor, Read, Seek};
+
+/// Hard limits for untrusted structure and number trees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedPdfLimits {
+    /// Maximum number of indirect structure/number-tree objects visited.
+    pub max_objects: usize,
+    /// Maximum nesting depth of `/K` and number-tree `/Kids` arrays.
+    pub max_depth: usize,
+    /// Maximum total children and number-tree entries inspected.
+    pub max_entries: usize,
+}
+
+impl Default for TaggedPdfLimits {
+    fn default() -> Self {
+        Self {
+            max_objects: 100_000,
+            max_depth: 256,
+            max_entries: 1_000_000,
+        }
+    }
+}
+
+/// Options for tagged-PDF inspection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaggedPdfValidationOptions {
+    /// Resource limits applied to the input document.
+    pub limits: TaggedPdfLimits,
+}
+
+/// Severity of a tagged-PDF finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TaggedPdfFindingSeverity {
+    /// The structure is malformed or has a broken bidirectional association.
+    Error,
+    /// The structure is readable, but incomplete for robust PDF/UA processing.
+    Warning,
+}
+
+/// Stable finding identifiers suitable for machine processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaggedPdfFindingCode {
+    MissingStructureTree,
+    InvalidStructureTreeRoot,
+    InvalidStructureElement,
+    MissingStructureType,
+    BrokenParentLink,
+    DuplicateStructureReference,
+    StructureCycle,
+    InvalidMarkedContentReference,
+    MissingParentTree,
+    InvalidParentTree,
+    MissingStructParents,
+    MissingParentTreeEntry,
+    ParentTreeOwnerMismatch,
+    UnmappedCustomRole,
+}
+
+/// An indirect object reference exposed without leaking parser internals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TaggedPdfObjectRef {
+    pub object_number: u32,
+    pub generation: u16,
+}
+
+impl From<(u32, u16)> for TaggedPdfObjectRef {
+    fn from(value: (u32, u16)) -> Self {
+        Self {
+            object_number: value.0,
+            generation: value.1,
+        }
+    }
+}
+
+/// One validation finding with a stable logical path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedPdfFinding {
+    pub severity: TaggedPdfFindingSeverity,
+    pub code: TaggedPdfFindingCode,
+    pub path: String,
+    pub message: String,
+    pub object: Option<TaggedPdfObjectRef>,
+}
+
+/// Read-only summary of one indirect structure element.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedPdfStructureElement {
+    pub object: TaggedPdfObjectRef,
+    pub structure_type: Option<String>,
+    pub parent: Option<TaggedPdfObjectRef>,
+    pub child_count: usize,
+    pub marked_content_count: usize,
+}
+
+/// Machine-readable result of tagged-PDF inspection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedPdfValidationReport {
+    pub tagged: bool,
+    pub valid: bool,
+    pub structure_tree_root: Option<TaggedPdfObjectRef>,
+    pub role_map: BTreeMap<String, String>,
+    pub class_names: Vec<String>,
+    pub elements: Vec<TaggedPdfStructureElement>,
+    pub parent_tree_entries: usize,
+    pub findings: Vec<TaggedPdfFinding>,
+}
+
+/// Inspect and validate the tagged structure of an existing PDF.
+///
+/// The traversal validates structure-element parent links and the page
+/// `/StructParents` -> structure `/ParentTree` -> MCID owner association.  It
+/// does not claim full PDF/UA conformance: language, headings, tables, lists,
+/// links and alternate-text rules will build on this structural foundation.
+pub fn validate_tagged_pdf(
+    pdf: &[u8],
+    options: &TaggedPdfValidationOptions,
+) -> Result<TaggedPdfValidationReport> {
+    let mut reader = PdfReader::new(Cursor::new(pdf))?;
+    if reader.is_encrypted() && !reader.is_unlocked() {
+        return Err(PdfError::EncryptionError(
+            "tagged-PDF validation requires an unlocked document".to_string(),
+        ));
+    }
+    Validator::new(&mut reader, &options.limits).run()
+}
+
+struct Validator<'a, R: Read + Seek> {
+    reader: &'a mut PdfReader<R>,
+    limits: &'a TaggedPdfLimits,
+    visited: HashSet<TaggedPdfObjectRef>,
+    active: HashSet<TaggedPdfObjectRef>,
+    entry_count: usize,
+    elements: Vec<TaggedPdfStructureElement>,
+    findings: Vec<TaggedPdfFinding>,
+    role_map: BTreeMap<String, String>,
+    class_names: Vec<String>,
+    parent_tree: BTreeMap<i64, PdfObject>,
+}
+
+impl<'a, R: Read + Seek> Validator<'a, R> {
+    fn new(reader: &'a mut PdfReader<R>, limits: &'a TaggedPdfLimits) -> Self {
+        Self {
+            reader,
+            limits,
+            visited: HashSet::new(),
+            active: HashSet::new(),
+            entry_count: 0,
+            elements: Vec::new(),
+            findings: Vec::new(),
+            role_map: BTreeMap::new(),
+            class_names: Vec::new(),
+            parent_tree: BTreeMap::new(),
+        }
+    }
+
+    fn run(mut self) -> Result<TaggedPdfValidationReport> {
+        let catalog = self.reader.catalog()?.clone();
+        let Some(root_value) = catalog.get("StructTreeRoot").cloned() else {
+            self.finding(
+                TaggedPdfFindingSeverity::Warning,
+                TaggedPdfFindingCode::MissingStructureTree,
+                "/Catalog/StructTreeRoot",
+                "document has no structure tree",
+                None,
+            );
+            return Ok(self.report(false, None));
+        };
+        let root_ref = root_value.as_reference().map(Into::into);
+        let Some(root) = self.resolve_dict(&root_value)? else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidStructureTreeRoot,
+                "/Catalog/StructTreeRoot",
+                "StructTreeRoot is not a dictionary",
+                root_ref,
+            );
+            return Ok(self.report(true, root_ref));
+        };
+        if root.get_type() != Some("StructTreeRoot") {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidStructureTreeRoot,
+                "/StructTreeRoot/Type",
+                "structure-tree root has no /Type /StructTreeRoot",
+                root_ref,
+            );
+        }
+        self.read_name_map(root.get("RoleMap").cloned(), true)?;
+        self.read_name_map(root.get("ClassMap").cloned(), false)?;
+
+        if let Some(parent_tree) = root.get("ParentTree").cloned() {
+            self.walk_number_tree(&parent_tree, 0)?;
+        } else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingParentTree,
+                "/StructTreeRoot/ParentTree",
+                "tagged structure has no ParentTree",
+                root_ref,
+            );
+        }
+
+        if let Some(kids) = root.get("K").cloned() {
+            self.walk_structure_value(&kids, root_ref, None, 0, "/StructTreeRoot/K")?;
+        }
+        self.elements.sort_by_key(|element| element.object);
+        self.class_names.sort();
+        self.class_names.dedup();
+        self.findings.sort_by(|a, b| {
+            a.path
+                .cmp(&b.path)
+                .then(a.severity.cmp(&b.severity))
+                .then(a.message.cmp(&b.message))
+        });
+        Ok(self.report(true, root_ref))
+    }
+
+    fn report(self, tagged: bool, root: Option<TaggedPdfObjectRef>) -> TaggedPdfValidationReport {
+        let valid = !self
+            .findings
+            .iter()
+            .any(|finding| finding.severity == TaggedPdfFindingSeverity::Error);
+        TaggedPdfValidationReport {
+            tagged,
+            valid,
+            structure_tree_root: root,
+            role_map: self.role_map,
+            class_names: self.class_names,
+            elements: self.elements,
+            parent_tree_entries: self.parent_tree.len(),
+            findings: self.findings,
+        }
+    }
+
+    fn resolve(&mut self, value: &PdfObject) -> Result<PdfObject> {
+        match value.as_reference() {
+            Some((number, generation)) => Ok(self.reader.get_object(number, generation)?.clone()),
+            None => Ok(value.clone()),
+        }
+    }
+
+    fn resolve_dict(&mut self, value: &PdfObject) -> Result<Option<PdfDictionary>> {
+        let object = self.resolve(value)?;
+        Ok(object
+            .as_dict()
+            .cloned()
+            .or_else(|| object.as_stream().map(|stream| stream.dict.clone())))
+    }
+
+    fn read_name_map(&mut self, value: Option<PdfObject>, role_map: bool) -> Result<()> {
+        let Some(value) = value else { return Ok(()) };
+        let Some(dict) = self.resolve_dict(&value)? else {
+            return Ok(());
+        };
+        for (name, value) in &dict.0 {
+            if role_map {
+                if let Some(target) = value.as_name() {
+                    self.role_map
+                        .insert(name.0.clone(), target.as_str().to_string());
+                }
+            } else {
+                self.class_names.push(name.0.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn walk_structure_value(
+        &mut self,
+        value: &PdfObject,
+        expected_parent: Option<TaggedPdfObjectRef>,
+        inherited_page: Option<TaggedPdfObjectRef>,
+        depth: usize,
+        path: &str,
+    ) -> Result<usize> {
+        self.check_depth(depth)?;
+        if let Some(array) = value.as_array() {
+            let mut marked = 0;
+            for (index, child) in array.0.iter().enumerate() {
+                self.bump_entry()?;
+                marked += self.walk_structure_value(
+                    child,
+                    expected_parent,
+                    inherited_page,
+                    depth + 1,
+                    &format!("{path}[{index}]"),
+                )?;
+            }
+            return Ok(marked);
+        }
+        if let Some(mcid) = value.as_integer() {
+            let mut mcr = PdfDictionary::new();
+            mcr.insert("MCID".to_string(), PdfObject::Integer(mcid));
+            if let Some(page) = inherited_page {
+                mcr.insert(
+                    "Pg".to_string(),
+                    PdfObject::Reference(page.object_number, page.generation),
+                );
+            }
+            return self
+                .validate_mcr(&mcr, expected_parent, inherited_page, path)
+                .map(usize::from);
+        }
+        let object_ref = value.as_reference().map(TaggedPdfObjectRef::from);
+        if let Some(reference) = object_ref {
+            if self.active.contains(&reference) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::StructureCycle,
+                    path,
+                    "cycle detected in structure tree",
+                    Some(reference),
+                );
+                return Ok(0);
+            }
+            if !self.visited.insert(reference) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::DuplicateStructureReference,
+                    path,
+                    "structure object is referenced by more than one child position",
+                    Some(reference),
+                );
+                return Ok(0);
+            }
+            if self.visited.len() > self.limits.max_objects {
+                return Err(self.limit_error("structure objects", self.limits.max_objects));
+            }
+            self.active.insert(reference);
+        }
+        let Some(dict) = self.resolve_dict(value)? else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidStructureElement,
+                path,
+                "structure child is not an integer, array, dictionary, or resolvable reference",
+                object_ref,
+            );
+            return Ok(0);
+        };
+        let kind = dict.get_type();
+        if matches!(kind, Some("MCR") | Some("OBJR")) || dict.contains_key("MCID") {
+            let marked = self.validate_mcr(&dict, expected_parent, inherited_page, path)?;
+            if let Some(reference) = object_ref {
+                self.active.remove(&reference);
+            }
+            return Ok(usize::from(marked));
+        }
+        let structure_type = dict
+            .get("S")
+            .and_then(PdfObject::as_name)
+            .map(|name| name.as_str().to_string());
+        if structure_type.is_none() {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingStructureType,
+                &format!("{path}/S"),
+                "structure element has no name-valued /S",
+                object_ref,
+            );
+        } else if let Some(name) = structure_type.as_deref() {
+            if !is_standard_structure_type(name) && !self.role_map.contains_key(name) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Warning,
+                    TaggedPdfFindingCode::UnmappedCustomRole,
+                    &format!("{path}/S"),
+                    "custom structure type is absent from RoleMap",
+                    object_ref,
+                );
+            }
+        }
+        let parent = dict
+            .get("P")
+            .and_then(PdfObject::as_reference)
+            .map(Into::into);
+        if expected_parent.is_some() && parent != expected_parent {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::BrokenParentLink,
+                &format!("{path}/P"),
+                "structure element /P does not point to its containing parent",
+                object_ref,
+            );
+        }
+        let page = dict
+            .get("Pg")
+            .and_then(PdfObject::as_reference)
+            .map(Into::into)
+            .or(inherited_page);
+        let mut marked_content_count = 0;
+        let child_count = dict
+            .get("K")
+            .map(|kids| match kids {
+                PdfObject::Array(array) => array.0.len(),
+                _ => 1,
+            })
+            .unwrap_or(0);
+        if let Some(kids) = dict.get("K") {
+            marked_content_count =
+                self.walk_structure_value(kids, object_ref, page, depth + 1, &format!("{path}/K"))?;
+        }
+        if let Some(reference) = object_ref {
+            self.elements.push(TaggedPdfStructureElement {
+                object: reference,
+                structure_type,
+                parent,
+                child_count,
+                marked_content_count,
+            });
+            self.active.remove(&reference);
+        }
+        Ok(marked_content_count)
+    }
+
+    fn validate_mcr(
+        &mut self,
+        dict: &PdfDictionary,
+        owner: Option<TaggedPdfObjectRef>,
+        inherited_page: Option<TaggedPdfObjectRef>,
+        path: &str,
+    ) -> Result<bool> {
+        let Some(mcid) = dict.get("MCID").and_then(PdfObject::as_integer) else {
+            if dict.get_type() == Some("MCR") {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidMarkedContentReference,
+                    &format!("{path}/MCID"),
+                    "marked-content reference has no non-negative integer MCID",
+                    owner,
+                );
+            }
+            return Ok(false);
+        };
+        if mcid < 0 {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidMarkedContentReference,
+                &format!("{path}/MCID"),
+                "MCID must be non-negative",
+                owner,
+            );
+            return Ok(false);
+        }
+        let page = dict
+            .get("Pg")
+            .and_then(PdfObject::as_reference)
+            .map(Into::into)
+            .or(inherited_page);
+        let Some(page) = page else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidMarkedContentReference,
+                &format!("{path}/Pg"),
+                "MCID has no page association",
+                owner,
+            );
+            return Ok(true);
+        };
+        let page_object = self
+            .reader
+            .get_object(page.object_number, page.generation)?
+            .clone();
+        let struct_parent = page_object
+            .as_dict()
+            .and_then(|page| page.get("StructParents"))
+            .and_then(PdfObject::as_integer);
+        let Some(key) = struct_parent else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingStructParents,
+                &format!("{path}/Pg/StructParents"),
+                "page associated with MCID has no integer StructParents key",
+                Some(page),
+            );
+            return Ok(true);
+        };
+        let Some(parent_entry) = self.parent_tree.get(&key).cloned() else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::MissingParentTreeEntry,
+                &format!("/StructTreeRoot/ParentTree/{key}"),
+                "ParentTree has no entry for the page StructParents key",
+                Some(page),
+            );
+            return Ok(true);
+        };
+        let resolved = self.resolve(&parent_entry)?;
+        let actual = resolved
+            .as_array()
+            .and_then(|array| array.0.get(mcid as usize))
+            .and_then(PdfObject::as_reference)
+            .map(TaggedPdfObjectRef::from);
+        if actual != owner {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::ParentTreeOwnerMismatch,
+                &format!("/StructTreeRoot/ParentTree/{key}[{mcid}]"),
+                "ParentTree MCID slot does not point back to its structure element",
+                owner,
+            );
+        }
+        Ok(true)
+    }
+
+    fn walk_number_tree(&mut self, value: &PdfObject, depth: usize) -> Result<()> {
+        self.check_depth(depth)?;
+        let reference = value.as_reference().map(TaggedPdfObjectRef::from);
+        if let Some(reference) = reference {
+            if !self.visited.insert(reference) {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree",
+                    "cycle or duplicate node in ParentTree",
+                    Some(reference),
+                );
+                return Ok(());
+            }
+            if self.visited.len() > self.limits.max_objects {
+                return Err(self.limit_error("indirect objects", self.limits.max_objects));
+            }
+        }
+        let Some(dict) = self.resolve_dict(value)? else {
+            self.finding(
+                TaggedPdfFindingSeverity::Error,
+                TaggedPdfFindingCode::InvalidParentTree,
+                "/StructTreeRoot/ParentTree",
+                "ParentTree node is not a dictionary",
+                reference,
+            );
+            return Ok(());
+        };
+        if let Some(nums) = dict.get("Nums") {
+            let nums = self.resolve(nums)?;
+            let Some(array) = nums.as_array() else {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree/Nums",
+                    "number-tree Nums is not an array",
+                    reference,
+                );
+                return Ok(());
+            };
+            if array.0.len() % 2 != 0 {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree/Nums",
+                    "number-tree Nums must contain key/value pairs",
+                    reference,
+                );
+            }
+            for pair in array.0.chunks_exact(2) {
+                self.bump_entry()?;
+                if let Some(key) = pair[0].as_integer() {
+                    if self.parent_tree.insert(key, pair[1].clone()).is_some() {
+                        self.finding(
+                            TaggedPdfFindingSeverity::Error,
+                            TaggedPdfFindingCode::InvalidParentTree,
+                            &format!("/StructTreeRoot/ParentTree/{key}"),
+                            "duplicate ParentTree key",
+                            reference,
+                        );
+                    }
+                } else {
+                    self.finding(
+                        TaggedPdfFindingSeverity::Error,
+                        TaggedPdfFindingCode::InvalidParentTree,
+                        "/StructTreeRoot/ParentTree/Nums",
+                        "number-tree key is not an integer",
+                        reference,
+                    );
+                }
+            }
+        }
+        if let Some(kids) = dict.get("Kids") {
+            let kids = self.resolve(kids)?;
+            if let Some(array) = kids.as_array() {
+                for kid in &array.0 {
+                    self.bump_entry()?;
+                    self.walk_number_tree(kid, depth + 1)?;
+                }
+            } else {
+                self.finding(
+                    TaggedPdfFindingSeverity::Error,
+                    TaggedPdfFindingCode::InvalidParentTree,
+                    "/StructTreeRoot/ParentTree/Kids",
+                    "number-tree Kids is not an array",
+                    reference,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn check_depth(&self, depth: usize) -> Result<()> {
+        if depth > self.limits.max_depth {
+            Err(self.limit_error("nesting depth", self.limits.max_depth))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn bump_entry(&mut self) -> Result<()> {
+        self.entry_count += 1;
+        if self.entry_count > self.limits.max_entries {
+            Err(self.limit_error("structure entries", self.limits.max_entries))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn limit_error(&self, resource: &str, limit: usize) -> PdfError {
+        PdfError::InvalidStructure(format!(
+            "tagged-PDF {resource} exceed configured limit {limit}"
+        ))
+    }
+
+    fn finding(
+        &mut self,
+        severity: TaggedPdfFindingSeverity,
+        code: TaggedPdfFindingCode,
+        path: impl Into<String>,
+        message: impl Into<String>,
+        object: Option<TaggedPdfObjectRef>,
+    ) {
+        self.findings.push(TaggedPdfFinding {
+            severity,
+            code,
+            path: path.into(),
+            message: message.into(),
+            object,
+        });
+    }
+}
+
+fn is_standard_structure_type(name: &str) -> bool {
+    matches!(
+        name,
+        "Document"
+            | "Part"
+            | "Art"
+            | "Sect"
+            | "Div"
+            | "BlockQuote"
+            | "Caption"
+            | "TOC"
+            | "TOCI"
+            | "Index"
+            | "NonStruct"
+            | "Private"
+            | "P"
+            | "H"
+            | "H1"
+            | "H2"
+            | "H3"
+            | "H4"
+            | "H5"
+            | "H6"
+            | "L"
+            | "LI"
+            | "Lbl"
+            | "LBody"
+            | "Table"
+            | "TR"
+            | "TH"
+            | "TD"
+            | "THead"
+            | "TBody"
+            | "TFoot"
+            | "Span"
+            | "Quote"
+            | "Note"
+            | "Reference"
+            | "BibEntry"
+            | "Code"
+            | "Link"
+            | "Annot"
+            | "Ruby"
+            | "RB"
+            | "RT"
+            | "RP"
+            | "Warichu"
+            | "WT"
+            | "WP"
+            | "Figure"
+            | "Formula"
+            | "Form"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pdf(objects: &[&str]) -> Vec<u8> {
+        let mut bytes = b"%PDF-1.7\n".to_vec();
+        let mut offsets = vec![0usize; objects.len() + 1];
+        for (index, object) in objects.iter().enumerate() {
+            offsets[index + 1] = bytes.len();
+            bytes
+                .extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", index + 1, object).as_bytes());
+        }
+        let xref = bytes.len();
+        bytes.extend_from_slice(
+            format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+        );
+        for offset in offsets.iter().skip(1) {
+            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        bytes.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+                objects.len() + 1
+            )
+            .as_bytes(),
+        );
+        bytes
+    }
+
+    fn valid_tagged_pdf() -> Vec<u8> {
+        pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 >>",
+            "<< /Length 0 >>\nstream\n\nendstream",
+            "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R /RoleMap << /CustomP /P >> /ClassMap << /C1 << /O /Layout >> >> >>",
+            "<< /Type /StructElem /S /CustomP /P 5 0 R /Pg 3 0 R /K [<< /Type /MCR /Pg 3 0 R /MCID 0 >>] >>",
+            "<< /Nums [0 [6 0 R]] >>",
+        ])
+    }
+
+    #[test]
+    fn validates_bidirectional_tagged_structure() {
+        let report = validate_tagged_pdf(&valid_tagged_pdf(), &Default::default()).unwrap();
+        assert!(report.tagged);
+        assert!(report.valid, "{:?}", report.findings);
+        assert_eq!(report.elements.len(), 1);
+        assert_eq!(report.elements[0].marked_content_count, 1);
+        assert_eq!(report.parent_tree_entries, 1);
+        assert_eq!(
+            report.role_map.get("CustomP").map(String::as_str),
+            Some("P")
+        );
+        assert_eq!(report.class_names, ["C1"]);
+    }
+
+    #[test]
+    fn reports_parent_tree_owner_mismatch() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /StructParents 0 >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [6 0 R] /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Nums [0 [5 0 R]] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| { finding.code == TaggedPdfFindingCode::ParentTreeOwnerMismatch }));
+    }
+
+    #[test]
+    fn rejects_structure_cycles_without_recursing_forever() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R >>",
+            "<< /Type /StructElem /S /Document /P 4 0 R /K 5 0 R >>",
+            "<< /Nums [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.valid);
+        assert!(report
+            .findings
+            .iter()
+            .any(|finding| finding.code == TaggedPdfFindingCode::StructureCycle));
+    }
+
+    #[test]
+    fn reports_untagged_document_without_failing_parse() {
+        let bytes = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+        ]);
+        let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+        assert!(!report.tagged);
+        assert!(report.valid);
+        assert_eq!(
+            report.findings[0].code,
+            TaggedPdfFindingCode::MissingStructureTree
+        );
+    }
+
+    #[test]
+    fn enforces_nesting_limit() {
+        let options = TaggedPdfValidationOptions {
+            limits: TaggedPdfLimits {
+                max_depth: 0,
+                ..Default::default()
+            },
+        };
+        let error = validate_tagged_pdf(&valid_tagged_pdf(), &options).unwrap_err();
+        assert!(error.to_string().contains("nesting depth"));
+    }
+}

--- a/oxidize-pdf-core/src/writer/incremental_tagged_pdf.rs
+++ b/oxidize-pdf-core/src/writer/incremental_tagged_pdf.rs
@@ -1,0 +1,533 @@
+//! Lossless incremental edits for existing tagged-PDF structure trees.
+
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use crate::verification::tagged_pdf::{
+    validate_tagged_pdf, TaggedPdfObjectRef, TaggedPdfValidationOptions, TaggedPdfValidationReport,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Cursor;
+
+/// One controlled tagged-structure mutation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaggedPdfMutation {
+    /// Set or remove a non-structural entry on an existing StructElem dictionary.
+    SetElementAttribute {
+        element: TaggedPdfObjectRef,
+        key: String,
+        value: Option<PdfObject>,
+    },
+    /// Associate an MCID already present in page content with a structure element.
+    AssociateMcid {
+        element: TaggedPdfObjectRef,
+        page: TaggedPdfObjectRef,
+        mcid: u32,
+    },
+    /// Set or remove one ParentTree entry while preserving all unrelated entries.
+    SetParentTreeEntry { key: i64, value: Option<PdfObject> },
+}
+
+/// Role of an indirect object changed by a tagged-PDF revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TaggedPdfChangedObjectKind {
+    StructureElement,
+    ParentTree,
+    CrossReference,
+}
+
+/// Exact object identified by a dry-run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TaggedPdfChangedObject {
+    pub object: TaggedPdfObjectRef,
+    pub kind: TaggedPdfChangedObjectKind,
+}
+
+/// Dry-run result for one atomic tagged-PDF revision.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaggedPdfEditPlan {
+    pub changed_objects: Vec<TaggedPdfChangedObject>,
+    pub mutations: Vec<TaggedPdfMutation>,
+}
+
+/// Machine-readable result of an applied tagged-PDF revision.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaggedPdfMutationReport {
+    pub pdf_bytes: Vec<u8>,
+    pub plan: TaggedPdfEditPlan,
+    pub validation_before: TaggedPdfValidationReport,
+    pub validation_after: TaggedPdfValidationReport,
+}
+
+/// Plans and applies one lossless incremental tagged-structure revision.
+pub struct IncrementalTaggedPdfEditor<'a> {
+    base_bytes: &'a [u8],
+    options: TaggedPdfValidationOptions,
+}
+
+impl<'a> IncrementalTaggedPdfEditor<'a> {
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self {
+            base_bytes,
+            options: TaggedPdfValidationOptions::default(),
+        }
+    }
+
+    pub fn with_validation_options(mut self, options: TaggedPdfValidationOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Validate a request and identify every indirect object that would change.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed requests, encrypted documents, unsupported
+    /// direct structure objects, missing content MCIDs, or forbidden DocMDP edits.
+    pub fn plan(&self, mutations: &[TaggedPdfMutation]) -> Result<TaggedPdfEditPlan> {
+        let validation = validate_tagged_pdf(self.base_bytes, &self.options)?;
+        let mut reader = policy_reader(self.base_bytes)?;
+        validate_mutations(&mut reader, &validation, mutations)?;
+        build_plan(self.base_bytes, &mut reader, &validation, mutations)
+    }
+
+    /// Append one incremental revision, preserving the input as an exact prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when planning, serialization, or reopening/validation fails.
+    pub fn apply(&self, mutations: &[TaggedPdfMutation]) -> Result<TaggedPdfMutationReport> {
+        let validation_before = validate_tagged_pdf(self.base_bytes, &self.options)?;
+        let mut reader = policy_reader(self.base_bytes)?;
+        validate_mutations(&mut reader, &validation_before, mutations)?;
+        let plan = build_plan(self.base_bytes, &mut reader, &validation_before, mutations)?;
+        if plan.changed_objects.is_empty() {
+            return Ok(TaggedPdfMutationReport {
+                pdf_bytes: self.base_bytes.to_vec(),
+                plan,
+                validation_after: validation_before.clone(),
+                validation_before,
+            });
+        }
+
+        let parent_tree = parent_tree_reference(&mut reader)?;
+        let mut replacements = BTreeMap::<TaggedPdfObjectRef, PdfDictionary>::new();
+        let mut parent_entries = validation_before.parent_tree.clone();
+        let mut touches_parent_tree = false;
+
+        for mutation in &plan.mutations {
+            match mutation {
+                TaggedPdfMutation::SetElementAttribute {
+                    element,
+                    key,
+                    value,
+                } => {
+                    let dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, *element)?;
+                    set_dictionary_value(dictionary, key, value.clone());
+                }
+                TaggedPdfMutation::AssociateMcid {
+                    element,
+                    page,
+                    mcid,
+                } => {
+                    let dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, *element)?;
+                    append_mcid(dictionary, *page, *mcid);
+                    let page_dictionary = resolve_dictionary(&mut reader, *page)?;
+                    let key = page_dictionary
+                        .get("StructParents")
+                        .and_then(PdfObject::as_integer)
+                        .ok_or_else(|| invalid("association page has no integer StructParents"))?;
+                    set_parent_owner(&mut reader, &mut parent_entries, key, *mcid, *element)?;
+                    touches_parent_tree = true;
+                }
+                TaggedPdfMutation::SetParentTreeEntry { key, value } => {
+                    if let Some(value) = value {
+                        parent_entries.insert(*key, value.clone());
+                    } else {
+                        parent_entries.remove(key);
+                    }
+                    touches_parent_tree = true;
+                }
+            }
+        }
+
+        if touches_parent_tree {
+            let reference =
+                parent_tree.ok_or_else(|| invalid("StructTreeRoot ParentTree must be indirect"))?;
+            let dictionary = replacement_dictionary(&mut reader, &mut replacements, reference)?;
+            write_flat_parent_tree(dictionary, &parent_entries);
+        }
+
+        let mut update = IncrementalUpdate::from_reader(self.base_bytes, &reader)?;
+        for (reference, dictionary) in replacements {
+            update.replace(
+                (reference.object_number, reference.generation),
+                PdfObject::Dictionary(dictionary),
+            )?;
+        }
+        let pdf_bytes = update.finish()?;
+        if !pdf_bytes.starts_with(self.base_bytes) {
+            return Err(invalid(
+                "incremental result does not preserve the base as an exact prefix",
+            ));
+        }
+        let validation_after = validate_tagged_pdf(&pdf_bytes, &self.options)?;
+        Ok(TaggedPdfMutationReport {
+            pdf_bytes,
+            plan,
+            validation_before,
+            validation_after,
+        })
+    }
+}
+
+fn policy_reader(bytes: &[u8]) -> Result<PdfReader<Cursor<&[u8]>>> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| invalid(format!("parse tagged PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "incremental tagged-PDF editing is not supported on encrypted PDFs".to_string(),
+        ));
+    }
+    let catalog = reader.catalog()?.clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::TaggedStructure,
+    )?;
+    Ok(reader)
+}
+
+fn validate_mutations(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    report: &TaggedPdfValidationReport,
+    mutations: &[TaggedPdfMutation],
+) -> Result<()> {
+    let elements: BTreeSet<_> = report
+        .elements
+        .iter()
+        .map(|element| element.object)
+        .collect();
+    for mutation in mutations {
+        match mutation {
+            TaggedPdfMutation::SetElementAttribute { element, key, .. } => {
+                if !elements.contains(element) {
+                    return Err(invalid(
+                        "attribute target is not an inspected structure element",
+                    ));
+                }
+                if key.is_empty() || matches!(key.as_str(), "Type" | "S" | "P" | "K" | "Pg") {
+                    return Err(invalid(
+                        "core structure keys cannot be edited as attributes",
+                    ));
+                }
+            }
+            TaggedPdfMutation::AssociateMcid {
+                element,
+                page,
+                mcid,
+            } => {
+                if !elements.contains(element) {
+                    return Err(invalid("MCID owner is not an inspected structure element"));
+                }
+                if !report
+                    .content_mcids
+                    .get(page)
+                    .is_some_and(|values| values.contains(&i64::from(*mcid)))
+                {
+                    return Err(invalid("requested MCID is absent from the page content"));
+                }
+                let page_dictionary = resolve_dictionary(reader, *page)?;
+                if page_dictionary.get_type() != Some("Page") {
+                    return Err(invalid("MCID association target is not a page"));
+                }
+                if page_dictionary
+                    .get("StructParents")
+                    .and_then(PdfObject::as_integer)
+                    .is_none()
+                {
+                    return Err(invalid("association page has no integer StructParents"));
+                }
+                let key = page_dictionary
+                    .get("StructParents")
+                    .and_then(PdfObject::as_integer)
+                    .expect("validated StructParents");
+                if report
+                    .parent_tree
+                    .get(&key)
+                    .and_then(PdfObject::as_array)
+                    .and_then(|owners| owners.0.get(*mcid as usize))
+                    .and_then(PdfObject::as_reference)
+                    == Some((element.object_number, element.generation))
+                {
+                    return Err(invalid("requested MCID association already exists"));
+                }
+            }
+            TaggedPdfMutation::SetParentTreeEntry { key, .. } if *key < 0 => {
+                return Err(invalid("ParentTree keys must be non-negative"));
+            }
+            TaggedPdfMutation::SetParentTreeEntry { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn build_plan(
+    base_bytes: &[u8],
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    report: &TaggedPdfValidationReport,
+    mutations: &[TaggedPdfMutation],
+) -> Result<TaggedPdfEditPlan> {
+    let mut changed = BTreeSet::new();
+    let mut parent_tree_changed = false;
+    let mut effective = Vec::new();
+    for mutation in mutations {
+        match mutation {
+            TaggedPdfMutation::SetElementAttribute {
+                element,
+                key,
+                value,
+            } => {
+                let dictionary = resolve_dictionary(reader, *element)?;
+                if dictionary.get(key) == value.as_ref() {
+                    continue;
+                }
+                changed.insert(TaggedPdfChangedObject {
+                    object: *element,
+                    kind: TaggedPdfChangedObjectKind::StructureElement,
+                });
+                effective.push(mutation.clone());
+            }
+            TaggedPdfMutation::AssociateMcid { element, .. } => {
+                changed.insert(TaggedPdfChangedObject {
+                    object: *element,
+                    kind: TaggedPdfChangedObjectKind::StructureElement,
+                });
+                parent_tree_changed = true;
+                effective.push(mutation.clone());
+            }
+            TaggedPdfMutation::SetParentTreeEntry { key, value }
+                if report.parent_tree.get(key) == value.as_ref() => {}
+            TaggedPdfMutation::SetParentTreeEntry { .. } => {
+                parent_tree_changed = true;
+                effective.push(mutation.clone());
+            }
+        }
+    }
+    if parent_tree_changed {
+        let object = parent_tree_reference(reader)?
+            .ok_or_else(|| invalid("StructTreeRoot ParentTree must be indirect"))?;
+        changed.insert(TaggedPdfChangedObject {
+            object,
+            kind: TaggedPdfChangedObjectKind::ParentTree,
+        });
+    }
+    if !changed.is_empty() {
+        if let Some(reference) = IncrementalUpdate::from_reader(base_bytes, reader)?
+            .pending_xref_stream_id()
+            .map(TaggedPdfObjectRef::from)
+        {
+            changed.insert(TaggedPdfChangedObject {
+                object: reference,
+                kind: TaggedPdfChangedObjectKind::CrossReference,
+            });
+        }
+    }
+    Ok(TaggedPdfEditPlan {
+        changed_objects: changed.into_iter().collect(),
+        mutations: effective,
+    })
+}
+
+fn parent_tree_reference(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+) -> Result<Option<TaggedPdfObjectRef>> {
+    let root = reader
+        .catalog()?
+        .get("StructTreeRoot")
+        .and_then(PdfObject::as_reference)
+        .map(TaggedPdfObjectRef::from)
+        .ok_or_else(|| invalid("Catalog StructTreeRoot must be indirect"))?;
+    let root = resolve_dictionary(reader, root)?;
+    Ok(root
+        .get("ParentTree")
+        .and_then(PdfObject::as_reference)
+        .map(TaggedPdfObjectRef::from))
+}
+
+fn resolve_dictionary(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    reference: TaggedPdfObjectRef,
+) -> Result<PdfDictionary> {
+    reader
+        .get_object(reference.object_number, reference.generation)?
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| {
+            invalid(format!(
+                "object {} is not a dictionary",
+                reference.object_number
+            ))
+        })
+}
+
+fn replacement_dictionary<'a>(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    replacements: &'a mut BTreeMap<TaggedPdfObjectRef, PdfDictionary>,
+    reference: TaggedPdfObjectRef,
+) -> Result<&'a mut PdfDictionary> {
+    if !replacements.contains_key(&reference) {
+        replacements.insert(reference, resolve_dictionary(reader, reference)?);
+    }
+    Ok(replacements
+        .get_mut(&reference)
+        .expect("inserted replacement"))
+}
+
+fn set_dictionary_value(dictionary: &mut PdfDictionary, key: &str, value: Option<PdfObject>) {
+    if let Some(value) = value {
+        dictionary.insert(key.to_string(), value);
+    } else {
+        dictionary.0.remove(&PdfName(key.to_string()));
+    }
+}
+
+fn append_mcid(dictionary: &mut PdfDictionary, page: TaggedPdfObjectRef, mcid: u32) {
+    let mut mcr = PdfDictionary::new();
+    mcr.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("MCR".to_string())),
+    );
+    mcr.insert(
+        "Pg".to_string(),
+        PdfObject::Reference(page.object_number, page.generation),
+    );
+    mcr.insert("MCID".to_string(), PdfObject::Integer(i64::from(mcid)));
+    let mcr = PdfObject::Dictionary(mcr);
+    match dictionary.get("K").cloned() {
+        None => dictionary.insert("K".to_string(), mcr),
+        Some(PdfObject::Array(mut kids)) => {
+            kids.push(mcr);
+            dictionary.insert("K".to_string(), PdfObject::Array(kids));
+        }
+        Some(existing) => dictionary.insert(
+            "K".to_string(),
+            PdfObject::Array(PdfArray(vec![existing, mcr])),
+        ),
+    }
+}
+
+fn set_parent_owner(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    entries: &mut BTreeMap<i64, PdfObject>,
+    key: i64,
+    mcid: u32,
+    owner: TaggedPdfObjectRef,
+) -> Result<()> {
+    let entry = entries
+        .entry(key)
+        .or_insert_with(|| PdfObject::Array(PdfArray::new()));
+    if let Some((number, generation)) = entry.as_reference() {
+        *entry = reader.get_object(number, generation)?.clone();
+    }
+    let array = match entry {
+        PdfObject::Array(array) => array,
+        _ => return Err(invalid("page ParentTree entry is not an owner array")),
+    };
+    let index = usize::try_from(mcid).map_err(|_| invalid("MCID does not fit in memory"))?;
+    array.0.resize(index + 1, PdfObject::Null);
+    array.0[index] = PdfObject::Reference(owner.object_number, owner.generation);
+    Ok(())
+}
+
+fn write_flat_parent_tree(dictionary: &mut PdfDictionary, entries: &BTreeMap<i64, PdfObject>) {
+    let mut nums = Vec::with_capacity(entries.len() * 2);
+    for (key, value) in entries {
+        nums.push(PdfObject::Integer(*key));
+        nums.push(value.clone());
+    }
+    dictionary.0.remove(&PdfName("Kids".to_string()));
+    dictionary.insert("Nums".to_string(), PdfObject::Array(PdfArray(nums)));
+    if let (Some(first), Some(last)) = (entries.keys().next(), entries.keys().next_back()) {
+        dictionary.insert(
+            "Limits".to_string(),
+            PdfObject::Array(PdfArray(vec![
+                PdfObject::Integer(*first),
+                PdfObject::Integer(*last),
+            ])),
+        );
+    } else {
+        dictionary.0.remove(&PdfName("Limits".to_string()));
+    }
+}
+
+fn invalid(message: impl Into<String>) -> PdfError {
+    PdfError::InvalidStructure(format!("tagged-PDF edit: {}", message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pdf(objects: &[&str]) -> Vec<u8> {
+        let mut bytes = b"%PDF-1.7\n".to_vec();
+        let mut offsets = vec![0];
+        for (index, object) in objects.iter().enumerate() {
+            offsets.push(bytes.len());
+            bytes.extend_from_slice(format!("{} 0 obj\n{object}\nendobj\n", index + 1).as_bytes());
+        }
+        let xref = bytes.len();
+        bytes.extend_from_slice(
+            format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+        );
+        for offset in offsets.iter().skip(1) {
+            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        bytes.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+                objects.len() + 1
+            )
+            .as_bytes(),
+        );
+        bytes
+    }
+
+    #[test]
+    fn association_resolves_an_indirect_parent_owner_array() {
+        let base = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /StructParents 0 /Contents 4 0 R >>",
+            "<< /Length 44 >>\nstream\n/P <</MCID 0>> BDC EMC /P <</MCID 1>> BDC EMC\nendstream",
+            "<< /Type /StructTreeRoot /K 6 0 R /ParentTree 7 0 R >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 0 >>",
+            "<< /Nums [0 8 0 R] >>",
+            "[6 0 R]",
+        ]);
+        let mutation = TaggedPdfMutation::AssociateMcid {
+            element: TaggedPdfObjectRef::from((6, 0)),
+            page: TaggedPdfObjectRef::from((3, 0)),
+            mcid: 1,
+        };
+        let update = IncrementalTaggedPdfEditor::new(&base)
+            .apply(&[mutation])
+            .unwrap();
+        assert!(
+            update.validation_after.valid,
+            "{:?}",
+            update.validation_after.findings
+        );
+        assert_eq!(
+            update.validation_after.parent_tree.get(&0),
+            Some(&PdfObject::Array(PdfArray(vec![
+                PdfObject::Reference(6, 0),
+                PdfObject::Reference(6, 0),
+            ])))
+        );
+    }
+}

--- a/oxidize-pdf-core/src/writer/incremental_tagged_pdf.rs
+++ b/oxidize-pdf-core/src/writer/incremental_tagged_pdf.rs
@@ -14,11 +14,25 @@ use std::io::Cursor;
 /// One controlled tagged-structure mutation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TaggedPdfMutation {
+    /// Create a new indirect StructElem and insert it below an existing parent.
+    CreateElement {
+        parent: TaggedPdfObjectRef,
+        structure_type: String,
+        attributes: PdfDictionary,
+        index: Option<usize>,
+    },
     /// Set or remove a non-structural entry on an existing StructElem dictionary.
     SetElementAttribute {
         element: TaggedPdfObjectRef,
         key: String,
         value: Option<PdfObject>,
+    },
+    /// Move an existing structure element under another element or StructTreeRoot.
+    ReparentElement {
+        element: TaggedPdfObjectRef,
+        new_parent: TaggedPdfObjectRef,
+        /// Child position in the new parent's `/K`; append when omitted.
+        index: Option<usize>,
     },
     /// Associate an MCID already present in page content with a structure element.
     AssociateMcid {
@@ -34,6 +48,7 @@ pub enum TaggedPdfMutation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TaggedPdfChangedObjectKind {
     StructureElement,
+    StructureTreeRoot,
     ParentTree,
     CrossReference,
 }
@@ -114,11 +129,43 @@ impl<'a> IncrementalTaggedPdfEditor<'a> {
 
         let parent_tree = parent_tree_reference(&mut reader)?;
         let mut replacements = BTreeMap::<TaggedPdfObjectRef, PdfDictionary>::new();
+        let mut update = IncrementalUpdate::from_reader(self.base_bytes, &reader)?;
         let mut parent_entries = validation_before.parent_tree.clone();
+        let mut current_parents: BTreeMap<_, _> = validation_before
+            .elements
+            .iter()
+            .map(|element| (element.object, element.parent))
+            .collect();
         let mut touches_parent_tree = false;
 
         for mutation in &plan.mutations {
             match mutation {
+                TaggedPdfMutation::CreateElement {
+                    parent,
+                    structure_type,
+                    attributes,
+                    index,
+                } => {
+                    let id = update.allocate_id()?;
+                    let reference = TaggedPdfObjectRef::from(id);
+                    let mut dictionary = attributes.clone();
+                    dictionary.insert(
+                        "Type".to_string(),
+                        PdfObject::Name(PdfName("StructElem".to_string())),
+                    );
+                    dictionary.insert(
+                        "S".to_string(),
+                        PdfObject::Name(PdfName(structure_type.clone())),
+                    );
+                    dictionary.insert(
+                        "P".to_string(),
+                        PdfObject::Reference(parent.object_number, parent.generation),
+                    );
+                    let parent_dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, *parent)?;
+                    insert_child_reference(parent_dictionary, reference, *index)?;
+                    update.replace(id, PdfObject::Dictionary(dictionary))?;
+                }
                 TaggedPdfMutation::SetElementAttribute {
                     element,
                     key,
@@ -127,6 +174,30 @@ impl<'a> IncrementalTaggedPdfEditor<'a> {
                     let dictionary =
                         replacement_dictionary(&mut reader, &mut replacements, *element)?;
                     set_dictionary_value(dictionary, key, value.clone());
+                }
+                TaggedPdfMutation::ReparentElement {
+                    element,
+                    new_parent,
+                    index,
+                } => {
+                    let old_parent = current_parents
+                        .get(element)
+                        .copied()
+                        .flatten()
+                        .ok_or_else(|| invalid("reparented element has no indirect parent"))?;
+                    let old_dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, old_parent)?;
+                    remove_child_reference(old_dictionary, *element)?;
+                    let new_dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, *new_parent)?;
+                    insert_child_reference(new_dictionary, *element, *index)?;
+                    let element_dictionary =
+                        replacement_dictionary(&mut reader, &mut replacements, *element)?;
+                    element_dictionary.insert(
+                        "P".to_string(),
+                        PdfObject::Reference(new_parent.object_number, new_parent.generation),
+                    );
+                    current_parents.insert(*element, Some(*new_parent));
                 }
                 TaggedPdfMutation::AssociateMcid {
                     element,
@@ -162,7 +233,6 @@ impl<'a> IncrementalTaggedPdfEditor<'a> {
             write_flat_parent_tree(dictionary, &parent_entries);
         }
 
-        let mut update = IncrementalUpdate::from_reader(self.base_bytes, &reader)?;
         for (reference, dictionary) in replacements {
             update.replace(
                 (reference.object_number, reference.generation),
@@ -212,8 +282,42 @@ fn validate_mutations(
         .iter()
         .map(|element| element.object)
         .collect();
+    let structure_root = report.structure_tree_root;
+    let mut parents: BTreeMap<_, _> = report
+        .elements
+        .iter()
+        .map(|element| (element.object, element.parent))
+        .collect();
     for mutation in mutations {
         match mutation {
+            TaggedPdfMutation::CreateElement {
+                parent,
+                structure_type,
+                attributes,
+                index,
+            } => {
+                if !elements.contains(parent) && Some(*parent) != structure_root {
+                    return Err(invalid(
+                        "creation parent is not a structure element or StructTreeRoot",
+                    ));
+                }
+                if structure_type.is_empty()
+                    || structure_type
+                        .bytes()
+                        .any(|byte| byte.is_ascii_whitespace())
+                {
+                    return Err(invalid("new structure type must be a non-empty PDF name"));
+                }
+                if ["Type", "S", "P", "K"]
+                    .iter()
+                    .any(|key| attributes.contains_key(key))
+                {
+                    return Err(invalid(
+                        "new-element attributes contain a core structure key",
+                    ));
+                }
+                validate_child_index(reader, *parent, *index, false)?;
+            }
             TaggedPdfMutation::SetElementAttribute { element, key, .. } => {
                 if !elements.contains(element) {
                     return Err(invalid(
@@ -225,6 +329,43 @@ fn validate_mutations(
                         "core structure keys cannot be edited as attributes",
                     ));
                 }
+            }
+            TaggedPdfMutation::ReparentElement {
+                element,
+                new_parent,
+                index,
+            } => {
+                if !elements.contains(element) {
+                    return Err(invalid(
+                        "reparent target is not an inspected structure element",
+                    ));
+                }
+                if !elements.contains(new_parent) && Some(*new_parent) != structure_root {
+                    return Err(invalid(
+                        "new parent is not a structure element or StructTreeRoot",
+                    ));
+                }
+                if element == new_parent {
+                    return Err(invalid("a structure element cannot parent itself"));
+                }
+                let mut ancestor = Some(*new_parent);
+                let mut seen = BTreeSet::new();
+                while let Some(candidate) = ancestor {
+                    if candidate == *element {
+                        return Err(invalid("reparenting would create a structure cycle"));
+                    }
+                    if !seen.insert(candidate) {
+                        return Err(invalid("existing parent chain contains a cycle"));
+                    }
+                    ancestor = parents.get(&candidate).copied().flatten();
+                }
+                validate_child_index(
+                    reader,
+                    *new_parent,
+                    *index,
+                    parents.get(element).copied().flatten() == Some(*new_parent),
+                )?;
+                parents.insert(*element, Some(*new_parent));
             }
             TaggedPdfMutation::AssociateMcid {
                 element,
@@ -285,8 +426,25 @@ fn build_plan(
     let mut changed = BTreeSet::new();
     let mut parent_tree_changed = false;
     let mut effective = Vec::new();
+    let mut update = IncrementalUpdate::from_reader(base_bytes, reader)?;
     for mutation in mutations {
         match mutation {
+            TaggedPdfMutation::CreateElement { parent, .. } => {
+                let object = TaggedPdfObjectRef::from(update.allocate_id()?);
+                changed.insert(TaggedPdfChangedObject {
+                    object,
+                    kind: TaggedPdfChangedObjectKind::StructureElement,
+                });
+                changed.insert(TaggedPdfChangedObject {
+                    object: *parent,
+                    kind: if Some(*parent) == report.structure_tree_root {
+                        TaggedPdfChangedObjectKind::StructureTreeRoot
+                    } else {
+                        TaggedPdfChangedObjectKind::StructureElement
+                    },
+                });
+                effective.push(mutation.clone());
+            }
             TaggedPdfMutation::SetElementAttribute {
                 element,
                 key,
@@ -300,6 +458,34 @@ fn build_plan(
                     object: *element,
                     kind: TaggedPdfChangedObjectKind::StructureElement,
                 });
+                effective.push(mutation.clone());
+            }
+            TaggedPdfMutation::ReparentElement {
+                element,
+                new_parent,
+                index,
+            } => {
+                let source = report
+                    .elements
+                    .iter()
+                    .find(|candidate| candidate.object == *element)
+                    .ok_or_else(|| invalid("reparent target disappeared"))?;
+                if source.parent == Some(*new_parent) && index.is_none() {
+                    continue;
+                }
+                let old_parent = source
+                    .parent
+                    .ok_or_else(|| invalid("reparent target has no indirect parent"))?;
+                for object in [*element, old_parent, *new_parent] {
+                    changed.insert(TaggedPdfChangedObject {
+                        object,
+                        kind: if Some(object) == report.structure_tree_root {
+                            TaggedPdfChangedObjectKind::StructureTreeRoot
+                        } else {
+                            TaggedPdfChangedObjectKind::StructureElement
+                        },
+                    });
+                }
                 effective.push(mutation.clone());
             }
             TaggedPdfMutation::AssociateMcid { element, .. } => {
@@ -327,7 +513,7 @@ fn build_plan(
         });
     }
     if !changed.is_empty() {
-        if let Some(reference) = IncrementalUpdate::from_reader(base_bytes, reader)?
+        if let Some(reference) = update
             .pending_xref_stream_id()
             .map(TaggedPdfObjectRef::from)
         {
@@ -388,6 +574,28 @@ fn replacement_dictionary<'a>(
         .expect("inserted replacement"))
 }
 
+fn validate_child_index(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    parent: TaggedPdfObjectRef,
+    index: Option<usize>,
+    moving_within_parent: bool,
+) -> Result<()> {
+    let Some(index) = index else { return Ok(()) };
+    let dictionary = resolve_dictionary(reader, parent)?;
+    let mut child_count = match dictionary.get("K") {
+        None => 0,
+        Some(PdfObject::Array(children)) => children.0.len(),
+        Some(_) => 1,
+    };
+    if moving_within_parent {
+        child_count = child_count.saturating_sub(1);
+    }
+    if index > child_count {
+        return Err(invalid("new-parent child index is out of bounds"));
+    }
+    Ok(())
+}
+
 fn set_dictionary_value(dictionary: &mut PdfDictionary, key: &str, value: Option<PdfObject>) {
     if let Some(value) = value {
         dictionary.insert(key.to_string(), value);
@@ -419,6 +627,52 @@ fn append_mcid(dictionary: &mut PdfDictionary, page: TaggedPdfObjectRef, mcid: u
             PdfObject::Array(PdfArray(vec![existing, mcr])),
         ),
     }
+}
+
+fn remove_child_reference(dictionary: &mut PdfDictionary, child: TaggedPdfObjectRef) -> Result<()> {
+    let target = (child.object_number, child.generation);
+    match dictionary.get("K").cloned() {
+        Some(PdfObject::Reference(number, generation)) if (number, generation) == target => {
+            dictionary.0.remove(&PdfName("K".to_string()));
+            Ok(())
+        }
+        Some(PdfObject::Array(mut children)) => {
+            let before = children.0.len();
+            children
+                .0
+                .retain(|value| value.as_reference() != Some(target));
+            if children.0.len() == before {
+                return Err(invalid("old parent does not contain the reparented child"));
+            }
+            if children.0.is_empty() {
+                dictionary.0.remove(&PdfName("K".to_string()));
+            } else {
+                dictionary.insert("K".to_string(), PdfObject::Array(children));
+            }
+            Ok(())
+        }
+        _ => Err(invalid("old parent does not contain the reparented child")),
+    }
+}
+
+fn insert_child_reference(
+    dictionary: &mut PdfDictionary,
+    child: TaggedPdfObjectRef,
+    index: Option<usize>,
+) -> Result<()> {
+    let child = PdfObject::Reference(child.object_number, child.generation);
+    let mut children = match dictionary.get("K").cloned() {
+        None => PdfArray::new(),
+        Some(PdfObject::Array(children)) => children,
+        Some(existing) => PdfArray(vec![existing]),
+    };
+    let index = index.unwrap_or(children.0.len());
+    if index > children.0.len() {
+        return Err(invalid("new-parent child index is out of bounds"));
+    }
+    children.0.insert(index, child);
+    dictionary.insert("K".to_string(), PdfObject::Array(children));
+    Ok(())
 }
 
 fn set_parent_owner(
@@ -529,5 +783,103 @@ mod tests {
                 PdfObject::Reference(6, 0),
             ])))
         );
+    }
+
+    #[test]
+    fn reparents_an_element_losslessly_and_rejects_cycles() {
+        let base = pdf(&[
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 4 0 R /Lang (en-US) >>",
+            "<< /Type /Pages /Count 0 /Kids [] >>",
+            "null",
+            "<< /Type /StructTreeRoot /K [5 0 R 6 0 R] /ParentTree 8 0 R >>",
+            "<< /Type /StructElem /S /Sect /P 4 0 R /K 7 0 R /OldKey /Preserved >>",
+            "<< /Type /StructElem /S /Sect /P 4 0 R /NewKey /Preserved >>",
+            "<< /Type /StructElem /S /P /P 5 0 R /CustomNS << /Value 9 >> >>",
+            "<< /Nums [] >>",
+        ]);
+        let mutation = TaggedPdfMutation::ReparentElement {
+            element: TaggedPdfObjectRef::from((7, 0)),
+            new_parent: TaggedPdfObjectRef::from((6, 0)),
+            index: Some(0),
+        };
+        let editor = IncrementalTaggedPdfEditor::new(&base);
+        let plan = editor.plan(std::slice::from_ref(&mutation)).unwrap();
+        assert_eq!(plan.changed_objects.len(), 3);
+        let update = editor.apply(&[mutation]).unwrap();
+        assert!(update.pdf_bytes.starts_with(&base));
+        assert!(
+            update.validation_after.valid,
+            "{:?}",
+            update.validation_after.findings
+        );
+        let moved = update
+            .validation_after
+            .elements
+            .iter()
+            .find(|element| element.object == TaggedPdfObjectRef::from((7, 0)))
+            .unwrap();
+        assert_eq!(moved.parent, Some(TaggedPdfObjectRef::from((6, 0))));
+        assert!(moved.dictionary.contains_key("CustomNS"));
+
+        let cycle = TaggedPdfMutation::ReparentElement {
+            element: TaggedPdfObjectRef::from((6, 0)),
+            new_parent: TaggedPdfObjectRef::from((7, 0)),
+            index: None,
+        };
+        assert!(IncrementalTaggedPdfEditor::new(&update.pdf_bytes)
+            .plan(&[cycle])
+            .is_err());
+
+        let collective_cycle = [
+            TaggedPdfMutation::ReparentElement {
+                element: TaggedPdfObjectRef::from((5, 0)),
+                new_parent: TaggedPdfObjectRef::from((6, 0)),
+                index: None,
+            },
+            TaggedPdfMutation::ReparentElement {
+                element: TaggedPdfObjectRef::from((6, 0)),
+                new_parent: TaggedPdfObjectRef::from((5, 0)),
+                index: None,
+            },
+        ];
+        assert!(IncrementalTaggedPdfEditor::new(&base)
+            .plan(&collective_cycle)
+            .is_err());
+
+        let mut attributes = PdfDictionary::new();
+        attributes.insert("CustomCreated".to_string(), PdfObject::Boolean(true));
+        let creation = TaggedPdfMutation::CreateElement {
+            parent: TaggedPdfObjectRef::from((6, 0)),
+            structure_type: "Span".to_string(),
+            attributes,
+            index: None,
+        };
+        let mut invalid_index = creation.clone();
+        if let TaggedPdfMutation::CreateElement { index, .. } = &mut invalid_index {
+            *index = Some(usize::MAX);
+        }
+        assert!(IncrementalTaggedPdfEditor::new(&update.pdf_bytes)
+            .plan(&[invalid_index])
+            .is_err());
+        let editor = IncrementalTaggedPdfEditor::new(&update.pdf_bytes);
+        let plan = editor.plan(std::slice::from_ref(&creation)).unwrap();
+        let created = plan
+            .changed_objects
+            .iter()
+            .find(|changed| {
+                changed.kind == TaggedPdfChangedObjectKind::StructureElement
+                    && changed.object.object_number > 8
+            })
+            .unwrap()
+            .object;
+        let created_update = editor.apply(&[creation]).unwrap();
+        let created_element = created_update
+            .validation_after
+            .elements
+            .iter()
+            .find(|element| element.object == created)
+            .unwrap();
+        assert_eq!(created_element.structure_type.as_deref(), Some("Span"));
+        assert!(created_element.dictionary.contains_key("CustomCreated"));
     }
 }

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -90,6 +90,10 @@ impl<'a> IncrementalUpdate<'a> {
         Ok(())
     }
 
+    pub(crate) fn pending_xref_stream_id(&self) -> Option<(u32, u16)> {
+        (self.xref_kind == XrefKind::Stream).then_some((self.next_id, 0))
+    }
+
     pub(crate) fn finish(mut self) -> Result<Vec<u8>> {
         self.replacements
             .sort_by_key(|(number, generation, _)| (*number, *generation));

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -5,6 +5,7 @@ mod incremental_annotations;
 mod incremental_form_fill;
 mod incremental_highlights;
 mod incremental_ocr_layer;
+mod incremental_tagged_pdf;
 mod incremental_text_notes;
 mod incremental_update;
 mod object_streams;
@@ -23,6 +24,10 @@ pub use incremental_highlights::{
 };
 pub use incremental_ocr_layer::{
     IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage, OcrLayerPlan, OcrLayerUpdate,
+};
+pub use incremental_tagged_pdf::{
+    IncrementalTaggedPdfEditor, TaggedPdfChangedObject, TaggedPdfChangedObjectKind,
+    TaggedPdfEditPlan, TaggedPdfMutation, TaggedPdfMutationReport,
 };
 pub use incremental_text_notes::{
     IncrementalTextNoteEditor, TextNote, TextNoteId, TextNoteMutation, TextNoteUpdate,

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1441,28 +1441,25 @@ impl<W: Write> PdfWriter<W> {
         let mut struct_tree_root = Dictionary::new();
         struct_tree_root.set("Type", Object::Name("StructTreeRoot".to_string()));
 
-        if !page_owners.is_empty() {
-            let parent_tree_id = self.allocate_object_id();
-            let mut nums = Vec::new();
-            for (struct_parent_key, (_page_index, owners)) in page_owners.iter().enumerate() {
-                let max_mcid = *owners.keys().next_back().expect("non-empty owner map");
-                let mut owner_array = vec![Object::Null; max_mcid as usize + 1];
-                for (&mcid, &element_index) in owners {
-                    owner_array[mcid as usize] = Object::Reference(element_ids[element_index]);
-                }
-                nums.push(Object::Integer(struct_parent_key as i64));
-                nums.push(Object::Array(owner_array));
+        let parent_tree_id = self.allocate_object_id();
+        let mut nums = Vec::new();
+        for (struct_parent_key, (_page_index, owners)) in page_owners.iter().enumerate() {
+            let max_mcid = *owners.keys().next_back().expect("non-empty owner map");
+            let mut owner_array = vec![Object::Null; max_mcid as usize + 1];
+            for (&mcid, &element_index) in owners {
+                owner_array[mcid as usize] = Object::Reference(element_ids[element_index]);
             }
-
-            let mut parent_tree = Dictionary::new();
-            parent_tree.set("Nums", Object::Array(nums));
-            self.write_object(parent_tree_id, Object::Dictionary(parent_tree))?;
-            struct_tree_root.set("ParentTree", Object::Reference(parent_tree_id));
-            struct_tree_root.set(
-                "ParentTreeNextKey",
-                Object::Integer(page_owners.len() as i64),
-            );
+            nums.push(Object::Integer(struct_parent_key as i64));
+            nums.push(Object::Array(owner_array));
         }
+        let mut parent_tree = Dictionary::new();
+        parent_tree.set("Nums", Object::Array(nums));
+        self.write_object(parent_tree_id, Object::Dictionary(parent_tree))?;
+        struct_tree_root.set("ParentTree", Object::Reference(parent_tree_id));
+        struct_tree_root.set(
+            "ParentTreeNextKey",
+            Object::Integer(page_owners.len() as i64),
+        );
 
         // Add root element(s) as K entry
         if let Some(root_index) = struct_tree.root_index() {

--- a/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/pdf_writer/mod.rs
@@ -1011,6 +1011,12 @@ impl<W: Write> PdfWriter<W> {
             if !struct_tree.is_empty() {
                 let struct_tree_root_id = self.write_struct_tree(struct_tree)?;
                 catalog.set("StructTreeRoot", Object::Reference(struct_tree_root_id));
+                if let Some(language) = struct_tree
+                    .root()
+                    .and_then(|root| root.attributes.lang.as_ref())
+                {
+                    catalog.set("Lang", Object::String(language.clone()));
+                }
                 // Mark as Tagged PDF
                 catalog.set("MarkInfo", {
                     let mut mark_info = Dictionary::new();

--- a/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
+++ b/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
@@ -1,0 +1,45 @@
+use oxidize_pdf::structure::{StandardStructureType, StructTree, StructureElement};
+use oxidize_pdf::verification::tagged_pdf::{
+    validate_tagged_pdf, TaggedPdfFindingCode, TaggedPdfValidationOptions,
+};
+use oxidize_pdf::{Document, Page};
+
+#[test]
+fn validates_a_tagged_pdf_created_by_the_public_writer() {
+    let mut page = Page::a4();
+    let mcid = page.begin_marked_content("P").unwrap();
+    page.end_marked_content().unwrap();
+
+    let mut tree = StructTree::new();
+    let document = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let mut paragraph = StructureElement::new(StandardStructureType::P);
+    paragraph.add_mcid(0, mcid);
+    tree.add_child(document, paragraph).unwrap();
+
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let bytes = document.to_bytes().unwrap();
+
+    let report = validate_tagged_pdf(&bytes, &TaggedPdfValidationOptions::default()).unwrap();
+    assert!(report.tagged);
+    assert!(report.valid, "{:?}", report.findings);
+    assert_eq!(report.elements.len(), 2);
+    assert_eq!(report.parent_tree_entries, 1);
+}
+
+#[test]
+fn exposes_stable_machine_readable_findings() {
+    // This is deliberately a malformed tagged PDF assembled in the unit tests;
+    // public callers should be able to branch on codes without parsing messages.
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    let bytes = document.to_bytes().unwrap();
+    let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(
+        report.findings[0].code,
+        TaggedPdfFindingCode::MissingStructureTree
+    );
+}

--- a/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
+++ b/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
@@ -11,7 +11,8 @@ fn validates_a_tagged_pdf_created_by_the_public_writer() {
     page.end_marked_content().unwrap();
 
     let mut tree = StructTree::new();
-    let document = tree.set_root(StructureElement::new(StandardStructureType::Document));
+    let document = tree
+        .set_root(StructureElement::new(StandardStructureType::Document).with_language("en-US"));
     let mut paragraph = StructureElement::new(StandardStructureType::P);
     paragraph.add_mcid(0, mcid);
     tree.add_child(document, paragraph).unwrap();

--- a/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
+++ b/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
@@ -1,7 +1,10 @@
+use oxidize_pdf::parser::objects::{PdfObject, PdfString};
 use oxidize_pdf::structure::{StandardStructureType, StructTree, StructureElement};
 use oxidize_pdf::verification::tagged_pdf::{
     validate_tagged_pdf, TaggedPdfFindingCode, TaggedPdfValidationOptions,
 };
+use oxidize_pdf::viewer_preferences::ViewerPreferences;
+use oxidize_pdf::writer::{IncrementalTaggedPdfEditor, TaggedPdfMutation};
 use oxidize_pdf::{Document, Page};
 
 #[test]
@@ -21,6 +24,9 @@ fn validates_a_tagged_pdf_created_by_the_public_writer() {
     document.add_page(page);
     document.set_struct_tree(tree);
     let bytes = document.to_bytes().unwrap();
+    if let Some(path) = std::env::var_os("OXIDIZE_ISSUE_544_PDF") {
+        std::fs::write(path, &bytes).unwrap();
+    }
 
     let report = validate_tagged_pdf(&bytes, &TaggedPdfValidationOptions::default()).unwrap();
     assert!(report.tagged);
@@ -55,4 +61,154 @@ fn exposes_stable_machine_readable_findings() {
         report.findings[0].code,
         TaggedPdfFindingCode::MissingStructureTree
     );
+}
+
+#[test]
+fn dry_run_and_incremental_edit_preserve_unrelated_bytes_and_unknown_entries() {
+    let mut page = Page::a4();
+    let first = page.begin_marked_content("P").unwrap();
+    page.end_marked_content().unwrap();
+    let second = page.begin_marked_content("P").unwrap();
+    page.end_marked_content().unwrap();
+
+    let mut tree = StructTree::new();
+    let root = tree
+        .set_root(StructureElement::new(StandardStructureType::Document).with_language("en-US"));
+    let mut paragraph = StructureElement::new(StandardStructureType::P);
+    paragraph.add_mcid(0, first);
+    tree.add_child(root, paragraph).unwrap();
+    let mut document = Document::new();
+    document.add_page(page);
+    document.set_struct_tree(tree);
+    let base = document.to_bytes().unwrap();
+
+    let before = validate_tagged_pdf(&base, &Default::default()).unwrap();
+    let paragraph = before
+        .elements
+        .iter()
+        .find(|element| element.structure_type.as_deref() == Some("P"))
+        .unwrap()
+        .object;
+    let page = *before.content_mcids.keys().next().unwrap();
+    let mutations = vec![
+        TaggedPdfMutation::SetElementAttribute {
+            element: paragraph,
+            key: "OxidizeUnknown".to_string(),
+            value: Some(PdfObject::String(PdfString::new(b"preserved".to_vec()))),
+        },
+        TaggedPdfMutation::AssociateMcid {
+            element: paragraph,
+            page,
+            mcid: second,
+        },
+    ];
+
+    let editor = IncrementalTaggedPdfEditor::new(&base);
+    let plan = editor.plan(&mutations).unwrap();
+    assert_eq!(plan.changed_objects.len(), 2);
+    let update = editor.apply(&mutations).unwrap();
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert!(
+        update.validation_after.valid,
+        "{:?}",
+        update.validation_after.findings
+    );
+    let paragraph = update
+        .validation_after
+        .elements
+        .iter()
+        .find(|element| element.object == paragraph)
+        .unwrap();
+    assert_eq!(paragraph.marked_content_count, 2);
+    assert!(paragraph.dictionary.contains_key("OxidizeUnknown"));
+
+    let no_op = TaggedPdfMutation::SetElementAttribute {
+        element: paragraph.object,
+        key: "OxidizeUnknown".to_string(),
+        value: Some(PdfObject::String(PdfString::new(b"preserved".to_vec()))),
+    };
+    let no_op_update = IncrementalTaggedPdfEditor::new(&update.pdf_bytes)
+        .apply(&[no_op])
+        .unwrap();
+    assert!(no_op_update.plan.changed_objects.is_empty());
+    assert_eq!(no_op_update.pdf_bytes, update.pdf_bytes);
+}
+
+#[test]
+fn cross_checks_missing_figure_alt_with_verapdf_when_available() {
+    let Some(verapdf) = std::env::var_os("VERAPDF") else {
+        return;
+    };
+    let mut tree = StructTree::new();
+    let root = tree
+        .set_root(StructureElement::new(StandardStructureType::Document).with_language("en-US"));
+    tree.add_child(root, StructureElement::new(StandardStructureType::Figure))
+        .unwrap();
+    let mut document = Document::new();
+    document.set_title("Issue 544 independent validation fixture");
+    document.set_viewer_preferences(ViewerPreferences::new().display_doc_title(true));
+    document.add_page(Page::a4());
+    document.set_struct_tree(tree);
+    let bytes = document.to_bytes().unwrap();
+    let local = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+    assert!(local
+        .findings
+        .iter()
+        .any(|finding| finding.code == TaggedPdfFindingCode::MissingAlternateText));
+
+    let path = std::env::temp_dir().join(format!("oxidize-issue-544-{}.pdf", std::process::id()));
+    std::fs::write(&path, bytes).unwrap();
+    let output = std::process::Command::new(verapdf)
+        .args(["--format", "xml", "--flavour", "ua1"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    let _ = std::fs::remove_file(path);
+    let report = String::from_utf8(output.stdout).unwrap();
+    assert!(!output.status.success());
+    assert!(report.contains("isCompliant=\"false\""));
+    assert!(
+        report.to_ascii_lowercase().contains("alternate")
+            || report.to_ascii_lowercase().contains("replacement text"),
+        "veraPDF did not report the missing Figure alternative: {report}"
+    );
+}
+
+#[test]
+fn round_trips_nested_table_and_figure_structure() {
+    let mut tree = StructTree::new();
+    let document = tree
+        .set_root(StructureElement::new(StandardStructureType::Document).with_language("en-US"));
+    let section = tree
+        .add_child(document, StructureElement::new(StandardStructureType::Sect))
+        .unwrap();
+    let table = tree
+        .add_child(section, StructureElement::new(StandardStructureType::Table))
+        .unwrap();
+    let row = tree
+        .add_child(table, StructureElement::new(StandardStructureType::TR))
+        .unwrap();
+    tree.add_child(row, StructureElement::new(StandardStructureType::TH))
+        .unwrap();
+    tree.add_child(row, StructureElement::new(StandardStructureType::TD))
+        .unwrap();
+    tree.add_child(
+        section,
+        StructureElement::new(StandardStructureType::Figure).with_alt_text("Accessible figure"),
+    )
+    .unwrap();
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.set_struct_tree(tree);
+    let bytes = document.to_bytes().unwrap();
+    let report = validate_tagged_pdf(&bytes, &Default::default()).unwrap();
+    assert!(report.valid, "{:?}", report.findings);
+    assert_eq!(report.elements.len(), 7);
+    for structure_type in ["Table", "TR", "TH", "TD", "Figure"] {
+        assert!(report
+            .elements
+            .iter()
+            .any(|element| element.structure_type.as_deref() == Some(structure_type)));
+    }
 }

--- a/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
+++ b/oxidize-pdf-core/tests/issue_544_tagged_pdf_validation_test.rs
@@ -26,6 +26,18 @@ fn validates_a_tagged_pdf_created_by_the_public_writer() {
     assert!(report.valid, "{:?}", report.findings);
     assert_eq!(report.elements.len(), 2);
     assert_eq!(report.parent_tree_entries, 1);
+    let root = report
+        .elements
+        .iter()
+        .find(|element| element.structure_type.as_deref() == Some("Document"))
+        .unwrap();
+    let paragraph = report
+        .elements
+        .iter()
+        .find(|element| element.structure_type.as_deref() == Some("P"))
+        .unwrap();
+    assert_eq!(root.marked_content_count, 0);
+    assert_eq!(paragraph.marked_content_count, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add bounded, lossless tagged-PDF structure inspection and machine-readable PDF/UA findings
- add incremental structure mutations for attributes, MCID associations, ParentTree repair, element creation, and reparenting
- preserve unknown attributes and unrelated bytes, enforce DocMDP policy, and expose exact dry-run mutation reports
- validate reading order, language, headings, tables, lists, links, figures, artifacts, role/class maps, MCRs, and bidirectional ParentTree links

## Validation
- cargo test -p oxidize-pdf --lib (6763 passed, 3 ignored)
- cargo test -p oxidize-pdf --test tagged_pdf_integration_test (10 passed)
- VERAPDF=/tmp/verapdf/verapdf cargo test -p oxidize-pdf --test issue_544_tagged_pdf_validation_test (5 passed)
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- Kripteia: editor 95/100, validator 96/100, acceptance 100/100; no security findings

Closes #544