### PR TITLE
feat: add incremental Ink annotation editing

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -52,6 +52,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_highlight_revisions
           -- --ignored --exact
 
+      - name: Validate incremental ink annotations
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_536_incremental_ink_test
+          qpdf_accepts_classic_and_xref_stream_ink_revisions
+          -- --ignored --exact
+
       - name: Validate incremental OCR layers
         run: >
           cargo test -p oxidize-pdf

--- a/oxidize-pdf-core/src/writer/incremental_ink.rs
+++ b/oxidize-pdf-core/src/writer/incremental_ink.rs
@@ -1,0 +1,863 @@
+//! Incremental editing of standard `/Ink` annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+
+const MAX_INK_STROKES: usize = 4_096;
+const MAX_INK_POINTS: usize = 1_000_000;
+const MAX_INK_APPEARANCE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Stable indirect-object identity of an Ink annotation.
+pub struct InkId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl InkId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A non-empty, finite sequence of points forming one ink stroke.
+pub struct InkStroke(Vec<Point>);
+
+impl InkStroke {
+    /// Validate and construct a stroke.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no points are supplied or a coordinate is non-finite.
+    pub fn new(points: Vec<Point>) -> Result<Self> {
+        if points.is_empty() {
+            return Err(invalid("ink stroke must contain at least one point"));
+        }
+        if points
+            .iter()
+            .any(|point| !point.x.is_finite() || !point.y.is_finite())
+        {
+            return Err(invalid("ink stroke coordinates must be finite"));
+        }
+        Ok(Self(points))
+    }
+    /// Return the stroke's points in drawing order.
+    pub fn points(&self) -> &[Point] {
+        &self.0
+    }
+}
+
+/// A validated PDF annotation color.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InkColor {
+    /// DeviceGray color with one component.
+    Gray([f64; 1]),
+    /// DeviceRGB color with three components.
+    Rgb([f64; 3]),
+    /// DeviceCMYK color with four components.
+    Cmyk([f64; 4]),
+}
+
+impl InkColor {
+    /// Construct a DeviceRGB color whose components are in `0..=1`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for non-finite or out-of-range components.
+    pub fn new(components: [f64; 3]) -> Result<Self> {
+        validate_unit(&components, "ink RGB color")?;
+        Ok(Self::Rgb(components))
+    }
+
+    /// Construct a DeviceGray color.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-finite or out-of-range component.
+    pub fn gray(component: f64) -> Result<Self> {
+        validate_unit(&[component], "ink grayscale color")?;
+        Ok(Self::Gray([component]))
+    }
+
+    /// Construct a DeviceCMYK color.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for non-finite or out-of-range components.
+    pub fn cmyk(components: [f64; 4]) -> Result<Self> {
+        validate_unit(&components, "ink CMYK color")?;
+        Ok(Self::Cmyk(components))
+    }
+
+    fn components(self) -> Vec<f64> {
+        match self {
+            Self::Gray(values) => values.to_vec(),
+            Self::Rgb(values) => values.to_vec(),
+            Self::Cmyk(values) => values.to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// A validated positive stroke width in PDF user-space units.
+pub struct InkWidth(f64);
+
+impl InkWidth {
+    /// Construct a finite, positive stroke width.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `value` is non-finite or not positive.
+    pub fn new(value: f64) -> Result<Self> {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(invalid("ink width must be finite and positive"));
+        }
+        Ok(Self(value))
+    }
+    /// Return the stroke width in user-space units.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// A validated constant opacity in the inclusive range `0..=1`.
+pub struct InkOpacity(f64);
+
+impl InkOpacity {
+    /// Construct an opacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `value` is non-finite or outside `0..=1`.
+    pub fn new(value: f64) -> Result<Self> {
+        validate_unit(&[value], "ink opacity")?;
+        Ok(Self(value))
+    }
+    /// Return the opacity value.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A standard PDF `/Ink` annotation read from an existing document.
+pub struct Ink {
+    /// Stable indirect-object identity.
+    pub id: InkId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Bounding rectangle including half the stroke width.
+    pub rect: [f64; 4],
+    /// One or more strokes in page coordinates.
+    pub strokes: Vec<InkStroke>,
+    /// DeviceGray, DeviceRGB, or DeviceCMYK stroke color.
+    pub color: InkColor,
+    /// Stroke width in PDF user-space units.
+    pub width: InkWidth,
+    /// Optional constant opacity.
+    pub opacity: Option<InkOpacity>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A requested change to the document's Ink annotations.
+pub enum InkMutation {
+    /// Add an Ink annotation to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Non-empty validated strokes.
+        strokes: Vec<InkStroke>,
+        /// Stroke color.
+        color: InkColor,
+        /// Positive stroke width.
+        width: InkWidth,
+        /// Optional constant opacity.
+        opacity: Option<InkOpacity>,
+    },
+    /// Update an existing annotation while preserving unrelated keys.
+    Update {
+        /// Existing Ink annotation identity.
+        id: InkId,
+        /// Replacement strokes.
+        strokes: Vec<InkStroke>,
+        /// Replacement color.
+        color: InkColor,
+        /// Replacement stroke width.
+        width: InkWidth,
+        /// Replacement optional opacity.
+        opacity: Option<InkOpacity>,
+    },
+    /// Remove an existing annotation reference from its page.
+    Remove {
+        /// Existing Ink annotation identity.
+        id: InkId,
+    },
+}
+
+#[derive(Debug, Clone)]
+/// Result of one atomic incremental Ink update.
+pub struct InkUpdate {
+    /// Complete PDF bytes; the original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Complete current Ink annotation set after the update.
+    pub annotations: Vec<Ink>,
+}
+
+/// Reads and atomically edits standard Ink annotations in an existing PDF.
+pub struct IncrementalInkEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalInkEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/Ink` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed, encrypted, inline, or resource-excessive input.
+    pub fn annotations(&self) -> Result<Vec<Ink>> {
+        let snapshot = AnnotationSnapshot::parse(self.base_bytes, "Ink", "ink annotation")?;
+        read_inks(&snapshot)
+    }
+
+    /// Validate and apply all mutations as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid geometry, pages, identities, conflicting
+    /// mutations, encryption, forbidden signature policies, or resource limits.
+    pub fn apply(&self, mutations: &[InkMutation]) -> Result<InkUpdate> {
+        let mut snapshot = AnnotationSnapshot::parse(self.base_bytes, "Ink", "ink annotation")?;
+        let existing = read_inks(&snapshot)?;
+        if mutations.is_empty() {
+            return Ok(InkUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                annotations: existing,
+            });
+        }
+        let pages = validate_batch(&snapshot, &existing, mutations)?;
+        validate_policy(self.base_bytes)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+        let mut rewritten = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                InkMutation::Add {
+                    page_index,
+                    strokes,
+                    color,
+                    width,
+                    opacity,
+                } => {
+                    let id = update.allocate_id()?;
+                    let appearance_id = update.allocate_id()?;
+                    let rect = bounds(strokes, *width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(strokes, *color, *width, *opacity, rect)?),
+                    )?;
+                    update.replace(
+                        id,
+                        PdfObject::Dictionary(new_dictionary(
+                            strokes,
+                            *color,
+                            *width,
+                            *opacity,
+                            rect,
+                            appearance_id,
+                        )),
+                    )?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    changed_pages.insert(*page_index);
+                }
+                InkMutation::Update {
+                    id,
+                    strokes,
+                    color,
+                    width,
+                    opacity,
+                } => {
+                    let state = snapshot
+                        .annotations
+                        .get(&id.tuple())
+                        .ok_or_else(|| missing(*id))?;
+                    if subtype(&state.dictionary) != Some("Ink") {
+                        return Err(missing(*id));
+                    }
+                    let mut dictionary = state.dictionary.clone();
+                    let appearance_id = update.allocate_id()?;
+                    let rect = bounds(strokes, *width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(strokes, *color, *width, *opacity, rect)?),
+                    )?;
+                    set_properties(
+                        &mut dictionary,
+                        strokes,
+                        *color,
+                        *width,
+                        *opacity,
+                        rect,
+                        appearance_id,
+                    );
+                    rewritten.insert(id.tuple(), dictionary);
+                }
+                InkMutation::Remove { id } => {
+                    let page_index = *pages.get(id).ok_or_else(|| missing(*id))?;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+        for (id, dictionary) in rewritten {
+            update.replace(id, PdfObject::Dictionary(dictionary))?;
+        }
+        rewrite_pages(&mut update, &mut snapshot, &changed_pages)?;
+        let pdf_bytes = update.finish()?;
+        let annotations = IncrementalInkEditor::new(&pdf_bytes).annotations()?;
+        Ok(InkUpdate {
+            pdf_bytes,
+            annotations,
+        })
+    }
+}
+
+fn read_inks(snapshot: &AnnotationSnapshot) -> Result<Vec<Ink>> {
+    let mut result = Vec::new();
+    for (&(number, generation), state) in &snapshot.annotations {
+        if subtype(&state.dictionary) == Some("Ink") {
+            let page = &snapshot.pages[state.page_index as usize];
+            result.push(parse_ink(
+                InkId::new(number, generation),
+                state.page_index,
+                &state.dictionary,
+                page.bounds,
+            )?);
+        }
+    }
+    result.sort_by_key(|ink| {
+        (
+            ink.page_index,
+            ink.id.object_number,
+            ink.id.generation_number,
+        )
+    });
+    Ok(result)
+}
+
+fn parse_ink(
+    id: InkId,
+    page_index: u32,
+    dict: &PdfDictionary,
+    page_bounds: [f64; 4],
+) -> Result<Ink> {
+    let rect_values = numeric_array(dict, "Rect", Some(4))?;
+    let rect = [
+        rect_values[0],
+        rect_values[1],
+        rect_values[2],
+        rect_values[3],
+    ];
+    if rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(invalid("/Ink /Rect must have positive width and height"));
+    }
+    if rect[0] < page_bounds[0]
+        || rect[1] < page_bounds[1]
+        || rect[2] > page_bounds[2]
+        || rect[3] > page_bounds[3]
+    {
+        return Err(invalid("/Ink /Rect is outside the page bounds"));
+    }
+    let lists = dict
+        .get("InkList")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid("/Ink /InkList is missing or is not an array"))?;
+    if lists.0.is_empty() {
+        return Err(invalid("/Ink /InkList must contain at least one stroke"));
+    }
+    if lists.0.len() > MAX_INK_STROKES {
+        return Err(invalid("/Ink /InkList exceeds the stroke limit"));
+    }
+    let mut point_count = 0usize;
+    let strokes = lists
+        .0
+        .iter()
+        .map(|value| {
+            let array = value
+                .as_array()
+                .ok_or_else(|| invalid("/Ink /InkList stroke is not an array"))?;
+            if array.0.len() < 2 || array.0.len() % 2 != 0 {
+                return Err(invalid(
+                    "/Ink /InkList stroke must contain coordinate pairs",
+                ));
+            }
+            point_count = point_count
+                .checked_add(array.0.len() / 2)
+                .ok_or_else(|| invalid("/Ink /InkList point count overflows"))?;
+            if point_count > MAX_INK_POINTS {
+                return Err(invalid("/Ink /InkList exceeds the point limit"));
+            }
+            let values = array
+                .0
+                .iter()
+                .map(|value| {
+                    number(value).ok_or_else(|| {
+                        invalid("/Ink /InkList contains a non-finite or non-numeric value")
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            InkStroke::new(
+                values
+                    .chunks_exact(2)
+                    .map(|p| Point::new(p[0], p[1]))
+                    .collect(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for point in strokes.iter().flat_map(InkStroke::points) {
+        if point.x < page_bounds[0]
+            || point.x > page_bounds[2]
+            || point.y < page_bounds[1]
+            || point.y > page_bounds[3]
+        {
+            return Err(invalid(
+                "/Ink /InkList coordinates are outside the page bounds",
+            ));
+        }
+    }
+    let color = match dict.get("C") {
+        None => InkColor::Gray([0.0]),
+        Some(_) => {
+            let colors = numeric_array(dict, "C", None)?;
+            match colors.as_slice() {
+                [gray] => InkColor::gray(*gray)?,
+                [red, green, blue] => InkColor::new([*red, *green, *blue])?,
+                [cyan, magenta, yellow, black] => {
+                    InkColor::cmyk([*cyan, *magenta, *yellow, *black])?
+                }
+                _ => return Err(invalid("/Ink /C must have one, three, or four components")),
+            }
+        }
+    };
+    let width_value = match dict.get("BS") {
+        Some(PdfObject::Dictionary(bs)) => match bs.get("W") {
+            None => 1.0,
+            Some(value) => {
+                number(value).ok_or_else(|| invalid("/Ink /BS /W must be a finite number"))?
+            }
+        },
+        Some(_) => return Err(invalid("/Ink /BS must be a dictionary")),
+        None => border_width(dict)?.unwrap_or(1.0),
+    };
+    let width = InkWidth::new(width_value)?;
+    let opacity = dict
+        .get("CA")
+        .map(|value| {
+            number(value)
+                .ok_or_else(|| invalid("/Ink /CA must be a finite number"))
+                .and_then(InkOpacity::new)
+        })
+        .transpose()?;
+    Ok(Ink {
+        id,
+        page_index,
+        rect,
+        strokes,
+        color,
+        width,
+        opacity,
+    })
+}
+
+fn validate_batch(
+    snapshot: &AnnotationSnapshot,
+    existing: &[Ink],
+    mutations: &[InkMutation],
+) -> Result<HashMap<InkId, u32>> {
+    let pages: HashMap<_, _> = existing
+        .iter()
+        .map(|ink| (ink.id, ink.page_index))
+        .collect();
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            InkMutation::Add {
+                page_index,
+                strokes,
+                width,
+                ..
+            } => {
+                let page = snapshot
+                    .pages
+                    .get(*page_index as usize)
+                    .ok_or_else(|| invalid(&format!("page {page_index} does not exist")))?;
+                validate_geometry(strokes, *width, page.bounds)?;
+            }
+            InkMutation::Update {
+                id, strokes, width, ..
+            } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("ink annotation is targeted more than once"));
+                }
+                let page_index = *pages.get(id).ok_or_else(|| missing(*id))?;
+                validate_geometry(strokes, *width, snapshot.pages[page_index as usize].bounds)?;
+            }
+            InkMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("ink annotation is targeted more than once"));
+                }
+                if !pages.contains_key(id) {
+                    return Err(missing(*id));
+                }
+            }
+        }
+    }
+    Ok(pages)
+}
+
+fn validate_geometry(strokes: &[InkStroke], width: InkWidth, page: [f64; 4]) -> Result<()> {
+    if strokes.is_empty() {
+        return Err(invalid("ink annotation must contain at least one stroke"));
+    }
+    if strokes.len() > MAX_INK_STROKES {
+        return Err(invalid("ink annotation exceeds the stroke limit"));
+    }
+    let point_count = strokes.iter().try_fold(0usize, |count, stroke| {
+        count
+            .checked_add(stroke.points().len())
+            .ok_or_else(|| invalid("ink point count overflows"))
+    })?;
+    if point_count > MAX_INK_POINTS {
+        return Err(invalid("ink annotation exceeds the point limit"));
+    }
+    let rect = bounds(strokes, width);
+    if rect[0] < page[0] || rect[1] < page[1] || rect[2] > page[2] || rect[3] > page[3] {
+        return Err(invalid(
+            "ink stroke and width extend outside the page bounds",
+        ));
+    }
+    Ok(())
+}
+
+fn bounds(strokes: &[InkStroke], width: InkWidth) -> [f64; 4] {
+    let half = width.value() / 2.0;
+    let mut rect = [
+        f64::INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NEG_INFINITY,
+    ];
+    for point in strokes.iter().flat_map(InkStroke::points) {
+        rect[0] = rect[0].min(point.x - half);
+        rect[1] = rect[1].min(point.y - half);
+        rect[2] = rect[2].max(point.x + half);
+        rect[3] = rect[3].max(point.y + half);
+    }
+    rect
+}
+
+fn new_dictionary(
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+    appearance: (u32, u16),
+) -> PdfDictionary {
+    let mut dict = PdfDictionary::new();
+    dict.insert("Type".into(), name("Annot"));
+    dict.insert("Subtype".into(), name("Ink"));
+    set_properties(&mut dict, strokes, color, width, opacity, rect, appearance);
+    dict
+}
+
+fn set_properties(
+    dict: &mut PdfDictionary,
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+    appearance: (u32, u16),
+) {
+    dict.insert("Rect".into(), numbers(&rect));
+    dict.insert(
+        "InkList".into(),
+        PdfObject::Array(PdfArray(
+            strokes
+                .iter()
+                .map(|stroke| {
+                    numbers(
+                        &stroke
+                            .points()
+                            .iter()
+                            .flat_map(|p| [p.x, p.y])
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        )),
+    );
+    dict.insert("C".into(), numbers(&color.components()));
+    let mut bs = match dict.get("BS") {
+        Some(PdfObject::Dictionary(existing)) => existing.clone(),
+        _ => PdfDictionary::new(),
+    };
+    bs.insert("W".into(), PdfObject::Real(width.value()));
+    dict.insert("BS".into(), PdfObject::Dictionary(bs));
+    match opacity {
+        Some(value) => {
+            dict.insert("CA".into(), PdfObject::Real(value.value()));
+        }
+        None => {
+            dict.0.remove(&PdfName("CA".into()));
+        }
+    }
+    let mut ap = match dict.get("AP") {
+        Some(PdfObject::Dictionary(existing)) => existing.clone(),
+        _ => PdfDictionary::new(),
+    };
+    ap.insert("N".into(), PdfObject::Reference(appearance.0, appearance.1));
+    dict.insert("AP".into(), PdfObject::Dictionary(ap));
+}
+
+fn appearance(
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+) -> Result<PdfStream> {
+    let color_operator = match color {
+        InkColor::Gray([gray]) => format!("{} G", pdf_number(gray)),
+        InkColor::Rgb([red, green, blue]) => format!(
+            "{} {} {} RG",
+            pdf_number(red),
+            pdf_number(green),
+            pdf_number(blue)
+        ),
+        InkColor::Cmyk([cyan, magenta, yellow, black]) => format!(
+            "{} {} {} {} K",
+            pdf_number(cyan),
+            pdf_number(magenta),
+            pdf_number(yellow),
+            pdf_number(black)
+        ),
+    };
+    let mut data = format!(
+        "q\n{color_operator}\n{} w\n1 J\n1 j\n",
+        pdf_number(width.value())
+    );
+    if let Some(value) = opacity {
+        data.push_str("/GS0 gs\n");
+        let _ = value;
+    }
+    for stroke in strokes {
+        let points = stroke.points();
+        data.push_str(&format!(
+            "{} {} m\n",
+            pdf_number(points[0].x - rect[0]),
+            pdf_number(points[0].y - rect[1])
+        ));
+        for point in &points[1..] {
+            data.push_str(&format!(
+                "{} {} l\n",
+                pdf_number(point.x - rect[0]),
+                pdf_number(point.y - rect[1])
+            ));
+            if data.len() > MAX_INK_APPEARANCE_BYTES {
+                return Err(invalid("ink appearance exceeds the byte limit"));
+            }
+        }
+        if points.len() == 1 {
+            data.push_str(&format!(
+                "{} {} l\n",
+                pdf_number(points[0].x - rect[0]),
+                pdf_number(points[0].y - rect[1])
+            ));
+        }
+        data.push_str("S\n");
+        if data.len() > MAX_INK_APPEARANCE_BYTES {
+            return Err(invalid("ink appearance exceeds the byte limit"));
+        }
+    }
+    data.push_str("Q");
+    let mut dict = PdfDictionary::new();
+    dict.insert("Type".into(), name("XObject"));
+    dict.insert("Subtype".into(), name("Form"));
+    dict.insert("FormType".into(), PdfObject::Integer(1));
+    dict.insert(
+        "BBox".into(),
+        numbers(&[0.0, 0.0, rect[2] - rect[0], rect[3] - rect[1]]),
+    );
+    if let Some(value) = opacity {
+        let mut gs = PdfDictionary::new();
+        gs.insert("CA".into(), PdfObject::Real(value.value()));
+        gs.insert("ca".into(), PdfObject::Real(value.value()));
+        let mut resources = PdfDictionary::new();
+        resources.insert("GS0".into(), PdfObject::Dictionary(gs));
+        let mut root = PdfDictionary::new();
+        root.insert("ExtGState".into(), PdfObject::Dictionary(resources));
+        dict.insert("Resources".into(), PdfObject::Dictionary(root));
+    }
+    Ok(PdfStream {
+        dict,
+        data: data.into_bytes(),
+    })
+}
+
+fn rewrite_pages(
+    update: &mut IncrementalUpdate,
+    snapshot: &mut AnnotationSnapshot,
+    changed: &HashSet<u32>,
+) -> Result<()> {
+    for page_index in changed {
+        let page = &mut snapshot.pages[*page_index as usize];
+        match page.container {
+            AnnotationContainer::Page => {
+                page.dictionary.insert(
+                    "Annots".into(),
+                    PdfObject::Array(PdfArray(page.annotations.clone())),
+                );
+                update.replace(
+                    page.reference,
+                    PdfObject::Dictionary(page.dictionary.clone()),
+                )?;
+            }
+            AnnotationContainer::Indirect(id) => {
+                update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut reader =
+        PdfReader::new(Cursor::new(bytes)).map_err(|e| invalid(&format!("parse base PDF: {e}")))?;
+    let catalog = reader
+        .catalog()
+        .map_err(|e| invalid(&format!("read catalog: {e}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::AddAnnotation,
+    )
+}
+
+fn numeric_array(dict: &PdfDictionary, key: &str, length: Option<usize>) -> Result<Vec<f64>> {
+    let array = dict
+        .get(key)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid(&format!("/Ink /{key} is missing or is not an array")))?;
+    if length.is_some_and(|len| array.0.len() != len) {
+        return Err(invalid(&format!(
+            "/Ink /{key} has the wrong number of values"
+        )));
+    }
+    array
+        .0
+        .iter()
+        .map(|value| {
+            number(value).ok_or_else(|| {
+                invalid(&format!(
+                    "/Ink /{key} contains a non-finite or non-numeric value"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn border_width(dict: &PdfDictionary) -> Result<Option<f64>> {
+    let Some(value) = dict.get("Border") else {
+        return Ok(None);
+    };
+    let array = value
+        .as_array()
+        .ok_or_else(|| invalid("/Ink /Border must be an array"))?;
+    if array.0.len() < 3 {
+        return Err(invalid("/Ink /Border must contain at least three values"));
+    }
+    number(&array.0[2])
+        .ok_or_else(|| invalid("/Ink /Border width must be a finite number"))
+        .map(Some)
+}
+
+fn number(value: &PdfObject) -> Option<f64> {
+    match value {
+        PdfObject::Integer(v) => Some(*v as f64),
+        PdfObject::Real(v) if v.is_finite() => Some(*v),
+        _ => None,
+    }
+}
+fn numbers(values: &[f64]) -> PdfObject {
+    PdfObject::Array(PdfArray(
+        values.iter().copied().map(PdfObject::Real).collect(),
+    ))
+}
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName(value.into()))
+}
+fn validate_unit(values: &[f64], label: &str) -> Result<()> {
+    if values
+        .iter()
+        .any(|v| !v.is_finite() || !(0.0..=1.0).contains(v))
+    {
+        Err(invalid(&format!(
+            "{label} components must be finite and between 0 and 1"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn missing(id: InkId) -> PdfError {
+    invalid(&format!(
+        "ink annotation {} {} does not exist",
+        id.object_number, id.generation_number
+    ))
+}
+fn invalid(message: &str) -> PdfError {
+    PdfError::InvalidStructure(message.into())
+}
+fn pdf_number(value: f64) -> String {
+    let mut s = format!("{value:.6}");
+    while s.contains('.') && s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    if s == "-0" {
+        "0".into()
+    } else {
+        s
+    }
+}

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -5,6 +5,7 @@ mod incremental_annotations;
 mod incremental_form_fill;
 mod incremental_free_text;
 mod incremental_highlights;
+mod incremental_ink;
 mod incremental_ocr_layer;
 mod incremental_tagged_pdf;
 mod incremental_text_notes;
@@ -26,6 +27,10 @@ pub use incremental_free_text::{
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
     HighlightUpdate, IncrementalHighlightEditor,
+};
+pub use incremental_ink::{
+    IncrementalInkEditor, Ink, InkColor, InkId, InkMutation, InkOpacity, InkStroke, InkUpdate,
+    InkWidth,
 };
 pub use incremental_ocr_layer::{
     IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage, OcrLayerPlan, OcrLayerUpdate,

--- a/oxidize-pdf-core/tests/cli_ocr_tests.rs
+++ b/oxidize-pdf-core/tests/cli_ocr_tests.rs
@@ -326,6 +326,5 @@ mod cli_ocr_disabled_tests {
     #[test]
     fn test_cli_without_ocr_feature() {
         println!("CLI OCR tests are disabled when 'ocr-tesseract' feature is not enabled");
-        assert!(true, "This is expected behavior");
     }
 }

--- a/oxidize-pdf-core/tests/issue_536_incremental_ink_test.rs
+++ b/oxidize-pdf-core/tests/issue_536_incremental_ink_test.rs
@@ -1,0 +1,455 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{
+    IncrementalInkEditor, InkColor, InkId, InkMutation, InkOpacity, InkStroke, InkWidth,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn build_pdf(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (number, body) in objects {
+        offsets[*number as usize] = out.len();
+        out.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn build_pdf_generations(objects: &[(u32, u16, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[*number as usize] = Some((out.len(), *generation));
+        out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => out.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn base() -> Vec<u8> {
+    build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R] /KeepPage true >>"),
+        (4, b"<< /Type /Annot /Subtype /Ink /Rect [10 10 80 60] /InkList [[10 10 20 20 30 15] [40 40 70 55]] /C [1 0 0] /BS << /W 2 /S /D /CustomBS true >> /CA 0.5 /AP << /N 6 0 R /R 6 0 R /CustomAP true >> /KeepInk (yes) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /KeepLink true >>"),
+        (6, b"<< /Type /XObject /Subtype /Form /BBox [10 10 80 60] /Length 0 >>\nstream\n\nendstream"),
+    ])
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = vec![0, 0, 0, 0, 0, 0xFF, 0xFF];
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn replace_policy(source: &[u8], permission: u8) -> Vec<u8> {
+    let mut result = source.to_vec();
+    let marker = b"/P 2";
+    let offset = result
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture must contain DocMDP P=2");
+    result[offset + 3] = b'0' + permission;
+    result
+}
+
+fn stroke(points: &[(f64, f64)]) -> InkStroke {
+    InkStroke::new(points.iter().map(|&(x, y)| Point::new(x, y)).collect()).unwrap()
+}
+
+fn color(rgb: [f64; 3]) -> InkColor {
+    InkColor::new(rgb).unwrap()
+}
+
+fn width(value: f64) -> InkWidth {
+    InkWidth::new(value).unwrap()
+}
+
+fn opacity(value: f64) -> InkOpacity {
+    InkOpacity::new(value).unwrap()
+}
+
+#[test]
+fn reads_updates_adds_and_removes_ink_atomically() {
+    let source = base();
+    let editor = IncrementalInkEditor::new(&source);
+    let inks = editor.annotations().unwrap();
+    assert_eq!(inks.len(), 1);
+    assert_eq!(inks[0].id, InkId::new(4, 0));
+    assert_eq!(inks[0].strokes.len(), 2);
+    assert_eq!(inks[0].color, color([1.0, 0.0, 0.0]));
+    assert_eq!(inks[0].width, width(2.0));
+    assert_eq!(inks[0].opacity, Some(opacity(0.5)));
+
+    let updated_strokes = vec![stroke(&[(20.0, 20.0), (30.0, 40.0), (50.0, 35.0)])];
+    let added_strokes = vec![
+        stroke(&[(100.0, 100.0), (120.0, 130.0)]),
+        stroke(&[(120.0, 130.0), (160.0, 110.0)]),
+    ];
+    let update = editor
+        .apply(&[
+            InkMutation::Update {
+                id: InkId::new(4, 0),
+                strokes: updated_strokes.clone(),
+                color: color([0.0, 0.0, 1.0]),
+                width: width(3.0),
+                opacity: None,
+            },
+            InkMutation::Add {
+                page_index: 0,
+                strokes: added_strokes,
+                color: color([0.0, 0.5, 0.0]),
+                width: width(1.5),
+                opacity: Some(opacity(0.75)),
+            },
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&source));
+    assert_eq!(update.annotations.len(), 2);
+    let changed = update
+        .annotations
+        .iter()
+        .find(|ink| ink.id == InkId::new(4, 0))
+        .unwrap();
+    assert_eq!(changed.strokes, updated_strokes);
+    assert_eq!(changed.rect, [18.5, 18.5, 51.5, 41.5]);
+    assert!(String::from_utf8_lossy(&update.pdf_bytes).contains("/KeepInk (yes)"));
+    assert!(String::from_utf8_lossy(&update.pdf_bytes).contains("/KeepLink true"));
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let dictionary = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    let bs = dictionary.get("BS").unwrap().as_dict().unwrap();
+    assert_eq!(bs.get("CustomBS"), Some(&PdfObject::Boolean(true)));
+    let ap = dictionary.get("AP").unwrap().as_dict().unwrap();
+    assert_eq!(ap.get("CustomAP"), Some(&PdfObject::Boolean(true)));
+    assert!(ap.get("R").is_some());
+
+    let added_id = update
+        .annotations
+        .iter()
+        .find(|ink| ink.id != InkId::new(4, 0))
+        .unwrap()
+        .id;
+    let removed = IncrementalInkEditor::new(&update.pdf_bytes)
+        .apply(&[InkMutation::Remove { id: added_id }])
+        .unwrap();
+    assert_eq!(removed.annotations.len(), 1);
+}
+
+#[test]
+fn validates_public_values_geometry_bounds_and_stale_ids() {
+    assert!(InkStroke::new(vec![]).is_err());
+    assert!(InkStroke::new(vec![Point::new(f64::NAN, 1.0)]).is_err());
+    assert!(InkColor::new([1.1, 0.0, 0.0]).is_err());
+    assert!(InkWidth::new(0.0).is_err());
+    assert!(InkOpacity::new(-0.1).is_err());
+
+    let source = base();
+    let result = IncrementalInkEditor::new(&source).apply(&[InkMutation::Add {
+        page_index: 0,
+        strokes: vec![stroke(&[(299.0, 299.0), (300.0, 300.0)])],
+        color: color([0.0, 0.0, 0.0]),
+        width: width(4.0),
+        opacity: None,
+    }]);
+    assert!(matches!(result, Err(PdfError::InvalidStructure(_))));
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Remove {
+            id: InkId::new(99, 0)
+        }])
+        .is_err());
+}
+
+#[test]
+fn rejects_malformed_ink_lists() {
+    for ink_list in ["[]", "[[10]]", "[[10 10 true 20]]"] {
+        let annotation = format!(
+            "<< /Type /Annot /Subtype /Ink /Rect [0 0 20 20] /InkList {ink_list} /C [0 0 0] /BS << /W 1 >> >>"
+        );
+        let source = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation.as_bytes()),
+        ]);
+        assert!(
+            IncrementalInkEditor::new(&source).annotations().is_err(),
+            "accepted malformed InkList {ink_list}"
+        );
+    }
+}
+
+#[test]
+fn reads_gray_and_cmyk_and_rejects_malformed_width() {
+    for (raw_color, expected) in [
+        ("[0.25]", InkColor::gray(0.25).unwrap()),
+        (
+            "[0.1 0.2 0.3 0.4]",
+            InkColor::cmyk([0.1, 0.2, 0.3, 0.4]).unwrap(),
+        ),
+    ] {
+        let annotation = format!(
+            "<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C {raw_color} /BS << /W 1 >> >>"
+        );
+        let source = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation.as_bytes()),
+        ]);
+        assert_eq!(
+            IncrementalInkEditor::new(&source).annotations().unwrap()[0].color,
+            expected
+        );
+    }
+
+    let malformed = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C [0] /BS << /W (wide) >> >>"),
+    ]);
+    assert!(IncrementalInkEditor::new(&malformed).annotations().is_err());
+}
+
+#[test]
+fn preserves_generation_and_updates_indirect_annots_array() {
+    let source = build_pdf_generations(&[
+        (1, 0, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, 0, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (
+            3,
+            0,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (
+            4,
+            7,
+            b"<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C [0] /BS << /W 1 >> >>",
+        ),
+        (5, 0, b"[4 7 R]"),
+    ]);
+    let existing = IncrementalInkEditor::new(&source).annotations().unwrap();
+    assert_eq!(existing[0].id, InkId::new(4, 7));
+    let update = IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Remove {
+            id: InkId::new(4, 7),
+        }])
+        .unwrap();
+    assert!(update.annotations.is_empty());
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    assert!(reader
+        .get_object(5, 0)
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .0
+        .is_empty());
+}
+
+#[test]
+fn rejects_excessive_strokes_and_conflicting_targets() {
+    let source = base();
+    let too_many = vec![stroke(&[(20.0, 20.0)]); 4_097];
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Add {
+            page_index: 0,
+            strokes: too_many,
+            color: color([0.0, 0.0, 0.0]),
+            width: width(1.0),
+            opacity: None,
+        }])
+        .is_err());
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[
+            InkMutation::Remove {
+                id: InkId::new(4, 0)
+            },
+            InkMutation::Remove {
+                id: InkId::new(4, 0)
+            },
+        ])
+        .is_err());
+}
+
+#[test]
+fn rejects_inline_and_encrypted_inputs_and_enforces_docmdp() {
+    let inline = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] >>] >>"),
+    ]);
+    assert!(IncrementalInkEditor::new(&inline).annotations().is_err());
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    let encrypted = document.to_bytes().unwrap();
+    assert!(IncrementalInkEditor::new(&encrypted).annotations().is_err());
+
+    let mutation = InkMutation::Add {
+        page_index: 0,
+        strokes: vec![stroke(&[(20.0, 20.0), (40.0, 40.0)])],
+        color: color([0.0, 0.0, 0.0]),
+        width: width(1.0),
+        opacity: None,
+    };
+    let certified_p2 = include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf");
+    for forbidden in [replace_policy(certified_p2, 1), certified_p2.to_vec()] {
+        assert!(matches!(
+            IncrementalInkEditor::new(&forbidden).apply(std::slice::from_ref(&mutation)),
+            Err(PdfError::PermissionDenied(_))
+        ));
+    }
+    let certified_p3 = replace_policy(certified_p2, 3);
+    assert!(IncrementalInkEditor::new(&certified_p3)
+        .apply(std::slice::from_ref(&mutation))
+        .unwrap()
+        .pdf_bytes
+        .starts_with(&certified_p3));
+    let approval = include_bytes!("fixtures/signatures/signed_rsa_incremental.pdf");
+    assert!(IncrementalInkEditor::new(approval)
+        .apply(&[mutation])
+        .unwrap()
+        .pdf_bytes
+        .starts_with(approval));
+}
+
+#[test]
+fn adds_high_point_count_ink_to_xref_stream_pdf() {
+    let source = xref_stream_base();
+    let points = (0..10_000)
+        .map(|index| Point::new(10.0 + index as f64 * 0.02, 100.0 + (index % 7) as f64))
+        .collect();
+    let update = IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Add {
+            page_index: 0,
+            strokes: vec![InkStroke::new(points).unwrap()],
+            color: color([0.1, 0.2, 0.3]),
+            width: width(1.0),
+            opacity: Some(opacity(0.8)),
+        }])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&source));
+    assert_eq!(
+        IncrementalInkEditor::new(&update.pdf_bytes)
+            .annotations()
+            .unwrap()[0]
+            .strokes[0]
+            .points()
+            .len(),
+        10_000
+    );
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_ink_revisions() {
+    for (name, source) in [("classic", base()), ("stream", xref_stream_base())] {
+        let update = IncrementalInkEditor::new(&source)
+            .apply(&[InkMutation::Add {
+                page_index: 0,
+                strokes: vec![stroke(&[(20.0, 20.0), (60.0, 80.0), (100.0, 30.0)])],
+                color: color([0.2, 0.4, 0.8]),
+                width: width(2.0),
+                opacity: Some(opacity(0.6)),
+            }])
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let raster_prefix = dir.path().join(format!("{name}-render"));
+        let render = Command::new("pdftoppm")
+            .args(["-mono", "-singlefile", "-r", "72"])
+            .arg(&path)
+            .arg(&raster_prefix)
+            .output()
+            .unwrap();
+        assert!(
+            render.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        let bitmap = std::fs::read(raster_prefix.with_extension("pbm")).unwrap();
+        let body = bitmap.splitn(3, |byte| *byte == b'\n').nth(2).unwrap();
+        assert!(
+            body.iter().any(|byte| *byte != 0),
+            "{name}: rendered page is blank"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add typed reading and atomic incremental add/update/remove APIs for standard Ink annotations
- generate viewer-compatible appearances while preserving prior bytes, unrelated annotation keys, signatures, and xref styles
- support DeviceGray, DeviceRGB, and DeviceCMYK with validation and resource limits
- add classic/xref-stream, DocMDP, encryption, generation, high-point-count, qpdf, and Poppler coverage
- run Ink interoperability validation in CI

## Validation
- cargo test -p oxidize-pdf --test issue_536_incremental_ink_test
- qpdf and Poppler interoperability test executed locally
- cargo clippy -p oxidize-pdf --lib --test issue_536_incremental_ink_test -- -D warnings
- 6764 library tests passed
- 215 doc tests passed
- Kripteia test-quality score: 97
- Kripteia Security: no findings

Closes #536