### PR TITLE
feat: add incremental FreeText annotation editing

### DIFF
--- a/oxidize-pdf-core/src/writer/incremental_free_text.rs
+++ b/oxidize-pdf-core/src/writer/incremental_free_text.rs
@@ -3,8 +3,12 @@
 use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot, PageState};
 use super::incremental_update::IncrementalUpdate;
 use crate::error::{PdfError, Result};
-use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream, PdfString};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use crate::text::{escape_pdf_string_literal, TextEncoding};
 use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
 
 /// Stable indirect-object identity of a free-text annotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -161,6 +165,7 @@ impl<'a> IncrementalFreeTextEditor<'a> {
             });
         }
         validate_batch(&snapshot, mutations)?;
+        validate_policy(self.base_bytes)?;
 
         let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
         let mut changed_pages = HashSet::new();
@@ -176,8 +181,17 @@ impl<'a> IncrementalFreeTextEditor<'a> {
                     alignment,
                 } => {
                     let id = update.allocate_id()?;
-                    let dictionary =
-                        new_dictionary(*rect, contents, default_appearance, *alignment);
+                    let appearance_id = update.allocate_id()?;
+                    let appearance =
+                        build_appearance(*rect, contents, default_appearance, *alignment)?;
+                    update.replace(appearance_id, PdfObject::Stream(appearance))?;
+                    let dictionary = new_dictionary(
+                        *rect,
+                        contents,
+                        default_appearance,
+                        *alignment,
+                        appearance_id,
+                    );
                     update.replace(id, PdfObject::Dictionary(dictionary.clone()))?;
                     snapshot.pages[*page_index as usize]
                         .annotations
@@ -201,15 +215,29 @@ impl<'a> IncrementalFreeTextEditor<'a> {
                 } => {
                     let state = target(&snapshot, *id)?;
                     let mut dictionary = state.dictionary.clone();
+                    let appearance_id = update.allocate_id()?;
+                    let appearance =
+                        build_appearance(*rect, contents, default_appearance, *alignment)?;
+                    update.replace(appearance_id, PdfObject::Stream(appearance))?;
                     set_properties(
                         &mut dictionary,
                         *rect,
                         contents,
                         default_appearance,
                         *alignment,
+                        appearance_id,
                     );
                     rewritten.insert(*id, dictionary.clone());
-                    snapshot.annotations.get_mut(id).unwrap().dictionary = dictionary;
+                    snapshot
+                        .annotations
+                        .get_mut(id)
+                        .ok_or_else(|| {
+                            PdfError::InvalidStructure(format!(
+                                "annotation {} {} disappeared during batch application",
+                                id.object_number, id.generation_number
+                            ))
+                        })?
+                        .dictionary = dictionary;
                 }
                 FreeTextMutation::Remove { id } => {
                     let page_index = target(&snapshot, *id)?.page_index;
@@ -422,12 +450,7 @@ fn validate_contents(contents: &str) -> Result<()> {
 }
 
 fn validate_default_appearance(value: &str) -> Result<()> {
-    if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
-        return Err(PdfError::InvalidStructure(
-            "free-text default appearance must be non-empty ASCII and contain no NUL".to_string(),
-        ));
-    }
-    Ok(())
+    AppearanceSpec::parse(value).map(|_| ())
 }
 
 fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
@@ -473,11 +496,215 @@ fn required_text(dictionary: &PdfDictionary, key: &str) -> Result<String> {
         })
 }
 
+struct AppearanceSpec {
+    resource_name: String,
+    base_font: &'static str,
+    font_size: f64,
+}
+
+impl AppearanceSpec {
+    fn parse(value: &str) -> Result<Self> {
+        if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance must be non-empty ASCII and contain no NUL"
+                    .to_string(),
+            ));
+        }
+        let tokens: Vec<_> = value.split_whitespace().collect();
+        let font_at = tokens
+            .windows(3)
+            .position(|window| window[0].starts_with('/') && window[2] == "Tf")
+            .ok_or_else(|| {
+                PdfError::InvalidStructure(
+                    "free-text default appearance must contain '/Font size Tf'".to_string(),
+                )
+            })?;
+        let resource_name = &tokens[font_at][1..];
+        let base_font = base_font(resource_name).ok_or_else(|| {
+            PdfError::InvalidStructure(format!(
+                "free-text default appearance font /{resource_name} is not a supported non-symbolic base-14 font"
+            ))
+        })?;
+        let font_size = parse_finite(tokens[font_at + 1], "font size")?;
+        if font_size <= 0.0 {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance font size must be positive".to_string(),
+            ));
+        }
+
+        let remaining: Vec<_> = tokens
+            .iter()
+            .enumerate()
+            .filter_map(|(index, token)| {
+                (!(font_at..font_at + 3).contains(&index)).then_some(*token)
+            })
+            .collect();
+        validate_color_tokens(&remaining)?;
+        Ok(Self {
+            resource_name: resource_name.to_string(),
+            base_font,
+            font_size,
+        })
+    }
+}
+
+fn parse_finite(token: &str, description: &str) -> Result<f64> {
+    let value = token.parse::<f64>().map_err(|_| {
+        PdfError::InvalidStructure(format!(
+            "free-text default appearance {description} is not numeric"
+        ))
+    })?;
+    if !value.is_finite() {
+        return Err(PdfError::InvalidStructure(format!(
+            "free-text default appearance {description} must be finite"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_color_tokens(tokens: &[&str]) -> Result<()> {
+    let component_count = match tokens.last().copied() {
+        None => return Ok(()),
+        Some("g") if tokens.len() == 2 => 1,
+        Some("rg") if tokens.len() == 4 => 3,
+        Some("k") if tokens.len() == 5 => 4,
+        _ => {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance may contain only one base-14 font and an optional g, rg, or k color"
+                    .to_string(),
+            ))
+        }
+    };
+    for token in &tokens[..component_count] {
+        let component = parse_finite(token, "color component")?;
+        if !(0.0..=1.0).contains(&component) {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance color components must be in the range 0..=1"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn base_font(resource_name: &str) -> Option<&'static str> {
+    match resource_name {
+        "Helv" | "Helvetica" => Some("Helvetica"),
+        "Helvetica-Bold" => Some("Helvetica-Bold"),
+        "Helvetica-Oblique" => Some("Helvetica-Oblique"),
+        "Helvetica-BoldOblique" => Some("Helvetica-BoldOblique"),
+        "Times-Roman" => Some("Times-Roman"),
+        "Times-Bold" => Some("Times-Bold"),
+        "Times-Italic" => Some("Times-Italic"),
+        "Times-BoldItalic" => Some("Times-BoldItalic"),
+        "Courier" => Some("Courier"),
+        "Courier-Bold" => Some("Courier-Bold"),
+        "Courier-Oblique" => Some("Courier-Oblique"),
+        "Courier-BoldOblique" => Some("Courier-BoldOblique"),
+        _ => None,
+    }
+}
+
+fn build_appearance(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) -> Result<PdfStream> {
+    let spec = AppearanceSpec::parse(default_appearance)?;
+    let width = rect[2] - rect[0];
+    let height = rect[3] - rect[1];
+    let padding = 2.0;
+    let line_height = spec.font_size * 1.2;
+    let mut content = format!(
+        "q\n0 0 {} {} re W n\nBT\n",
+        pdf_number(width),
+        pdf_number(height)
+    );
+    content.push_str(default_appearance);
+    content.push('\n');
+    for (line_index, line) in contents.lines().enumerate() {
+        let encoded = TextEncoding::WinAnsiEncoding.encode(line);
+        let estimated_width = encoded.len() as f64 * spec.font_size * 0.5;
+        let x = match alignment {
+            FreeTextAlignment::Left => padding,
+            FreeTextAlignment::Center => ((width - estimated_width) / 2.0).max(padding),
+            FreeTextAlignment::Right => (width - estimated_width - padding).max(padding),
+        };
+        let y = height - padding - spec.font_size - line_index as f64 * line_height;
+        if y < 0.0 {
+            break;
+        }
+        content.push_str(&format!(
+            "1 0 0 1 {} {} Tm\n({}) Tj\n",
+            pdf_number(x),
+            pdf_number(y),
+            escape_pdf_string_literal(&encoded)
+        ));
+    }
+    content.push_str("ET\nQ");
+
+    let mut font = PdfDictionary::new();
+    font.insert("Type".to_string(), name("Font"));
+    font.insert("Subtype".to_string(), name("Type1"));
+    font.insert("BaseFont".to_string(), name(spec.base_font));
+    font.insert("Encoding".to_string(), name("WinAnsiEncoding"));
+    let mut fonts = PdfDictionary::new();
+    fonts.insert(spec.resource_name, PdfObject::Dictionary(font));
+    let mut resources = PdfDictionary::new();
+    resources.insert("Font".to_string(), PdfObject::Dictionary(fonts));
+
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("Type".to_string(), name("XObject"));
+    dictionary.insert("Subtype".to_string(), name("Form"));
+    dictionary.insert("FormType".to_string(), PdfObject::Integer(1));
+    dictionary.insert("BBox".to_string(), rectangle([0.0, 0.0, width, height]));
+    dictionary.insert("Resources".to_string(), PdfObject::Dictionary(resources));
+    Ok(PdfStream {
+        dict: dictionary,
+        data: content.into_bytes(),
+    })
+}
+
+fn pdf_number(value: f64) -> String {
+    let mut formatted = format!("{value:.6}");
+    while formatted.contains('.') && formatted.ends_with('0') {
+        formatted.pop();
+    }
+    if formatted.ends_with('.') {
+        formatted.pop();
+    }
+    if formatted == "-0" {
+        "0".to_string()
+    } else {
+        formatted
+    }
+}
+
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName(value.to_string()))
+}
+
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| PdfError::InvalidStructure(format!("parse base PDF: {error}")))?;
+    let catalog = reader
+        .catalog()
+        .map_err(|error| PdfError::InvalidStructure(format!("read catalog: {error}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::AddAnnotation,
+    )
+}
+
 fn new_dictionary(
     rect: [f64; 4],
     contents: &str,
     default_appearance: &str,
     alignment: FreeTextAlignment,
+    appearance_id: (u32, u16),
 ) -> PdfDictionary {
     let mut dictionary = PdfDictionary::new();
     dictionary.insert(
@@ -494,6 +721,7 @@ fn new_dictionary(
         contents,
         default_appearance,
         alignment,
+        appearance_id,
     );
     dictionary
 }
@@ -504,6 +732,7 @@ fn set_properties(
     contents: &str,
     default_appearance: &str,
     alignment: FreeTextAlignment,
+    appearance_id: (u32, u16),
 ) {
     dictionary.insert("Rect".to_string(), rectangle(rect));
     dictionary.insert("Contents".to_string(), unicode_text(contents));
@@ -512,6 +741,12 @@ fn set_properties(
         PdfObject::String(PdfString(default_appearance.as_bytes().to_vec())),
     );
     dictionary.insert("Q".to_string(), PdfObject::Integer(alignment.pdf_value()));
+    let mut appearance = PdfDictionary::new();
+    appearance.insert(
+        "N".to_string(),
+        PdfObject::Reference(appearance_id.0, appearance_id.1),
+    );
+    dictionary.insert("AP".to_string(), PdfObject::Dictionary(appearance));
 }
 
 fn rectangle(rect: [f64; 4]) -> PdfObject {

--- a/oxidize-pdf-core/src/writer/incremental_free_text.rs
+++ b/oxidize-pdf-core/src/writer/incremental_free_text.rs
@@ -1,0 +1,553 @@
+//! Incremental editing of standard `/FreeText` annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot, PageState};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use std::collections::{HashMap, HashSet};
+
+/// Stable indirect-object identity of a free-text annotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FreeTextId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl FreeTextId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// Horizontal alignment stored in a free-text annotation's `/Q` entry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FreeTextAlignment {
+    /// Left justified (`/Q 0`).
+    #[default]
+    Left,
+    /// Centered (`/Q 1`).
+    Center,
+    /// Right justified (`/Q 2`).
+    Right,
+}
+
+impl FreeTextAlignment {
+    fn from_pdf(value: i64) -> Result<Self> {
+        match value {
+            0 => Ok(Self::Left),
+            1 => Ok(Self::Center),
+            2 => Ok(Self::Right),
+            _ => Err(PdfError::InvalidStructure(format!(
+                "/FreeText annotation /Q must be 0, 1, or 2, found {value}"
+            ))),
+        }
+    }
+
+    const fn pdf_value(self) -> i64 {
+        match self {
+            Self::Left => 0,
+            Self::Center => 1,
+            Self::Right => 2,
+        }
+    }
+}
+
+/// A standard PDF free-text annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FreeText {
+    /// Stable indirect-object identity.
+    pub id: FreeTextId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Annotation rectangle `[left, bottom, right, top]`.
+    pub rect: [f64; 4],
+    /// Annotation contents decoded as Unicode.
+    pub contents: String,
+    /// Default appearance string (`/DA`).
+    pub default_appearance: String,
+    /// Horizontal text alignment.
+    pub alignment: FreeTextAlignment,
+}
+
+/// A requested change to the document's free-text annotations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FreeTextMutation {
+    /// Add a free-text annotation to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Annotation rectangle `[left, bottom, right, top]`.
+        rect: [f64; 4],
+        /// Non-empty annotation contents.
+        contents: String,
+        /// Non-empty ASCII PDF default appearance string, for example `/Helv 12 Tf 0 g`.
+        default_appearance: String,
+        /// Horizontal text alignment.
+        alignment: FreeTextAlignment,
+    },
+    /// Update an existing annotation while preserving all unrelated keys.
+    Update {
+        /// Existing free-text annotation identity.
+        id: FreeTextId,
+        /// New annotation rectangle `[left, bottom, right, top]`.
+        rect: [f64; 4],
+        /// New non-empty annotation contents.
+        contents: String,
+        /// New non-empty ASCII PDF default appearance string.
+        default_appearance: String,
+        /// New horizontal text alignment.
+        alignment: FreeTextAlignment,
+    },
+    /// Remove an existing annotation reference from its page.
+    Remove {
+        /// Existing free-text annotation identity.
+        id: FreeTextId,
+    },
+}
+
+/// Result of one atomic incremental free-text update.
+#[derive(Debug, Clone)]
+pub struct FreeTextUpdate {
+    /// Complete PDF bytes. The original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Complete current free-text set after the update.
+    pub annotations: Vec<FreeText>,
+}
+
+/// Reads and atomically edits standard free-text annotations in an existing PDF.
+pub struct IncrementalFreeTextEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalFreeTextEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/FreeText` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF is malformed or encrypted, or when a
+    /// free-text annotation has no stable identity or invalid properties.
+    pub fn annotations(&self) -> Result<Vec<FreeText>> {
+        Snapshot::parse(self.base_bytes)?.annotations()
+    }
+
+    /// Validate and apply a batch as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed or encrypted PDFs, invalid pages or
+    /// identities, conflicting mutations, invalid annotation properties, or
+    /// exhausted indirect-object numbers.
+    pub fn apply(&self, mutations: &[FreeTextMutation]) -> Result<FreeTextUpdate> {
+        let mut snapshot = Snapshot::parse(self.base_bytes)?;
+        if mutations.is_empty() {
+            return Ok(FreeTextUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                annotations: snapshot.annotations()?,
+            });
+        }
+        validate_batch(&snapshot, mutations)?;
+
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+        let mut rewritten = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                FreeTextMutation::Add {
+                    page_index,
+                    rect,
+                    contents,
+                    default_appearance,
+                    alignment,
+                } => {
+                    let id = update.allocate_id()?;
+                    let dictionary =
+                        new_dictionary(*rect, contents, default_appearance, *alignment);
+                    update.replace(id, PdfObject::Dictionary(dictionary.clone()))?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    snapshot.annotations.insert(
+                        FreeTextId::new(id.0, id.1),
+                        AnnotationState {
+                            page_index: *page_index,
+                            dictionary,
+                            is_free_text: true,
+                        },
+                    );
+                    changed_pages.insert(*page_index);
+                }
+                FreeTextMutation::Update {
+                    id,
+                    rect,
+                    contents,
+                    default_appearance,
+                    alignment,
+                } => {
+                    let state = target(&snapshot, *id)?;
+                    let mut dictionary = state.dictionary.clone();
+                    set_properties(
+                        &mut dictionary,
+                        *rect,
+                        contents,
+                        default_appearance,
+                        *alignment,
+                    );
+                    rewritten.insert(*id, dictionary.clone());
+                    snapshot.annotations.get_mut(id).unwrap().dictionary = dictionary;
+                }
+                FreeTextMutation::Remove { id } => {
+                    let page_index = target(&snapshot, *id)?.page_index;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    snapshot.annotations.remove(id);
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+
+        for (id, dictionary) in rewritten {
+            update.replace(id.tuple(), PdfObject::Dictionary(dictionary))?;
+        }
+        rewrite_pages(&mut update, &mut snapshot.pages, &changed_pages)?;
+        let annotations = snapshot.annotations()?;
+        Ok(FreeTextUpdate {
+            pdf_bytes: update.finish()?,
+            annotations,
+        })
+    }
+}
+
+struct AnnotationState {
+    page_index: u32,
+    dictionary: PdfDictionary,
+    is_free_text: bool,
+}
+
+struct Snapshot {
+    pages: Vec<PageState>,
+    annotations: HashMap<FreeTextId, AnnotationState>,
+}
+
+impl Snapshot {
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        let shared = AnnotationSnapshot::parse(bytes, "FreeText", "free-text annotation")?;
+        let annotations = shared
+            .annotations
+            .into_iter()
+            .map(|((number, generation), state)| {
+                (
+                    FreeTextId::new(number, generation),
+                    AnnotationState {
+                        page_index: state.page_index,
+                        is_free_text: subtype(&state.dictionary) == Some("FreeText"),
+                        dictionary: state.dictionary,
+                    },
+                )
+            })
+            .collect();
+        let snapshot = Self {
+            pages: shared.pages,
+            annotations,
+        };
+        snapshot.annotations()?;
+        Ok(snapshot)
+    }
+
+    fn annotations(&self) -> Result<Vec<FreeText>> {
+        let mut result = Vec::new();
+        for (id, state) in &self.annotations {
+            if state.is_free_text {
+                result.push(parse_annotation(
+                    *id,
+                    state,
+                    self.pages[state.page_index as usize].bounds,
+                )?);
+            }
+        }
+        result.sort_by_key(|annotation| {
+            (
+                annotation.page_index,
+                annotation.id.object_number,
+                annotation.id.generation_number,
+            )
+        });
+        Ok(result)
+    }
+}
+
+fn parse_annotation(
+    id: FreeTextId,
+    state: &AnnotationState,
+    page_bounds: [f64; 4],
+) -> Result<FreeText> {
+    let rect = parse_rectangle(&state.dictionary)?;
+    validate_rectangle(rect, page_bounds)?;
+    let contents = required_text(&state.dictionary, "Contents")?;
+    let default_appearance = required_text(&state.dictionary, "DA")?;
+    validate_contents(&contents)?;
+    validate_default_appearance(&default_appearance)?;
+    let alignment = match state.dictionary.get("Q") {
+        None => Ok(FreeTextAlignment::Left),
+        Some(PdfObject::Integer(value)) => FreeTextAlignment::from_pdf(*value),
+        Some(_) => Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Q must be an integer".to_string(),
+        )),
+    }?;
+    Ok(FreeText {
+        id,
+        page_index: state.page_index,
+        rect,
+        contents,
+        default_appearance,
+        alignment,
+    })
+}
+
+fn validate_batch(snapshot: &Snapshot, mutations: &[FreeTextMutation]) -> Result<()> {
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            FreeTextMutation::Add {
+                page_index,
+                rect,
+                contents,
+                default_appearance,
+                ..
+            } => {
+                let page = snapshot.pages.get(*page_index as usize).ok_or_else(|| {
+                    PdfError::InvalidStructure(format!("page {page_index} does not exist"))
+                })?;
+                validate_properties(*rect, contents, default_appearance, page.bounds)?;
+            }
+            FreeTextMutation::Update {
+                id,
+                rect,
+                contents,
+                default_appearance,
+                ..
+            } => {
+                ensure_unique_target(&mut targeted, *id)?;
+                let state = target(snapshot, *id)?;
+                validate_properties(
+                    *rect,
+                    contents,
+                    default_appearance,
+                    snapshot.pages[state.page_index as usize].bounds,
+                )?;
+            }
+            FreeTextMutation::Remove { id } => {
+                ensure_unique_target(&mut targeted, *id)?;
+                target(snapshot, *id)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_unique_target(targeted: &mut HashSet<FreeTextId>, id: FreeTextId) -> Result<()> {
+    if !targeted.insert(id) {
+        return Err(PdfError::InvalidStructure(format!(
+            "free-text annotation {} {} is targeted more than once",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(())
+}
+
+fn target(snapshot: &Snapshot, id: FreeTextId) -> Result<&AnnotationState> {
+    let state = snapshot.annotations.get(&id).ok_or_else(|| {
+        PdfError::InvalidStructure(format!(
+            "annotation {} {} does not exist",
+            id.object_number, id.generation_number
+        ))
+    })?;
+    if !state.is_free_text {
+        return Err(PdfError::InvalidStructure(format!(
+            "annotation {} {} is not a /FreeText annotation",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(state)
+}
+
+fn validate_properties(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    bounds: [f64; 4],
+) -> Result<()> {
+    validate_rectangle(rect, bounds)?;
+    validate_contents(contents)?;
+    validate_default_appearance(default_appearance)
+}
+
+fn validate_rectangle(rect: [f64; 4], bounds: [f64; 4]) -> Result<()> {
+    if rect.iter().any(|value| !value.is_finite()) || rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(PdfError::InvalidStructure(
+            "free-text rectangle must contain finite, ordered coordinates".to_string(),
+        ));
+    }
+    if rect[0] < bounds[0] || rect[1] < bounds[1] || rect[2] > bounds[2] || rect[3] > bounds[3] {
+        return Err(PdfError::InvalidStructure(
+            "free-text rectangle is outside the page bounds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_contents(contents: &str) -> Result<()> {
+    if contents.trim().is_empty() {
+        return Err(PdfError::InvalidStructure(
+            "free-text contents must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_default_appearance(value: &str) -> Result<()> {
+    if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
+        return Err(PdfError::InvalidStructure(
+            "free-text default appearance must be non-empty ASCII and contain no NUL".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
+    let array = dictionary
+        .get("Rect")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| {
+            PdfError::InvalidStructure("/FreeText annotation has no /Rect".to_string())
+        })?;
+    if array.0.len() != 4 {
+        return Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Rect must have four numbers".to_string(),
+        ));
+    }
+    let mut rect = [0.0; 4];
+    for (index, value) in array.0.iter().enumerate() {
+        rect[index] = match value {
+            PdfObject::Integer(value) => *value as f64,
+            PdfObject::Real(value) if value.is_finite() => *value,
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "/FreeText annotation /Rect contains a non-finite or non-numeric value"
+                        .to_string(),
+                ))
+            }
+        };
+    }
+    if rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Rect coordinates are not ordered".to_string(),
+        ));
+    }
+    Ok(rect)
+}
+
+fn required_text(dictionary: &PdfDictionary, key: &str) -> Result<String> {
+    dictionary
+        .get(key)
+        .and_then(PdfObject::as_string)
+        .map(PdfString::to_text)
+        .ok_or_else(|| {
+            PdfError::InvalidStructure(format!("/FreeText annotation /{key} must be a string"))
+        })
+}
+
+fn new_dictionary(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Annot".to_string())),
+    );
+    dictionary.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("FreeText".to_string())),
+    );
+    set_properties(
+        &mut dictionary,
+        rect,
+        contents,
+        default_appearance,
+        alignment,
+    );
+    dictionary
+}
+
+fn set_properties(
+    dictionary: &mut PdfDictionary,
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) {
+    dictionary.insert("Rect".to_string(), rectangle(rect));
+    dictionary.insert("Contents".to_string(), unicode_text(contents));
+    dictionary.insert(
+        "DA".to_string(),
+        PdfObject::String(PdfString(default_appearance.as_bytes().to_vec())),
+    );
+    dictionary.insert("Q".to_string(), PdfObject::Integer(alignment.pdf_value()));
+}
+
+fn rectangle(rect: [f64; 4]) -> PdfObject {
+    PdfObject::Array(PdfArray(rect.into_iter().map(PdfObject::Real).collect()))
+}
+
+fn unicode_text(contents: &str) -> PdfObject {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in contents.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    PdfObject::String(PdfString(bytes))
+}
+
+fn rewrite_pages(
+    update: &mut IncrementalUpdate,
+    pages: &mut [PageState],
+    changed_pages: &HashSet<u32>,
+) -> Result<()> {
+    for page_index in changed_pages {
+        let page = &mut pages[*page_index as usize];
+        match page.container {
+            AnnotationContainer::Page => {
+                page.dictionary.insert(
+                    "Annots".to_string(),
+                    PdfObject::Array(PdfArray(page.annotations.clone())),
+                );
+                update.replace(
+                    page.reference,
+                    PdfObject::Dictionary(page.dictionary.clone()),
+                )?;
+            }
+            AnnotationContainer::Indirect(id) => {
+                update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -3,6 +3,7 @@
 mod content_stream_utils;
 mod incremental_annotations;
 mod incremental_form_fill;
+mod incremental_free_text;
 mod incremental_highlights;
 mod incremental_ocr_layer;
 mod incremental_tagged_pdf;
@@ -18,6 +19,10 @@ pub(crate) use content_stream_utils::{
     apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
 };
 pub use incremental_form_fill::IncrementalFormFiller;
+pub use incremental_free_text::{
+    FreeText, FreeTextAlignment, FreeTextId, FreeTextMutation, FreeTextUpdate,
+    IncrementalFreeTextEditor,
+};
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
     HighlightUpdate, IncrementalHighlightEditor,

--- a/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
@@ -11,9 +11,10 @@ fn classic_base() -> Vec<u8> {
         (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
         (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
         (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R /CustomPageKey 42 >>"),
-        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /CustomKey (preserve-me) >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /AP << /N 7 0 R >> /CustomKey (preserve-me) >>"),
         (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /CustomLinkKey 99 >>"),
         (6, b"[4 0 R 5 0 R]"),
+        (7, b"<< /Type /XObject /Subtype /Form /BBox [0 0 130 50] /Length 3 >>\nstream\nold\nendstream"),
     ])
 }
 
@@ -36,6 +37,43 @@ fn build_classic(objects: &[(u32, &[u8])]) -> Vec<u8> {
         format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
     );
     out
+}
+
+fn build_classic_generations(objects: &[(u32, u16, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap_or(0) + 1;
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[*number as usize] = Some((out.len(), *generation));
+        out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => out.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn replace_policy(source: &[u8], permission: u8) -> Vec<u8> {
+    let mut result = source.to_vec();
+    let marker = b"/P 2";
+    let offset = result
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture must contain DocMDP P=2");
+    result[offset + 3] = b'0' + permission;
+    result
 }
 
 fn xref_stream_base() -> Vec<u8> {
@@ -170,8 +208,70 @@ fn mixed_batch_is_atomic_round_trips_unicode_and_preserves_unknown_keys() {
         "preserve-me"
     );
     assert_eq!(dictionary.get("Q"), Some(&PdfObject::Integer(2)));
+    let appearance_id = dictionary
+        .get("AP")
+        .and_then(PdfObject::as_dict)
+        .and_then(|appearance| appearance.get("N"))
+        .and_then(PdfObject::as_reference)
+        .expect("updated annotation must reference a normal appearance stream");
+    assert_ne!(appearance_id, (7, 0), "stale appearance must be replaced");
+    let appearance = reader
+        .get_object(appearance_id.0, appearance_id.1)
+        .unwrap()
+        .as_stream()
+        .unwrap();
+    assert!(appearance
+        .data
+        .windows(8)
+        .any(|window| window == b"l\\355nea"));
+    assert!(appearance.dict.get("Resources").is_some());
     let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
     assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
+
+#[test]
+fn preserves_nonzero_generation_identities() {
+    let base = build_classic_generations(&[
+        (1, 0, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, 0, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, 0, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 7 R] >>"),
+        (4, 7, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (generation) /DA (/Helv 10 Tf 0 g) >>"),
+    ]);
+    let annotations = IncrementalFreeTextEditor::new(&base).annotations().unwrap();
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 7));
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[FreeTextMutation::Update {
+            id: FreeTextId::new(4, 7),
+            rect: [20.0, 30.0, 150.0, 80.0],
+            contents: "updated".to_string(),
+            default_appearance: "/Helv 11 Tf 0 g".to_string(),
+            alignment: FreeTextAlignment::Left,
+        }])
+        .unwrap();
+    assert_eq!(update.annotations[0].id, FreeTextId::new(4, 7));
+}
+
+#[test]
+fn enforces_docmdp_and_preserves_approval_signed_prefixes() {
+    let certified_p2 = include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf");
+    for source in [replace_policy(certified_p2, 1), certified_p2.to_vec()] {
+        let error = IncrementalFreeTextEditor::new(&source)
+            .apply(&[add_mutation("forbidden")])
+            .unwrap_err();
+        assert!(matches!(error, PdfError::PermissionDenied(message) if message.contains("DocMDP")));
+    }
+
+    let certified_p3 = replace_policy(certified_p2, 3);
+    let allowed = IncrementalFreeTextEditor::new(&certified_p3)
+        .apply(&[add_mutation("allowed")])
+        .unwrap();
+    assert!(allowed.pdf_bytes.starts_with(&certified_p3));
+
+    let approval = include_bytes!("fixtures/signatures/signed_rsa_incremental.pdf");
+    let approval_update = IncrementalFreeTextEditor::new(approval)
+        .apply(&[add_mutation("approval")])
+        .unwrap();
+    assert!(approval_update.pdf_bytes.starts_with(approval));
 }
 
 #[test]
@@ -302,6 +402,25 @@ fn rejects_invalid_properties_pages_stale_ids_and_conflicting_batches() {
         IncrementalFreeTextEditor::new(&base).apply(&[non_ascii_appearance]),
         "ASCII",
     );
+    for appearance in [
+        "/Unknown 10 Tf 0 g",
+        "/Helv nope Tf 0 g",
+        "/Helv 0 Tf 0 g",
+        "/Helv 10 Tf 2 0 0 rg",
+        "/Helv 10 Tf q",
+    ] {
+        let mutation = FreeTextMutation::Add {
+            page_index: 0,
+            rect: [20.0, 100.0, 180.0, 150.0],
+            contents: "valid".to_string(),
+            default_appearance: appearance.to_string(),
+            alignment: FreeTextAlignment::Left,
+        };
+        assert_invalid(
+            IncrementalFreeTextEditor::new(&base).apply(&[mutation]),
+            "default appearance",
+        );
+    }
     assert_invalid(
         IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Remove {
             id: FreeTextId::new(99, 0),

--- a/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
@@ -1,0 +1,365 @@
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{
+    FreeTextAlignment, FreeTextId, FreeTextMutation, IncrementalFreeTextEditor,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn classic_base() -> Vec<u8> {
+    build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R /CustomPageKey 42 >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /CustomKey (preserve-me) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /CustomLinkKey 99 >>"),
+        (6, b"[4 0 R 5 0 R]"),
+    ])
+}
+
+fn build_classic(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n".to_vec();
+    let size = objects.iter().map(|(number, _)| *number).max().unwrap_or(0) + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (number, body) in objects {
+        offsets[*number as usize] = out.len();
+        out.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = vec![0, 0, 0, 0, 0, 0xFF, 0xFF];
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn add_mutation(contents: &str) -> FreeTextMutation {
+    FreeTextMutation::Add {
+        page_index: 0,
+        rect: [20.0, 100.0, 180.0, 150.0],
+        contents: contents.to_string(),
+        default_appearance: "/Helv 12 Tf 0 0 1 rg".to_string(),
+        alignment: FreeTextAlignment::Center,
+    }
+}
+
+fn assert_invalid<T>(result: Result<T, PdfError>, expected: &str) {
+    match result {
+        Err(PdfError::InvalidStructure(message)) => assert!(
+            message.contains(expected),
+            "expected {expected:?} in {message:?}"
+        ),
+        Err(other) => panic!("expected InvalidStructure, got {other:?}"),
+        Ok(_) => panic!("expected InvalidStructure containing {expected:?}"),
+    }
+}
+
+#[test]
+fn reads_free_text_with_stable_identity_and_default_alignment() {
+    let base = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (hello) /DA (/Helv 10 Tf 0 g) >>"),
+    ]);
+
+    let annotations = IncrementalFreeTextEditor::new(&base).annotations().unwrap();
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 0));
+    assert_eq!(annotations[0].page_index, 0);
+    assert_eq!(annotations[0].rect, [10.0, 20.0, 140.0, 70.0]);
+    assert_eq!(annotations[0].contents, "hello");
+    assert_eq!(annotations[0].default_appearance, "/Helv 10 Tf 0 g");
+    assert_eq!(annotations[0].alignment, FreeTextAlignment::Left);
+}
+
+#[test]
+fn empty_batch_is_a_true_noop() {
+    let base = classic_base();
+    let update = IncrementalFreeTextEditor::new(&base).apply(&[]).unwrap();
+    assert_eq!(update.pdf_bytes, base);
+    assert_eq!(update.annotations.len(), 1);
+}
+
+#[test]
+fn mixed_batch_is_atomic_round_trips_unicode_and_preserves_unknown_keys() {
+    let base = classic_base();
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[
+            FreeTextMutation::Update {
+                id: FreeTextId::new(4, 0),
+                rect: [30.0, 40.0, 190.0, 100.0],
+                contents: "línea uno\nlínea dos ✓".to_string(),
+                default_appearance: "/Helv 14 Tf 1 0 0 rg".to_string(),
+                alignment: FreeTextAlignment::Right,
+            },
+            add_mutation("new annotation"),
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert_eq!(
+        update
+            .pdf_bytes
+            .windows(9)
+            .filter(|window| *window == b"startxref")
+            .count(),
+        2
+    );
+    assert_eq!(update.annotations.len(), 2);
+
+    let reopened = IncrementalFreeTextEditor::new(&update.pdf_bytes)
+        .annotations()
+        .unwrap();
+    let changed = reopened
+        .iter()
+        .find(|annotation| annotation.id == FreeTextId::new(4, 0))
+        .unwrap();
+    assert_eq!(changed.contents, "línea uno\nlínea dos ✓");
+    assert_eq!(changed.alignment, FreeTextAlignment::Right);
+    assert_eq!(changed.default_appearance, "/Helv 14 Tf 1 0 0 rg");
+
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let dictionary = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        dictionary
+            .get("CustomKey")
+            .and_then(PdfObject::as_string)
+            .unwrap()
+            .to_text(),
+        "preserve-me"
+    );
+    assert_eq!(dictionary.get("Q"), Some(&PdfObject::Integer(2)));
+    let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
+    assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
+
+#[test]
+fn add_and_remove_update_indirect_annots_without_rewriting_other_annotations() {
+    let base = classic_base();
+    let added = IncrementalFreeTextEditor::new(&base)
+        .apply(&[add_mutation("temporary")])
+        .unwrap();
+    let new_id = added
+        .annotations
+        .iter()
+        .find(|annotation| annotation.contents == "temporary")
+        .unwrap()
+        .id;
+    let removed = IncrementalFreeTextEditor::new(&added.pdf_bytes)
+        .apply(&[FreeTextMutation::Remove { id: new_id }])
+        .unwrap();
+
+    let annotations = IncrementalFreeTextEditor::new(&removed.pdf_bytes)
+        .annotations()
+        .unwrap();
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 0));
+    let mut reader = PdfReader::new(Cursor::new(&removed.pdf_bytes)).unwrap();
+    assert_eq!(
+        reader
+            .get_object(5, 0)
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .get("CustomLinkKey"),
+        Some(&PdfObject::Integer(99))
+    );
+}
+
+#[test]
+fn supports_xref_stream_inputs_and_emits_a_reopenable_incremental_revision() {
+    let base = xref_stream_base();
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[add_mutation("xref stream")])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    let reopened = IncrementalFreeTextEditor::new(&update.pdf_bytes)
+        .annotations()
+        .unwrap();
+    assert_eq!(reopened.len(), 1);
+    assert_eq!(reopened[0].contents, "xref stream");
+    PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_free_text_revisions() {
+    for (name, base) in [("classic", classic_base()), ("stream", xref_stream_base())] {
+        let update = IncrementalFreeTextEditor::new(&base)
+            .apply(&[add_mutation("interop")])
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(format!("free-text-{name}.pdf"));
+        std::fs::write(&path, &update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn rejects_invalid_properties_pages_stale_ids_and_conflicting_batches() {
+    let base = classic_base();
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Add {
+            page_index: 1,
+            rect: [10.0, 10.0, 20.0, 20.0],
+            contents: "text".to_string(),
+            default_appearance: "/Helv 10 Tf".to_string(),
+            alignment: FreeTextAlignment::Left,
+        }]),
+        "page 1 does not exist",
+    );
+    for (rect, expected) in [
+        ([f64::NAN, 10.0, 20.0, 20.0], "finite, ordered"),
+        ([20.0, 10.0, 10.0, 20.0], "finite, ordered"),
+        ([10.0, 10.0, 310.0, 20.0], "outside the page"),
+    ] {
+        let mut mutation = add_mutation("text");
+        if let FreeTextMutation::Add { rect: target, .. } = &mut mutation {
+            *target = rect;
+        }
+        assert_invalid(
+            IncrementalFreeTextEditor::new(&base).apply(&[mutation]),
+            expected,
+        );
+    }
+    let mut empty_contents = add_mutation(" ");
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[empty_contents.clone()]),
+        "contents must not be empty",
+    );
+    if let FreeTextMutation::Add {
+        default_appearance, ..
+    } = &mut empty_contents
+    {
+        *default_appearance = "".to_string();
+        if let FreeTextMutation::Add { contents, .. } = &mut empty_contents {
+            *contents = "valid".to_string();
+        }
+    }
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[empty_contents]),
+        "default appearance",
+    );
+    let mut non_ascii_appearance = add_mutation("valid");
+    if let FreeTextMutation::Add {
+        default_appearance, ..
+    } = &mut non_ascii_appearance
+    {
+        *default_appearance = "/Helv 10 Tf café".to_string();
+    }
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[non_ascii_appearance]),
+        "ASCII",
+    );
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Remove {
+            id: FreeTextId::new(99, 0),
+        }]),
+        "does not exist",
+    );
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[
+            FreeTextMutation::Remove {
+                id: FreeTextId::new(4, 0),
+            },
+            FreeTextMutation::Remove {
+                id: FreeTextId::new(4, 0),
+            },
+        ]),
+        "targeted more than once",
+    );
+}
+
+#[test]
+fn rejects_malformed_inline_and_encrypted_inputs() {
+    for annotation in [
+        b"<< /Subtype /FreeText /Rect [10 10 20] /Contents (x) /DA (/Helv 10 Tf) >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents 42 /DA (/Helv 10 Tf) >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA 42 >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA (/Helv 10 Tf) /Q 3 >>"
+            .as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 310 20] /Contents (x) /DA (/Helv 10 Tf) >>".as_slice(),
+    ] {
+        let base = build_classic(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation),
+        ]);
+        assert!(IncrementalFreeTextEditor::new(&base).annotations().is_err());
+    }
+
+    let inline = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA (/Helv 10 Tf) >>] >>"),
+    ]);
+    assert!(IncrementalFreeTextEditor::new(&inline)
+        .annotations()
+        .is_err());
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    let encrypted = document.to_bytes().unwrap();
+    assert!(IncrementalFreeTextEditor::new(&encrypted)
+        .annotations()
+        .is_err());
+    assert!(IncrementalFreeTextEditor::new(&encrypted)
+        .apply(&[])
+        .is_err());
+}


### PR DESCRIPTION
## Summary

- add a public incremental editor for standard FreeText annotations
- read annotations with stable indirect-object identities
- add, update, and remove annotations in one atomic incremental revision
- support Unicode and multiline contents, validated default appearances, and alignment
- generate fresh self-contained normal appearance streams for additions and updates
- preserve unrelated objects and existing bytes as an exact prefix
- enforce DocMDP certification permissions and reject encrypted inputs

## Compatibility and safety

- supports classic xref tables and xref streams
- preserves nonzero object generations and approval-signed document prefixes
- rejects malformed annotations, stale IDs, conflicting batches, invalid geometry, unsupported appearance syntax, and forbidden DocMDP changes
- replaces stale appearance streams instead of leaving visually outdated content

## Validation

- cargo test -p oxidize-pdf --lib: 6,764 passed, 0 failed
- issue-specific tests: 10 passed, 0 failed, including qpdf checks for classic and xref-stream inputs
- neighboring incremental text-note and highlight suites: 19 passed, 0 failed
- cargo clippy for the library and issue-specific test with -D warnings
- Kripteia test quality: 97/100
- Kripteia security: no findings

Closes #534