### PR TITLE
feat: add public outline and bookmark reading API

### DIFF
--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -342,7 +342,8 @@ pub use recovery::{
 // Re-export structure types
 pub use structure::{
     Destination, DestinationType, NameTree, NameTreeNode, NamedDestinations, OutlineBuilder,
-    OutlineItem, OutlineTree, PageDestination, PageTree, PageTreeBuilder, PageTreeNode,
+    OutlineFlags, OutlineItem, OutlineTree, PageDestination, PageTree, PageTreeBuilder,
+    PageTreeNode,
 };
 
 // Re-export action types

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -247,6 +247,9 @@ impl<R: Read + Seek> PdfDocument<R> {
         &self,
         options: &super::outline::OutlineReadOptions,
     ) -> ParseResult<Option<crate::structure::OutlineTree>> {
+        if !self.catalog_dictionary()?.contains_key("Outlines") {
+            return Ok(None);
+        }
         let count = self.page_count()?;
         let mut pages = HashMap::with_capacity(count as usize);
         for index in 0..count {

--- a/oxidize-pdf-core/src/parser/document.rs
+++ b/oxidize-pdf-core/src/parser/document.rs
@@ -227,6 +227,34 @@ pub struct PdfDocument<R: Read + Seek> {
 }
 
 impl<R: Read + Seek> PdfDocument<R> {
+    /// Read the complete document outline with default resource limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the page tree, outline hierarchy, sibling links,
+    /// or a referenced destination is malformed or exceeds a configured limit.
+    pub fn outline(&self) -> ParseResult<Option<crate::structure::OutlineTree>> {
+        self.outline_with_options(&super::outline::OutlineReadOptions::default())
+    }
+
+    /// Read the complete document outline with explicit resource limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the page tree, outline hierarchy, sibling links,
+    /// or a referenced destination is malformed or exceeds `options`.
+    pub fn outline_with_options(
+        &self,
+        options: &super::outline::OutlineReadOptions,
+    ) -> ParseResult<Option<crate::structure::OutlineTree>> {
+        let count = self.page_count()?;
+        let mut pages = HashMap::with_capacity(count as usize);
+        for index in 0..count {
+            pages.insert(self.get_page(index)?.obj_ref, index);
+        }
+        super::outline::read_outline(&mut self.reader.borrow_mut(), &pages, options)
+    }
+
     /// Create a new PDF document from a reader
     pub fn new(reader: PdfReader<R>) -> Self {
         Self {

--- a/oxidize-pdf-core/src/parser/mod.rs
+++ b/oxidize-pdf-core/src/parser/mod.rs
@@ -142,6 +142,7 @@ pub mod lexer;
 pub mod object_stream;
 pub mod objects;
 pub mod optimized_reader;
+pub mod outline;
 pub mod page_tree;
 pub mod reader;
 pub mod stack_safe;
@@ -170,6 +171,7 @@ pub use self::encryption_handler::{
 };
 pub use self::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream, PdfString};
 pub use self::optimized_reader::OptimizedPdfReader;
+pub use self::outline::OutlineReadOptions;
 pub use self::page_tree::ParsedPage;
 pub use self::reader::{DocumentMetadata, PdfReader};
 

--- a/oxidize-pdf-core/src/parser/outline.rs
+++ b/oxidize-pdf-core/src/parser/outline.rs
@@ -1,0 +1,596 @@
+//! Bounded, read-only parsing of document outlines and destinations.
+
+use super::objects::{PdfArray, PdfDictionary, PdfObject};
+use super::{ParseError, ParseResult, PdfReader};
+use crate::geometry::{Point, Rectangle};
+use crate::graphics::Color;
+use crate::structure::{
+    Destination, DestinationType, OutlineFlags, OutlineItem, OutlineTree, PageDestination,
+};
+use std::collections::{HashMap, HashSet};
+use std::io::{Read, Seek};
+
+type ObjectRef = (u32, u16);
+
+/// Resource limits for parsing untrusted outline and destination trees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutlineReadOptions {
+    /// Maximum outline items visited.
+    pub max_items: usize,
+    /// Maximum outline and name-tree nesting depth.
+    pub max_depth: usize,
+    /// Maximum named destinations collected.
+    pub max_named_destinations: usize,
+    /// Maximum name-tree nodes visited, including empty intermediate nodes.
+    pub max_name_tree_nodes: usize,
+}
+
+impl Default for OutlineReadOptions {
+    fn default() -> Self {
+        Self {
+            max_items: 100_000,
+            max_depth: 256,
+            max_named_destinations: 100_000,
+            max_name_tree_nodes: 100_000,
+        }
+    }
+}
+
+pub(crate) fn read_outline<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    pages: &HashMap<ObjectRef, u32>,
+    options: &OutlineReadOptions,
+) -> ParseResult<Option<OutlineTree>> {
+    let catalog = reader.catalog()?.clone();
+    let Some(outlines_value) = catalog.get("Outlines").cloned() else {
+        return Ok(None);
+    };
+    let (root, root_ref) = resolve_dictionary(reader, &outlines_value, "/Catalog/Outlines")?;
+    let root_ref = root_ref.ok_or_else(|| malformed("/Outlines must be an indirect object"))?;
+    let Some(first) = root.get("First") else {
+        if root.contains_key("Last") {
+            return Err(malformed("/Outlines has Last without First"));
+        }
+        return Ok(Some(OutlineTree::new()));
+    };
+    let first = require_reference(first, "/Outlines/First")?;
+    let named = read_named_destinations(reader, &catalog, options)?;
+    let last = root
+        .get("Last")
+        .ok_or_else(|| malformed("/Outlines has First without Last"))
+        .and_then(|value| require_reference(value, "/Outlines/Last"))?;
+    let mut parser = OutlineParser {
+        reader,
+        pages,
+        named,
+        options,
+        visited: HashSet::new(),
+        active_destinations: HashSet::new(),
+        active_names: HashSet::new(),
+        item_count: 0,
+    };
+    let items = parser.read_siblings(first, Some(root_ref), Some(last), 0, "/Outlines")?;
+    Ok(Some(OutlineTree { items }))
+}
+
+struct OutlineParser<'a, R: Read + Seek> {
+    reader: &'a mut PdfReader<R>,
+    pages: &'a HashMap<ObjectRef, u32>,
+    named: HashMap<Vec<u8>, PdfObject>,
+    options: &'a OutlineReadOptions,
+    visited: HashSet<ObjectRef>,
+    active_destinations: HashSet<ObjectRef>,
+    active_names: HashSet<Vec<u8>>,
+    item_count: usize,
+}
+
+impl<R: Read + Seek> OutlineParser<'_, R> {
+    fn read_siblings(
+        &mut self,
+        first: ObjectRef,
+        parent: Option<ObjectRef>,
+        expected_last: Option<ObjectRef>,
+        depth: usize,
+        path: &str,
+    ) -> ParseResult<Vec<OutlineItem>> {
+        if depth > self.options.max_depth {
+            return Err(malformed("outline nesting exceeds configured limit"));
+        }
+        let mut result = Vec::new();
+        let mut current = Some(first);
+        let mut previous = None;
+        let mut final_ref = None;
+        while let Some(reference) = current {
+            self.item_count = self
+                .item_count
+                .checked_add(1)
+                .ok_or_else(|| malformed("outline item count overflow"))?;
+            if self.item_count > self.options.max_items {
+                return Err(malformed("outline item count exceeds configured limit"));
+            }
+            if !self.visited.insert(reference) {
+                return Err(malformed(
+                    "outline hierarchy contains a cycle or duplicate item",
+                ));
+            }
+            let value = PdfObject::Reference(reference.0, reference.1);
+            let (dictionary, _) = resolve_dictionary(self.reader, &value, path)?;
+            if dictionary.get("Parent").and_then(PdfObject::as_reference) != parent {
+                return Err(malformed(
+                    "outline item Parent does not match its containing list",
+                ));
+            }
+            if dictionary.get("Prev").and_then(PdfObject::as_reference) != previous {
+                return Err(malformed("outline item Prev link is inconsistent"));
+            }
+            let title = dictionary
+                .get("Title")
+                .and_then(PdfObject::as_string)
+                .map(|title| title.to_text())
+                .ok_or_else(|| malformed("outline item has no string Title"))?;
+            let destination = self.read_item_destination(&dictionary, path)?;
+            let flags = dictionary
+                .get("F")
+                .and_then(PdfObject::as_integer)
+                .unwrap_or(0);
+            if flags < 0 || flags & !3 != 0 {
+                return Err(malformed("outline item F contains unsupported flag bits"));
+            }
+            let color = read_color(dictionary.get("C"))?;
+            let first_child = dictionary
+                .get("First")
+                .map(|value| require_reference(value, "outline First"))
+                .transpose()?;
+            let last_child = dictionary
+                .get("Last")
+                .map(|value| require_reference(value, "outline Last"))
+                .transpose()?;
+            if first_child.is_some() != last_child.is_some() {
+                return Err(malformed(
+                    "outline item must contain both First and Last child links",
+                ));
+            }
+            let children = match first_child {
+                Some(first_child) => {
+                    self.read_siblings(first_child, Some(reference), last_child, depth + 1, path)?
+                }
+                None => Vec::new(),
+            };
+            let open = dictionary
+                .get("Count")
+                .and_then(PdfObject::as_integer)
+                .map_or(true, |count| count >= 0);
+            result.push(OutlineItem {
+                title,
+                destination,
+                children,
+                color,
+                flags: OutlineFlags {
+                    italic: flags & 1 != 0,
+                    bold: flags & 2 != 0,
+                },
+                open,
+            });
+            previous = Some(reference);
+            final_ref = Some(reference);
+            current = dictionary
+                .get("Next")
+                .map(|value| require_reference(value, "outline Next"))
+                .transpose()?;
+        }
+        if expected_last.is_some() && final_ref != expected_last {
+            return Err(malformed(
+                "outline Last link does not identify the final sibling",
+            ));
+        }
+        Ok(result)
+    }
+
+    fn read_item_destination(
+        &mut self,
+        dictionary: &PdfDictionary,
+        path: &str,
+    ) -> ParseResult<Option<Destination>> {
+        if dictionary.contains_key("Dest") && dictionary.contains_key("A") {
+            return Err(malformed("outline item contains both Dest and A"));
+        }
+        if let Some(value) = dictionary.get("Dest") {
+            return self.resolve_destination(value, path).map(Some);
+        }
+        let Some(action_value) = dictionary.get("A") else {
+            return Ok(None);
+        };
+        let (action, _) = resolve_dictionary(self.reader, action_value, "outline action")?;
+        if action
+            .get("S")
+            .and_then(PdfObject::as_name)
+            .map(|name| name.as_str())
+            != Some("GoTo")
+        {
+            return Ok(None);
+        }
+        let value = action
+            .get("D")
+            .ok_or_else(|| malformed("GoTo action has no D destination"))?;
+        self.resolve_destination(value, path).map(Some)
+    }
+
+    fn resolve_destination(&mut self, value: &PdfObject, path: &str) -> ParseResult<Destination> {
+        self.resolve_destination_at(value, path, 0)
+    }
+
+    fn resolve_destination_at(
+        &mut self,
+        value: &PdfObject,
+        path: &str,
+        depth: usize,
+    ) -> ParseResult<Destination> {
+        if depth > self.options.max_depth {
+            return Err(malformed("destination resolution exceeds configured depth"));
+        }
+        let reference = value.as_reference();
+        if reference.is_some_and(|reference| !self.active_destinations.insert(reference)) {
+            return Err(malformed("destination objects contain a cycle"));
+        }
+        let value = resolve_object(self.reader, value)?;
+        let result = match value {
+            PdfObject::Array(array) => parse_destination_array(&array, self.pages),
+            PdfObject::Name(name) => self.resolve_named(name.as_str().as_bytes(), path),
+            PdfObject::String(name) => self.resolve_named(name.as_bytes(), path),
+            PdfObject::Dictionary(dictionary) => {
+                let value = dictionary
+                    .get("D")
+                    .ok_or_else(|| malformed("destination dictionary has no D entry"))?;
+                self.resolve_destination_at(value, path, depth + 1)
+            }
+            _ => Err(malformed(format!("malformed destination at {path}"))),
+        };
+        if let Some(reference) = reference {
+            self.active_destinations.remove(&reference);
+        }
+        result
+    }
+
+    fn resolve_named(&mut self, name: &[u8], path: &str) -> ParseResult<Destination> {
+        if !self.active_names.insert(name.to_vec()) {
+            return Err(malformed("named destinations contain a cycle"));
+        }
+        let value = self
+            .named
+            .get(name)
+            .cloned()
+            .ok_or_else(|| malformed(format!("unknown named destination at {path}")))?;
+        let result = self.resolve_destination_at(&value, path, self.active_names.len());
+        self.active_names.remove(name);
+        result
+    }
+}
+
+fn parse_destination_array(
+    array: &PdfArray,
+    pages: &HashMap<ObjectRef, u32>,
+) -> ParseResult<Destination> {
+    if array.0.len() < 2 {
+        return Err(malformed("destination array has fewer than two entries"));
+    }
+    let page = match &array.0[0] {
+        PdfObject::Reference(number, generation) => pages
+            .get(&(*number, *generation))
+            .copied()
+            .ok_or_else(|| malformed("destination page reference is not in the page tree"))?,
+        PdfObject::Integer(index) if *index >= 0 => {
+            let index = u32::try_from(*index)
+                .map_err(|_| malformed("destination page index is out of range"))?;
+            if index as usize >= pages.len() {
+                return Err(malformed("destination page index is outside the page tree"));
+            }
+            index
+        }
+        _ => {
+            return Err(malformed(
+                "destination target is not a page reference or non-negative index",
+            ))
+        }
+    };
+    let kind = array.0[1]
+        .as_name()
+        .ok_or_else(|| malformed("destination view type is not a name"))?
+        .as_str();
+    let param = |index: usize| -> ParseResult<Option<f64>> {
+        match array.0.get(index) {
+            Some(PdfObject::Null) => Ok(None),
+            Some(value) => value
+                .as_real()
+                .filter(|value| value.is_finite())
+                .map(Some)
+                .ok_or_else(|| malformed("destination parameter is not a finite number or null")),
+            None => Err(malformed("destination is missing a required parameter")),
+        }
+    };
+    let required =
+        |index: usize| param(index)?.ok_or_else(|| malformed("FitR parameters cannot be null"));
+    let dest_type = match kind {
+        "XYZ" => {
+            let zoom = param(4)?;
+            if zoom.is_some_and(|zoom| zoom < 0.0) {
+                return Err(malformed("XYZ zoom cannot be negative"));
+            }
+            DestinationType::XYZ {
+                left: param(2)?,
+                top: param(3)?,
+                zoom,
+            }
+        }
+        "Fit" => DestinationType::Fit,
+        "FitH" => DestinationType::FitH { top: param(2)? },
+        "FitV" => DestinationType::FitV { left: param(2)? },
+        "FitR" => DestinationType::FitR {
+            rect: Rectangle::new(
+                Point::new(required(2)?, required(3)?),
+                Point::new(required(4)?, required(5)?),
+            ),
+        },
+        "FitB" => DestinationType::FitB,
+        "FitBH" => DestinationType::FitBH { top: param(2)? },
+        "FitBV" => DestinationType::FitBV { left: param(2)? },
+        _ => return Err(malformed(format!("unknown destination view type {kind}"))),
+    };
+    Ok(Destination {
+        page: PageDestination::PageNumber(page),
+        dest_type,
+    })
+}
+
+fn read_named_destinations<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+    options: &OutlineReadOptions,
+) -> ParseResult<HashMap<Vec<u8>, PdfObject>> {
+    let mut result = HashMap::new();
+    if let Some(legacy) = catalog.get("Dests") {
+        let (dictionary, _) = resolve_dictionary(reader, legacy, "/Catalog/Dests")?;
+        for (name, value) in dictionary.0 {
+            insert_named(&mut result, name.0.into_bytes(), value, options)?;
+        }
+    }
+    if let Some(names) = catalog.get("Names") {
+        let (names, _) = resolve_dictionary(reader, names, "/Catalog/Names")?;
+        if let Some(destinations) = names.get("Dests") {
+            let mut active = HashSet::new();
+            let mut nodes = 0usize;
+            read_name_tree(
+                reader,
+                destinations,
+                0,
+                &mut active,
+                &mut nodes,
+                &mut result,
+                options,
+            )?;
+        }
+    }
+    Ok(result)
+}
+
+fn read_name_tree<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    value: &PdfObject,
+    depth: usize,
+    active: &mut HashSet<ObjectRef>,
+    nodes: &mut usize,
+    result: &mut HashMap<Vec<u8>, PdfObject>,
+    options: &OutlineReadOptions,
+) -> ParseResult<()> {
+    if depth > options.max_depth {
+        return Err(malformed("destination name tree exceeds configured depth"));
+    }
+    *nodes = nodes
+        .checked_add(1)
+        .ok_or_else(|| malformed("destination name-tree node count overflow"))?;
+    if *nodes > options.max_name_tree_nodes {
+        return Err(malformed(
+            "destination name-tree nodes exceed configured limit",
+        ));
+    }
+    let reference = value.as_reference();
+    if reference.is_some_and(|reference| !active.insert(reference)) {
+        return Err(malformed("destination name tree contains a cycle"));
+    }
+    let (dictionary, _) = resolve_dictionary(reader, value, "destination name tree")?;
+    if dictionary.contains_key("Names") && dictionary.contains_key("Kids") {
+        return Err(malformed("name-tree node contains both Names and Kids"));
+    }
+    let limits = dictionary.get("Limits").map(read_name_limits).transpose()?;
+    if let Some(names) = dictionary.get("Names") {
+        let names = resolve_object(reader, names)?;
+        let names = names
+            .as_array()
+            .ok_or_else(|| malformed("name-tree Names is not an array"))?;
+        if names.0.len() % 2 != 0 {
+            return Err(malformed("name-tree Names array has odd length"));
+        }
+        let mut previous: Option<Vec<u8>> = None;
+        let mut first_key = None;
+        let mut last_key = None;
+        for pair in names.0.chunks_exact(2) {
+            let key = pair[0]
+                .as_string()
+                .ok_or_else(|| malformed("name-tree key is not a string"))?
+                .as_bytes()
+                .to_vec();
+            if previous.as_ref().is_some_and(|previous| previous >= &key) {
+                return Err(malformed("name-tree keys are not strictly increasing"));
+            }
+            first_key.get_or_insert_with(|| key.clone());
+            last_key = Some(key.clone());
+            previous = Some(key.clone());
+            insert_named(result, key, pair[1].clone(), options)?;
+        }
+        if let Some((lower, upper)) = limits {
+            if first_key.as_deref() != Some(lower.as_slice())
+                || last_key.as_deref() != Some(upper.as_slice())
+            {
+                return Err(malformed("name-tree Limits do not match leaf keys"));
+            }
+        }
+    }
+    if let Some(kids) = dictionary.get("Kids") {
+        let kids = resolve_object(reader, kids)?;
+        let kids = kids
+            .as_array()
+            .ok_or_else(|| malformed("name-tree Kids is not an array"))?;
+        for child in &kids.0 {
+            read_name_tree(reader, child, depth + 1, active, nodes, result, options)?;
+        }
+    }
+    if let Some(reference) = reference {
+        active.remove(&reference);
+    }
+    Ok(())
+}
+
+fn read_name_limits(value: &PdfObject) -> ParseResult<(Vec<u8>, Vec<u8>)> {
+    let limits = value
+        .as_array()
+        .ok_or_else(|| malformed("name-tree Limits is not an array"))?;
+    if limits.0.len() != 2 {
+        return Err(malformed("name-tree Limits must contain two strings"));
+    }
+    let lower = limits.0[0]
+        .as_string()
+        .ok_or_else(|| malformed("name-tree lower limit is not a string"))?
+        .as_bytes()
+        .to_vec();
+    let upper = limits.0[1]
+        .as_string()
+        .ok_or_else(|| malformed("name-tree upper limit is not a string"))?
+        .as_bytes()
+        .to_vec();
+    if lower > upper {
+        return Err(malformed("name-tree Limits are reversed"));
+    }
+    Ok((lower, upper))
+}
+
+fn insert_named(
+    result: &mut HashMap<Vec<u8>, PdfObject>,
+    key: Vec<u8>,
+    value: PdfObject,
+    options: &OutlineReadOptions,
+) -> ParseResult<()> {
+    if result.contains_key(&key) {
+        return Err(malformed("duplicate named destination"));
+    }
+    if result.len() >= options.max_named_destinations {
+        return Err(malformed("named destinations exceed configured limit"));
+    }
+    result.insert(key, value);
+    Ok(())
+}
+
+fn read_color(value: Option<&PdfObject>) -> ParseResult<Option<Color>> {
+    let Some(value) = value else { return Ok(None) };
+    let array = value
+        .as_array()
+        .ok_or_else(|| malformed("outline C is not an RGB array"))?;
+    if array.0.len() != 3 {
+        return Err(malformed("outline C must have exactly three components"));
+    }
+    let mut values = [0.0; 3];
+    for (index, value) in array.0.iter().enumerate() {
+        values[index] = value
+            .as_real()
+            .filter(|value| value.is_finite() && (0.0..=1.0).contains(value))
+            .ok_or_else(|| malformed("outline color component is outside 0..=1"))?;
+    }
+    Ok(Some(Color::Rgb(values[0], values[1], values[2])))
+}
+
+fn resolve_object<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    value: &PdfObject,
+) -> ParseResult<PdfObject> {
+    match value.as_reference() {
+        Some((number, generation)) => reader.get_object(number, generation).cloned(),
+        None => Ok(value.clone()),
+    }
+}
+
+fn resolve_dictionary<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    value: &PdfObject,
+    path: &str,
+) -> ParseResult<(PdfDictionary, Option<ObjectRef>)> {
+    let reference = value.as_reference();
+    let value = resolve_object(reader, value)?;
+    value
+        .as_dict()
+        .cloned()
+        .map(|dictionary| (dictionary, reference))
+        .ok_or_else(|| malformed(format!("{path} is not a dictionary")))
+}
+
+fn require_reference(value: &PdfObject, path: &str) -> ParseResult<ObjectRef> {
+    value
+        .as_reference()
+        .ok_or_else(|| malformed(format!("{path} is not an indirect reference")))
+}
+
+fn malformed(message: impl Into<String>) -> ParseError {
+    ParseError::SyntaxError {
+        position: 0,
+        message: format!("outline: {}", message.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::objects::PdfName;
+
+    fn destination(kind: &str, parameters: Vec<PdfObject>) -> DestinationType {
+        let mut values = vec![
+            PdfObject::Reference(10, 0),
+            PdfObject::Name(PdfName(kind.to_string())),
+        ];
+        values.extend(parameters);
+        let pages = HashMap::from([((10, 0), 3)]);
+        parse_destination_array(&PdfArray(values), &pages)
+            .expect("valid destination")
+            .dest_type
+    }
+
+    #[test]
+    fn exposes_every_standard_destination_view() {
+        assert!(matches!(destination("Fit", vec![]), DestinationType::Fit));
+        assert!(matches!(
+            destination("FitH", vec![PdfObject::Integer(20)]),
+            DestinationType::FitH { top: Some(20.0) }
+        ));
+        assert!(matches!(
+            destination("FitV", vec![PdfObject::Null]),
+            DestinationType::FitV { left: None }
+        ));
+        assert!(matches!(
+            destination(
+                "FitR",
+                vec![
+                    PdfObject::Integer(0),
+                    PdfObject::Integer(1),
+                    PdfObject::Integer(2),
+                    PdfObject::Integer(3),
+                ],
+            ),
+            DestinationType::FitR { .. }
+        ));
+        assert!(matches!(destination("FitB", vec![]), DestinationType::FitB));
+        assert!(matches!(
+            destination("FitBH", vec![PdfObject::Real(4.0)]),
+            DestinationType::FitBH { top: Some(4.0) }
+        ));
+        assert!(matches!(
+            destination("FitBV", vec![PdfObject::Null]),
+            DestinationType::FitBV { left: None }
+        ));
+    }
+}

--- a/oxidize-pdf-core/src/parser/outline.rs
+++ b/oxidize-pdf-core/src/parser/outline.rs
@@ -123,20 +123,22 @@ impl<R: Read + Seek> OutlineParser<'_, R> {
             if dictionary.get("Prev").and_then(PdfObject::as_reference) != previous {
                 return Err(malformed("outline item Prev link is inconsistent"));
             }
-            let title = dictionary
-                .get("Title")
+            let title = self
+                .resolve_optional(dictionary.get("Title"))?
+                .as_ref()
                 .and_then(PdfObject::as_string)
                 .map(|title| title.to_text())
                 .ok_or_else(|| malformed("outline item has no string Title"))?;
             let destination = self.read_item_destination(&dictionary, path)?;
-            let flags = dictionary
-                .get("F")
+            let flags = self
+                .resolve_optional(dictionary.get("F"))?
+                .as_ref()
                 .and_then(PdfObject::as_integer)
                 .unwrap_or(0);
             if flags < 0 || flags & !3 != 0 {
                 return Err(malformed("outline item F contains unsupported flag bits"));
             }
-            let color = read_color(dictionary.get("C"))?;
+            let color = read_color(self.resolve_optional(dictionary.get("C"))?.as_ref())?;
             let first_child = dictionary
                 .get("First")
                 .map(|value| require_reference(value, "outline First"))
@@ -156,8 +158,9 @@ impl<R: Read + Seek> OutlineParser<'_, R> {
                 }
                 None => Vec::new(),
             };
-            let open = dictionary
-                .get("Count")
+            let open = self
+                .resolve_optional(dictionary.get("Count"))?
+                .as_ref()
                 .and_then(PdfObject::as_integer)
                 .map_or(true, |count| count >= 0);
             result.push(OutlineItem {
@@ -213,6 +216,12 @@ impl<R: Read + Seek> OutlineParser<'_, R> {
             .get("D")
             .ok_or_else(|| malformed("GoTo action has no D destination"))?;
         self.resolve_destination(value, path).map(Some)
+    }
+
+    fn resolve_optional(&mut self, value: Option<&PdfObject>) -> ParseResult<Option<PdfObject>> {
+        value
+            .map(|value| resolve_object(self.reader, value))
+            .transpose()
     }
 
     fn resolve_destination(&mut self, value: &PdfObject, path: &str) -> ParseResult<Destination> {
@@ -380,7 +389,7 @@ fn read_name_tree<R: Read + Seek>(
     nodes: &mut usize,
     result: &mut HashMap<Vec<u8>, PdfObject>,
     options: &OutlineReadOptions,
-) -> ParseResult<()> {
+) -> ParseResult<Option<(Vec<u8>, Vec<u8>)>> {
     if depth > options.max_depth {
         return Err(malformed("destination name tree exceeds configured depth"));
     }
@@ -401,7 +410,7 @@ fn read_name_tree<R: Read + Seek>(
         return Err(malformed("name-tree node contains both Names and Kids"));
     }
     let limits = dictionary.get("Limits").map(read_name_limits).transpose()?;
-    if let Some(names) = dictionary.get("Names") {
+    let actual_range = if let Some(names) = dictionary.get("Names") {
         let names = resolve_object(reader, names)?;
         let names = names
             .as_array()
@@ -426,27 +435,47 @@ fn read_name_tree<R: Read + Seek>(
             previous = Some(key.clone());
             insert_named(result, key, pair[1].clone(), options)?;
         }
-        if let Some((lower, upper)) = limits {
-            if first_key.as_deref() != Some(lower.as_slice())
-                || last_key.as_deref() != Some(upper.as_slice())
-            {
-                return Err(malformed("name-tree Limits do not match leaf keys"));
-            }
-        }
-    }
-    if let Some(kids) = dictionary.get("Kids") {
+        first_key.zip(last_key)
+    } else if let Some(kids) = dictionary.get("Kids") {
         let kids = resolve_object(reader, kids)?;
         let kids = kids
             .as_array()
             .ok_or_else(|| malformed("name-tree Kids is not an array"))?;
+        let mut first_key = None;
+        let mut last_key: Option<Vec<u8>> = None;
         for child in &kids.0 {
-            read_name_tree(reader, child, depth + 1, active, nodes, result, options)?;
+            let child_range =
+                read_name_tree(reader, child, depth + 1, active, nodes, result, options)?;
+            let Some((lower, upper)) = child_range else {
+                continue;
+            };
+            if last_key.as_ref().is_some_and(|previous| previous >= &lower) {
+                return Err(malformed(
+                    "name-tree child ranges overlap or are not strictly increasing",
+                ));
+            }
+            first_key.get_or_insert_with(|| lower.clone());
+            last_key = Some(upper);
         }
+        first_key.zip(last_key)
+    } else {
+        None
+    };
+    match (limits, actual_range.as_ref()) {
+        (Some((lower, upper)), Some((actual_lower, actual_upper)))
+            if lower != *actual_lower || upper != *actual_upper =>
+        {
+            return Err(malformed("name-tree Limits do not match subtree keys"));
+        }
+        (Some(_), None) => {
+            return Err(malformed("empty name-tree node has non-empty Limits"));
+        }
+        _ => {}
     }
     if let Some(reference) = reference {
         active.remove(&reference);
     }
-    Ok(())
+    Ok(actual_range)
 }
 
 fn read_name_limits(value: &PdfObject) -> ParseResult<(Vec<u8>, Vec<u8>)> {

--- a/oxidize-pdf-core/src/structure/destination.rs
+++ b/oxidize-pdf-core/src/structure/destination.rs
@@ -29,7 +29,7 @@ pub enum DestinationType {
 }
 
 /// Page destination reference
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PageDestination {
     /// Page number (0-based)
     PageNumber(u32),
@@ -38,7 +38,7 @@ pub enum PageDestination {
 }
 
 /// PDF destination
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Destination {
     /// Target page
     pub page: PageDestination,

--- a/oxidize-pdf-core/src/structure/mod.rs
+++ b/oxidize-pdf-core/src/structure/mod.rs
@@ -11,7 +11,7 @@ mod tagged;
 pub use destination::{Destination, DestinationType, PageDestination};
 pub use marked_content::{MarkedContent, MarkedContentProperty};
 pub use name_tree::{NameTree, NameTreeNode, NamedDestinations};
-pub use outline::{outline_item_to_dict, OutlineBuilder, OutlineItem, OutlineTree};
+pub use outline::{outline_item_to_dict, OutlineBuilder, OutlineFlags, OutlineItem, OutlineTree};
 pub use page_tree::{PageTree, PageTreeBuilder, PageTreeNode};
 pub use tagged::{
     MarkedContentReference, RoleMap, StandardStructureType, StructTree, StructureAttributes,

--- a/oxidize-pdf-core/src/structure/outline.rs
+++ b/oxidize-pdf-core/src/structure/outline.rs
@@ -6,7 +6,7 @@ use crate::structure::destination::Destination;
 use std::collections::VecDeque;
 
 /// Outline item flags
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct OutlineFlags {
     /// Italic text
     pub italic: bool,
@@ -30,7 +30,7 @@ impl OutlineFlags {
 }
 
 /// Outline item (bookmark)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OutlineItem {
     /// Item title
     pub title: String,
@@ -116,6 +116,7 @@ impl OutlineItem {
 }
 
 /// Outline tree structure
+#[derive(Debug, Clone, PartialEq)]
 pub struct OutlineTree {
     /// Root items
     pub items: Vec<OutlineItem>,

--- a/oxidize-pdf-core/tests/issue_548_outline_reading_test.rs
+++ b/oxidize-pdf-core/tests/issue_548_outline_reading_test.rs
@@ -3,6 +3,17 @@ use oxidize_pdf::parser::{OutlineReadOptions, PdfDocument, PdfReader};
 use oxidize_pdf::{DestinationType, PageDestination};
 use std::io::Cursor;
 
+fn assert_error_contains<T>(result: Result<T, impl std::fmt::Display>, expected: &str) {
+    let message = match result {
+        Ok(_) => panic!("expected error containing {expected:?}"),
+        Err(error) => error.to_string(),
+    };
+    assert!(
+        message.contains(expected),
+        "expected {expected:?} in error, got {message:?}"
+    );
+}
+
 fn pdf(objects: &[&str]) -> Vec<u8> {
     let mut bytes = b"%PDF-1.7\n".to_vec();
     let mut offsets = vec![0usize; objects.len() + 1];
@@ -110,7 +121,7 @@ fn rejects_cycles_broken_links_and_resource_limit_exhaustion() {
         "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
         "<< /Title (Cycle) /Parent 4 0 R /Next 5 0 R >>",
     ]);
-    assert!(document(cycle).outline().is_err());
+    assert_error_contains(document(cycle).outline(), "cycle or duplicate");
 
     let broken = pdf(&[
         "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
@@ -120,7 +131,7 @@ fn rejects_cycles_broken_links_and_resource_limit_exhaustion() {
         "<< /Title (One) /Parent 4 0 R /Next 6 0 R >>",
         "<< /Title (Two) /Parent 4 0 R >>",
     ]);
-    assert!(document(broken).outline().is_err());
+    assert_error_contains(document(broken).outline(), "Prev link");
 
     let limited = pdf(&[
         "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
@@ -133,7 +144,10 @@ fn rejects_cycles_broken_links_and_resource_limit_exhaustion() {
         max_items: 0,
         ..Default::default()
     };
-    assert!(document(limited).outline_with_options(&options).is_err());
+    assert_error_contains(
+        document(limited).outline_with_options(&options),
+        "item count exceeds",
+    );
 }
 
 #[test]
@@ -146,7 +160,10 @@ fn rejects_destinations_to_objects_outside_the_nested_page_tree() {
         "<< /Type /Outlines /First 6 0 R /Last 6 0 R >>",
         "<< /Title (Wrong page) /Parent 5 0 R /Dest [4 0 R /Fit] >>",
     ]);
-    assert!(document(bytes).outline().is_err());
+    assert_error_contains(
+        document(bytes).outline(),
+        "page reference is not in the page tree",
+    );
 }
 
 #[test]
@@ -158,7 +175,10 @@ fn rejects_cycles_between_named_destinations() {
         "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
         "<< /Title (Named cycle) /Parent 4 0 R /Dest /A >>",
     ]);
-    assert!(document(bytes).outline().is_err());
+    assert_error_contains(
+        document(bytes).outline(),
+        "named destinations contain a cycle",
+    );
 }
 
 #[test]
@@ -176,5 +196,58 @@ fn bounds_empty_name_tree_nodes_independently_from_destination_count() {
         max_name_tree_nodes: 1,
         ..Default::default()
     };
-    assert!(document(bytes).outline_with_options(&options).is_err());
+    assert_error_contains(
+        document(bytes).outline_with_options(&options),
+        "name-tree nodes exceed",
+    );
+}
+
+#[test]
+fn absence_does_not_parse_a_broken_page_tree() {
+    let bytes = pdf(&["<< /Type /Catalog /Pages 99 0 R >>"]);
+    assert_eq!(document(bytes).outline().expect("outline absence"), None);
+}
+
+#[test]
+fn resolves_indirect_title_flags_color_and_open_state() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title 6 0 R /Parent 4 0 R /F 7 0 R /C 8 0 R /Count 9 0 R /First 10 0 R /Last 10 0 R >>",
+        "(Indirect title)",
+        "3",
+        "[0.25 0.5 0.75]",
+        "-1",
+        "<< /Title (Child) /Parent 5 0 R >>",
+    ]);
+    let outline = document(bytes)
+        .outline()
+        .expect("read outline")
+        .expect("outline");
+    let item = &outline.items[0];
+    assert_eq!(item.title, "Indirect title");
+    assert!(item.flags.bold && item.flags.italic);
+    assert_eq!(item.color, Some(Color::Rgb(0.25, 0.5, 0.75)));
+    assert!(!item.open);
+    assert_eq!(item.children.len(), 1);
+}
+
+#[test]
+fn rejects_overlapping_name_tree_child_ranges() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R /Names << /Dests 6 0 R >> >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (Item) /Parent 4 0 R >>",
+        "<< /Kids [7 0 R 8 0 R] /Limits [(L) (M)] >>",
+        "<< /Names [(M) [3 0 R /Fit]] /Limits [(M) (M)] >>",
+        "<< /Names [(L) [3 0 R /Fit]] /Limits [(L) (L)] >>",
+    ]);
+    assert_error_contains(
+        document(bytes).outline(),
+        "overlap or are not strictly increasing",
+    );
 }

--- a/oxidize-pdf-core/tests/issue_548_outline_reading_test.rs
+++ b/oxidize-pdf-core/tests/issue_548_outline_reading_test.rs
@@ -1,0 +1,180 @@
+use oxidize_pdf::graphics::Color;
+use oxidize_pdf::parser::{OutlineReadOptions, PdfDocument, PdfReader};
+use oxidize_pdf::{DestinationType, PageDestination};
+use std::io::Cursor;
+
+fn pdf(objects: &[&str]) -> Vec<u8> {
+    let mut bytes = b"%PDF-1.7\n".to_vec();
+    let mut offsets = vec![0usize; objects.len() + 1];
+    for (index, object) in objects.iter().enumerate() {
+        offsets[index + 1] = bytes.len();
+        bytes.extend_from_slice(format!("{} 0 obj\n{object}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref = bytes.len();
+    bytes.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets.iter().skip(1) {
+        bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    bytes.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    bytes
+}
+
+fn document(bytes: Vec<u8>) -> PdfDocument<Cursor<Vec<u8>>> {
+    PdfDocument::new(PdfReader::new(Cursor::new(bytes)).expect("parse fixture"))
+}
+
+#[test]
+fn reads_complete_hierarchy_and_resolves_direct_legacy_and_name_tree_destinations() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 8 0 R /Dests << /Legacy [5 0 R /FitH 700] >> /Names << /Dests 14 0 R >> >>",
+        "<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] >>",
+        "<< /Type /Pages /Count 1 /Kids [5 0 R] /Parent 2 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [6 0 R] /Parent 2 0 R >>",
+        "<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] >>",
+        "<< /Type /Page /Parent 4 0 R /MediaBox [0 0 612 792] >>",
+        "null",
+        "<< /Type /Outlines /First 9 0 R /Last 11 0 R /Count 3 >>",
+        "<< /Title (Direct) /Parent 8 0 R /Next 10 0 R /Dest [5 0 R /XYZ 10 20 1] /C [1 0.5 0] /F 3 >>",
+        "<< /Title (Legacy) /Parent 8 0 R /Prev 9 0 R /Next 11 0 R /Dest /Legacy /First 12 0 R /Last 12 0 R /Count -1 >>",
+        "<< /Title (Action) /Parent 8 0 R /Prev 10 0 R /A << /S /GoTo /D (Modern) >> >>",
+        "<< /Title (Nested) /Parent 10 0 R /Dest [6 0 R /FitR 0 0 100 200] >>",
+        "null",
+        "<< /Names [(Modern) [6 0 R /FitBV null]] >>",
+    ]);
+    let outline = document(bytes)
+        .outline()
+        .expect("read outline")
+        .expect("outline");
+    assert_eq!(outline.items.len(), 3);
+    assert_eq!(outline.items[0].title, "Direct");
+    assert_eq!(outline.items[0].color, Some(Color::Rgb(1.0, 0.5, 0.0)));
+    assert!(outline.items[0].flags.bold && outline.items[0].flags.italic);
+    assert_eq!(
+        outline.items[0].destination.as_ref().unwrap().page,
+        PageDestination::PageNumber(0)
+    );
+    assert!(matches!(
+        outline.items[0].destination.as_ref().unwrap().dest_type,
+        DestinationType::XYZ {
+            left: Some(10.0),
+            top: Some(20.0),
+            zoom: Some(1.0)
+        }
+    ));
+    assert!(!outline.items[1].open);
+    assert_eq!(outline.items[1].children[0].title, "Nested");
+    assert!(matches!(
+        outline.items[1].destination.as_ref().unwrap().dest_type,
+        DestinationType::FitH { top: Some(700.0) }
+    ));
+    assert_eq!(
+        outline.items[1].children[0]
+            .destination
+            .as_ref()
+            .unwrap()
+            .page,
+        PageDestination::PageNumber(1)
+    );
+    assert!(matches!(
+        outline.items[2].destination.as_ref().unwrap().dest_type,
+        DestinationType::FitBV { left: None }
+    ));
+}
+
+#[test]
+fn absence_is_not_an_error_and_parsing_is_repeatable() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+    ]);
+    let document = document(bytes);
+    assert_eq!(document.outline().expect("first read"), None);
+    assert_eq!(document.outline().expect("second read"), None);
+}
+
+#[test]
+fn rejects_cycles_broken_links_and_resource_limit_exhaustion() {
+    let cycle = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (Cycle) /Parent 4 0 R /Next 5 0 R >>",
+    ]);
+    assert!(document(cycle).outline().is_err());
+
+    let broken = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 6 0 R >>",
+        "<< /Title (One) /Parent 4 0 R /Next 6 0 R >>",
+        "<< /Title (Two) /Parent 4 0 R >>",
+    ]);
+    assert!(document(broken).outline().is_err());
+
+    let limited = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (One) /Parent 4 0 R >>",
+    ]);
+    let options = OutlineReadOptions {
+        max_items: 0,
+        ..Default::default()
+    };
+    assert!(document(limited).outline_with_options(&options).is_err());
+}
+
+#[test]
+fn rejects_destinations_to_objects_outside_the_nested_page_tree() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 5 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Page /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 6 0 R /Last 6 0 R >>",
+        "<< /Title (Wrong page) /Parent 5 0 R /Dest [4 0 R /Fit] >>",
+    ]);
+    assert!(document(bytes).outline().is_err());
+}
+
+#[test]
+fn rejects_cycles_between_named_destinations() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R /Dests << /A /B /B /A >> >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (Named cycle) /Parent 4 0 R /Dest /A >>",
+    ]);
+    assert!(document(bytes).outline().is_err());
+}
+
+#[test]
+fn bounds_empty_name_tree_nodes_independently_from_destination_count() {
+    let bytes = pdf(&[
+        "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R /Names << /Dests 6 0 R >> >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>",
+        "<< /Type /Outlines /First 5 0 R /Last 5 0 R >>",
+        "<< /Title (No destination needed) /Parent 4 0 R >>",
+        "<< /Kids [7 0 R] >>",
+        "<< /Names [] >>",
+    ]);
+    let options = OutlineReadOptions {
+        max_name_tree_nodes: 1,
+        ..Default::default()
+    };
+    assert!(document(bytes).outline_with_options(&options).is_err());
+}


### PR DESCRIPTION
## Summary
- add public read-only outline APIs on PdfDocument with configurable traversal limits
- parse complete bookmark hierarchies, open state, styles, colours, direct destinations, and GoTo actions
- resolve legacy and name-tree destinations to stable zero-based page indexes
- expose XYZ, Fit, FitH, FitV, FitR, FitB, FitBH, and FitBV view parameters
- reject cycles, broken sibling links, malformed destinations, invalid name-tree ranges, and resource-limit exhaustion
- support indirect title, flags, colour, and count objects without rewriting the source PDF

## Validation
- cargo test -p oxidize-pdf --lib: 6734 passed, 3 ignored
- cargo test -p oxidize-pdf --test issue_548_outline_reading_test: 9 passed
- cargo clippy -p oxidize-pdf --lib -- -D warnings
- cargo clippy -p oxidize-pdf --test issue_548_outline_reading_test -- -D warnings
- Kripteia security: no findings

Closes #548