### PR TITLE
feat: add lossless page-tree mutation batches

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -66,6 +66,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_geometric_revisions
           -- --ignored --exact
 
+      - name: Validate lossless page-tree mutations
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_538_page_tree_mutations_test
+          qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations
+          -- --ignored --exact
+
       - name: Validate incremental OCR layers
         run: >
           cargo test -p oxidize-pdf

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -302,11 +302,12 @@ pub use parser::{
 
 // Re-export operations
 pub use operations::{
-    extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page, overlay_pdf,
-    reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf,
-    swap_pdf_pages, ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
+    extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page,
+    mutate_pdf_pages_lossless, overlay_pdf, plan_pdf_page_mutations, reorder_pdf_pages,
+    reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
+    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
     ImageExtractionLimits, ImageExtractionResult, ImageExtractor, OverlayOptions, OverlayPosition,
-    ReorderOptions,
+    PageMutation, PageMutationBatch, PageMutationReport, ReorderOptions,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -31,8 +31,9 @@ pub use page_extraction::{
 };
 pub use pdf_ocr_converter::{ConversionOptions, ConversionResult, PdfOcrConverter};
 pub use reorder::{
-    move_pdf_page, reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages,
-    swap_pdf_pages, PageReorderer, ReorderOptions,
+    move_pdf_page, mutate_pdf_pages_lossless, plan_pdf_page_mutations, reorder_pdf_pages,
+    reorder_pdf_pages_lossless, reverse_pdf_pages, swap_pdf_pages, PageMutation, PageMutationBatch,
+    PageMutationReport, PageReorderer, ReorderOptions,
 };
 pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions, RotationAngle};
 pub use semantic_redactor::{

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 const INHERITABLE_PAGE_KEYS: [&str; 4] = ["Resources", "MediaBox", "CropBox", "Rotate"];
 const MAX_PAGE_TREE_DEPTH: usize = 256;
 const MAX_PAGE_COUNT: usize = 100_000;
+const MAX_CLONED_OBJECTS_PER_PAGE: usize = 100_000;
+const MAX_OBJECT_GRAPH_DEPTH: usize = 256;
 
 #[derive(Debug)]
 struct LosslessPage {
@@ -31,6 +33,78 @@ struct LosslessValidation {
     root_reference: (u32, u16),
     catalog: PdfDictionary,
     pages: Vec<((u32, u16), HashMap<&'static str, PdfObject>)>,
+}
+
+/// One operation in an atomic lossless page-tree mutation batch.
+///
+/// Page indexes are zero based and are resolved against the result of all
+/// preceding operations in the batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageMutation {
+    /// Move a page to a new position.
+    Move { from: usize, to: usize },
+    /// Rotate a page clockwise by a multiple of 90 degrees.
+    Rotate { page: usize, degrees: i32 },
+    /// Remove a page from the page tree.
+    Delete { page: usize },
+    /// Duplicate a page, inserting the independent clone at `at`.
+    Duplicate { page: usize, at: usize },
+    /// Import one page from another PDF file and insert it at `at`.
+    Insert {
+        source: std::path::PathBuf,
+        page: usize,
+        at: usize,
+    },
+}
+
+/// A sequence of page mutations committed as one incremental revision.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PageMutationBatch {
+    /// Operations to apply in order.
+    pub operations: Vec<PageMutation>,
+}
+
+impl PageMutationBatch {
+    /// Create an empty batch.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an operation.
+    pub fn push(&mut self, operation: PageMutation) -> &mut Self {
+        self.operations.push(operation);
+        self
+    }
+}
+
+/// Objects affected by a planned or completed page-tree mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageMutationReport {
+    /// Existing indirect objects that will receive a new definition.
+    pub replaced_objects: Vec<(u32, u16)>,
+    /// New indirect objects allocated by the revision.
+    pub added_objects: Vec<(u32, u16)>,
+    /// Source objects reachable from the old catalog but not the new catalog.
+    pub unreachable_objects: Vec<(u32, u16)>,
+    /// Number of pages after applying the batch.
+    pub page_count: usize,
+}
+
+#[derive(Debug, Clone)]
+enum PlannedPage {
+    Existing {
+        source_index: usize,
+        rotation: Option<i32>,
+    },
+    Clone {
+        source_index: usize,
+        rotation: Option<i32>,
+    },
+    Import {
+        source: std::path::PathBuf,
+        source_index: usize,
+        rotation: Option<i32>,
+    },
 }
 
 /// Options for page reordering
@@ -178,6 +252,817 @@ pub fn reorder_pdf_pages<P: AsRef<Path>, Q: AsRef<Path>>(
 
     let reorderer = PageReorderer::new(document, options);
     reorderer.reorder_to_file(output_path)
+}
+
+/// Inspect an atomic page-tree mutation without writing an output file.
+pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
+    input_path: P,
+    batch: &PageMutationBatch,
+) -> OperationResult<PageMutationReport> {
+    let base = std::fs::read(input_path)?;
+    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    Ok(report)
+}
+
+/// Apply page-tree mutations as one lossless incremental revision.
+///
+/// The source bytes remain an exact prefix. The completed temporary file is
+/// reopened and checked before it atomically replaces `output_path`.
+pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
+    input_path: P,
+    output_path: Q,
+    batch: &PageMutationBatch,
+) -> OperationResult<PageMutationReport> {
+    let base = std::fs::read(input_path)?;
+    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    validate_lossless_output(&base, &updated, &expected)?;
+
+    let output_path = output_path.as_ref();
+    let parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty());
+    let mut temporary = tempfile::NamedTempFile::new_in(parent.unwrap_or_else(|| Path::new(".")))?;
+    temporary.write_all(&updated)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    validate_lossless_file(&base, temporary.path(), &expected)?;
+    temporary
+        .persist(output_path)
+        .map_err(|error| OperationError::Io(error.error))?;
+    Ok(report)
+}
+
+fn mutate_pdf_bytes_lossless(
+    base: &[u8],
+    batch: &PageMutationBatch,
+) -> Result<(Vec<u8>, LosslessValidation, PageMutationReport), PdfError> {
+    if batch.operations.is_empty() {
+        return Err(invalid_lossless("page mutation batch cannot be empty"));
+    }
+    let mut reader = PdfReader::new(Cursor::new(base))
+        .map_err(|error| invalid_lossless(format!("parse source PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "lossless page-tree mutation does not support encrypted PDFs".to_string(),
+        ));
+    }
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read document catalog: {error}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::PageTreeMutation,
+    )?;
+    let root_reference = catalog
+        .get("Pages")
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid_lossless("catalog /Pages must be an indirect reference"))?;
+    let root_dictionary = object_dictionary(&mut reader, root_reference, "page-tree root")?;
+    let mut source_pages = Vec::new();
+    let mut visited = HashSet::new();
+    walk_page_tree(
+        &mut reader,
+        root_reference,
+        None,
+        HashMap::new(),
+        &mut visited,
+        &mut source_pages,
+        0,
+    )?;
+
+    let mut planned: Vec<_> = (0..source_pages.len())
+        .map(|source_index| PlannedPage::Existing {
+            source_index,
+            rotation: None,
+        })
+        .collect();
+    for operation in &batch.operations {
+        apply_page_mutation(&mut planned, operation)?;
+    }
+    if planned.is_empty() {
+        return Err(invalid_lossless(
+            "a page-tree mutation cannot remove every page",
+        ));
+    }
+    if planned.len() > MAX_PAGE_COUNT {
+        return Err(invalid_lossless(
+            "page mutation exceeds the supported page count",
+        ));
+    }
+
+    let retained: HashSet<_> = planned
+        .iter()
+        .filter_map(|page| match page {
+            PlannedPage::Existing { source_index, .. } => Some(*source_index),
+            _ => None,
+        })
+        .collect();
+    let deleted_refs: HashSet<_> = source_pages
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !retained.contains(index))
+        .map(|(_, page)| page.reference)
+        .collect();
+    ensure_catalog_does_not_reference_deleted_pages(
+        &mut reader,
+        &catalog,
+        root_reference,
+        &deleted_refs,
+    )?;
+    ensure_retained_pages_do_not_reference_deleted_pages(
+        &mut reader,
+        &source_pages,
+        &retained,
+        root_reference,
+        &deleted_refs,
+    )?;
+    let source_reachable = reachable_from_catalog(&mut reader, &catalog)?;
+
+    let root_inherited = inherited_values(&root_dictionary);
+    let mut update = IncrementalUpdate::from_base(base)?;
+    let mut added_objects = Vec::new();
+    let mut final_pages = Vec::with_capacity(planned.len());
+    let mut validation_pages = Vec::with_capacity(planned.len());
+    let mut replacements = HashSet::new();
+    replacements.insert(root_reference);
+
+    for plan in planned {
+        match plan {
+            PlannedPage::Existing {
+                source_index,
+                rotation,
+            } => {
+                let page = &source_pages[source_index];
+                let mut dictionary = page.dictionary.clone();
+                let mut changed = dictionary.get("Parent").and_then(PdfObject::as_reference)
+                    != Some(root_reference);
+                dictionary.insert(
+                    "Parent".to_string(),
+                    PdfObject::Reference(root_reference.0, root_reference.1),
+                );
+                materialize_inherited(
+                    &mut dictionary,
+                    &page.effective_inherited,
+                    &root_inherited,
+                    &mut changed,
+                );
+                apply_rotation(
+                    &mut dictionary,
+                    &page.effective_inherited,
+                    rotation,
+                    &mut changed,
+                )?;
+                let effective = effective_for_flat_page(&dictionary, &root_inherited);
+                if changed {
+                    update.replace(page.reference, PdfObject::Dictionary(dictionary))?;
+                    replacements.insert(page.reference);
+                }
+                final_pages.push(page.reference);
+                validation_pages.push((page.reference, effective));
+            }
+            PlannedPage::Clone {
+                source_index,
+                rotation,
+            } => {
+                let page = &source_pages[source_index];
+                let id = clone_page_into_update(
+                    &mut reader,
+                    page,
+                    root_reference,
+                    rotation,
+                    false,
+                    &mut update,
+                    &mut added_objects,
+                )?;
+                let object = object_from_pending(&added_objects, id);
+                final_pages.push(id);
+                validation_pages.push((id, effective_for_flat_page(&object, &root_inherited)));
+            }
+            PlannedPage::Import {
+                source,
+                source_index,
+                rotation,
+            } => {
+                let bytes = std::fs::read(&source).map_err(|error| {
+                    invalid_lossless(format!("read imported PDF {}: {error}", source.display()))
+                })?;
+                let mut imported_reader = PdfReader::new(Cursor::new(&bytes)).map_err(|error| {
+                    invalid_lossless(format!("parse imported PDF {}: {error}", source.display()))
+                })?;
+                if imported_reader.is_encrypted() {
+                    return Err(PdfError::PermissionDenied(format!(
+                        "cannot import a page from encrypted PDF {}",
+                        source.display()
+                    )));
+                }
+                let imported_catalog = imported_reader
+                    .catalog()
+                    .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
+                    .clone();
+                let imported_root = imported_catalog
+                    .get("Pages")
+                    .and_then(PdfObject::as_reference)
+                    .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
+                let mut imported_pages = Vec::new();
+                let mut imported_visited = HashSet::new();
+                walk_page_tree(
+                    &mut imported_reader,
+                    imported_root,
+                    None,
+                    HashMap::new(),
+                    &mut imported_visited,
+                    &mut imported_pages,
+                    0,
+                )?;
+                let page = imported_pages.get(source_index).ok_or_else(|| {
+                    invalid_lossless(format!(
+                        "imported page index {source_index} is out of bounds for {} pages",
+                        imported_pages.len()
+                    ))
+                })?;
+                let id = clone_page_into_update(
+                    &mut imported_reader,
+                    page,
+                    root_reference,
+                    rotation,
+                    true,
+                    &mut update,
+                    &mut added_objects,
+                )?;
+                let object = object_from_pending(&added_objects, id);
+                final_pages.push(id);
+                validation_pages.push((id, effective_for_flat_page(&object, &root_inherited)));
+            }
+        }
+    }
+
+    let mut root_replacement = root_dictionary;
+    root_replacement.insert(
+        "Kids".to_string(),
+        PdfObject::Array(PdfArray(
+            final_pages
+                .iter()
+                .map(|id| PdfObject::Reference(id.0, id.1))
+                .collect(),
+        )),
+    );
+    root_replacement.insert(
+        "Count".to_string(),
+        PdfObject::Integer(final_pages.len() as i64),
+    );
+    update.replace(root_reference, PdfObject::Dictionary(root_replacement))?;
+    for (id, object) in &added_objects {
+        update.replace(*id, object.clone())?;
+    }
+    let updated = update.finish()?;
+
+    let mut output_reader = PdfReader::new(Cursor::new(&updated))
+        .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
+    let output_catalog = output_reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
+        .clone();
+    let output_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+    let mut unreachable_objects: Vec<_> = source_reachable
+        .difference(&output_reachable)
+        .copied()
+        .collect();
+    unreachable_objects.sort_unstable();
+    let mut replaced_objects: Vec<_> = replacements.into_iter().collect();
+    replaced_objects.sort_unstable();
+    let mut added_ids: Vec<_> = added_objects.iter().map(|(id, _)| *id).collect();
+    added_ids.sort_unstable();
+    let report = PageMutationReport {
+        replaced_objects,
+        added_objects: added_ids,
+        unreachable_objects,
+        page_count: final_pages.len(),
+    };
+    Ok((
+        updated,
+        LosslessValidation {
+            root_reference,
+            catalog,
+            pages: validation_pages,
+        },
+        report,
+    ))
+}
+
+fn apply_page_mutation(
+    pages: &mut Vec<PlannedPage>,
+    operation: &PageMutation,
+) -> Result<(), PdfError> {
+    let check_page = |index: usize, len: usize, role: &str| {
+        if index < len {
+            Ok(())
+        } else {
+            Err(invalid_lossless(format!(
+                "{role} page index {index} is out of bounds for {len} pages"
+            )))
+        }
+    };
+    match operation {
+        PageMutation::Move { from, to } => {
+            check_page(*from, pages.len(), "move source")?;
+            check_page(*to, pages.len(), "move destination")?;
+            let page = pages.remove(*from);
+            pages.insert(*to, page);
+        }
+        PageMutation::Rotate { page, degrees } => {
+            check_page(*page, pages.len(), "rotation")?;
+            if degrees.rem_euclid(90) != 0 {
+                return Err(invalid_lossless(format!(
+                    "page rotation {degrees} must be a multiple of 90 degrees"
+                )));
+            }
+            let rotation = match &mut pages[*page] {
+                PlannedPage::Existing { rotation, .. }
+                | PlannedPage::Clone { rotation, .. }
+                | PlannedPage::Import { rotation, .. } => rotation,
+            };
+            *rotation = Some(
+                rotation
+                    .unwrap_or(0)
+                    .checked_add(*degrees)
+                    .ok_or_else(|| invalid_lossless("accumulated page rotation overflows i32"))?,
+            );
+        }
+        PageMutation::Delete { page } => {
+            check_page(*page, pages.len(), "delete")?;
+            pages.remove(*page);
+        }
+        PageMutation::Duplicate { page, at } => {
+            check_page(*page, pages.len(), "duplicate source")?;
+            if *at > pages.len() {
+                return Err(invalid_lossless(format!(
+                    "duplicate insertion index {at} is out of bounds for {} pages",
+                    pages.len()
+                )));
+            }
+            let clone = match &pages[*page] {
+                PlannedPage::Existing {
+                    source_index,
+                    rotation,
+                }
+                | PlannedPage::Clone {
+                    source_index,
+                    rotation,
+                } => PlannedPage::Clone {
+                    source_index: *source_index,
+                    rotation: *rotation,
+                },
+                PlannedPage::Import {
+                    source,
+                    source_index,
+                    rotation,
+                } => PlannedPage::Import {
+                    source: source.clone(),
+                    source_index: *source_index,
+                    rotation: *rotation,
+                },
+            };
+            pages.insert(*at, clone);
+        }
+        PageMutation::Insert { source, page, at } => {
+            if *at > pages.len() {
+                return Err(invalid_lossless(format!(
+                    "import insertion index {at} is out of bounds for {} pages",
+                    pages.len()
+                )));
+            }
+            pages.insert(
+                *at,
+                PlannedPage::Import {
+                    source: source.clone(),
+                    source_index: *page,
+                    rotation: None,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn materialize_inherited(
+    dictionary: &mut PdfDictionary,
+    effective: &HashMap<&'static str, PdfObject>,
+    root_effective: &HashMap<&'static str, PdfObject>,
+    changed: &mut bool,
+) {
+    for (key, value) in effective {
+        if dictionary.contains_key(key) || root_effective.get(key) == Some(value) {
+            continue;
+        }
+        dictionary.insert((*key).to_string(), value.clone());
+        *changed = true;
+    }
+}
+
+fn apply_rotation(
+    dictionary: &mut PdfDictionary,
+    effective: &HashMap<&'static str, PdfObject>,
+    delta: Option<i32>,
+    changed: &mut bool,
+) -> Result<(), PdfError> {
+    let Some(delta) = delta else { return Ok(()) };
+    let current = effective
+        .get("Rotate")
+        .and_then(PdfObject::as_integer)
+        .unwrap_or(0);
+    let current = i32::try_from(current)
+        .map_err(|_| invalid_lossless("effective page /Rotate does not fit in i32"))?;
+    let rotation = current
+        .checked_add(delta)
+        .ok_or_else(|| invalid_lossless("effective page rotation overflows i32"))?
+        .rem_euclid(360);
+    dictionary.insert("Rotate".to_string(), PdfObject::Integer(rotation as i64));
+    *changed = true;
+    Ok(())
+}
+
+fn effective_for_flat_page(
+    dictionary: &PdfDictionary,
+    root: &HashMap<&'static str, PdfObject>,
+) -> HashMap<&'static str, PdfObject> {
+    let mut effective = root.clone();
+    for key in INHERITABLE_PAGE_KEYS {
+        if let Some(value) = dictionary.get(key) {
+            effective.insert(key, value.clone());
+        }
+    }
+    effective
+}
+
+fn clone_page_into_update<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+    destination_root: (u32, u16),
+    rotation: Option<i32>,
+    external: bool,
+    update: &mut IncrementalUpdate<'_>,
+    added: &mut Vec<((u32, u16), PdfObject)>,
+) -> Result<(u32, u16), PdfError> {
+    ensure_page_can_be_cloned(reader, page, external)?;
+    let page_id = update.allocate_id()?;
+    let mut mapping = HashMap::new();
+    mapping.insert(page.reference, page_id);
+    let mut dictionary = page.dictionary.clone();
+    dictionary.0.retain(|key, _| key.0 != "Parent");
+    for (key, value) in &page.effective_inherited {
+        if !dictionary.contains_key(key) {
+            dictionary.insert((*key).to_string(), value.clone());
+        }
+    }
+    let mut keys: Vec<_> = dictionary.0.keys().cloned().collect();
+    keys.sort_by(|left, right| left.0.cmp(&right.0));
+    for key in keys {
+        let value = dictionary.0[&key].clone();
+        let cloned = clone_page_object(
+            reader,
+            &value,
+            page.reference,
+            external,
+            update,
+            added,
+            &mut mapping,
+            0,
+        )?;
+        dictionary.0.insert(key, cloned);
+    }
+    dictionary.insert(
+        "Parent".to_string(),
+        PdfObject::Reference(destination_root.0, destination_root.1),
+    );
+    let mut changed = false;
+    apply_rotation(
+        &mut dictionary,
+        &page.effective_inherited,
+        rotation,
+        &mut changed,
+    )?;
+    added.push((page_id, PdfObject::Dictionary(dictionary)));
+    Ok(page_id)
+}
+
+fn ensure_page_can_be_cloned<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+    external: bool,
+) -> Result<(), PdfError> {
+    let action = if external { "import" } else { "duplicate" };
+    if page.dictionary.contains_key("StructParents") {
+        return Err(invalid_lossless(format!(
+            "cannot {action} a tagged page without remapping its parent-tree entry"
+        )));
+    }
+    let Some(annots) = page.dictionary.get("Annots") else {
+        return Ok(());
+    };
+    let annotations = match annots {
+        PdfObject::Array(array) => array.clone(),
+        PdfObject::Reference(number, generation) => reader
+            .get_object(*number, *generation)
+            .map_err(|error| invalid_lossless(format!("resolve page /Annots: {error}")))?
+            .as_array()
+            .cloned()
+            .ok_or_else(|| invalid_lossless("indirect page /Annots is not an array"))?,
+        _ => {
+            return Err(invalid_lossless(
+                "page /Annots must be an array or reference",
+            ))
+        }
+    };
+    for annotation in annotations.0 {
+        let dictionary = match annotation {
+            PdfObject::Reference(number, generation) => reader
+                .get_object(number, generation)
+                .map_err(|error| invalid_lossless(format!("resolve page annotation: {error}")))?
+                .as_dict(),
+            PdfObject::Dictionary(ref dictionary) => Some(dictionary),
+            _ => None,
+        };
+        if dictionary.is_some_and(|dictionary| {
+            dictionary
+                .get("Subtype")
+                .and_then(PdfObject::as_name)
+                .is_some_and(|name| name.0 == "Widget")
+        }) {
+            return Err(invalid_lossless(format!(
+                "cannot {action} a widget page without remapping its AcroForm field tree"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn clone_page_object<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    object: &PdfObject,
+    source_page: (u32, u16),
+    external: bool,
+    update: &mut IncrementalUpdate<'_>,
+    added: &mut Vec<((u32, u16), PdfObject)>,
+    mapping: &mut HashMap<(u32, u16), (u32, u16)>,
+    depth: usize,
+) -> Result<PdfObject, PdfError> {
+    if depth > MAX_OBJECT_GRAPH_DEPTH {
+        return Err(invalid_lossless(
+            "page object graph exceeds the supported nesting depth",
+        ));
+    }
+    match object {
+        PdfObject::Reference(number, generation) => {
+            let source_id = (*number, *generation);
+            if let Some(id) = mapping.get(&source_id) {
+                return Ok(PdfObject::Reference(id.0, id.1));
+            }
+            let source_object = reader
+                .get_object(*number, *generation)
+                .map_err(|error| {
+                    invalid_lossless(format!(
+                        "clone page object {number} {generation} R: {error}"
+                    ))
+                })?
+                .clone();
+            let structural_type = source_object
+                .as_dict()
+                .and_then(PdfDictionary::get_type)
+                .is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog"));
+            if structural_type {
+                if external {
+                    return Err(invalid_lossless(format!(
+                        "imported page graph references foreign structural object {number} {generation} R"
+                    )));
+                }
+                return Ok(object.clone());
+            }
+            if mapping.len() >= MAX_CLONED_OBJECTS_PER_PAGE {
+                return Err(invalid_lossless(
+                    "page object graph exceeds the supported object count",
+                ));
+            }
+            let id = update.allocate_id()?;
+            mapping.insert(source_id, id);
+            let cloned = clone_page_object(
+                reader,
+                &source_object,
+                source_page,
+                external,
+                update,
+                added,
+                mapping,
+                depth + 1,
+            )?;
+            added.push((id, cloned));
+            Ok(PdfObject::Reference(id.0, id.1))
+        }
+        PdfObject::Array(array) => Ok(PdfObject::Array(PdfArray(
+            array
+                .0
+                .iter()
+                .map(|value| {
+                    clone_page_object(
+                        reader,
+                        value,
+                        source_page,
+                        external,
+                        update,
+                        added,
+                        mapping,
+                        depth + 1,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        ))),
+        PdfObject::Dictionary(dictionary) => {
+            let mut dictionary = dictionary.clone();
+            let mut keys: Vec<_> = dictionary.0.keys().cloned().collect();
+            keys.sort_by(|left, right| left.0.cmp(&right.0));
+            for key in keys {
+                let value = dictionary.0[&key].clone();
+                let cloned = clone_page_object(
+                    reader,
+                    &value,
+                    source_page,
+                    external,
+                    update,
+                    added,
+                    mapping,
+                    depth + 1,
+                )?;
+                dictionary.0.insert(key, cloned);
+            }
+            Ok(PdfObject::Dictionary(dictionary))
+        }
+        PdfObject::Stream(stream) => {
+            let mut stream = stream.clone();
+            let mut keys: Vec<_> = stream.dict.0.keys().cloned().collect();
+            keys.sort_by(|left, right| left.0.cmp(&right.0));
+            for key in keys {
+                let value = stream.dict.0[&key].clone();
+                let cloned = clone_page_object(
+                    reader,
+                    &value,
+                    source_page,
+                    external,
+                    update,
+                    added,
+                    mapping,
+                    depth + 1,
+                )?;
+                stream.dict.0.insert(key, cloned);
+            }
+            Ok(PdfObject::Stream(stream))
+        }
+        _ => Ok(object.clone()),
+    }
+}
+
+fn object_from_pending(added: &[((u32, u16), PdfObject)], id: (u32, u16)) -> PdfDictionary {
+    added
+        .iter()
+        .find(|(candidate, _)| *candidate == id)
+        .and_then(|(_, object)| object.as_dict())
+        .cloned()
+        .expect("new page dictionary was just queued")
+}
+
+fn reachable_from_catalog<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+) -> Result<HashSet<(u32, u16)>, PdfError> {
+    let mut pending: Vec<_> = catalog.0.values().cloned().collect();
+    let mut reachable = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !reachable.insert(id) {
+                    continue;
+                }
+                if reachable.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "document object graph exceeds the supported object count",
+                    ));
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("walk document object graph: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(reachable)
+}
+
+fn ensure_catalog_does_not_reference_deleted_pages<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+    page_root: (u32, u16),
+    deleted: &HashSet<(u32, u16)>,
+) -> Result<(), PdfError> {
+    if deleted.is_empty() {
+        return Ok(());
+    }
+    let mut pending: Vec<_> = catalog
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Pages")
+        .map(|(_, value)| value.clone())
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if deleted.contains(&id) {
+                    return Err(invalid_lossless(format!(
+                        "cannot delete page {number} {generation} R because a catalog-level structure references it"
+                    )));
+                }
+                if id == page_root || !visited.insert(id) {
+                    continue;
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect catalog references: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn ensure_retained_pages_do_not_reference_deleted_pages<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    pages: &[LosslessPage],
+    retained: &HashSet<usize>,
+    page_root: (u32, u16),
+    deleted: &HashSet<(u32, u16)>,
+) -> Result<(), PdfError> {
+    if deleted.is_empty() {
+        return Ok(());
+    }
+    let mut pending: Vec<_> = pages
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| retained.contains(index))
+        .flat_map(|(_, page)| {
+            page.dictionary
+                .0
+                .iter()
+                .filter(|(key, _)| key.0 != "Parent")
+                .map(|(_, value)| value.clone())
+        })
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if deleted.contains(&id) {
+                    return Err(invalid_lossless(format!(
+                        "cannot delete page {number} {generation} R because a retained page structure references it"
+                    )));
+                }
+                if id == page_root || !visited.insert(id) {
+                    continue;
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect retained page references: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Reorder every page as one lossless incremental revision.

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -107,6 +107,11 @@ enum PlannedPage {
     },
 }
 
+struct ImportedDocument {
+    reader: PdfReader<Cursor<Vec<u8>>>,
+    pages: Vec<LosslessPage>,
+}
+
 /// Options for page reordering
 #[derive(Debug, Clone)]
 pub struct ReorderOptions {
@@ -255,12 +260,24 @@ pub fn reorder_pdf_pages<P: AsRef<Path>, Q: AsRef<Path>>(
 }
 
 /// Inspect an atomic page-tree mutation without writing an output file.
+///
+/// This is an exact dry run: imported object graphs and reachability are
+/// analyzed in memory, but the prospective revision is neither serialized nor
+/// reopened. It returns the same object report as [`mutate_pdf_pages_lossless`]
+/// without creating or replacing a destination file.
+///
+/// # Errors
+///
+/// Returns an error for malformed or encrypted PDFs, forbidden DocMDP edits,
+/// invalid indexes, dangling semantic references, unsupported page labels,
+/// or imports that require catalog-level AcroForm, tagged-PDF, named-
+/// destination, or optional-content remapping.
 pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
     input_path: P,
     batch: &PageMutationBatch,
 ) -> OperationResult<PageMutationReport> {
     let base = std::fs::read(input_path)?;
-    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch, false)?;
     Ok(report)
 }
 
@@ -268,13 +285,21 @@ pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
 ///
 /// The source bytes remain an exact prefix. The completed temporary file is
 /// reopened and checked before it atomically replaces `output_path`.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as
+/// [`plan_pdf_page_mutations`], or when temporary-file creation, validation,
+/// syncing, or atomic publication fails. The destination is not replaced when
+/// validation fails.
 pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
     input_path: P,
     output_path: Q,
     batch: &PageMutationBatch,
 ) -> OperationResult<PageMutationReport> {
     let base = std::fs::read(input_path)?;
-    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch, true)?;
+    let updated = updated.expect("materialized page mutation must return bytes");
     validate_lossless_output(&base, &updated, &expected)?;
 
     let output_path = output_path.as_ref();
@@ -295,7 +320,8 @@ pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
 fn mutate_pdf_bytes_lossless(
     base: &[u8],
     batch: &PageMutationBatch,
-) -> Result<(Vec<u8>, LosslessValidation, PageMutationReport), PdfError> {
+    materialize: bool,
+) -> Result<(Option<Vec<u8>>, LosslessValidation, PageMutationReport), PdfError> {
     if batch.operations.is_empty() {
         return Err(invalid_lossless("page mutation batch cannot be empty"));
     }
@@ -310,6 +336,16 @@ fn mutate_pdf_bytes_lossless(
         .catalog()
         .map_err(|error| invalid_lossless(format!("read document catalog: {error}")))?
         .clone();
+    if catalog.contains_key("PageLabels")
+        && batch
+            .operations
+            .iter()
+            .any(|operation| !matches!(operation, PageMutation::Rotate { .. }))
+    {
+        return Err(invalid_lossless(
+            "page reordering, insertion, duplication, or deletion with catalog /PageLabels is unsupported because label indexes require remapping",
+        ));
+    }
     ensure_modification_allowed(
         &mut reader,
         &catalog,
@@ -381,12 +417,28 @@ fn mutate_pdf_bytes_lossless(
     let source_reachable = reachable_from_catalog(&mut reader, &catalog)?;
 
     let root_inherited = inherited_values(&root_dictionary);
+    let root_preserved_values: Vec<_> = root_dictionary
+        .0
+        .iter()
+        .filter(|(key, _)| !matches!(key.0.as_str(), "Kids" | "Count"))
+        .map(|(_, value)| value.clone())
+        .collect();
     let mut update = IncrementalUpdate::from_base(base)?;
     let mut added_objects = Vec::new();
     let mut final_pages = Vec::with_capacity(planned.len());
     let mut validation_pages = Vec::with_capacity(planned.len());
     let mut replacements = HashSet::new();
+    let mut preserved_source_refs = HashSet::new();
     replacements.insert(root_reference);
+    let mut imported_documents = HashMap::new();
+    for source in planned.iter().filter_map(|page| match page {
+        PlannedPage::Import { source, .. } => Some(source),
+        _ => None,
+    }) {
+        if !imported_documents.contains_key(source) {
+            imported_documents.insert(source.clone(), load_imported_document(source)?);
+        }
+    }
 
     for plan in planned {
         match plan {
@@ -435,6 +487,7 @@ fn mutate_pdf_bytes_lossless(
                     false,
                     &mut update,
                     &mut added_objects,
+                    &mut preserved_source_refs,
                 )?;
                 let object = object_from_pending(&added_objects, id);
                 final_pages.push(id);
@@ -445,51 +498,24 @@ fn mutate_pdf_bytes_lossless(
                 source_index,
                 rotation,
             } => {
-                let bytes = std::fs::read(&source).map_err(|error| {
-                    invalid_lossless(format!("read imported PDF {}: {error}", source.display()))
-                })?;
-                let mut imported_reader = PdfReader::new(Cursor::new(&bytes)).map_err(|error| {
-                    invalid_lossless(format!("parse imported PDF {}: {error}", source.display()))
-                })?;
-                if imported_reader.is_encrypted() {
-                    return Err(PdfError::PermissionDenied(format!(
-                        "cannot import a page from encrypted PDF {}",
-                        source.display()
-                    )));
-                }
-                let imported_catalog = imported_reader
-                    .catalog()
-                    .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
-                    .clone();
-                let imported_root = imported_catalog
-                    .get("Pages")
-                    .and_then(PdfObject::as_reference)
-                    .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
-                let mut imported_pages = Vec::new();
-                let mut imported_visited = HashSet::new();
-                walk_page_tree(
-                    &mut imported_reader,
-                    imported_root,
-                    None,
-                    HashMap::new(),
-                    &mut imported_visited,
-                    &mut imported_pages,
-                    0,
-                )?;
-                let page = imported_pages.get(source_index).ok_or_else(|| {
+                let imported = imported_documents
+                    .get_mut(&source)
+                    .ok_or_else(|| invalid_lossless("planned import source was not loaded"))?;
+                let page = imported.pages.get(source_index).ok_or_else(|| {
                     invalid_lossless(format!(
                         "imported page index {source_index} is out of bounds for {} pages",
-                        imported_pages.len()
+                        imported.pages.len()
                     ))
                 })?;
                 let id = clone_page_into_update(
-                    &mut imported_reader,
+                    &mut imported.reader,
                     page,
                     root_reference,
                     rotation,
                     true,
                     &mut update,
                     &mut added_objects,
+                    &mut preserved_source_refs,
                 )?;
                 let object = object_from_pending(&added_objects, id);
                 final_pages.push(id);
@@ -516,15 +542,15 @@ fn mutate_pdf_bytes_lossless(
     for (id, object) in &added_objects {
         update.replace(*id, object.clone())?;
     }
-    let updated = update.finish()?;
-
-    let mut output_reader = PdfReader::new(Cursor::new(&updated))
-        .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
-    let output_catalog = output_reader
-        .catalog()
-        .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
-        .clone();
-    let output_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+    let output_reachable = prospective_source_references(
+        &mut reader,
+        &catalog,
+        root_reference,
+        &root_preserved_values,
+        &source_pages,
+        &retained,
+        &preserved_source_refs,
+    )?;
     let mut unreachable_objects: Vec<_> = source_reachable
         .difference(&output_reachable)
         .copied()
@@ -540,6 +566,29 @@ fn mutate_pdf_bytes_lossless(
         unreachable_objects,
         page_count: final_pages.len(),
     };
+    let updated = if materialize {
+        let bytes = update.finish()?;
+        let mut output_reader = PdfReader::new(Cursor::new(&bytes))
+            .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
+        let output_catalog = output_reader
+            .catalog()
+            .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
+            .clone();
+        let actual_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+        let mut actual_unreachable: Vec<_> = source_reachable
+            .difference(&actual_reachable)
+            .copied()
+            .collect();
+        actual_unreachable.sort_unstable();
+        if actual_unreachable != report.unreachable_objects {
+            return Err(invalid_lossless(
+                "dry-run reachability report differs from the materialized revision",
+            ));
+        }
+        Some(bytes)
+    } else {
+        None
+    };
     Ok((
         updated,
         LosslessValidation {
@@ -549,6 +598,40 @@ fn mutate_pdf_bytes_lossless(
         },
         report,
     ))
+}
+
+fn load_imported_document(path: &Path) -> Result<ImportedDocument, PdfError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        invalid_lossless(format!("read imported PDF {}: {error}", path.display()))
+    })?;
+    let mut reader = PdfReader::new(Cursor::new(bytes)).map_err(|error| {
+        invalid_lossless(format!("parse imported PDF {}: {error}", path.display()))
+    })?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(format!(
+            "cannot import a page from encrypted PDF {}",
+            path.display()
+        )));
+    }
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
+        .clone();
+    let root = catalog
+        .get("Pages")
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
+    let mut pages = Vec::new();
+    walk_page_tree(
+        &mut reader,
+        root,
+        None,
+        HashMap::new(),
+        &mut HashSet::new(),
+        &mut pages,
+        0,
+    )?;
+    Ok(ImportedDocument { reader, pages })
 }
 
 fn apply_page_mutation(
@@ -704,6 +787,7 @@ fn clone_page_into_update<R: Read + Seek>(
     external: bool,
     update: &mut IncrementalUpdate<'_>,
     added: &mut Vec<((u32, u16), PdfObject)>,
+    preserved_source_refs: &mut HashSet<(u32, u16)>,
 ) -> Result<(u32, u16), PdfError> {
     ensure_page_can_be_cloned(reader, page, external)?;
     let page_id = update.allocate_id()?;
@@ -728,6 +812,7 @@ fn clone_page_into_update<R: Read + Seek>(
             update,
             added,
             &mut mapping,
+            preserved_source_refs,
             0,
         )?;
         dictionary.0.insert(key, cloned);
@@ -757,6 +842,9 @@ fn ensure_page_can_be_cloned<R: Read + Seek>(
         return Err(invalid_lossless(format!(
             "cannot {action} a tagged page without remapping its parent-tree entry"
         )));
+    }
+    if external {
+        ensure_import_graph_supported(reader, page)?;
     }
     let Some(annots) = page.dictionary.get("Annots") else {
         return Ok(());
@@ -798,6 +886,81 @@ fn ensure_page_can_be_cloned<R: Read + Seek>(
     Ok(())
 }
 
+fn ensure_import_graph_supported<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+) -> Result<(), PdfError> {
+    let mut pending: Vec<_> = page
+        .dictionary
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Parent")
+        .map(|(_, value)| value.clone())
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !visited.insert(id) {
+                    continue;
+                }
+                if visited.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "imported page graph exceeds the supported object count",
+                    ));
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect imported page graph: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => {
+                reject_unsupported_import_dictionary(&dictionary)?;
+                pending.extend(dictionary.0.into_values());
+            }
+            PdfObject::Stream(stream) => {
+                reject_unsupported_import_dictionary(&stream.dict)?;
+                pending.extend(stream.dict.0.into_values());
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn reject_unsupported_import_dictionary(dictionary: &PdfDictionary) -> Result<(), PdfError> {
+    if dictionary
+        .get_type()
+        .is_some_and(|kind| matches!(kind, "OCG" | "OCMD"))
+    {
+        return Err(invalid_lossless(
+            "cannot import optional-content groups without remapping catalog /OCProperties",
+        ));
+    }
+    let named_destination = dictionary
+        .get("Dest")
+        .is_some_and(|value| matches!(value, PdfObject::Name(_) | PdfObject::String(_)))
+        || (dictionary
+            .get("S")
+            .and_then(PdfObject::as_name)
+            .is_some_and(|name| name.0 == "GoTo")
+            && dictionary
+                .get("D")
+                .is_some_and(|value| matches!(value, PdfObject::Name(_) | PdfObject::String(_))));
+    if named_destination {
+        return Err(invalid_lossless(
+            "cannot import a named destination without remapping the destination name tree",
+        ));
+    }
+    Ok(())
+}
+
 fn clone_page_object<R: Read + Seek>(
     reader: &mut PdfReader<R>,
     object: &PdfObject,
@@ -806,6 +969,7 @@ fn clone_page_object<R: Read + Seek>(
     update: &mut IncrementalUpdate<'_>,
     added: &mut Vec<((u32, u16), PdfObject)>,
     mapping: &mut HashMap<(u32, u16), (u32, u16)>,
+    preserved_source_refs: &mut HashSet<(u32, u16)>,
     depth: usize,
 ) -> Result<PdfObject, PdfError> {
     if depth > MAX_OBJECT_GRAPH_DEPTH {
@@ -827,16 +991,23 @@ fn clone_page_object<R: Read + Seek>(
                     ))
                 })?
                 .clone();
-            let structural_type = source_object
-                .as_dict()
-                .and_then(PdfDictionary::get_type)
-                .is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog"));
-            if structural_type {
+            let object_type = source_object.as_dict().and_then(PdfDictionary::get_type);
+            if object_type.is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog")) {
                 if external {
                     return Err(invalid_lossless(format!(
                         "imported page graph references foreign structural object {number} {generation} R"
                     )));
                 }
+                preserved_source_refs.insert(source_id);
+                return Ok(object.clone());
+            }
+            if object_type.is_some_and(|kind| matches!(kind, "OCG" | "OCMD")) {
+                if external {
+                    return Err(invalid_lossless(
+                        "cannot import optional-content groups without remapping catalog /OCProperties",
+                    ));
+                }
+                preserved_source_refs.insert(source_id);
                 return Ok(object.clone());
             }
             if mapping.len() >= MAX_CLONED_OBJECTS_PER_PAGE {
@@ -854,6 +1025,7 @@ fn clone_page_object<R: Read + Seek>(
                 update,
                 added,
                 mapping,
+                preserved_source_refs,
                 depth + 1,
             )?;
             added.push((id, cloned));
@@ -872,6 +1044,7 @@ fn clone_page_object<R: Read + Seek>(
                         update,
                         added,
                         mapping,
+                        preserved_source_refs,
                         depth + 1,
                     )
                 })
@@ -891,6 +1064,7 @@ fn clone_page_object<R: Read + Seek>(
                     update,
                     added,
                     mapping,
+                    preserved_source_refs,
                     depth + 1,
                 )?;
                 dictionary.0.insert(key, cloned);
@@ -911,6 +1085,7 @@ fn clone_page_object<R: Read + Seek>(
                     update,
                     added,
                     mapping,
+                    preserved_source_refs,
                     depth + 1,
                 )?;
                 stream.dict.0.insert(key, cloned);
@@ -956,6 +1131,89 @@ fn reachable_from_catalog<R: Read + Seek>(
                         })?
                         .clone(),
                 );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(reachable)
+}
+
+fn prospective_source_references<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+    page_root: (u32, u16),
+    root_preserved_values: &[PdfObject],
+    pages: &[LosslessPage],
+    retained: &HashSet<usize>,
+    preserved: &HashSet<(u32, u16)>,
+) -> Result<HashSet<(u32, u16)>, PdfError> {
+    let mut pending: Vec<_> = catalog
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Pages")
+        .map(|(_, value)| value.clone())
+        .collect();
+    pending.extend(root_preserved_values.iter().cloned());
+    pending.extend(
+        pages
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| retained.contains(index))
+            .flat_map(|(_, page)| {
+                page.dictionary
+                    .0
+                    .iter()
+                    .filter(|(key, _)| key.0 != "Parent")
+                    .map(|(_, value)| value.clone())
+            }),
+    );
+    pending.extend(preserved.iter().map(|id| PdfObject::Reference(id.0, id.1)));
+
+    let mut reachable = HashSet::from([page_root]);
+    reachable.extend(
+        pages
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| retained.contains(index))
+            .map(|(_, page)| page.reference),
+    );
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !reachable.insert(id) || id == page_root {
+                    continue;
+                }
+                if reachable.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "prospective document graph exceeds the supported object count",
+                    ));
+                }
+                let object = reader
+                    .get_object(number, generation)
+                    .map_err(|error| {
+                        invalid_lossless(format!("plan prospective object graph: {error}"))
+                    })?
+                    .clone();
+                match object {
+                    PdfObject::Dictionary(dictionary)
+                        if dictionary
+                            .get_type()
+                            .is_some_and(|kind| matches!(kind, "Pages" | "Catalog")) => {}
+                    PdfObject::Dictionary(dictionary) if dictionary.get_type() == Some("Page") => {
+                        pending.extend(
+                            dictionary
+                                .0
+                                .into_iter()
+                                .filter(|(key, _)| key.0 != "Parent")
+                                .map(|(_, value)| value),
+                        );
+                    }
+                    object => pending.push(object),
+                }
             }
             PdfObject::Array(array) => pending.extend(array.0),
             PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),

--- a/oxidize-pdf-core/src/signatures/permissions.rs
+++ b/oxidize-pdf-core/src/signatures/permissions.rs
@@ -9,6 +9,7 @@ use std::io::{Read, Seek};
 #[allow(dead_code)] // Additional variants are the shared contract for upcoming editors.
 pub(crate) enum IncrementalModification {
     PageTreeReorder,
+    PageTreeMutation,
     FormFill,
     AddSignature,
     AddAnnotation,
@@ -336,6 +337,7 @@ fn enforce_permission(
     }
     let edit = match modification {
         IncrementalModification::PageTreeReorder => "page-tree reordering",
+        IncrementalModification::PageTreeMutation => "page-tree mutation",
         IncrementalModification::FormFill => "form filling",
         IncrementalModification::AddSignature => "adding signatures",
         IncrementalModification::AddAnnotation => "adding annotations",
@@ -393,6 +395,19 @@ mod tests {
         ] {
             assert!(
                 enforce_permission(IncrementalModification::PageTreeReorder, permission).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn page_tree_mutations_are_forbidden_at_every_permission_level() {
+        for permission in [
+            DocMdpPermission::NoChanges,
+            DocMdpPermission::FormFillAndSign,
+            DocMdpPermission::FormFillSignAndAnnotate,
+        ] {
+            assert!(
+                enforce_permission(IncrementalModification::PageTreeMutation, permission).is_err()
             );
         }
     }

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -67,7 +67,7 @@ impl<'a> IncrementalUpdate<'a> {
         Self::from_reader(base, &reader)
     }
 
-    pub(super) fn allocate_id(&mut self) -> Result<(u32, u16)> {
+    pub(crate) fn allocate_id(&mut self) -> Result<(u32, u16)> {
         let id = (self.next_id, 0);
         self.next_id = self.next_id.checked_add(1).ok_or_else(|| {
             PdfError::InvalidStructure("PDF object number space is exhausted".to_string())

--- a/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
+++ b/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
@@ -255,6 +255,156 @@ fn supports_xref_stream_input_and_rejects_invalid_batches() {
 }
 
 #[test]
+fn rejects_encryption_docmdp_and_page_labels_without_replacing_output() {
+    let directory = TempDir::new().unwrap();
+    let output = directory.path().join("output.pdf");
+    fs::write(&output, b"keep").unwrap();
+
+    let encrypted = directory.path().join("encrypted.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    fs::write(&encrypted, document.to_bytes().unwrap()).unwrap();
+    let rotate = PageMutationBatch {
+        operations: vec![PageMutation::Rotate {
+            page: 0,
+            degrees: 90,
+        }],
+    };
+    let error = mutate_pdf_pages_lossless(&encrypted, &output, &rotate)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("encrypted PDFs"), "{error}");
+
+    let certified = directory.path().join("certified.pdf");
+    fs::write(
+        &certified,
+        include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf"),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(&certified, &output, &rotate)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("DocMDP"), "{error}");
+
+    let labelled = directory.path().join("labelled.pdf");
+    fs::write(
+        &labelled,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /PageLabels << /Nums [0 << /S /D >>] >> >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(
+        &labelled,
+        &output,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Delete { page: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("PageLabels"), "{error}");
+    mutate_pdf_pages_lossless(&labelled, &output, &rotate)
+        .expect("rotation does not change page-label indexes");
+}
+
+#[test]
+fn rejects_imports_with_named_destinations_or_optional_content() {
+    let directory = TempDir::new().unwrap();
+    let target = directory.path().join("target.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(&target, base_pdf("")).unwrap();
+
+    let named = directory.path().join("named.pdf");
+    fs::write(
+        &named,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Link /Rect [0 0 1 1] /Dest /chapter >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let insert = |source| PageMutationBatch {
+        operations: vec![PageMutation::Insert {
+            source,
+            page: 0,
+            at: 0,
+        }],
+    };
+    let error = plan_pdf_page_mutations(&target, &insert(named))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("named destination"), "{error}");
+
+    let ocg = directory.path().join("ocg.pdf");
+    fs::write(
+        &ocg,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [5 0 R] >> >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Resources << /Properties << /Layer 5 0 R >> >> >>"
+                .to_vec(),
+            b"null".to_vec(),
+            b"<< /Type /OCG /Name (Layer) >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = plan_pdf_page_mutations(&target, &insert(ocg))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("optional-content"), "{error}");
+    assert!(!output.exists());
+}
+
+#[test]
+fn mutates_a_nested_page_tree_and_preserves_effective_inheritance() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("nested.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(
+        &input,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>".to_vec(),
+            b"<< /Type /Pages /Parent 2 0 R /Kids [5 0 R] /Count 1 /MediaBox [0 0 100 200] >>".to_vec(),
+            b"<< /Type /Pages /Parent 2 0 R /Kids [6 0 R] /Count 1 /MediaBox [0 0 300 400] /Rotate 90 >>".to_vec(),
+            b"<< /Type /Page /Parent 3 0 R >>".to_vec(),
+            b"<< /Type /Page /Parent 4 0 R >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    mutate_pdf_pages_lossless(
+        &input,
+        &output,
+        &PageMutationBatch {
+            operations: vec![
+                PageMutation::Move { from: 1, to: 0 },
+                PageMutation::Rotate {
+                    page: 0,
+                    degrees: 90,
+                },
+            ],
+        },
+    )
+    .unwrap();
+    let bytes = fs::read(output).unwrap();
+    assert_eq!(page_refs(&bytes), vec![(6, 0), (5, 0)]);
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let page = reader.get_object(6, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        page.get("Rotate").and_then(PdfObject::as_integer),
+        Some(180)
+    );
+    assert!(page.contains_key("MediaBox"));
+}
+
+#[test]
 #[ignore = "requires qpdf and Poppler command-line tools"]
 fn qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations() {
     for (name, config) in [

--- a/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
+++ b/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
@@ -1,0 +1,312 @@
+//! Regression coverage for issue #538: mixed page-tree changes are one
+//! lossless, validated incremental revision.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::operations::{
+    mutate_pdf_pages_lossless, plan_pdf_page_mutations, PageMutation, PageMutationBatch,
+};
+use oxidize_pdf::parser::{PdfObject, PdfReader};
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Document, Page};
+use std::fs;
+use std::io::Cursor;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn base_pdf(catalog_extra: &str) -> Vec<u8> {
+    assemble_pdf(&[
+        format!("<< /Type /Catalog /Pages 2 0 R {catalog_extra} >>").into_bytes(),
+        b"<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 /MediaBox [0 0 200 300] /Resources 9 0 R >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 6 0 R /Annots [10 0 R] >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 7 0 R /Rotate 90 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>".to_vec(),
+        stream_obj("", b"first"),
+        stream_obj("", b"second"),
+        stream_obj("", b"third"),
+        b"<< /ProcSet [/PDF] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Text /P 3 0 R /Rect [0 0 10 10] /Contents (note) >>".to_vec(),
+        b"<< /Dests << /third [5 0 R /Fit] >> >>".to_vec(),
+    ])
+}
+
+fn page_refs(bytes: &[u8]) -> Vec<(u32, u16)> {
+    let document = PdfReader::new(Cursor::new(bytes)).unwrap().into_document();
+    (0..document.page_count().unwrap())
+        .map(|index| document.get_page(index).unwrap().obj_ref)
+        .collect()
+}
+
+#[test]
+fn applies_mixed_move_rotate_delete_and_duplicate_atomically() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = base_pdf("");
+    fs::write(&input, &source).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![
+            PageMutation::Move { from: 2, to: 0 },
+            PageMutation::Rotate {
+                page: 1,
+                degrees: 90,
+            },
+            PageMutation::Duplicate { page: 1, at: 2 },
+            PageMutation::Delete { page: 3 },
+        ],
+    };
+
+    let planned = plan_pdf_page_mutations(&input, &batch).unwrap();
+    assert_eq!(planned.page_count, 3);
+    assert_eq!(planned.unreachable_objects, vec![(4, 0), (7, 0)]);
+    let report = mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    assert_eq!(report, planned);
+
+    let bytes = fs::read(output).unwrap();
+    assert!(bytes.starts_with(&source));
+    let refs = page_refs(&bytes);
+    assert_eq!(refs[0], (5, 0));
+    assert_eq!(refs[1], (3, 0));
+    assert_ne!(refs[2], (3, 0));
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let original = reader.get_object(3, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        original.get("Rotate").and_then(PdfObject::as_integer),
+        Some(90)
+    );
+    let duplicate = reader
+        .get_object(refs[2].0, refs[2].1)
+        .unwrap()
+        .as_dict()
+        .unwrap();
+    assert_eq!(
+        duplicate.get("Rotate").and_then(PdfObject::as_integer),
+        Some(90)
+    );
+    assert_ne!(
+        duplicate
+            .get("Annots")
+            .and_then(PdfObject::as_array)
+            .unwrap()
+            .0[0]
+            .as_reference(),
+        Some((10, 0)),
+        "duplicate annotations must have independent identities"
+    );
+}
+
+#[test]
+fn imports_a_page_and_its_reachable_object_graph() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let imported = directory.path().join("imported.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = base_pdf("");
+    fs::write(&input, &source).unwrap();
+    fs::write(&imported, base_pdf("")).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Insert {
+            source: imported,
+            page: 1,
+            at: 1,
+        }],
+    };
+
+    let report = mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    assert_eq!(report.page_count, 4);
+    assert!(!report.added_objects.is_empty());
+    let bytes = fs::read(output).unwrap();
+    assert!(bytes.starts_with(&source));
+    let refs = page_refs(&bytes);
+    assert_eq!(&refs[0..1], &[(3, 0)]);
+    assert_ne!(refs[1], (4, 0));
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let page = reader
+        .get_object(refs[1].0, refs[1].1)
+        .unwrap()
+        .as_dict()
+        .unwrap();
+    assert_eq!(page.get("Rotate").and_then(PdfObject::as_integer), Some(90));
+    let contents = page
+        .get("Contents")
+        .and_then(PdfObject::as_reference)
+        .unwrap();
+    assert!(reader
+        .get_object(contents.0, contents.1)
+        .unwrap()
+        .as_stream()
+        .is_some());
+}
+
+#[test]
+fn rejects_deletion_referenced_by_catalog_semantics_without_touching_destination() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(&input, base_pdf("/Names 11 0 R")).unwrap();
+    fs::write(&output, b"keep destination").unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Delete { page: 2 }],
+    };
+
+    let error = mutate_pdf_pages_lossless(&input, &output, &batch)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("catalog-level structure references it"),
+        "{error}"
+    );
+    assert_eq!(fs::read(output).unwrap(), b"keep destination");
+}
+
+#[test]
+fn rejects_dangling_page_links_and_unsupported_widget_duplication() {
+    let directory = TempDir::new().unwrap();
+    let output = directory.path().join("output.pdf");
+    let linked = directory.path().join("linked.pdf");
+    fs::write(
+        &linked,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [5 0 R] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Link /Rect [0 0 1 1] /Dest [4 0 R /Fit] >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = plan_pdf_page_mutations(
+        &linked,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Delete { page: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        error.contains("retained page structure references it"),
+        "{error}"
+    );
+
+    let widget = directory.path().join("widget.pdf");
+    fs::write(
+        &widget,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Widget /FT /Tx /P 3 0 R /Rect [0 0 1 1] >>".to_vec(),
+            b"<< /Fields [4 0 R] >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(
+        &widget,
+        &output,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Duplicate { page: 0, at: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("AcroForm field tree"), "{error}");
+    assert!(!output.exists());
+}
+
+#[test]
+fn supports_xref_stream_input_and_rejects_invalid_batches() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("modern.pdf");
+    let output = directory.path().join("output.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.add_page(Page::letter());
+    let source = document
+        .to_bytes_with_config(WriterConfig::modern())
+        .unwrap();
+    fs::write(&input, &source).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Rotate {
+            page: 0,
+            degrees: -90,
+        }],
+    };
+    mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    let bytes = fs::read(&output).unwrap();
+    assert!(bytes.starts_with(&source));
+    assert!(bytes
+        .windows(b"/Type /XRef".len())
+        .any(|window| window == b"/Type /XRef"));
+
+    for operations in [
+        vec![],
+        vec![PageMutation::Rotate {
+            page: 0,
+            degrees: 45,
+        }],
+        vec![
+            PageMutation::Delete { page: 0 },
+            PageMutation::Delete { page: 0 },
+        ],
+    ] {
+        assert!(plan_pdf_page_mutations(&input, &PageMutationBatch { operations }).is_err());
+    }
+}
+
+#[test]
+#[ignore = "requires qpdf and Poppler command-line tools"]
+fn qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations() {
+    for (name, config) in [
+        ("classic", WriterConfig::default()),
+        ("xref-stream", WriterConfig::modern()),
+    ] {
+        let directory = TempDir::new().unwrap();
+        let input = directory.path().join(format!("{name}-input.pdf"));
+        let output = directory.path().join(format!("{name}-output.pdf"));
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.add_page(Page::letter());
+        let source = document.to_bytes_with_config(config).unwrap();
+        fs::write(&input, source).unwrap();
+        mutate_pdf_pages_lossless(
+            &input,
+            &output,
+            &PageMutationBatch {
+                operations: vec![
+                    PageMutation::Duplicate { page: 0, at: 1 },
+                    PageMutation::Rotate {
+                        page: 1,
+                        degrees: 90,
+                    },
+                    PageMutation::Delete { page: 2 },
+                ],
+            },
+        )
+        .unwrap();
+
+        let check = Command::new("qpdf")
+            .arg("--check")
+            .arg(&output)
+            .output()
+            .unwrap();
+        assert!(
+            check.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&check.stderr)
+        );
+        let render_prefix = directory.path().join(format!("{name}-render"));
+        let render = Command::new("pdftoppm")
+            .args(["-f", "1", "-singlefile", "-png"])
+            .arg(&output)
+            .arg(&render_prefix)
+            .output()
+            .unwrap();
+        assert!(
+            render.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        assert!(render_prefix.with_extension("png").is_file());
+    }
+}


### PR DESCRIPTION
## Summary
- add an atomic incremental page-tree mutation API for move, rotate, delete, duplicate, and cross-document page insertion
- preserve prior bytes, indirect identities, inherited page attributes, catalog semantics, xref style, and unrelated objects
- provide dry-run reports for replaced, added, and newly unreachable objects
- reject encrypted inputs, DocMDP-forbidden edits, dangling page references, and imports or duplicates that require unsupported AcroForm/tagged-PDF remapping
- reopen and validate temporary output before atomic publication

## Validation
- cargo fmt --all -- --check
- cargo clippy -p oxidize-pdf --lib --test issue_538_page_tree_mutations_test -- -D warnings
- cargo test -p oxidize-pdf --test issue_538_page_tree_mutations_test
- ignored qpdf/Poppler interoperability test executed explicitly for classic xref tables and xref streams
- issue #531 lossless reorder and #532 DocMDP regression suites
- cargo test -p oxidize-pdf --lib: 6,765 passed, 3 ignored
- cargo test -p oxidize-pdf --doc: 215 passed, 26 ignored

Closes #538