### PR TITLE
Release v4.9.0

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -66,6 +66,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_geometric_revisions
           -- --ignored --exact
 
+      - name: Validate lossless page-tree mutations
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_538_page_tree_mutations_test
+          qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations
+          -- --ignored --exact
+
       - name: Validate incremental OCR layers
         run: >
           cargo test -p oxidize-pdf

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -52,6 +52,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_highlight_revisions
           -- --ignored --exact
 
+      - name: Validate incremental ink annotations
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_536_incremental_ink_test
+          qpdf_accepts_classic_and_xref_stream_ink_revisions
+          -- --ignored --exact
+
       - name: Validate incremental OCR layers
         run: >
           cargo test -p oxidize-pdf

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -59,6 +59,13 @@ jobs:
           qpdf_accepts_classic_and_xref_stream_ink_revisions
           -- --ignored --exact
 
+      - name: Validate incremental geometric annotations
+        run: >
+          cargo test -p oxidize-pdf
+          --test issue_537_incremental_geometric_test
+          qpdf_accepts_classic_and_xref_stream_geometric_revisions
+          -- --ignored --exact
+
       - name: Validate incremental OCR layers
         run: >
           cargo test -p oxidize-pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,8 +203,6 @@ jobs:
           if [ -z "$PREVIOUS_TAG" ]; then
             echo "No previous tag found, assuming core package changed"
             echo "core_changed=true" >> $GITHUB_OUTPUT
-            echo "cli_changed=false" >> $GITHUB_OUTPUT
-            echo "api_changed=false" >> $GITHUB_OUTPUT
           else
             CURRENT_TAG="${{ needs.verify-release-conditions.outputs.version_tag }}"
             echo "Comparing changes from $PREVIOUS_TAG to $CURRENT_TAG"
@@ -216,9 +214,6 @@ jobs:
               echo "core_changed=false" >> $GITHUB_OUTPUT
             fi
 
-            # CLI and API packages are in separate repositories
-            echo "cli_changed=false" >> $GITHUB_OUTPUT
-            echo "api_changed=false" >> $GITHUB_OUTPUT
           fi
 
       # Check if packages need new versions before publishing
@@ -255,22 +250,6 @@ jobs:
         if: steps.changes.outputs.core_changed == 'true' && steps.version_check.outputs.core_needs_publish == 'true'
         run: sleep 60
 
-      - name: Publish oxidize-pdf-cli to crates.io
-        if: steps.changes.outputs.cli_changed == 'true' && steps.version_check.outputs.cli_needs_publish == 'true'
-        run: cargo publish -p oxidize-pdf-cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Wait for crates.io (cli)
-        if: steps.changes.outputs.cli_changed == 'true' && steps.version_check.outputs.cli_needs_publish == 'true'
-        run: sleep 30
-
-      - name: Publish oxidize-pdf-api to crates.io
-        if: steps.changes.outputs.api_changed == 'true' && steps.version_check.outputs.api_needs_publish == 'true'
-        run: cargo publish -p oxidize-pdf-api
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
       - name: Release Summary
         run: |
           echo "🎉 Release v${{ steps.get_version.outputs.VERSION }} completed successfully!"
@@ -278,12 +257,6 @@ jobs:
           echo "✅ Released packages:"
           if [ "${{ steps.changes.outputs.core_changed }}" == "true" ] && [ "${{ steps.version_check.outputs.core_needs_publish }}" == "true" ]; then
             echo "  - oxidize-pdf v${{ steps.get_version.outputs.VERSION }}"
-          fi
-          if [ "${{ steps.changes.outputs.cli_changed }}" == "true" ] && [ "${{ steps.version_check.outputs.cli_needs_publish }}" == "true" ]; then
-            echo "  - oxidize-pdf-cli"
-          fi
-          if [ "${{ steps.changes.outputs.api_changed }}" == "true" ] && [ "${{ steps.version_check.outputs.api_needs_publish }}" == "true" ]; then
-            echo "  - oxidize-pdf-api"
           fi
           echo ""
           echo "📦 GitHub Release: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.get_version.outputs.VERSION }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [4.9.0] - 2026-08-30
+
+### Added
+
+- **Provider-neutral incremental PDF signing** (#540, #558). New two-phase
+  preparation and finalization APIs support caller-produced CMS signatures,
+  visible and invisible fields, existing-field selection, successive
+  signatures, xref tables and streams, and DocMDP and FieldMDP enforcement
+  while preserving the source PDF as an exact byte prefix.
+- **Lossless incremental FreeText annotation editing** (#534, #553). A typed
+  editor can enumerate, add, update, and remove FreeText annotations without
+  rebuilding unrelated document content.
+- **Lossless incremental Ink annotation editing** (#536, #554). Typed APIs can
+  enumerate and atomically mutate ink strokes, appearance properties, and
+  annotation metadata while preserving prior PDF bytes.
+- **Lossless incremental geometric annotation editing** (#537, #555). Typed
+  editors support line, square, circle, polygon, and polyline annotations,
+  including geometry, color, opacity, width, dash patterns, and line endings.
+- **Atomic page-tree mutation batches** (#538, #556). New planning and mutation
+  APIs can reorder, insert, duplicate, and remove pages in one validated,
+  lossless incremental revision.
+- **Document-semantic preservation for structural operations** (#539, #557).
+  Merge, split, extraction, and page mutation APIs preserve or safely reconcile
+  outlines, named destinations, page labels, AcroForm state, metadata, and
+  associated document structures.
+
+### Changed
+
+- **Obsolete CLI and API release artifacts were retired** (#552). The
+  `oxidize-pdf` library is now the sole maintained and published artifact.
+
 ## [4.8.0] - 2026-08-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "4.8.0"
+version = "4.9.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "4.8.0"
+version = "4.9.0"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,6 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4"
 
-# CLI dependencies
-clap = { version = "4.5", features = ["derive"] }
-
-# API dependencies
-axum = "0.8.4"
-tower = "0.5.2"
-tower-http = { version = "0.6.6", features = ["cors", "trace"] }
-
-# Async runtime
-tokio = { version = "1.40", features = ["full"] }
-
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -67,16 +56,11 @@ rand = "0.10"
 hex = "0.4"
 regex = "1.11"
 
-# Pro dependencies
-base64 = "0.21"
-uuid = { version = "1.0", features = ["v4"] }
 # XMP metadata parsing uses only the streaming pull-parser (Reader/Event); the
 # `serialize` (serde) feature was enabled but never used. Pinned >= 0.41 to
 # clear RUSTSEC-2026-0194/0195 (DoS in NsReader / duplicate-attribute check).
 # See issue #416.
 quick-xml = { version = "0.41" }
-reqwest = { version = "0.11", features = ["json"] }
-
 [profile.release]
 lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most PDF libraries give you a wall of text. oxidize-pdf gives you **structured, 
 
 ```toml
 [dependencies]
-oxidize-pdf = "4.0"
+oxidize-pdf = "4.9.0"
 ```
 
 ### RAG Pipeline -- One Liner

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,5 +1,11 @@
 # Release Process Guidelines
 
+## Supported artifact
+
+`oxidize-pdf` is the only maintained and published artifact. The former
+`oxidize-pdf-cli` and `oxidize-pdf-api` crates are discontinued and are not
+part of this repository or its release process.
+
 ## ⚠️ Critical Rules
 
 ### 1. **NEVER create a release tag without green CI**
@@ -17,7 +23,7 @@
 - [ ] Run `cargo test --workspace` locally
 - [ ] Run `cargo clippy --workspace -- -D warnings` locally
 - [ ] All CI checks pass on the target branch
-- [ ] Version numbers are updated in all Cargo.toml files
+- [ ] The workspace version is updated in `Cargo.toml`
 - [ ] CHANGELOG.md is updated with release notes
 - [ ] ISO_COMPLIANCE_REPORT.md is current
 
@@ -92,8 +98,6 @@ The release workflow now includes:
 
 When preparing a release, update versions in:
 - `Cargo.toml` (workspace version)
-- `oxidize-pdf-cli/Cargo.toml`
-- `oxidize-pdf-api/Cargo.toml`
 - Update `ISO_COMPLIANCE_REPORT.md` if compliance changed
 - Update `CHANGELOG.md` with new features/fixes
 
@@ -103,7 +107,6 @@ After successful release:
 1. ✅ Verify `cargo search oxidize-pdf` shows new version
 2. ✅ Check GitHub Release is properly formatted
 3. ✅ Confirm CI is green on main branch
-4. ✅ Test installation: `cargo install oxidize-pdf-cli --version X.X.X`
 
 ## ❌ What NOT to Do
 
@@ -124,5 +127,5 @@ If the release process is broken:
 
 ---
 
-*Last updated: August 2025*
+*Last updated: August 2026*
 *This document reflects lessons learned from v1.1.9 release issues*

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -302,11 +302,12 @@ pub use parser::{
 
 // Re-export operations
 pub use operations::{
-    extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page, overlay_pdf,
-    reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf,
-    swap_pdf_pages, ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
+    extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page,
+    mutate_pdf_pages_lossless, overlay_pdf, plan_pdf_page_mutations, reorder_pdf_pages,
+    reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
+    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
     ImageExtractionLimits, ImageExtractionResult, ImageExtractor, OverlayOptions, OverlayPosition,
-    ReorderOptions,
+    PageMutation, PageMutationBatch, PageMutationReport, ReorderOptions,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -302,12 +302,16 @@ pub use parser::{
 
 // Re-export operations
 pub use operations::{
-    extract_images_from_pages, extract_images_from_pdf, merge_pdfs, move_pdf_page,
-    mutate_pdf_pages_lossless, overlay_pdf, plan_pdf_page_mutations, reorder_pdf_pages,
-    reorder_pdf_pages_lossless, reverse_pdf_pages, rotate_pdf_pages, split_pdf, swap_pdf_pages,
+    extract_images_from_pages, extract_images_from_pdf, extract_pdf_pages_lossless, merge_pdfs,
+    merge_pdfs_lossless, move_pdf_page, mutate_pdf_pages_lossless, overlay_pdf,
+    plan_extract_pdf_pages_lossless, plan_merge_pdfs_lossless, plan_pdf_page_mutations,
+    plan_split_pdf_lossless, reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages,
+    rotate_pdf_pages, split_pdf, split_pdf_lossless, swap_pdf_pages, DocumentStructure,
     ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
-    ImageExtractionLimits, ImageExtractionResult, ImageExtractor, OverlayOptions, OverlayPosition,
-    PageMutation, PageMutationBatch, PageMutationReport, ReorderOptions,
+    ImageExtractionLimits, ImageExtractionResult, ImageExtractor, InputSemanticReport,
+    InputSemanticRole, LosslessMergeInput, OverlayOptions, OverlayPosition, PageMutation,
+    PageMutationBatch, PageMutationReport, ReorderOptions, SemanticPreservationReport,
+    StructureDisposition, StructureSemanticReport,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/operations/merge.rs
+++ b/oxidize-pdf-core/src/operations/merge.rs
@@ -13,9 +13,17 @@ use std::path::{Path, PathBuf};
 pub struct MergeOptions {
     /// Page ranges to include from each input file
     pub page_ranges: Option<Vec<PageRange>>,
-    /// Whether to preserve bookmarks/outlines
+    /// Unsupported legacy request to preserve bookmarks/outlines.
+    ///
+    /// The `Document` reconstruction API cannot preserve arbitrary source
+    /// outline graphs. Setting this to `true` returns an error; use
+    /// `plan_merge_pdfs_lossless` and `merge_pdfs_lossless` instead.
     pub preserve_bookmarks: bool,
-    /// Whether to preserve form fields
+    /// Unsupported legacy request to preserve form fields.
+    ///
+    /// The `Document` reconstruction API cannot preserve arbitrary source
+    /// field trees. Setting this to `true` returns an error; use the lossless
+    /// merge API when forms must be retained.
     pub preserve_forms: bool,
     /// Whether to optimize the output
     pub optimize: bool,
@@ -27,7 +35,7 @@ impl Default for MergeOptions {
     fn default() -> Self {
         Self {
             page_ranges: None,
-            preserve_bookmarks: true,
+            preserve_bookmarks: false,
             preserve_forms: false,
             optimize: false,
             metadata_mode: MetadataMode::FromFirst,
@@ -107,6 +115,12 @@ impl PdfMerger {
 
     /// Merge all input files into a single document
     pub fn merge(&mut self) -> OperationResult<Document> {
+        if self.options.preserve_bookmarks || self.options.preserve_forms {
+            return Err(OperationError::ProcessingError(
+                "legacy Document reconstruction cannot honor preserve_bookmarks or preserve_forms; use merge_pdfs_lossless"
+                    .to_string(),
+            ));
+        }
         if self.inputs.is_empty() {
             return Err(OperationError::NoPagesToProcess);
         }
@@ -249,10 +263,23 @@ mod tests {
     fn test_merge_options_default() {
         let options = MergeOptions::default();
         assert!(options.page_ranges.is_none());
-        assert!(options.preserve_bookmarks);
+        assert!(!options.preserve_bookmarks);
         assert!(!options.preserve_forms);
         assert!(!options.optimize);
         assert!(matches!(options.metadata_mode, MetadataMode::FromFirst));
+    }
+
+    #[test]
+    fn legacy_preservation_flags_fail_instead_of_being_ignored() {
+        let mut merger = PdfMerger::new(MergeOptions {
+            preserve_bookmarks: true,
+            ..MergeOptions::default()
+        });
+        let error = match merger.merge() {
+            Ok(_) => panic!("legacy preservation flag must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("merge_pdfs_lossless"));
     }
 
     #[test]

--- a/oxidize-pdf-core/src/operations/merge_tests.rs
+++ b/oxidize-pdf-core/src/operations/merge_tests.rs
@@ -370,7 +370,7 @@ mod tests {
     fn test_merge_options_variants() {
         // Test all MergeOptions variants
         let default_options = MergeOptions::default();
-        assert!(default_options.preserve_bookmarks);
+        assert!(!default_options.preserve_bookmarks);
         assert!(!default_options.preserve_forms);
         assert!(!default_options.optimize);
         assert!(matches!(
@@ -414,7 +414,7 @@ mod tests {
                 ..Default::default()
             };
             // Just verify we can create options with all metadata modes
-            assert!(options.preserve_bookmarks);
+            assert!(!options.preserve_bookmarks);
         }
     }
 

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -31,8 +31,9 @@ pub use page_extraction::{
 };
 pub use pdf_ocr_converter::{ConversionOptions, ConversionResult, PdfOcrConverter};
 pub use reorder::{
-    move_pdf_page, reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages,
-    swap_pdf_pages, PageReorderer, ReorderOptions,
+    move_pdf_page, mutate_pdf_pages_lossless, plan_pdf_page_mutations, reorder_pdf_pages,
+    reorder_pdf_pages_lossless, reverse_pdf_pages, swap_pdf_pages, PageMutation, PageMutationBatch,
+    PageMutationReport, PageReorderer, ReorderOptions,
 };
 pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions, RotationAngle};
 pub use semantic_redactor::{

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -12,6 +12,7 @@ pub mod page_extraction;
 pub mod pdf_ocr_converter;
 pub mod reorder;
 pub mod rotate;
+pub mod semantic_preservation;
 pub mod semantic_redactor;
 pub mod source_highlighter;
 pub mod split;
@@ -36,6 +37,12 @@ pub use reorder::{
     PageMutationReport, PageReorderer, ReorderOptions,
 };
 pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions, RotationAngle};
+pub use semantic_preservation::{
+    extract_pdf_pages_lossless, merge_pdfs_lossless, plan_extract_pdf_pages_lossless,
+    plan_merge_pdfs_lossless, plan_split_pdf_lossless, split_pdf_lossless, DocumentStructure,
+    InputSemanticReport, InputSemanticRole, LosslessMergeInput, SemanticPreservationReport,
+    StructureDisposition, StructureSemanticReport,
+};
 pub use semantic_redactor::{
     RedactionConfig, RedactionEntry, RedactionMode, RedactionReport, RedactionStyle,
     SemanticRedactor, SemanticRedactorError, SemanticRedactorResult,

--- a/oxidize-pdf-core/src/operations/page_extraction.rs
+++ b/oxidize-pdf-core/src/operations/page_extraction.rs
@@ -3,6 +3,10 @@
 //! This module provides functionality to extract individual pages or ranges of pages
 //! from PDF documents. It builds upon the split module but provides a more focused
 //! API specifically for page extraction use cases.
+//!
+//! This legacy API returns a reconstructed [`crate::Document`]. Use
+//! [`super::extract_pdf_pages_lossless`] when annotations and document-level
+//! structures must be retained or rejected explicitly before writing.
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::{ParsedPage, PdfDocument, PdfReader};

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 const INHERITABLE_PAGE_KEYS: [&str; 4] = ["Resources", "MediaBox", "CropBox", "Rotate"];
 const MAX_PAGE_TREE_DEPTH: usize = 256;
 const MAX_PAGE_COUNT: usize = 100_000;
+const MAX_CLONED_OBJECTS_PER_PAGE: usize = 100_000;
+const MAX_OBJECT_GRAPH_DEPTH: usize = 256;
 
 #[derive(Debug)]
 struct LosslessPage {
@@ -31,6 +33,78 @@ struct LosslessValidation {
     root_reference: (u32, u16),
     catalog: PdfDictionary,
     pages: Vec<((u32, u16), HashMap<&'static str, PdfObject>)>,
+}
+
+/// One operation in an atomic lossless page-tree mutation batch.
+///
+/// Page indexes are zero based and are resolved against the result of all
+/// preceding operations in the batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageMutation {
+    /// Move a page to a new position.
+    Move { from: usize, to: usize },
+    /// Rotate a page clockwise by a multiple of 90 degrees.
+    Rotate { page: usize, degrees: i32 },
+    /// Remove a page from the page tree.
+    Delete { page: usize },
+    /// Duplicate a page, inserting the independent clone at `at`.
+    Duplicate { page: usize, at: usize },
+    /// Import one page from another PDF file and insert it at `at`.
+    Insert {
+        source: std::path::PathBuf,
+        page: usize,
+        at: usize,
+    },
+}
+
+/// A sequence of page mutations committed as one incremental revision.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PageMutationBatch {
+    /// Operations to apply in order.
+    pub operations: Vec<PageMutation>,
+}
+
+impl PageMutationBatch {
+    /// Create an empty batch.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an operation.
+    pub fn push(&mut self, operation: PageMutation) -> &mut Self {
+        self.operations.push(operation);
+        self
+    }
+}
+
+/// Objects affected by a planned or completed page-tree mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageMutationReport {
+    /// Existing indirect objects that will receive a new definition.
+    pub replaced_objects: Vec<(u32, u16)>,
+    /// New indirect objects allocated by the revision.
+    pub added_objects: Vec<(u32, u16)>,
+    /// Source objects reachable from the old catalog but not the new catalog.
+    pub unreachable_objects: Vec<(u32, u16)>,
+    /// Number of pages after applying the batch.
+    pub page_count: usize,
+}
+
+#[derive(Debug, Clone)]
+enum PlannedPage {
+    Existing {
+        source_index: usize,
+        rotation: Option<i32>,
+    },
+    Clone {
+        source_index: usize,
+        rotation: Option<i32>,
+    },
+    Import {
+        source: std::path::PathBuf,
+        source_index: usize,
+        rotation: Option<i32>,
+    },
 }
 
 /// Options for page reordering
@@ -178,6 +252,817 @@ pub fn reorder_pdf_pages<P: AsRef<Path>, Q: AsRef<Path>>(
 
     let reorderer = PageReorderer::new(document, options);
     reorderer.reorder_to_file(output_path)
+}
+
+/// Inspect an atomic page-tree mutation without writing an output file.
+pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
+    input_path: P,
+    batch: &PageMutationBatch,
+) -> OperationResult<PageMutationReport> {
+    let base = std::fs::read(input_path)?;
+    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    Ok(report)
+}
+
+/// Apply page-tree mutations as one lossless incremental revision.
+///
+/// The source bytes remain an exact prefix. The completed temporary file is
+/// reopened and checked before it atomically replaces `output_path`.
+pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
+    input_path: P,
+    output_path: Q,
+    batch: &PageMutationBatch,
+) -> OperationResult<PageMutationReport> {
+    let base = std::fs::read(input_path)?;
+    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    validate_lossless_output(&base, &updated, &expected)?;
+
+    let output_path = output_path.as_ref();
+    let parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty());
+    let mut temporary = tempfile::NamedTempFile::new_in(parent.unwrap_or_else(|| Path::new(".")))?;
+    temporary.write_all(&updated)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    validate_lossless_file(&base, temporary.path(), &expected)?;
+    temporary
+        .persist(output_path)
+        .map_err(|error| OperationError::Io(error.error))?;
+    Ok(report)
+}
+
+fn mutate_pdf_bytes_lossless(
+    base: &[u8],
+    batch: &PageMutationBatch,
+) -> Result<(Vec<u8>, LosslessValidation, PageMutationReport), PdfError> {
+    if batch.operations.is_empty() {
+        return Err(invalid_lossless("page mutation batch cannot be empty"));
+    }
+    let mut reader = PdfReader::new(Cursor::new(base))
+        .map_err(|error| invalid_lossless(format!("parse source PDF: {error}")))?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(
+            "lossless page-tree mutation does not support encrypted PDFs".to_string(),
+        ));
+    }
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read document catalog: {error}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::PageTreeMutation,
+    )?;
+    let root_reference = catalog
+        .get("Pages")
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid_lossless("catalog /Pages must be an indirect reference"))?;
+    let root_dictionary = object_dictionary(&mut reader, root_reference, "page-tree root")?;
+    let mut source_pages = Vec::new();
+    let mut visited = HashSet::new();
+    walk_page_tree(
+        &mut reader,
+        root_reference,
+        None,
+        HashMap::new(),
+        &mut visited,
+        &mut source_pages,
+        0,
+    )?;
+
+    let mut planned: Vec<_> = (0..source_pages.len())
+        .map(|source_index| PlannedPage::Existing {
+            source_index,
+            rotation: None,
+        })
+        .collect();
+    for operation in &batch.operations {
+        apply_page_mutation(&mut planned, operation)?;
+    }
+    if planned.is_empty() {
+        return Err(invalid_lossless(
+            "a page-tree mutation cannot remove every page",
+        ));
+    }
+    if planned.len() > MAX_PAGE_COUNT {
+        return Err(invalid_lossless(
+            "page mutation exceeds the supported page count",
+        ));
+    }
+
+    let retained: HashSet<_> = planned
+        .iter()
+        .filter_map(|page| match page {
+            PlannedPage::Existing { source_index, .. } => Some(*source_index),
+            _ => None,
+        })
+        .collect();
+    let deleted_refs: HashSet<_> = source_pages
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !retained.contains(index))
+        .map(|(_, page)| page.reference)
+        .collect();
+    ensure_catalog_does_not_reference_deleted_pages(
+        &mut reader,
+        &catalog,
+        root_reference,
+        &deleted_refs,
+    )?;
+    ensure_retained_pages_do_not_reference_deleted_pages(
+        &mut reader,
+        &source_pages,
+        &retained,
+        root_reference,
+        &deleted_refs,
+    )?;
+    let source_reachable = reachable_from_catalog(&mut reader, &catalog)?;
+
+    let root_inherited = inherited_values(&root_dictionary);
+    let mut update = IncrementalUpdate::from_base(base)?;
+    let mut added_objects = Vec::new();
+    let mut final_pages = Vec::with_capacity(planned.len());
+    let mut validation_pages = Vec::with_capacity(planned.len());
+    let mut replacements = HashSet::new();
+    replacements.insert(root_reference);
+
+    for plan in planned {
+        match plan {
+            PlannedPage::Existing {
+                source_index,
+                rotation,
+            } => {
+                let page = &source_pages[source_index];
+                let mut dictionary = page.dictionary.clone();
+                let mut changed = dictionary.get("Parent").and_then(PdfObject::as_reference)
+                    != Some(root_reference);
+                dictionary.insert(
+                    "Parent".to_string(),
+                    PdfObject::Reference(root_reference.0, root_reference.1),
+                );
+                materialize_inherited(
+                    &mut dictionary,
+                    &page.effective_inherited,
+                    &root_inherited,
+                    &mut changed,
+                );
+                apply_rotation(
+                    &mut dictionary,
+                    &page.effective_inherited,
+                    rotation,
+                    &mut changed,
+                )?;
+                let effective = effective_for_flat_page(&dictionary, &root_inherited);
+                if changed {
+                    update.replace(page.reference, PdfObject::Dictionary(dictionary))?;
+                    replacements.insert(page.reference);
+                }
+                final_pages.push(page.reference);
+                validation_pages.push((page.reference, effective));
+            }
+            PlannedPage::Clone {
+                source_index,
+                rotation,
+            } => {
+                let page = &source_pages[source_index];
+                let id = clone_page_into_update(
+                    &mut reader,
+                    page,
+                    root_reference,
+                    rotation,
+                    false,
+                    &mut update,
+                    &mut added_objects,
+                )?;
+                let object = object_from_pending(&added_objects, id);
+                final_pages.push(id);
+                validation_pages.push((id, effective_for_flat_page(&object, &root_inherited)));
+            }
+            PlannedPage::Import {
+                source,
+                source_index,
+                rotation,
+            } => {
+                let bytes = std::fs::read(&source).map_err(|error| {
+                    invalid_lossless(format!("read imported PDF {}: {error}", source.display()))
+                })?;
+                let mut imported_reader = PdfReader::new(Cursor::new(&bytes)).map_err(|error| {
+                    invalid_lossless(format!("parse imported PDF {}: {error}", source.display()))
+                })?;
+                if imported_reader.is_encrypted() {
+                    return Err(PdfError::PermissionDenied(format!(
+                        "cannot import a page from encrypted PDF {}",
+                        source.display()
+                    )));
+                }
+                let imported_catalog = imported_reader
+                    .catalog()
+                    .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
+                    .clone();
+                let imported_root = imported_catalog
+                    .get("Pages")
+                    .and_then(PdfObject::as_reference)
+                    .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
+                let mut imported_pages = Vec::new();
+                let mut imported_visited = HashSet::new();
+                walk_page_tree(
+                    &mut imported_reader,
+                    imported_root,
+                    None,
+                    HashMap::new(),
+                    &mut imported_visited,
+                    &mut imported_pages,
+                    0,
+                )?;
+                let page = imported_pages.get(source_index).ok_or_else(|| {
+                    invalid_lossless(format!(
+                        "imported page index {source_index} is out of bounds for {} pages",
+                        imported_pages.len()
+                    ))
+                })?;
+                let id = clone_page_into_update(
+                    &mut imported_reader,
+                    page,
+                    root_reference,
+                    rotation,
+                    true,
+                    &mut update,
+                    &mut added_objects,
+                )?;
+                let object = object_from_pending(&added_objects, id);
+                final_pages.push(id);
+                validation_pages.push((id, effective_for_flat_page(&object, &root_inherited)));
+            }
+        }
+    }
+
+    let mut root_replacement = root_dictionary;
+    root_replacement.insert(
+        "Kids".to_string(),
+        PdfObject::Array(PdfArray(
+            final_pages
+                .iter()
+                .map(|id| PdfObject::Reference(id.0, id.1))
+                .collect(),
+        )),
+    );
+    root_replacement.insert(
+        "Count".to_string(),
+        PdfObject::Integer(final_pages.len() as i64),
+    );
+    update.replace(root_reference, PdfObject::Dictionary(root_replacement))?;
+    for (id, object) in &added_objects {
+        update.replace(*id, object.clone())?;
+    }
+    let updated = update.finish()?;
+
+    let mut output_reader = PdfReader::new(Cursor::new(&updated))
+        .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
+    let output_catalog = output_reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
+        .clone();
+    let output_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+    let mut unreachable_objects: Vec<_> = source_reachable
+        .difference(&output_reachable)
+        .copied()
+        .collect();
+    unreachable_objects.sort_unstable();
+    let mut replaced_objects: Vec<_> = replacements.into_iter().collect();
+    replaced_objects.sort_unstable();
+    let mut added_ids: Vec<_> = added_objects.iter().map(|(id, _)| *id).collect();
+    added_ids.sort_unstable();
+    let report = PageMutationReport {
+        replaced_objects,
+        added_objects: added_ids,
+        unreachable_objects,
+        page_count: final_pages.len(),
+    };
+    Ok((
+        updated,
+        LosslessValidation {
+            root_reference,
+            catalog,
+            pages: validation_pages,
+        },
+        report,
+    ))
+}
+
+fn apply_page_mutation(
+    pages: &mut Vec<PlannedPage>,
+    operation: &PageMutation,
+) -> Result<(), PdfError> {
+    let check_page = |index: usize, len: usize, role: &str| {
+        if index < len {
+            Ok(())
+        } else {
+            Err(invalid_lossless(format!(
+                "{role} page index {index} is out of bounds for {len} pages"
+            )))
+        }
+    };
+    match operation {
+        PageMutation::Move { from, to } => {
+            check_page(*from, pages.len(), "move source")?;
+            check_page(*to, pages.len(), "move destination")?;
+            let page = pages.remove(*from);
+            pages.insert(*to, page);
+        }
+        PageMutation::Rotate { page, degrees } => {
+            check_page(*page, pages.len(), "rotation")?;
+            if degrees.rem_euclid(90) != 0 {
+                return Err(invalid_lossless(format!(
+                    "page rotation {degrees} must be a multiple of 90 degrees"
+                )));
+            }
+            let rotation = match &mut pages[*page] {
+                PlannedPage::Existing { rotation, .. }
+                | PlannedPage::Clone { rotation, .. }
+                | PlannedPage::Import { rotation, .. } => rotation,
+            };
+            *rotation = Some(
+                rotation
+                    .unwrap_or(0)
+                    .checked_add(*degrees)
+                    .ok_or_else(|| invalid_lossless("accumulated page rotation overflows i32"))?,
+            );
+        }
+        PageMutation::Delete { page } => {
+            check_page(*page, pages.len(), "delete")?;
+            pages.remove(*page);
+        }
+        PageMutation::Duplicate { page, at } => {
+            check_page(*page, pages.len(), "duplicate source")?;
+            if *at > pages.len() {
+                return Err(invalid_lossless(format!(
+                    "duplicate insertion index {at} is out of bounds for {} pages",
+                    pages.len()
+                )));
+            }
+            let clone = match &pages[*page] {
+                PlannedPage::Existing {
+                    source_index,
+                    rotation,
+                }
+                | PlannedPage::Clone {
+                    source_index,
+                    rotation,
+                } => PlannedPage::Clone {
+                    source_index: *source_index,
+                    rotation: *rotation,
+                },
+                PlannedPage::Import {
+                    source,
+                    source_index,
+                    rotation,
+                } => PlannedPage::Import {
+                    source: source.clone(),
+                    source_index: *source_index,
+                    rotation: *rotation,
+                },
+            };
+            pages.insert(*at, clone);
+        }
+        PageMutation::Insert { source, page, at } => {
+            if *at > pages.len() {
+                return Err(invalid_lossless(format!(
+                    "import insertion index {at} is out of bounds for {} pages",
+                    pages.len()
+                )));
+            }
+            pages.insert(
+                *at,
+                PlannedPage::Import {
+                    source: source.clone(),
+                    source_index: *page,
+                    rotation: None,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn materialize_inherited(
+    dictionary: &mut PdfDictionary,
+    effective: &HashMap<&'static str, PdfObject>,
+    root_effective: &HashMap<&'static str, PdfObject>,
+    changed: &mut bool,
+) {
+    for (key, value) in effective {
+        if dictionary.contains_key(key) || root_effective.get(key) == Some(value) {
+            continue;
+        }
+        dictionary.insert((*key).to_string(), value.clone());
+        *changed = true;
+    }
+}
+
+fn apply_rotation(
+    dictionary: &mut PdfDictionary,
+    effective: &HashMap<&'static str, PdfObject>,
+    delta: Option<i32>,
+    changed: &mut bool,
+) -> Result<(), PdfError> {
+    let Some(delta) = delta else { return Ok(()) };
+    let current = effective
+        .get("Rotate")
+        .and_then(PdfObject::as_integer)
+        .unwrap_or(0);
+    let current = i32::try_from(current)
+        .map_err(|_| invalid_lossless("effective page /Rotate does not fit in i32"))?;
+    let rotation = current
+        .checked_add(delta)
+        .ok_or_else(|| invalid_lossless("effective page rotation overflows i32"))?
+        .rem_euclid(360);
+    dictionary.insert("Rotate".to_string(), PdfObject::Integer(rotation as i64));
+    *changed = true;
+    Ok(())
+}
+
+fn effective_for_flat_page(
+    dictionary: &PdfDictionary,
+    root: &HashMap<&'static str, PdfObject>,
+) -> HashMap<&'static str, PdfObject> {
+    let mut effective = root.clone();
+    for key in INHERITABLE_PAGE_KEYS {
+        if let Some(value) = dictionary.get(key) {
+            effective.insert(key, value.clone());
+        }
+    }
+    effective
+}
+
+fn clone_page_into_update<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+    destination_root: (u32, u16),
+    rotation: Option<i32>,
+    external: bool,
+    update: &mut IncrementalUpdate<'_>,
+    added: &mut Vec<((u32, u16), PdfObject)>,
+) -> Result<(u32, u16), PdfError> {
+    ensure_page_can_be_cloned(reader, page, external)?;
+    let page_id = update.allocate_id()?;
+    let mut mapping = HashMap::new();
+    mapping.insert(page.reference, page_id);
+    let mut dictionary = page.dictionary.clone();
+    dictionary.0.retain(|key, _| key.0 != "Parent");
+    for (key, value) in &page.effective_inherited {
+        if !dictionary.contains_key(key) {
+            dictionary.insert((*key).to_string(), value.clone());
+        }
+    }
+    let mut keys: Vec<_> = dictionary.0.keys().cloned().collect();
+    keys.sort_by(|left, right| left.0.cmp(&right.0));
+    for key in keys {
+        let value = dictionary.0[&key].clone();
+        let cloned = clone_page_object(
+            reader,
+            &value,
+            page.reference,
+            external,
+            update,
+            added,
+            &mut mapping,
+            0,
+        )?;
+        dictionary.0.insert(key, cloned);
+    }
+    dictionary.insert(
+        "Parent".to_string(),
+        PdfObject::Reference(destination_root.0, destination_root.1),
+    );
+    let mut changed = false;
+    apply_rotation(
+        &mut dictionary,
+        &page.effective_inherited,
+        rotation,
+        &mut changed,
+    )?;
+    added.push((page_id, PdfObject::Dictionary(dictionary)));
+    Ok(page_id)
+}
+
+fn ensure_page_can_be_cloned<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+    external: bool,
+) -> Result<(), PdfError> {
+    let action = if external { "import" } else { "duplicate" };
+    if page.dictionary.contains_key("StructParents") {
+        return Err(invalid_lossless(format!(
+            "cannot {action} a tagged page without remapping its parent-tree entry"
+        )));
+    }
+    let Some(annots) = page.dictionary.get("Annots") else {
+        return Ok(());
+    };
+    let annotations = match annots {
+        PdfObject::Array(array) => array.clone(),
+        PdfObject::Reference(number, generation) => reader
+            .get_object(*number, *generation)
+            .map_err(|error| invalid_lossless(format!("resolve page /Annots: {error}")))?
+            .as_array()
+            .cloned()
+            .ok_or_else(|| invalid_lossless("indirect page /Annots is not an array"))?,
+        _ => {
+            return Err(invalid_lossless(
+                "page /Annots must be an array or reference",
+            ))
+        }
+    };
+    for annotation in annotations.0 {
+        let dictionary = match annotation {
+            PdfObject::Reference(number, generation) => reader
+                .get_object(number, generation)
+                .map_err(|error| invalid_lossless(format!("resolve page annotation: {error}")))?
+                .as_dict(),
+            PdfObject::Dictionary(ref dictionary) => Some(dictionary),
+            _ => None,
+        };
+        if dictionary.is_some_and(|dictionary| {
+            dictionary
+                .get("Subtype")
+                .and_then(PdfObject::as_name)
+                .is_some_and(|name| name.0 == "Widget")
+        }) {
+            return Err(invalid_lossless(format!(
+                "cannot {action} a widget page without remapping its AcroForm field tree"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn clone_page_object<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    object: &PdfObject,
+    source_page: (u32, u16),
+    external: bool,
+    update: &mut IncrementalUpdate<'_>,
+    added: &mut Vec<((u32, u16), PdfObject)>,
+    mapping: &mut HashMap<(u32, u16), (u32, u16)>,
+    depth: usize,
+) -> Result<PdfObject, PdfError> {
+    if depth > MAX_OBJECT_GRAPH_DEPTH {
+        return Err(invalid_lossless(
+            "page object graph exceeds the supported nesting depth",
+        ));
+    }
+    match object {
+        PdfObject::Reference(number, generation) => {
+            let source_id = (*number, *generation);
+            if let Some(id) = mapping.get(&source_id) {
+                return Ok(PdfObject::Reference(id.0, id.1));
+            }
+            let source_object = reader
+                .get_object(*number, *generation)
+                .map_err(|error| {
+                    invalid_lossless(format!(
+                        "clone page object {number} {generation} R: {error}"
+                    ))
+                })?
+                .clone();
+            let structural_type = source_object
+                .as_dict()
+                .and_then(PdfDictionary::get_type)
+                .is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog"));
+            if structural_type {
+                if external {
+                    return Err(invalid_lossless(format!(
+                        "imported page graph references foreign structural object {number} {generation} R"
+                    )));
+                }
+                return Ok(object.clone());
+            }
+            if mapping.len() >= MAX_CLONED_OBJECTS_PER_PAGE {
+                return Err(invalid_lossless(
+                    "page object graph exceeds the supported object count",
+                ));
+            }
+            let id = update.allocate_id()?;
+            mapping.insert(source_id, id);
+            let cloned = clone_page_object(
+                reader,
+                &source_object,
+                source_page,
+                external,
+                update,
+                added,
+                mapping,
+                depth + 1,
+            )?;
+            added.push((id, cloned));
+            Ok(PdfObject::Reference(id.0, id.1))
+        }
+        PdfObject::Array(array) => Ok(PdfObject::Array(PdfArray(
+            array
+                .0
+                .iter()
+                .map(|value| {
+                    clone_page_object(
+                        reader,
+                        value,
+                        source_page,
+                        external,
+                        update,
+                        added,
+                        mapping,
+                        depth + 1,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        ))),
+        PdfObject::Dictionary(dictionary) => {
+            let mut dictionary = dictionary.clone();
+            let mut keys: Vec<_> = dictionary.0.keys().cloned().collect();
+            keys.sort_by(|left, right| left.0.cmp(&right.0));
+            for key in keys {
+                let value = dictionary.0[&key].clone();
+                let cloned = clone_page_object(
+                    reader,
+                    &value,
+                    source_page,
+                    external,
+                    update,
+                    added,
+                    mapping,
+                    depth + 1,
+                )?;
+                dictionary.0.insert(key, cloned);
+            }
+            Ok(PdfObject::Dictionary(dictionary))
+        }
+        PdfObject::Stream(stream) => {
+            let mut stream = stream.clone();
+            let mut keys: Vec<_> = stream.dict.0.keys().cloned().collect();
+            keys.sort_by(|left, right| left.0.cmp(&right.0));
+            for key in keys {
+                let value = stream.dict.0[&key].clone();
+                let cloned = clone_page_object(
+                    reader,
+                    &value,
+                    source_page,
+                    external,
+                    update,
+                    added,
+                    mapping,
+                    depth + 1,
+                )?;
+                stream.dict.0.insert(key, cloned);
+            }
+            Ok(PdfObject::Stream(stream))
+        }
+        _ => Ok(object.clone()),
+    }
+}
+
+fn object_from_pending(added: &[((u32, u16), PdfObject)], id: (u32, u16)) -> PdfDictionary {
+    added
+        .iter()
+        .find(|(candidate, _)| *candidate == id)
+        .and_then(|(_, object)| object.as_dict())
+        .cloned()
+        .expect("new page dictionary was just queued")
+}
+
+fn reachable_from_catalog<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+) -> Result<HashSet<(u32, u16)>, PdfError> {
+    let mut pending: Vec<_> = catalog.0.values().cloned().collect();
+    let mut reachable = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !reachable.insert(id) {
+                    continue;
+                }
+                if reachable.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "document object graph exceeds the supported object count",
+                    ));
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("walk document object graph: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(reachable)
+}
+
+fn ensure_catalog_does_not_reference_deleted_pages<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+    page_root: (u32, u16),
+    deleted: &HashSet<(u32, u16)>,
+) -> Result<(), PdfError> {
+    if deleted.is_empty() {
+        return Ok(());
+    }
+    let mut pending: Vec<_> = catalog
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Pages")
+        .map(|(_, value)| value.clone())
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if deleted.contains(&id) {
+                    return Err(invalid_lossless(format!(
+                        "cannot delete page {number} {generation} R because a catalog-level structure references it"
+                    )));
+                }
+                if id == page_root || !visited.insert(id) {
+                    continue;
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect catalog references: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn ensure_retained_pages_do_not_reference_deleted_pages<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    pages: &[LosslessPage],
+    retained: &HashSet<usize>,
+    page_root: (u32, u16),
+    deleted: &HashSet<(u32, u16)>,
+) -> Result<(), PdfError> {
+    if deleted.is_empty() {
+        return Ok(());
+    }
+    let mut pending: Vec<_> = pages
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| retained.contains(index))
+        .flat_map(|(_, page)| {
+            page.dictionary
+                .0
+                .iter()
+                .filter(|(key, _)| key.0 != "Parent")
+                .map(|(_, value)| value.clone())
+        })
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if deleted.contains(&id) {
+                    return Err(invalid_lossless(format!(
+                        "cannot delete page {number} {generation} R because a retained page structure references it"
+                    )));
+                }
+                if id == page_root || !visited.insert(id) {
+                    continue;
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect retained page references: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Reorder every page as one lossless incremental revision.

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -107,6 +107,11 @@ enum PlannedPage {
     },
 }
 
+struct ImportedDocument {
+    reader: PdfReader<Cursor<Vec<u8>>>,
+    pages: Vec<LosslessPage>,
+}
+
 /// Options for page reordering
 #[derive(Debug, Clone)]
 pub struct ReorderOptions {
@@ -255,12 +260,24 @@ pub fn reorder_pdf_pages<P: AsRef<Path>, Q: AsRef<Path>>(
 }
 
 /// Inspect an atomic page-tree mutation without writing an output file.
+///
+/// This is an exact dry run: imported object graphs and reachability are
+/// analyzed in memory, but the prospective revision is neither serialized nor
+/// reopened. It returns the same object report as [`mutate_pdf_pages_lossless`]
+/// without creating or replacing a destination file.
+///
+/// # Errors
+///
+/// Returns an error for malformed or encrypted PDFs, forbidden DocMDP edits,
+/// invalid indexes, dangling semantic references, unsupported page labels,
+/// or imports that require catalog-level AcroForm, tagged-PDF, named-
+/// destination, or optional-content remapping.
 pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
     input_path: P,
     batch: &PageMutationBatch,
 ) -> OperationResult<PageMutationReport> {
     let base = std::fs::read(input_path)?;
-    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    let (_, _, report) = mutate_pdf_bytes_lossless(&base, batch, false)?;
     Ok(report)
 }
 
@@ -268,13 +285,21 @@ pub fn plan_pdf_page_mutations<P: AsRef<Path>>(
 ///
 /// The source bytes remain an exact prefix. The completed temporary file is
 /// reopened and checked before it atomically replaces `output_path`.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as
+/// [`plan_pdf_page_mutations`], or when temporary-file creation, validation,
+/// syncing, or atomic publication fails. The destination is not replaced when
+/// validation fails.
 pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
     input_path: P,
     output_path: Q,
     batch: &PageMutationBatch,
 ) -> OperationResult<PageMutationReport> {
     let base = std::fs::read(input_path)?;
-    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch)?;
+    let (updated, expected, report) = mutate_pdf_bytes_lossless(&base, batch, true)?;
+    let updated = updated.expect("materialized page mutation must return bytes");
     validate_lossless_output(&base, &updated, &expected)?;
 
     let output_path = output_path.as_ref();
@@ -295,7 +320,8 @@ pub fn mutate_pdf_pages_lossless<P: AsRef<Path>, Q: AsRef<Path>>(
 fn mutate_pdf_bytes_lossless(
     base: &[u8],
     batch: &PageMutationBatch,
-) -> Result<(Vec<u8>, LosslessValidation, PageMutationReport), PdfError> {
+    materialize: bool,
+) -> Result<(Option<Vec<u8>>, LosslessValidation, PageMutationReport), PdfError> {
     if batch.operations.is_empty() {
         return Err(invalid_lossless("page mutation batch cannot be empty"));
     }
@@ -310,6 +336,16 @@ fn mutate_pdf_bytes_lossless(
         .catalog()
         .map_err(|error| invalid_lossless(format!("read document catalog: {error}")))?
         .clone();
+    if catalog.contains_key("PageLabels")
+        && batch
+            .operations
+            .iter()
+            .any(|operation| !matches!(operation, PageMutation::Rotate { .. }))
+    {
+        return Err(invalid_lossless(
+            "page reordering, insertion, duplication, or deletion with catalog /PageLabels is unsupported because label indexes require remapping",
+        ));
+    }
     ensure_modification_allowed(
         &mut reader,
         &catalog,
@@ -381,12 +417,28 @@ fn mutate_pdf_bytes_lossless(
     let source_reachable = reachable_from_catalog(&mut reader, &catalog)?;
 
     let root_inherited = inherited_values(&root_dictionary);
+    let root_preserved_values: Vec<_> = root_dictionary
+        .0
+        .iter()
+        .filter(|(key, _)| !matches!(key.0.as_str(), "Kids" | "Count"))
+        .map(|(_, value)| value.clone())
+        .collect();
     let mut update = IncrementalUpdate::from_base(base)?;
     let mut added_objects = Vec::new();
     let mut final_pages = Vec::with_capacity(planned.len());
     let mut validation_pages = Vec::with_capacity(planned.len());
     let mut replacements = HashSet::new();
+    let mut preserved_source_refs = HashSet::new();
     replacements.insert(root_reference);
+    let mut imported_documents = HashMap::new();
+    for source in planned.iter().filter_map(|page| match page {
+        PlannedPage::Import { source, .. } => Some(source),
+        _ => None,
+    }) {
+        if !imported_documents.contains_key(source) {
+            imported_documents.insert(source.clone(), load_imported_document(source)?);
+        }
+    }
 
     for plan in planned {
         match plan {
@@ -435,6 +487,7 @@ fn mutate_pdf_bytes_lossless(
                     false,
                     &mut update,
                     &mut added_objects,
+                    &mut preserved_source_refs,
                 )?;
                 let object = object_from_pending(&added_objects, id);
                 final_pages.push(id);
@@ -445,51 +498,24 @@ fn mutate_pdf_bytes_lossless(
                 source_index,
                 rotation,
             } => {
-                let bytes = std::fs::read(&source).map_err(|error| {
-                    invalid_lossless(format!("read imported PDF {}: {error}", source.display()))
-                })?;
-                let mut imported_reader = PdfReader::new(Cursor::new(&bytes)).map_err(|error| {
-                    invalid_lossless(format!("parse imported PDF {}: {error}", source.display()))
-                })?;
-                if imported_reader.is_encrypted() {
-                    return Err(PdfError::PermissionDenied(format!(
-                        "cannot import a page from encrypted PDF {}",
-                        source.display()
-                    )));
-                }
-                let imported_catalog = imported_reader
-                    .catalog()
-                    .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
-                    .clone();
-                let imported_root = imported_catalog
-                    .get("Pages")
-                    .and_then(PdfObject::as_reference)
-                    .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
-                let mut imported_pages = Vec::new();
-                let mut imported_visited = HashSet::new();
-                walk_page_tree(
-                    &mut imported_reader,
-                    imported_root,
-                    None,
-                    HashMap::new(),
-                    &mut imported_visited,
-                    &mut imported_pages,
-                    0,
-                )?;
-                let page = imported_pages.get(source_index).ok_or_else(|| {
+                let imported = imported_documents
+                    .get_mut(&source)
+                    .ok_or_else(|| invalid_lossless("planned import source was not loaded"))?;
+                let page = imported.pages.get(source_index).ok_or_else(|| {
                     invalid_lossless(format!(
                         "imported page index {source_index} is out of bounds for {} pages",
-                        imported_pages.len()
+                        imported.pages.len()
                     ))
                 })?;
                 let id = clone_page_into_update(
-                    &mut imported_reader,
+                    &mut imported.reader,
                     page,
                     root_reference,
                     rotation,
                     true,
                     &mut update,
                     &mut added_objects,
+                    &mut preserved_source_refs,
                 )?;
                 let object = object_from_pending(&added_objects, id);
                 final_pages.push(id);
@@ -516,15 +542,15 @@ fn mutate_pdf_bytes_lossless(
     for (id, object) in &added_objects {
         update.replace(*id, object.clone())?;
     }
-    let updated = update.finish()?;
-
-    let mut output_reader = PdfReader::new(Cursor::new(&updated))
-        .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
-    let output_catalog = output_reader
-        .catalog()
-        .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
-        .clone();
-    let output_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+    let output_reachable = prospective_source_references(
+        &mut reader,
+        &catalog,
+        root_reference,
+        &root_preserved_values,
+        &source_pages,
+        &retained,
+        &preserved_source_refs,
+    )?;
     let mut unreachable_objects: Vec<_> = source_reachable
         .difference(&output_reachable)
         .copied()
@@ -540,6 +566,29 @@ fn mutate_pdf_bytes_lossless(
         unreachable_objects,
         page_count: final_pages.len(),
     };
+    let updated = if materialize {
+        let bytes = update.finish()?;
+        let mut output_reader = PdfReader::new(Cursor::new(&bytes))
+            .map_err(|error| invalid_lossless(format!("reopen page mutation: {error}")))?;
+        let output_catalog = output_reader
+            .catalog()
+            .map_err(|error| invalid_lossless(format!("read output catalog: {error}")))?
+            .clone();
+        let actual_reachable = reachable_from_catalog(&mut output_reader, &output_catalog)?;
+        let mut actual_unreachable: Vec<_> = source_reachable
+            .difference(&actual_reachable)
+            .copied()
+            .collect();
+        actual_unreachable.sort_unstable();
+        if actual_unreachable != report.unreachable_objects {
+            return Err(invalid_lossless(
+                "dry-run reachability report differs from the materialized revision",
+            ));
+        }
+        Some(bytes)
+    } else {
+        None
+    };
     Ok((
         updated,
         LosslessValidation {
@@ -549,6 +598,40 @@ fn mutate_pdf_bytes_lossless(
         },
         report,
     ))
+}
+
+fn load_imported_document(path: &Path) -> Result<ImportedDocument, PdfError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        invalid_lossless(format!("read imported PDF {}: {error}", path.display()))
+    })?;
+    let mut reader = PdfReader::new(Cursor::new(bytes)).map_err(|error| {
+        invalid_lossless(format!("parse imported PDF {}: {error}", path.display()))
+    })?;
+    if reader.is_encrypted() {
+        return Err(PdfError::PermissionDenied(format!(
+            "cannot import a page from encrypted PDF {}",
+            path.display()
+        )));
+    }
+    let catalog = reader
+        .catalog()
+        .map_err(|error| invalid_lossless(format!("read imported catalog: {error}")))?
+        .clone();
+    let root = catalog
+        .get("Pages")
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid_lossless("imported catalog /Pages is not indirect"))?;
+    let mut pages = Vec::new();
+    walk_page_tree(
+        &mut reader,
+        root,
+        None,
+        HashMap::new(),
+        &mut HashSet::new(),
+        &mut pages,
+        0,
+    )?;
+    Ok(ImportedDocument { reader, pages })
 }
 
 fn apply_page_mutation(
@@ -704,6 +787,7 @@ fn clone_page_into_update<R: Read + Seek>(
     external: bool,
     update: &mut IncrementalUpdate<'_>,
     added: &mut Vec<((u32, u16), PdfObject)>,
+    preserved_source_refs: &mut HashSet<(u32, u16)>,
 ) -> Result<(u32, u16), PdfError> {
     ensure_page_can_be_cloned(reader, page, external)?;
     let page_id = update.allocate_id()?;
@@ -728,6 +812,7 @@ fn clone_page_into_update<R: Read + Seek>(
             update,
             added,
             &mut mapping,
+            preserved_source_refs,
             0,
         )?;
         dictionary.0.insert(key, cloned);
@@ -757,6 +842,9 @@ fn ensure_page_can_be_cloned<R: Read + Seek>(
         return Err(invalid_lossless(format!(
             "cannot {action} a tagged page without remapping its parent-tree entry"
         )));
+    }
+    if external {
+        ensure_import_graph_supported(reader, page)?;
     }
     let Some(annots) = page.dictionary.get("Annots") else {
         return Ok(());
@@ -798,6 +886,81 @@ fn ensure_page_can_be_cloned<R: Read + Seek>(
     Ok(())
 }
 
+fn ensure_import_graph_supported<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    page: &LosslessPage,
+) -> Result<(), PdfError> {
+    let mut pending: Vec<_> = page
+        .dictionary
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Parent")
+        .map(|(_, value)| value.clone())
+        .collect();
+    let mut visited = HashSet::new();
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !visited.insert(id) {
+                    continue;
+                }
+                if visited.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "imported page graph exceeds the supported object count",
+                    ));
+                }
+                pending.push(
+                    reader
+                        .get_object(number, generation)
+                        .map_err(|error| {
+                            invalid_lossless(format!("inspect imported page graph: {error}"))
+                        })?
+                        .clone(),
+                );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => {
+                reject_unsupported_import_dictionary(&dictionary)?;
+                pending.extend(dictionary.0.into_values());
+            }
+            PdfObject::Stream(stream) => {
+                reject_unsupported_import_dictionary(&stream.dict)?;
+                pending.extend(stream.dict.0.into_values());
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn reject_unsupported_import_dictionary(dictionary: &PdfDictionary) -> Result<(), PdfError> {
+    if dictionary
+        .get_type()
+        .is_some_and(|kind| matches!(kind, "OCG" | "OCMD"))
+    {
+        return Err(invalid_lossless(
+            "cannot import optional-content groups without remapping catalog /OCProperties",
+        ));
+    }
+    let named_destination = dictionary
+        .get("Dest")
+        .is_some_and(|value| matches!(value, PdfObject::Name(_) | PdfObject::String(_)))
+        || (dictionary
+            .get("S")
+            .and_then(PdfObject::as_name)
+            .is_some_and(|name| name.0 == "GoTo")
+            && dictionary
+                .get("D")
+                .is_some_and(|value| matches!(value, PdfObject::Name(_) | PdfObject::String(_))));
+    if named_destination {
+        return Err(invalid_lossless(
+            "cannot import a named destination without remapping the destination name tree",
+        ));
+    }
+    Ok(())
+}
+
 fn clone_page_object<R: Read + Seek>(
     reader: &mut PdfReader<R>,
     object: &PdfObject,
@@ -806,6 +969,7 @@ fn clone_page_object<R: Read + Seek>(
     update: &mut IncrementalUpdate<'_>,
     added: &mut Vec<((u32, u16), PdfObject)>,
     mapping: &mut HashMap<(u32, u16), (u32, u16)>,
+    preserved_source_refs: &mut HashSet<(u32, u16)>,
     depth: usize,
 ) -> Result<PdfObject, PdfError> {
     if depth > MAX_OBJECT_GRAPH_DEPTH {
@@ -827,16 +991,23 @@ fn clone_page_object<R: Read + Seek>(
                     ))
                 })?
                 .clone();
-            let structural_type = source_object
-                .as_dict()
-                .and_then(PdfDictionary::get_type)
-                .is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog"));
-            if structural_type {
+            let object_type = source_object.as_dict().and_then(PdfDictionary::get_type);
+            if object_type.is_some_and(|kind| matches!(kind, "Page" | "Pages" | "Catalog")) {
                 if external {
                     return Err(invalid_lossless(format!(
                         "imported page graph references foreign structural object {number} {generation} R"
                     )));
                 }
+                preserved_source_refs.insert(source_id);
+                return Ok(object.clone());
+            }
+            if object_type.is_some_and(|kind| matches!(kind, "OCG" | "OCMD")) {
+                if external {
+                    return Err(invalid_lossless(
+                        "cannot import optional-content groups without remapping catalog /OCProperties",
+                    ));
+                }
+                preserved_source_refs.insert(source_id);
                 return Ok(object.clone());
             }
             if mapping.len() >= MAX_CLONED_OBJECTS_PER_PAGE {
@@ -854,6 +1025,7 @@ fn clone_page_object<R: Read + Seek>(
                 update,
                 added,
                 mapping,
+                preserved_source_refs,
                 depth + 1,
             )?;
             added.push((id, cloned));
@@ -872,6 +1044,7 @@ fn clone_page_object<R: Read + Seek>(
                         update,
                         added,
                         mapping,
+                        preserved_source_refs,
                         depth + 1,
                     )
                 })
@@ -891,6 +1064,7 @@ fn clone_page_object<R: Read + Seek>(
                     update,
                     added,
                     mapping,
+                    preserved_source_refs,
                     depth + 1,
                 )?;
                 dictionary.0.insert(key, cloned);
@@ -911,6 +1085,7 @@ fn clone_page_object<R: Read + Seek>(
                     update,
                     added,
                     mapping,
+                    preserved_source_refs,
                     depth + 1,
                 )?;
                 stream.dict.0.insert(key, cloned);
@@ -956,6 +1131,89 @@ fn reachable_from_catalog<R: Read + Seek>(
                         })?
                         .clone(),
                 );
+            }
+            PdfObject::Array(array) => pending.extend(array.0),
+            PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),
+            PdfObject::Stream(stream) => pending.extend(stream.dict.0.into_values()),
+            _ => {}
+        }
+    }
+    Ok(reachable)
+}
+
+fn prospective_source_references<R: Read + Seek>(
+    reader: &mut PdfReader<R>,
+    catalog: &PdfDictionary,
+    page_root: (u32, u16),
+    root_preserved_values: &[PdfObject],
+    pages: &[LosslessPage],
+    retained: &HashSet<usize>,
+    preserved: &HashSet<(u32, u16)>,
+) -> Result<HashSet<(u32, u16)>, PdfError> {
+    let mut pending: Vec<_> = catalog
+        .0
+        .iter()
+        .filter(|(key, _)| key.0 != "Pages")
+        .map(|(_, value)| value.clone())
+        .collect();
+    pending.extend(root_preserved_values.iter().cloned());
+    pending.extend(
+        pages
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| retained.contains(index))
+            .flat_map(|(_, page)| {
+                page.dictionary
+                    .0
+                    .iter()
+                    .filter(|(key, _)| key.0 != "Parent")
+                    .map(|(_, value)| value.clone())
+            }),
+    );
+    pending.extend(preserved.iter().map(|id| PdfObject::Reference(id.0, id.1)));
+
+    let mut reachable = HashSet::from([page_root]);
+    reachable.extend(
+        pages
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| retained.contains(index))
+            .map(|(_, page)| page.reference),
+    );
+    while let Some(object) = pending.pop() {
+        match object {
+            PdfObject::Reference(number, generation) => {
+                let id = (number, generation);
+                if !reachable.insert(id) || id == page_root {
+                    continue;
+                }
+                if reachable.len() > MAX_CLONED_OBJECTS_PER_PAGE {
+                    return Err(invalid_lossless(
+                        "prospective document graph exceeds the supported object count",
+                    ));
+                }
+                let object = reader
+                    .get_object(number, generation)
+                    .map_err(|error| {
+                        invalid_lossless(format!("plan prospective object graph: {error}"))
+                    })?
+                    .clone();
+                match object {
+                    PdfObject::Dictionary(dictionary)
+                        if dictionary
+                            .get_type()
+                            .is_some_and(|kind| matches!(kind, "Pages" | "Catalog")) => {}
+                    PdfObject::Dictionary(dictionary) if dictionary.get_type() == Some("Page") => {
+                        pending.extend(
+                            dictionary
+                                .0
+                                .into_iter()
+                                .filter(|(key, _)| key.0 != "Parent")
+                                .map(|(_, value)| value),
+                        );
+                    }
+                    object => pending.push(object),
+                }
             }
             PdfObject::Array(array) => pending.extend(array.0),
             PdfObject::Dictionary(dictionary) => pending.extend(dictionary.0.into_values()),

--- a/oxidize-pdf-core/src/operations/reorder.rs
+++ b/oxidize-pdf-core/src/operations/reorder.rs
@@ -600,6 +600,27 @@ fn mutate_pdf_bytes_lossless(
     ))
 }
 
+/// Plan a mutation against an immutable caller-owned source snapshot.
+pub(crate) fn plan_pdf_page_mutations_from_bytes(
+    base: &[u8],
+    batch: &PageMutationBatch,
+) -> OperationResult<PageMutationReport> {
+    let (_, _, report) = mutate_pdf_bytes_lossless(base, batch, false)?;
+    Ok(report)
+}
+
+/// Materialize and validate a mutation without publishing a destination.
+pub(crate) fn materialize_pdf_page_mutations_from_bytes(
+    base: &[u8],
+    batch: &PageMutationBatch,
+) -> OperationResult<(Vec<u8>, PageMutationReport)> {
+    let (updated, expected, report) = mutate_pdf_bytes_lossless(base, batch, true)?;
+    let updated =
+        updated.ok_or_else(|| invalid_lossless("materialized mutation returned no bytes"))?;
+    validate_lossless_output(base, &updated, &expected)?;
+    Ok((updated, report))
+}
+
 fn load_imported_document(path: &Path) -> Result<ImportedDocument, PdfError> {
     let bytes = std::fs::read(path).map_err(|error| {
         invalid_lossless(format!("read imported PDF {}: {error}", path.display()))

--- a/oxidize-pdf-core/src/operations/semantic_preservation.rs
+++ b/oxidize-pdf-core/src/operations/semantic_preservation.rs
@@ -1,0 +1,738 @@
+//! Lossless split, extraction, and merge operations for existing PDFs.
+//!
+//! These APIs use the incremental page-tree mutation engine. The first input
+//! remains an exact byte prefix of the result, and unsupported document-level
+//! combinations are rejected during planning rather than silently discarded.
+
+use super::reorder::{
+    materialize_pdf_page_mutations_from_bytes, plan_pdf_page_mutations_from_bytes,
+};
+use super::{
+    OperationError, OperationResult, PageMutation, PageMutationBatch, PageMutationReport, PageRange,
+};
+use crate::parser::PdfReader;
+use std::collections::BTreeSet;
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+
+const MAX_SELECTION_PLANNING_WORK: usize = 10_000_000;
+
+const DOCUMENT_STRUCTURES: [(&str, DocumentStructure); 8] = [
+    ("AcroForm", DocumentStructure::Forms),
+    ("Outlines", DocumentStructure::Outlines),
+    ("Names", DocumentStructure::NamesAndAttachments),
+    ("Dests", DocumentStructure::NamedDestinations),
+    ("OCProperties", DocumentStructure::OptionalContent),
+    ("StructTreeRoot", DocumentStructure::StructureTree),
+    ("Metadata", DocumentStructure::MetadataStream),
+    ("PageLabels", DocumentStructure::PageLabels),
+];
+
+/// A catalog-level semantic structure considered by lossless operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DocumentStructure {
+    /// Interactive form field tree.
+    Forms,
+    /// Document outline/bookmark tree.
+    Outlines,
+    /// Catalog name trees, including embedded files.
+    NamesAndAttachments,
+    /// Legacy catalog destination dictionary.
+    NamedDestinations,
+    /// Optional-content configuration and groups.
+    OptionalContent,
+    /// Tagged-PDF structure tree.
+    StructureTree,
+    /// Catalog metadata stream.
+    MetadataStream,
+    /// Page-label number tree.
+    PageLabels,
+}
+
+/// Policy applied to a detected document structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructureDisposition {
+    /// Retained through the byte-preserved base catalog.
+    Preserved,
+    /// The first input wins and the secondary value is deliberately ignored.
+    FirstInputWins,
+    /// The combination cannot be represented safely and planning fails.
+    Rejected,
+}
+
+/// One detected structure and its explicit operation policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StructureSemanticReport {
+    /// Detected structure.
+    pub structure: DocumentStructure,
+    /// Policy applied by the operation.
+    pub disposition: StructureDisposition,
+}
+
+/// How an input document participates in a planned operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputSemanticRole {
+    /// The input is the byte-preserved base document.
+    PreservedBase,
+    /// The input contributes cloned page graphs.
+    ImportedPages,
+}
+
+/// Semantic inventory for one input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputSemanticReport {
+    /// Source path.
+    pub path: PathBuf,
+    /// Role in the output.
+    pub role: InputSemanticRole,
+    /// Catalog-level structures detected in the source.
+    pub structures: Vec<StructureSemanticReport>,
+    /// Selected zero-based source page indexes.
+    pub selected_pages: Vec<usize>,
+}
+
+/// Exact dry-run report returned before a lossless operation writes output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticPreservationReport {
+    /// Per-input semantic inventory and policy.
+    pub inputs: Vec<InputSemanticReport>,
+    /// Exact object-level page mutation plan.
+    pub mutation: PageMutationReport,
+}
+
+/// Input to a lossless merge.
+#[derive(Debug, Clone)]
+pub struct LosslessMergeInput {
+    /// PDF path.
+    pub path: PathBuf,
+    /// Pages to include, or all pages when omitted.
+    pub pages: Option<PageRange>,
+}
+
+impl LosslessMergeInput {
+    /// Include every page from `path`.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            pages: None,
+        }
+    }
+
+    /// Include the selected pages from `path`.
+    pub fn with_pages(path: impl Into<PathBuf>, pages: PageRange) -> Self {
+        Self {
+            path: path.into(),
+            pages: Some(pages),
+        }
+    }
+}
+
+fn inspect_input_bytes(
+    path: &Path,
+    bytes: &[u8],
+    role: InputSemanticRole,
+    range: Option<&PageRange>,
+) -> OperationResult<InputSemanticReport> {
+    let mut reader = PdfReader::new(Cursor::new(bytes)).map_err(|error| {
+        OperationError::ParseError(format!("open snapshot of {}: {error}", path.display()))
+    })?;
+    if reader.is_encrypted() {
+        return Err(OperationError::PdfError(crate::PdfError::PermissionDenied(
+            format!(
+                "lossless semantic operations do not support encrypted PDF {}",
+                path.display()
+            ),
+        )));
+    }
+    let page_count = reader.page_count().map_err(|error| {
+        OperationError::ParseError(format!("count pages in {}: {error}", path.display()))
+    })? as usize;
+    let selected_pages = range.unwrap_or(&PageRange::All).get_indices(page_count)?;
+    if selected_pages.is_empty() {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    let catalog = reader.catalog().map_err(|error| {
+        OperationError::ParseError(format!("read catalog in {}: {error}", path.display()))
+    })?;
+    let structures = DOCUMENT_STRUCTURES
+        .iter()
+        .filter_map(|(key, structure)| {
+            catalog
+                .contains_key(key)
+                .then_some(StructureSemanticReport {
+                    structure: *structure,
+                    disposition: match role {
+                        InputSemanticRole::PreservedBase => StructureDisposition::Preserved,
+                        InputSemanticRole::ImportedPages
+                            if *structure == DocumentStructure::MetadataStream =>
+                        {
+                            StructureDisposition::FirstInputWins
+                        }
+                        InputSemanticRole::ImportedPages => StructureDisposition::Rejected,
+                    },
+                })
+        })
+        .collect();
+    Ok(InputSemanticReport {
+        path: path.to_path_buf(),
+        role,
+        structures,
+        selected_pages,
+    })
+}
+
+fn reject_secondary_document_structures(report: &InputSemanticReport) -> OperationResult<()> {
+    // Metadata has a deterministic first-input-wins policy. Other catalog
+    // structures require cross-document identity/name remapping and therefore
+    // fail closed until that mapping is representable.
+    let unsupported: Vec<_> = report
+        .structures
+        .iter()
+        .filter(|entry| entry.disposition == StructureDisposition::Rejected)
+        .map(|entry| entry.structure)
+        .collect();
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+    Err(OperationError::ProcessingError(format!(
+        "cannot merge document-level structures from secondary input {}: {:?}; the operation was not written",
+        report.path.display(), unsupported
+    )))
+}
+
+fn selection_batch(page_count: usize, selected: &[usize]) -> OperationResult<PageMutationBatch> {
+    let selected_set: BTreeSet<_> = selected.iter().copied().collect();
+    let mut operations: Vec<_> = (0..page_count)
+        .rev()
+        .filter(|index| !selected_set.contains(index))
+        .map(|page| PageMutation::Delete { page })
+        .collect();
+    let mut current: Vec<_> = (0..page_count)
+        .filter(|index| selected_set.contains(index))
+        .collect();
+    let estimated_work = current.len().checked_mul(selected.len()).ok_or_else(|| {
+        OperationError::ProcessingError("page selection work overflow".to_string())
+    })?;
+    let already_ordered = current.as_slice() == selected;
+    if !already_ordered && estimated_work > MAX_SELECTION_PLANNING_WORK {
+        return Err(OperationError::ProcessingError(format!(
+            "page selection would require excessive reorder work ({estimated_work} position checks)"
+        )));
+    }
+    for (target, &source_page) in selected.iter().enumerate() {
+        if current.get(target) == Some(&source_page) {
+            continue;
+        }
+        if let Some(from) = current
+            .iter()
+            .enumerate()
+            .skip(target + 1)
+            .find_map(|(index, page)| (*page == source_page).then_some(index))
+        {
+            operations.push(PageMutation::Move { from, to: target });
+            let page = current.remove(from);
+            current.insert(target, page);
+        } else if let Some(from) = current.iter().position(|page| *page == source_page) {
+            operations.push(PageMutation::Duplicate {
+                page: from,
+                at: target,
+            });
+            current.insert(target, source_page);
+        }
+    }
+    Ok(PageMutationBatch { operations })
+}
+
+fn read_snapshot(path: &Path) -> OperationResult<Vec<u8>> {
+    std::fs::read(path).map_err(OperationError::Io)
+}
+
+fn ensure_snapshot_unchanged(path: &Path, expected: &[u8]) -> OperationResult<()> {
+    if read_snapshot(path)? != expected {
+        return Err(OperationError::ProcessingError(format!(
+            "source {} changed after planning; no output was published",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn stage_output(path: &Path, bytes: &[u8]) -> OperationResult<tempfile::NamedTempFile> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let mut temporary = tempfile::NamedTempFile::new_in(parent.unwrap_or_else(|| Path::new(".")))?;
+    temporary.write_all(bytes)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    Ok(temporary)
+}
+
+fn normalized_path(path: &Path) -> OperationResult<PathBuf> {
+    if path.exists() {
+        return path.canonicalize().map_err(OperationError::Io);
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .canonicalize()?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| OperationError::InvalidPath {
+            reason: format!("output path {} has no file name", path.display()),
+        })?;
+    Ok(parent.join(name))
+}
+
+fn plan_batch(
+    base: &[u8],
+    batch: &PageMutationBatch,
+    page_count: usize,
+) -> OperationResult<PageMutationReport> {
+    if batch.operations.is_empty() {
+        return Ok(PageMutationReport {
+            replaced_objects: Vec::new(),
+            added_objects: Vec::new(),
+            unreachable_objects: Vec::new(),
+            page_count,
+        });
+    }
+    plan_pdf_page_mutations_from_bytes(base, batch)
+}
+
+fn materialize_batch(
+    base: &[u8],
+    batch: &PageMutationBatch,
+    page_count: usize,
+) -> OperationResult<(Vec<u8>, PageMutationReport)> {
+    if batch.operations.is_empty() {
+        return Ok((base.to_vec(), plan_batch(base, batch, page_count)?));
+    }
+    materialize_pdf_page_mutations_from_bytes(base, batch)
+}
+
+/// Plan a sparse lossless extraction without writing output.
+///
+/// # Errors
+///
+/// Returns an error for invalid page indexes, encrypted or restricted inputs,
+/// and catalog/page structures that reference pages being removed.
+pub fn plan_extract_pdf_pages_lossless(
+    input: impl AsRef<Path>,
+    pages: &[usize],
+) -> OperationResult<SemanticPreservationReport> {
+    let input = input.as_ref();
+    if pages.is_empty() {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    let range = PageRange::List(pages.to_vec());
+    let base = read_snapshot(input)?;
+    let report = inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(&range))?;
+    let page_count = PdfReader::new(Cursor::new(&base))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    let batch = selection_batch(page_count, &report.selected_pages)?;
+    let mutation = plan_batch(&base, &batch, page_count)?;
+    Ok(SemanticPreservationReport {
+        inputs: vec![report],
+        mutation,
+    })
+}
+
+/// Extract pages while retaining the source bytes and complete reachable semantics.
+///
+/// Planning is repeated immediately before the atomic write. The output is
+/// reopened and its reachability is checked by the mutation engine.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as
+/// [`plan_extract_pdf_pages_lossless`], or when atomic publication fails.
+pub fn extract_pdf_pages_lossless(
+    input: impl AsRef<Path>,
+    output: impl AsRef<Path>,
+    pages: &[usize],
+) -> OperationResult<SemanticPreservationReport> {
+    let input = input.as_ref();
+    let output = output.as_ref();
+    let base = read_snapshot(input)?;
+    let range = PageRange::List(pages.to_vec());
+    let input_report =
+        inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(&range))?;
+    let actual_count = PdfReader::new(Cursor::new(&base))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    let batch = selection_batch(actual_count, &input_report.selected_pages)?;
+    let planned = plan_batch(&base, &batch, actual_count)?;
+    let (updated, written) = materialize_batch(&base, &batch, actual_count)?;
+    if written != planned {
+        return Err(OperationError::ProcessingError(
+            "dry-run report differed from materialized extraction; no output was published"
+                .to_string(),
+        ));
+    }
+    ensure_snapshot_unchanged(input, &base)?;
+    stage_output(output, &updated)?
+        .persist(output)
+        .map_err(|error| OperationError::Io(error.error))?;
+    let report = SemanticPreservationReport {
+        inputs: vec![input_report],
+        mutation: planned,
+    };
+    Ok(report)
+}
+
+/// Plan every output of a lossless split without writing files.
+///
+/// # Errors
+///
+/// Returns an error when a range is empty or cannot be represented while
+/// preserving the source's reachable document semantics.
+pub fn plan_split_pdf_lossless(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    let input = input.as_ref();
+    if ranges.is_empty() {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    let base = read_snapshot(input)?;
+    let mut reader = PdfReader::new(Cursor::new(&base))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?;
+    let page_count = reader
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    ranges
+        .iter()
+        .map(|range| {
+            let pages = range.get_indices(page_count)?;
+            let report =
+                inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(range))?;
+            let batch = selection_batch(page_count, &pages)?;
+            let mutation = plan_batch(&base, &batch, page_count)?;
+            Ok(SemanticPreservationReport {
+                inputs: vec![report],
+                mutation,
+            })
+        })
+        .collect()
+}
+
+/// Split a PDF into caller-selected outputs using lossless atomic extraction.
+///
+/// Every output is planned, materialized, and staged before the first
+/// destination is replaced. Each replacement is atomic; if a later filesystem
+/// replacement fails, previously replaced destinations are restored from
+/// snapshots.
+///
+/// # Errors
+///
+/// Returns an error when the range/output counts differ, paths alias, any dry
+/// run fails, or an output cannot be validated and transactionally published.
+pub fn split_pdf_lossless(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+    outputs: &[PathBuf],
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    if ranges.len() != outputs.len() {
+        return Err(OperationError::InvalidPath {
+            reason: format!(
+                "lossless split has {} ranges but {} output paths",
+                ranges.len(),
+                outputs.len()
+            ),
+        });
+    }
+    let input = input.as_ref();
+    let normalized_input = normalized_path(input)?;
+    let mut normalized_outputs = BTreeSet::new();
+    for output in outputs {
+        let normalized = normalized_path(output)?;
+        if normalized == normalized_input {
+            return Err(OperationError::InvalidPath {
+                reason: format!("split output {} aliases the input", output.display()),
+            });
+        }
+        if !normalized_outputs.insert(normalized) {
+            return Err(OperationError::InvalidPath {
+                reason: format!("duplicate split output path {}", output.display()),
+            });
+        }
+    }
+    let base = read_snapshot(input)?;
+    let mut reader = PdfReader::new(Cursor::new(&base))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?;
+    let page_count = reader
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    let mut reports = Vec::with_capacity(ranges.len());
+    let mut materialized = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        let pages = range.get_indices(page_count)?;
+        let input_report =
+            inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(range))?;
+        let batch = selection_batch(page_count, &pages)?;
+        let planned = plan_batch(&base, &batch, page_count)?;
+        let (bytes, written) = materialize_batch(&base, &batch, page_count)?;
+        if written != planned {
+            return Err(OperationError::ProcessingError(
+                "dry-run report differed from a materialized split output; no output was published"
+                    .to_string(),
+            ));
+        }
+        reports.push(SemanticPreservationReport {
+            inputs: vec![input_report],
+            mutation: planned,
+        });
+        materialized.push(bytes);
+    }
+    ensure_snapshot_unchanged(input, &base)?;
+    let mut staged = outputs
+        .iter()
+        .zip(&materialized)
+        .map(|(path, bytes)| stage_output(path, bytes))
+        .collect::<OperationResult<Vec<_>>>()?;
+    let backups = outputs
+        .iter()
+        .map(|path| {
+            if path.exists() {
+                std::fs::read(path).map(Some)
+            } else {
+                Ok(None)
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    for index in 0..staged.len() {
+        let temporary = staged.remove(0);
+        if let Err(error) = temporary.persist(&outputs[index]) {
+            for rollback in 0..index {
+                match &backups[rollback] {
+                    Some(bytes) => {
+                        stage_output(&outputs[rollback], bytes)?
+                            .persist(&outputs[rollback])
+                            .map_err(|persist| OperationError::Io(persist.error))?;
+                    }
+                    None => {
+                        let _ = std::fs::remove_file(&outputs[rollback]);
+                    }
+                }
+            }
+            return Err(OperationError::Io(error.error));
+        }
+    }
+    Ok(reports)
+}
+
+/// Plan a deterministic lossless merge without writing output.
+///
+/// The first input is the preserved base. Secondary inputs may contribute
+/// self-contained page graphs; catalog-level structures in secondary inputs
+/// are rejected because combining their policies would be ambiguous.
+///
+/// # Errors
+///
+/// Returns an error for fewer than one input, invalid selections, encrypted or
+/// restricted PDFs, unsupported imported page graphs, or secondary document
+/// structures that cannot be combined safely.
+pub fn plan_merge_pdfs_lossless(
+    inputs: &[LosslessMergeInput],
+) -> OperationResult<SemanticPreservationReport> {
+    let Some(first) = inputs.first() else {
+        return Err(OperationError::NoPagesToProcess);
+    };
+    let snapshots = inputs
+        .iter()
+        .map(|input| read_snapshot(&input.path))
+        .collect::<OperationResult<Vec<_>>>()?;
+    let base = inspect_input_bytes(
+        &first.path,
+        &snapshots[0],
+        InputSemanticRole::PreservedBase,
+        first.pages.as_ref(),
+    )?;
+    let base_count = PdfReader::new(Cursor::new(&snapshots[0]))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    let mut batch = selection_batch(base_count, &base.selected_pages)?;
+    let mut reports = vec![base];
+    let mut insertion_index = reports[0].selected_pages.len();
+    for (input, snapshot) in inputs.iter().skip(1).zip(snapshots.iter().skip(1)) {
+        let report = inspect_input_bytes(
+            &input.path,
+            snapshot,
+            InputSemanticRole::ImportedPages,
+            input.pages.as_ref(),
+        )?;
+        reject_secondary_document_structures(&report)?;
+        for &page in &report.selected_pages {
+            batch.operations.push(PageMutation::Insert {
+                source: input.path.clone(),
+                page,
+                at: insertion_index,
+            });
+            insertion_index += 1;
+        }
+        reports.push(report);
+    }
+    let mutation = plan_batch(&snapshots[0], &batch, base_count)?;
+    for (input, snapshot) in inputs.iter().zip(&snapshots) {
+        ensure_snapshot_unchanged(&input.path, snapshot)?;
+    }
+    Ok(SemanticPreservationReport {
+        inputs: reports,
+        mutation,
+    })
+}
+
+/// Merge PDFs losslessly and publish the validated output atomically.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as [`plan_merge_pdfs_lossless`],
+/// or when atomic publication or output validation fails.
+pub fn merge_pdfs_lossless(
+    inputs: &[LosslessMergeInput],
+    output: impl AsRef<Path>,
+) -> OperationResult<SemanticPreservationReport> {
+    let Some(first) = inputs.first() else {
+        return Err(OperationError::NoPagesToProcess);
+    };
+    let snapshots = inputs
+        .iter()
+        .map(|input| read_snapshot(&input.path))
+        .collect::<OperationResult<Vec<_>>>()?;
+    let base_report = inspect_input_bytes(
+        &first.path,
+        &snapshots[0],
+        InputSemanticRole::PreservedBase,
+        first.pages.as_ref(),
+    )?;
+    let base_count = PdfReader::new(Cursor::new(&snapshots[0]))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        .page_count()
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        as usize;
+    let mut batch = selection_batch(base_count, &base_report.selected_pages)?;
+    let mut reports = vec![base_report];
+    let mut at = reports[0].selected_pages.len();
+    for (input, snapshot) in inputs.iter().zip(&snapshots).skip(1) {
+        let input_report = inspect_input_bytes(
+            &input.path,
+            snapshot,
+            InputSemanticRole::ImportedPages,
+            input.pages.as_ref(),
+        )?;
+        reject_secondary_document_structures(&input_report)?;
+        for &page in &input_report.selected_pages {
+            batch.operations.push(PageMutation::Insert {
+                source: input.path.clone(),
+                page,
+                at,
+            });
+            at += 1;
+        }
+        reports.push(input_report);
+    }
+    let final_count = at;
+    let planned = plan_batch(&snapshots[0], &batch, final_count)?;
+    let (updated, written) = materialize_batch(&snapshots[0], &batch, final_count)?;
+    if written != planned {
+        return Err(OperationError::ProcessingError(
+            "dry-run report differed from materialized merge; no output was published".to_string(),
+        ));
+    }
+    for (input, snapshot) in inputs.iter().zip(&snapshots) {
+        ensure_snapshot_unchanged(&input.path, snapshot)?;
+    }
+    let output = output.as_ref();
+    stage_output(output, &updated)?
+        .persist(output)
+        .map_err(|error| OperationError::Io(error.error))?;
+    let report = SemanticPreservationReport {
+        inputs: reports,
+        mutation: planned,
+    };
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn semantic_fixture() -> Vec<u8> {
+        let objects = [
+            b"<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [6 0 R] >> /Outlines << /Type /Outlines /Count 0 >> /Names << /EmbeddedFiles << /Names [(attachment.txt) << /F (attachment.txt) >>] >> >> /Dests << >> /OCProperties << /OCGs [] /D << >> >> /StructTreeRoot << /Type /StructTreeRoot /K [] >> /Metadata 4 0 R /PageLabels << /Nums [] >> >>".as_slice(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".as_slice(),
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << >> /StructParents 0 /Annots [5 0 R 6 0 R] >>".as_slice(),
+            b"<< /Type /Metadata /Subtype /XML /Length 0 >>\nstream\n\nendstream".as_slice(),
+            b"<< /Type /Annot /Subtype /Link /Rect [0 0 10 10] /Dest [3 0 R /Fit] >>".as_slice(),
+            b"<< /Type /Annot /Subtype /Widget /FT /Tx /T (field) /P 3 0 R /Rect [0 0 10 10] >>".as_slice(),
+        ];
+        let mut bytes = b"%PDF-1.7\n".to_vec();
+        let mut offsets = Vec::new();
+        for (index, object) in objects.iter().enumerate() {
+            offsets.push(bytes.len());
+            bytes.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+            bytes.extend_from_slice(object);
+            bytes.extend_from_slice(b"\nendobj\n");
+        }
+        let xref = bytes.len();
+        bytes.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+        for offset in offsets {
+            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        bytes.extend_from_slice(
+            format!("trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+        );
+        bytes
+    }
+
+    #[test]
+    fn inventories_every_required_catalog_structure_with_explicit_dispositions() {
+        let bytes = semantic_fixture();
+        let path = Path::new("semantic-fixture.pdf");
+        let base =
+            inspect_input_bytes(path, &bytes, InputSemanticRole::PreservedBase, None).unwrap();
+        assert_eq!(base.structures.len(), DOCUMENT_STRUCTURES.len());
+        assert!(base
+            .structures
+            .iter()
+            .all(|entry| entry.disposition == StructureDisposition::Preserved));
+
+        let imported =
+            inspect_input_bytes(path, &bytes, InputSemanticRole::ImportedPages, None).unwrap();
+        assert_eq!(imported.structures.len(), DOCUMENT_STRUCTURES.len());
+        assert!(imported
+            .structures
+            .iter()
+            .any(|entry| entry.structure == DocumentStructure::MetadataStream
+                && entry.disposition == StructureDisposition::FirstInputWins));
+        assert_eq!(
+            imported
+                .structures
+                .iter()
+                .filter(|entry| entry.disposition == StructureDisposition::Rejected)
+                .count(),
+            DOCUMENT_STRUCTURES.len() - 1
+        );
+    }
+
+    #[test]
+    fn all_page_selection_preserves_annotations_forms_links_and_catalog_bytes_exactly() {
+        let bytes = semantic_fixture();
+        let batch = selection_batch(1, &[0]).unwrap();
+        let (output, report) = materialize_batch(&bytes, &batch, 1).unwrap();
+        assert_eq!(output, bytes);
+        assert_eq!(report.page_count, 1);
+        assert!(report.replaced_objects.is_empty());
+    }
+}

--- a/oxidize-pdf-core/src/operations/split.rs
+++ b/oxidize-pdf-core/src/operations/split.rs
@@ -2,6 +2,10 @@
 //!
 //! This module provides functionality to split PDF documents into multiple files
 //! based on page ranges or other criteria.
+//!
+//! This legacy API reconstructs a new [`crate::Document`]. Use
+//! [`super::split_pdf_lossless`] when complete reachable source semantics must
+//! be retained or rejected explicitly through a dry-run report.
 
 use super::{OperationError, OperationResult, PageRange};
 use crate::parser::page_tree::ParsedPage;

--- a/oxidize-pdf-core/src/signatures/mod.rs
+++ b/oxidize-pdf-core/src/signatures/mod.rs
@@ -31,6 +31,7 @@ mod cms;
 mod detection;
 mod error;
 mod permissions;
+mod signing;
 mod types;
 mod verification;
 
@@ -48,6 +49,10 @@ pub use cms::{
 pub use detection::detect_signature_fields;
 pub use error::{SignatureError, SignatureResult};
 pub(crate) use permissions::{ensure_modification_allowed, IncrementalModification};
+pub use signing::{
+    prepare_incremental_signature, CertificationPermission, FieldLock, PreparedSignature,
+    SignaturePreparationOptions, SignatureRect, SignatureTarget,
+};
 pub use types::{ByteRange, SignatureField};
 // FullSignatureValidationResult is defined below in this file
 pub use verification::{

--- a/oxidize-pdf-core/src/signatures/permissions.rs
+++ b/oxidize-pdf-core/src/signatures/permissions.rs
@@ -9,6 +9,7 @@ use std::io::{Read, Seek};
 #[allow(dead_code)] // Additional variants are the shared contract for upcoming editors.
 pub(crate) enum IncrementalModification {
     PageTreeReorder,
+    PageTreeMutation,
     FormFill,
     AddSignature,
     AddAnnotation,
@@ -336,6 +337,7 @@ fn enforce_permission(
     }
     let edit = match modification {
         IncrementalModification::PageTreeReorder => "page-tree reordering",
+        IncrementalModification::PageTreeMutation => "page-tree mutation",
         IncrementalModification::FormFill => "form filling",
         IncrementalModification::AddSignature => "adding signatures",
         IncrementalModification::AddAnnotation => "adding annotations",
@@ -393,6 +395,19 @@ mod tests {
         ] {
             assert!(
                 enforce_permission(IncrementalModification::PageTreeReorder, permission).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn page_tree_mutations_are_forbidden_at_every_permission_level() {
+        for permission in [
+            DocMdpPermission::NoChanges,
+            DocMdpPermission::FormFillAndSign,
+            DocMdpPermission::FormFillSignAndAnnotate,
+        ] {
+            assert!(
+                enforce_permission(IncrementalModification::PageTreeMutation, permission).is_err()
             );
         }
     }

--- a/oxidize-pdf-core/src/signatures/signing.rs
+++ b/oxidize-pdf-core/src/signatures/signing.rs
@@ -1,0 +1,973 @@
+//! Provider-neutral two-phase incremental PDF signing.
+
+use super::{
+    ensure_modification_allowed, IncrementalModification, SignatureError, SignatureResult,
+};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream, PdfString};
+use crate::parser::{PdfDocument, PdfReader};
+use crate::writer::IncrementalUpdate;
+use std::collections::HashSet;
+use std::io::Cursor;
+use std::ops::Range;
+
+const BYTE_RANGE_SENTINEL: i64 = i64::MAX;
+const BYTE_RANGE_WIDTH: usize = 19;
+const MIN_PLACEHOLDER_BYTES: usize = 256;
+const MAX_PLACEHOLDER_BYTES: usize = 16 * 1024 * 1024;
+
+/// Rectangle for a visible signature widget.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SignatureRect {
+    pub left: f64,
+    pub bottom: f64,
+    pub right: f64,
+    pub top: f64,
+}
+
+impl SignatureRect {
+    fn validate(self) -> SignatureResult<()> {
+        let values = [self.left, self.bottom, self.right, self.top];
+        if values.iter().any(|value| !value.is_finite())
+            || self.right <= self.left
+            || self.top <= self.bottom
+        {
+            return Err(invalid("signature rectangle must be finite and non-empty"));
+        }
+        Ok(())
+    }
+
+    fn object(self) -> PdfObject {
+        PdfObject::Array(PdfArray(vec![
+            PdfObject::Real(self.left),
+            PdfObject::Real(self.bottom),
+            PdfObject::Real(self.right),
+            PdfObject::Real(self.top),
+        ]))
+    }
+}
+
+/// Select an empty signature field or create a new widget.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignatureTarget {
+    Existing {
+        field_name: String,
+        /// Child widget to update. `None` selects a combined field/widget.
+        widget_index: Option<usize>,
+        /// Optional replacement rectangle and generated normal appearance.
+        rect: Option<SignatureRect>,
+    },
+    New {
+        field_name: String,
+        page_index: usize,
+        rect: Option<SignatureRect>,
+    },
+}
+
+/// Generic DocMDP permission written by a certification signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CertificationPermission {
+    NoChanges = 1,
+    FormFillAndSign = 2,
+    FormFillSignAndAnnotate = 3,
+}
+
+/// Generic FieldMDP field selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldLock {
+    All,
+    Include(Vec<String>),
+    Exclude(Vec<String>),
+}
+
+/// Input for the prepare phase. No key or signer handle is accepted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SignaturePreparationOptions {
+    pub target: SignatureTarget,
+    pub placeholder_bytes: usize,
+    /// PDF signature handler name, normally `Adobe.PPKLite`.
+    pub filter: String,
+    /// Signature container profile, for example `adbe.pkcs7.detached`.
+    pub sub_filter: String,
+    pub reason: Option<String>,
+    pub location: Option<String>,
+    pub contact_info: Option<String>,
+    pub signing_time: Option<String>,
+    pub certification: Option<CertificationPermission>,
+    pub field_lock: Option<FieldLock>,
+    /// Profile-specific signature dictionary entries.
+    ///
+    /// Structural entries owned by the signing engine cannot be overridden.
+    pub additional_signature_entries: PdfDictionary,
+}
+
+impl SignaturePreparationOptions {
+    pub fn invisible(field_name: impl Into<String>) -> Self {
+        Self {
+            target: SignatureTarget::New {
+                field_name: field_name.into(),
+                page_index: 0,
+                rect: None,
+            },
+            placeholder_bytes: 16_384,
+            filter: "Adobe.PPKLite".to_string(),
+            sub_filter: "adbe.pkcs7.detached".to_string(),
+            reason: None,
+            location: None,
+            contact_info: None,
+            signing_time: None,
+            certification: None,
+            field_lock: None,
+            additional_signature_entries: PdfDictionary::new(),
+        }
+    }
+
+    /// Select an existing signature field without changing its widget appearance.
+    pub fn existing(field_name: impl Into<String>) -> Self {
+        let mut options = Self::invisible(field_name);
+        let field_name = match options.target {
+            SignatureTarget::New { field_name, .. } => field_name,
+            SignatureTarget::Existing { .. } => unreachable!(),
+        };
+        options.target = SignatureTarget::Existing {
+            field_name,
+            widget_index: None,
+            rect: None,
+        };
+        options
+    }
+}
+
+/// Prepared PDF and exact detached-signature coverage.
+#[derive(Debug, Clone)]
+pub struct PreparedSignature {
+    pdf: Vec<u8>,
+    byte_range: super::ByteRange,
+    contents_hex: Range<usize>,
+    placeholder_bytes: usize,
+}
+
+impl PreparedSignature {
+    pub fn prepared_pdf(&self) -> &[u8] {
+        &self.pdf
+    }
+
+    pub fn byte_range(&self) -> &super::ByteRange {
+        &self.byte_range
+    }
+
+    /// Concatenate the exact bytes that an external signer must digest.
+    pub fn bytes_to_digest(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.byte_range.total_bytes() as usize);
+        for &(offset, length) in self.byte_range.ranges() {
+            let start = offset as usize;
+            bytes.extend_from_slice(&self.pdf[start..start + length as usize]);
+        }
+        bytes
+    }
+
+    /// Embed a caller-produced DER CMS container without rewriting prior bytes.
+    pub fn finalize(mut self, cms: &[u8]) -> SignatureResult<Vec<u8>> {
+        validate_cms_container(cms)?;
+        if cms.len() > self.placeholder_bytes {
+            return Err(SignatureError::ContentsExtractionFailed {
+                details: format!(
+                    "CMS container needs {} bytes but the placeholder reserves {}",
+                    cms.len(),
+                    self.placeholder_bytes
+                ),
+            });
+        }
+        let slot = &mut self.pdf[self.contents_hex.clone()];
+        slot.fill(b'0');
+        for (index, byte) in cms.iter().enumerate() {
+            let encoded = format!("{byte:02X}");
+            slot[index * 2..index * 2 + 2].copy_from_slice(encoded.as_bytes());
+        }
+        Ok(self.pdf)
+    }
+}
+
+/// Prepare an incremental revision for an external CMS signer.
+pub fn prepare_incremental_signature(
+    base: &[u8],
+    options: &SignaturePreparationOptions,
+) -> SignatureResult<PreparedSignature> {
+    validate_options(options)?;
+    let mut reader =
+        PdfReader::new(Cursor::new(base)).map_err(|error| invalid(error.to_string()))?;
+    if reader.is_encrypted() {
+        return Err(invalid(
+            "incremental signing does not support encrypted PDFs",
+        ));
+    }
+    let mut catalog = reader
+        .catalog()
+        .map_err(|error| invalid(error.to_string()))?
+        .clone();
+    ensure_modification_allowed(&mut reader, &catalog, IncrementalModification::AddSignature)?;
+    let target_field_name = match &options.target {
+        SignatureTarget::Existing { field_name, .. } | SignatureTarget::New { field_name, .. } => {
+            field_name
+        }
+    };
+    ensure_fieldmdp_allows_signature(&mut reader, target_field_name)?;
+    let mut update = IncrementalUpdate::from_base(base)?;
+    let signature_id = update.allocate_id()?;
+    let mut signature = signature_dictionary(options);
+    signature.insert(
+        "ByteRange".to_string(),
+        PdfObject::Array(PdfArray(vec![
+            PdfObject::Integer(0),
+            PdfObject::Integer(BYTE_RANGE_SENTINEL),
+            PdfObject::Integer(BYTE_RANGE_SENTINEL),
+            PdfObject::Integer(BYTE_RANGE_SENTINEL),
+        ])),
+    );
+    signature.insert(
+        "Contents".to_string(),
+        PdfObject::String(PdfString::new(vec![0xA5; options.placeholder_bytes])),
+    );
+    update.replace(signature_id, PdfObject::Dictionary(signature))?;
+
+    match &options.target {
+        SignatureTarget::Existing {
+            field_name,
+            widget_index,
+            rect,
+        } => {
+            let field = find_signature_field(&mut reader, &catalog, field_name)?;
+            let mut dictionary = reader
+                .get_object(field.0, field.1)
+                .map_err(|error| invalid(format!("resolve signature field: {error}")))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| invalid("signature field is not a dictionary"))?;
+            if dictionary.contains_key("V") {
+                return Err(invalid("selected signature field is already signed"));
+            }
+            dictionary.insert("V".to_string(), reference(signature_id));
+            update.replace(field, PdfObject::Dictionary(dictionary))?;
+            if rect.is_some() {
+                let widget = select_widget(&mut reader, field, *widget_index)?;
+                let mut widget_dictionary = reader
+                    .get_object(widget.0, widget.1)
+                    .map_err(|error| invalid(format!("resolve signature widget: {error}")))?
+                    .as_dict()
+                    .cloned()
+                    .ok_or_else(|| invalid("signature widget is not a dictionary"))?;
+                let appearance_id = update.allocate_id()?;
+                let rect = (*rect).ok_or_else(|| invalid("visible widget requires a rectangle"))?;
+                widget_dictionary.insert("Rect".to_string(), rect.object());
+                let mut appearance = PdfDictionary::new();
+                appearance.insert("N".to_string(), reference(appearance_id));
+                widget_dictionary.insert("AP".to_string(), PdfObject::Dictionary(appearance));
+                update.replace(widget, PdfObject::Dictionary(widget_dictionary))?;
+                update.replace(appearance_id, visible_appearance(rect))?;
+            } else if widget_index.is_some() {
+                select_widget(&mut reader, field, *widget_index)?;
+            }
+        }
+        SignatureTarget::New {
+            field_name,
+            page_index,
+            rect,
+        } => {
+            ensure_field_name_available(&mut reader, &catalog, field_name)?;
+            let page_reader = PdfReader::new(Cursor::new(base))
+                .map_err(|error| invalid(format!("open signature page snapshot: {error}")))?;
+            let page_document = PdfDocument::new(page_reader);
+            let page = page_document
+                .get_page(*page_index as u32)
+                .map_err(|error| invalid(format!("select signature page: {error}")))?;
+            let field_id = update.allocate_id()?;
+            let appearance_id = rect.map(|_| update.allocate_id()).transpose()?;
+            let mut field = PdfDictionary::new();
+            field.insert("Type".to_string(), name("Annot"));
+            field.insert("Subtype".to_string(), name("Widget"));
+            field.insert("FT".to_string(), name("Sig"));
+            field.insert("T".to_string(), text(field_name));
+            field.insert("F".to_string(), PdfObject::Integer(4));
+            field.insert("P".to_string(), reference(page.obj_ref));
+            field.insert("V".to_string(), reference(signature_id));
+            field.insert(
+                "Rect".to_string(),
+                rect.map(SignatureRect::object)
+                    .unwrap_or_else(|| PdfObject::Array(PdfArray(vec![PdfObject::Integer(0); 4]))),
+            );
+            if let (Some(rect), Some(appearance_id)) = (rect, appearance_id) {
+                field.insert("AP".to_string(), {
+                    let mut ap = PdfDictionary::new();
+                    ap.insert("N".to_string(), reference(appearance_id));
+                    PdfObject::Dictionary(ap)
+                });
+                update.replace(appearance_id, visible_appearance(*rect))?;
+            }
+            update.replace(field_id, PdfObject::Dictionary(field))?;
+            append_page_annotation(&mut reader, &mut update, page.obj_ref, &page.dict, field_id)?;
+            append_acroform_field(&mut reader, &mut update, &mut catalog, field_id)?;
+        }
+    }
+
+    if options.certification.is_some() {
+        if catalog.contains_key("Perms") {
+            return Err(invalid(
+                "catalog already contains certification permissions",
+            ));
+        }
+        let mut perms = PdfDictionary::new();
+        perms.insert("DocMDP".to_string(), reference(signature_id));
+        catalog.insert("Perms".to_string(), PdfObject::Dictionary(perms));
+    }
+    let root = reader
+        .trailer()
+        .root()
+        .map_err(|error| invalid(error.to_string()))?;
+    update.replace(root, PdfObject::Dictionary(catalog))?;
+    let prepared = update.finish()?;
+    locate_and_patch_placeholders(prepared, base.len(), options.placeholder_bytes)
+}
+
+fn validate_options(options: &SignaturePreparationOptions) -> SignatureResult<()> {
+    if !(MIN_PLACEHOLDER_BYTES..=MAX_PLACEHOLDER_BYTES).contains(&options.placeholder_bytes) {
+        return Err(invalid(format!(
+            "placeholder_bytes must be between {MIN_PLACEHOLDER_BYTES} and {MAX_PLACEHOLDER_BYTES}"
+        )));
+    }
+    let name = match &options.target {
+        SignatureTarget::Existing { field_name, .. } | SignatureTarget::New { field_name, .. } => {
+            field_name
+        }
+    };
+    if name.is_empty() || name.as_bytes().contains(&0) {
+        return Err(invalid("signature field name is empty or contains NUL"));
+    }
+    validate_pdf_name(&options.filter, "filter")?;
+    validate_pdf_name(&options.sub_filter, "sub_filter")?;
+    const RESERVED: [&str; 7] = [
+        "Type",
+        "Filter",
+        "SubFilter",
+        "ByteRange",
+        "Contents",
+        "Reference",
+        "M",
+    ];
+    if let Some(key) = RESERVED
+        .iter()
+        .find(|key| options.additional_signature_entries.contains_key(**key))
+    {
+        return Err(invalid(format!(
+            "additional signature entry {key:?} is owned by the signing engine"
+        )));
+    }
+    let rect = match options.target {
+        SignatureTarget::Existing { rect, .. } | SignatureTarget::New { rect, .. } => rect,
+    };
+    if let Some(rect) = rect {
+        rect.validate()?;
+    }
+    Ok(())
+}
+
+fn signature_dictionary(options: &SignaturePreparationOptions) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("Type".to_string(), name("Sig"));
+    dictionary.insert("Filter".to_string(), name(&options.filter));
+    dictionary.insert("SubFilter".to_string(), name(&options.sub_filter));
+    dictionary
+        .0
+        .extend(options.additional_signature_entries.0.clone());
+    for (key, value) in [
+        ("Reason", &options.reason),
+        ("Location", &options.location),
+        ("ContactInfo", &options.contact_info),
+        ("M", &options.signing_time),
+    ] {
+        if let Some(value) = value {
+            dictionary.insert(key.to_string(), text(value));
+        }
+    }
+    let mut transforms = Vec::new();
+    if let Some(permission) = options.certification {
+        let mut params = PdfDictionary::new();
+        params.insert("Type".to_string(), name("TransformParams"));
+        params.insert("P".to_string(), PdfObject::Integer(permission as i64));
+        params.insert("V".to_string(), name("1.2"));
+        transforms.push(transform("DocMDP", params));
+    }
+    if let Some(lock) = &options.field_lock {
+        let mut params = PdfDictionary::new();
+        params.insert("Type".to_string(), name("TransformParams"));
+        params.insert("V".to_string(), name("1.2"));
+        match lock {
+            FieldLock::All => {
+                params.insert("Action".to_string(), name("All"));
+            }
+            FieldLock::Include(fields) | FieldLock::Exclude(fields) => {
+                params.insert(
+                    "Action".to_string(),
+                    name(if matches!(lock, FieldLock::Include(_)) {
+                        "Include"
+                    } else {
+                        "Exclude"
+                    }),
+                );
+                params.insert(
+                    "Fields".to_string(),
+                    PdfObject::Array(PdfArray(fields.iter().map(|field| text(field)).collect())),
+                );
+            }
+        }
+        transforms.push(transform("FieldMDP", params));
+    }
+    if !transforms.is_empty() {
+        dictionary.insert(
+            "Reference".to_string(),
+            PdfObject::Array(PdfArray(transforms)),
+        );
+    }
+    dictionary
+}
+
+fn transform(method: &str, params: PdfDictionary) -> PdfObject {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("Type".to_string(), name("SigRef"));
+    dictionary.insert("TransformMethod".to_string(), name(method));
+    dictionary.insert("TransformParams".to_string(), PdfObject::Dictionary(params));
+    PdfObject::Dictionary(dictionary)
+}
+
+fn append_page_annotation(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    update: &mut IncrementalUpdate<'_>,
+    page_id: (u32, u16),
+    original: &PdfDictionary,
+    field_id: (u32, u16),
+) -> SignatureResult<()> {
+    let mut page = original.clone();
+    let mut annotations = match page.get("Annots") {
+        None => Vec::new(),
+        Some(PdfObject::Array(array)) => array.0.clone(),
+        Some(PdfObject::Reference(n, g)) => reader
+            .get_object(*n, *g)
+            .map_err(|error| invalid(error.to_string()))?
+            .as_array()
+            .ok_or_else(|| invalid("page /Annots reference is not an array"))?
+            .0
+            .clone(),
+        _ => return Err(invalid("page /Annots is not an array")),
+    };
+    annotations.push(reference(field_id));
+    page.insert(
+        "Annots".to_string(),
+        PdfObject::Array(PdfArray(annotations)),
+    );
+    update.replace(page_id, PdfObject::Dictionary(page))?;
+    Ok(())
+}
+
+fn append_acroform_field(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    update: &mut IncrementalUpdate<'_>,
+    catalog: &mut PdfDictionary,
+    field_id: (u32, u16),
+) -> SignatureResult<()> {
+    let mut form = match catalog.get("AcroForm") {
+        None => PdfDictionary::new(),
+        Some(PdfObject::Dictionary(dictionary)) => dictionary.clone(),
+        Some(PdfObject::Reference(n, g)) => {
+            let id = (*n, *g);
+            let mut dictionary = reader
+                .get_object(*n, *g)
+                .map_err(|error| invalid(error.to_string()))?
+                .as_dict()
+                .cloned()
+                .ok_or_else(|| invalid("/AcroForm reference is not a dictionary"))?;
+            append_field_array(reader, &mut dictionary, field_id)?;
+            update.replace(id, PdfObject::Dictionary(dictionary))?;
+            return Ok(());
+        }
+        _ => return Err(invalid("catalog /AcroForm is not a dictionary")),
+    };
+    append_field_array(reader, &mut form, field_id)?;
+    form.insert("SigFlags".to_string(), PdfObject::Integer(3));
+    catalog.insert("AcroForm".to_string(), PdfObject::Dictionary(form));
+    Ok(())
+}
+
+fn append_field_array(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    form: &mut PdfDictionary,
+    field_id: (u32, u16),
+) -> SignatureResult<()> {
+    let mut fields = match form.get("Fields") {
+        None => Vec::new(),
+        Some(PdfObject::Array(array)) => array.0.clone(),
+        Some(PdfObject::Reference(n, g)) => reader
+            .get_object(*n, *g)
+            .map_err(|error| invalid(error.to_string()))?
+            .as_array()
+            .ok_or_else(|| invalid("/AcroForm /Fields reference is not an array"))?
+            .0
+            .clone(),
+        _ => return Err(invalid("/AcroForm /Fields is not an array")),
+    };
+    fields.push(reference(field_id));
+    form.insert("Fields".to_string(), PdfObject::Array(PdfArray(fields)));
+    form.insert("SigFlags".to_string(), PdfObject::Integer(3));
+    Ok(())
+}
+
+fn root_field_references(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    catalog: &PdfDictionary,
+) -> SignatureResult<Vec<(u32, u16)>> {
+    let Some(form) = catalog.get("AcroForm") else {
+        return Ok(Vec::new());
+    };
+    let form = match form {
+        PdfObject::Dictionary(d) => d.clone(),
+        PdfObject::Reference(n, g) => reader
+            .get_object(*n, *g)
+            .map_err(|e| invalid(e.to_string()))?
+            .as_dict()
+            .cloned()
+            .ok_or_else(|| invalid("/AcroForm is not a dictionary"))?,
+        _ => return Err(invalid("/AcroForm is not a dictionary")),
+    };
+    let Some(fields) = form.get("Fields") else {
+        return Ok(Vec::new());
+    };
+    Ok(resolve_array(reader, fields, "/AcroForm /Fields")?
+        .iter()
+        .map(|field| {
+            field
+                .as_reference()
+                .ok_or_else(|| invalid("/AcroForm /Fields entries must be indirect references"))
+        })
+        .collect::<SignatureResult<Vec<_>>>()?)
+}
+
+fn ensure_field_name_available(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    catalog: &PdfDictionary,
+    name: &str,
+) -> SignatureResult<()> {
+    if find_named_field(reader, catalog, name)?.is_some() {
+        return Err(invalid(format!("field name {name:?} already exists")));
+    }
+    Ok(())
+}
+
+fn find_signature_field(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    catalog: &PdfDictionary,
+    name: &str,
+) -> SignatureResult<(u32, u16)> {
+    let field = find_named_field(reader, catalog, name)?
+        .ok_or_else(|| invalid(format!("signature field {name:?} was not found")))?;
+    if field.field_type.as_deref() != Some("Sig") {
+        return Err(invalid("selected field is not a signature field"));
+    }
+    Ok(field.id)
+}
+
+fn select_widget(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    field: (u32, u16),
+    widget_index: Option<usize>,
+) -> SignatureResult<(u32, u16)> {
+    let dictionary = reader
+        .get_object(field.0, field.1)
+        .map_err(|error| invalid(format!("resolve signature field widgets: {error}")))?
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| invalid("signature field is not a dictionary"))?;
+    let Some(index) = widget_index else {
+        if dictionary
+            .get("Subtype")
+            .and_then(PdfObject::as_name)
+            .is_some_and(|subtype| subtype.0 == "Widget")
+        {
+            return Ok(field);
+        }
+        return Err(invalid(
+            "existing field is not a combined widget; specify widget_index",
+        ));
+    };
+    let kids = dictionary
+        .get("Kids")
+        .ok_or_else(|| invalid("existing field has no child widgets"))?;
+    let kids = resolve_array(reader, kids, "signature field /Kids")?;
+    let widget = kids
+        .get(index)
+        .and_then(PdfObject::as_reference)
+        .ok_or_else(|| invalid(format!("signature widget index {index} is out of bounds")))?;
+    let widget_dictionary = reader
+        .get_object(widget.0, widget.1)
+        .map_err(|error| invalid(format!("resolve signature widget: {error}")))?
+        .as_dict()
+        .ok_or_else(|| invalid("signature widget is not a dictionary"))?;
+    if widget_dictionary
+        .get("Subtype")
+        .and_then(PdfObject::as_name)
+        .is_none_or(|subtype| subtype.0 != "Widget")
+    {
+        return Err(invalid("selected child is not a widget annotation"));
+    }
+    Ok(widget)
+}
+
+#[derive(Clone, Debug)]
+struct NamedField {
+    id: (u32, u16),
+    field_type: Option<String>,
+}
+
+fn find_named_field(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    catalog: &PdfDictionary,
+    wanted: &str,
+) -> SignatureResult<Option<NamedField>> {
+    let mut stack: Vec<_> = root_field_references(reader, catalog)?
+        .into_iter()
+        .map(|id| (id, String::new(), None::<String>))
+        .collect();
+    let mut visited = HashSet::new();
+    let mut found = None;
+    while let Some((id, parent_name, inherited_type)) = stack.pop() {
+        if !visited.insert(id) || visited.len() > 100_000 {
+            continue;
+        }
+        let dictionary = reader
+            .get_object(id.0, id.1)
+            .map_err(|e| invalid(e.to_string()))?
+            .as_dict()
+            .cloned()
+            .ok_or_else(|| invalid("field tree node is not a dictionary"))?;
+        let partial_name = dictionary
+            .get("T")
+            .and_then(PdfObject::as_string)
+            .map(|value| value.to_text());
+        let qualified_name = match (parent_name.as_str(), partial_name.as_deref()) {
+            ("", Some(partial)) => partial.to_string(),
+            (_, Some(partial)) => format!("{parent_name}.{partial}"),
+            (_, None) => parent_name.clone(),
+        };
+        let field_type = dictionary
+            .get("FT")
+            .and_then(PdfObject::as_name)
+            .map(|value| value.0.clone())
+            .or(inherited_type);
+        if partial_name.is_some() && qualified_name == wanted {
+            if found
+                .replace(NamedField {
+                    id,
+                    field_type: field_type.clone(),
+                })
+                .is_some()
+            {
+                return Err(invalid(format!("field identity {wanted:?} is ambiguous")));
+            }
+        }
+        if let Some(kids) = dictionary.get("Kids") {
+            for kid in resolve_array(reader, kids, "field /Kids")? {
+                let kid = kid
+                    .as_reference()
+                    .ok_or_else(|| invalid("field /Kids entries must be indirect references"))?;
+                stack.push((kid, qualified_name.clone(), field_type.clone()));
+            }
+        }
+    }
+    Ok(found)
+}
+
+fn ensure_fieldmdp_allows_signature(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    target: &str,
+) -> SignatureResult<()> {
+    for id in reader.object_references() {
+        let object = reader
+            .get_object(id.0, id.1)
+            .map_err(|error| invalid(format!("inspect FieldMDP signature: {error}")))?
+            .clone();
+        let Some(signature) = object.as_dict() else {
+            continue;
+        };
+        if signature.get_type() != Some("Sig")
+            || !signature.contains_key("ByteRange")
+            || !signature.contains_key("Contents")
+        {
+            continue;
+        }
+        ensure_signature_definition_is_covered(reader, id, signature)?;
+        let Some(references) = signature.get("Reference") else {
+            continue;
+        };
+        for transform in resolve_array(reader, references, "signature /Reference")? {
+            let transform = resolve_dictionary(reader, &transform, "FieldMDP transform")?;
+            if transform
+                .get("TransformMethod")
+                .and_then(PdfObject::as_name)
+                .is_none_or(|method| method.0 != "FieldMDP")
+            {
+                continue;
+            }
+            let params = transform
+                .get("TransformParams")
+                .ok_or_else(|| invalid("FieldMDP transform has no /TransformParams"))?;
+            let params = resolve_dictionary(reader, params, "FieldMDP /TransformParams")?;
+            let action = params
+                .get("Action")
+                .and_then(PdfObject::as_name)
+                .ok_or_else(|| invalid("FieldMDP /TransformParams requires /Action"))?;
+            let fields = match params.get("Fields") {
+                None => Vec::new(),
+                Some(value) => resolve_array(reader, value, "FieldMDP /Fields")?
+                    .into_iter()
+                    .map(|field| {
+                        field
+                            .as_string()
+                            .map(|value| value.to_text())
+                            .ok_or_else(|| invalid("FieldMDP /Fields must contain strings"))
+                    })
+                    .collect::<SignatureResult<Vec<_>>>()?,
+            };
+            let locked = match action.0.as_str() {
+                "All" if fields.is_empty() => true,
+                "Include" => fields.iter().any(|field| field == target),
+                "Exclude" => !fields.iter().any(|field| field == target),
+                "All" => return Err(invalid("FieldMDP /All must not specify /Fields")),
+                other => return Err(invalid(format!("unsupported FieldMDP action /{other}"))),
+            };
+            if locked {
+                return Err(invalid(format!(
+                    "FieldMDP locks signature field {target:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_signature_definition_is_covered(
+    reader: &PdfReader<Cursor<&[u8]>>,
+    id: (u32, u16),
+    signature: &PdfDictionary,
+) -> SignatureResult<()> {
+    let values = signature
+        .get("ByteRange")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid("FieldMDP signature requires an array /ByteRange"))?
+        .0
+        .iter()
+        .map(|value| {
+            value
+                .as_integer()
+                .ok_or_else(|| invalid("FieldMDP /ByteRange must contain integers"))
+        })
+        .collect::<SignatureResult<Vec<_>>>()?;
+    let byte_range = super::ByteRange::from_array(&values)
+        .map_err(|error| invalid(format!("invalid FieldMDP /ByteRange: {error}")))?;
+    byte_range
+        .validate()
+        .map_err(|error| invalid(format!("invalid FieldMDP /ByteRange: {error}")))?;
+    let offset = reader
+        .object_storage_offset(id.0)
+        .ok_or_else(|| invalid("cannot locate FieldMDP signature definition"))?;
+    if !byte_range.ranges().iter().any(|(start, length)| {
+        start
+            .checked_add(*length)
+            .is_some_and(|end| offset >= *start && offset < end)
+    }) {
+        return Err(invalid(
+            "latest FieldMDP signature definition is outside its signed byte ranges",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_dictionary(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    value: &PdfObject,
+    role: &str,
+) -> SignatureResult<PdfDictionary> {
+    let value = resolve_object(reader, value, role)?;
+    value
+        .as_dict()
+        .cloned()
+        .ok_or_else(|| invalid(format!("{role} is not a dictionary")))
+}
+
+fn resolve_array(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    value: &PdfObject,
+    role: &str,
+) -> SignatureResult<Vec<PdfObject>> {
+    let value = resolve_object(reader, value, role)?;
+    value
+        .as_array()
+        .map(|array| array.0.clone())
+        .ok_or_else(|| invalid(format!("{role} is not an array")))
+}
+
+fn resolve_object(
+    reader: &mut PdfReader<Cursor<&[u8]>>,
+    value: &PdfObject,
+    role: &str,
+) -> SignatureResult<PdfObject> {
+    match value {
+        PdfObject::Reference(number, generation) => reader
+            .get_object(*number, *generation)
+            .cloned()
+            .map_err(|error| invalid(format!("resolve {role}: {error}"))),
+        value => Ok(value.clone()),
+    }
+}
+
+fn visible_appearance(rect: SignatureRect) -> PdfObject {
+    let width = rect.right - rect.left;
+    let height = rect.top - rect.bottom;
+    let data = format!("q 0 0 {width} {height} re S Q\n").into_bytes();
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("Type".to_string(), name("XObject"));
+    dictionary.insert("Subtype".to_string(), name("Form"));
+    dictionary.insert(
+        "BBox".to_string(),
+        PdfObject::Array(PdfArray(vec![
+            PdfObject::Integer(0),
+            PdfObject::Integer(0),
+            PdfObject::Real(width),
+            PdfObject::Real(height),
+        ])),
+    );
+    dictionary.insert(
+        "Resources".to_string(),
+        PdfObject::Dictionary(PdfDictionary::new()),
+    );
+    PdfObject::Stream(PdfStream {
+        dict: dictionary,
+        data,
+    })
+}
+
+fn locate_and_patch_placeholders(
+    mut pdf: Vec<u8>,
+    base_len: usize,
+    placeholder_bytes: usize,
+) -> SignatureResult<PreparedSignature> {
+    let marker = format!("<{}>", "A5".repeat(placeholder_bytes));
+    let appended = pdf
+        .get(base_len..)
+        .ok_or_else(|| invalid("incremental revision is shorter than its source"))?;
+    let contents_start =
+        base_len + find_unique(appended, marker.as_bytes(), "/Contents placeholder")?;
+    let contents_end = contents_start + marker.len();
+    let ranges = [
+        0u64,
+        contents_start as u64,
+        contents_end as u64,
+        (pdf.len() - contents_end) as u64,
+    ];
+    let sentinel = BYTE_RANGE_SENTINEL.to_string();
+    let locations: Vec<_> = find_all(&pdf[base_len..], sentinel.as_bytes())
+        .into_iter()
+        .map(|location| base_len + location)
+        .collect();
+    if locations.len() != 3 {
+        return Err(invalid(
+            "could not locate the three ByteRange placeholders uniquely",
+        ));
+    }
+    for (location, value) in locations.into_iter().zip(ranges[1..].iter()) {
+        let encoded = format!("{value:0BYTE_RANGE_WIDTH$}");
+        if encoded.len() != BYTE_RANGE_WIDTH {
+            return Err(invalid("PDF offsets exceed the reserved ByteRange width"));
+        }
+        pdf[location..location + BYTE_RANGE_WIDTH].copy_from_slice(encoded.as_bytes());
+    }
+    Ok(PreparedSignature {
+        pdf,
+        byte_range: super::ByteRange::new(vec![(0, ranges[1]), (ranges[2], ranges[3])]),
+        contents_hex: contents_start + 1..contents_end - 1,
+        placeholder_bytes,
+    })
+}
+
+fn validate_cms_container(cms: &[u8]) -> SignatureResult<()> {
+    if cms.len() < 2 || cms[0] != 0x30 {
+        return Err(SignatureError::CmsParsingFailed {
+            details: "CMS must be a non-empty DER SEQUENCE".to_string(),
+        });
+    }
+    let (header, content_len) = if cms[1] & 0x80 == 0 {
+        (2, cms[1] as usize)
+    } else {
+        let count = (cms[1] & 0x7f) as usize;
+        if count == 0 || count > 8 || cms.len() < 2 + count {
+            return Err(SignatureError::CmsParsingFailed {
+                details: "invalid DER length".to_string(),
+            });
+        }
+        let mut length = 0usize;
+        for byte in &cms[2..2 + count] {
+            length = length
+                .checked_mul(256)
+                .and_then(|v| v.checked_add(*byte as usize))
+                .ok_or_else(|| SignatureError::CmsParsingFailed {
+                    details: "DER length overflow".to_string(),
+                })?;
+        }
+        (2 + count, length)
+    };
+    if header.checked_add(content_len) != Some(cms.len()) {
+        return Err(SignatureError::CmsParsingFailed {
+            details: "DER sequence length does not match CMS size".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn find_unique(haystack: &[u8], needle: &[u8], role: &str) -> SignatureResult<usize> {
+    let matches = find_all(haystack, needle);
+    if matches.len() != 1 {
+        return Err(invalid(format!("{role} occurs {} times", matches.len())));
+    }
+    Ok(matches[0])
+}
+fn find_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    haystack
+        .windows(needle.len())
+        .enumerate()
+        .filter_map(|(index, value)| (value == needle).then_some(index))
+        .collect()
+}
+fn reference(id: (u32, u16)) -> PdfObject {
+    PdfObject::Reference(id.0, id.1)
+}
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName::new(value.to_string()))
+}
+fn text(value: &str) -> PdfObject {
+    PdfObject::String(PdfString::new(value.as_bytes().to_vec()))
+}
+fn invalid(details: impl Into<String>) -> SignatureError {
+    SignatureError::InvalidSignatureDict {
+        details: details.into(),
+    }
+}
+
+fn validate_pdf_name(value: &str, role: &str) -> SignatureResult<()> {
+    if value.is_empty()
+        || value.bytes().any(|byte| {
+            byte.is_ascii_whitespace()
+                || matches!(
+                    byte,
+                    b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%' | b'#'
+                )
+        })
+    {
+        return Err(invalid(format!("{role} is not a safe PDF name")));
+    }
+    Ok(())
+}

--- a/oxidize-pdf-core/src/writer/incremental_annotations.rs
+++ b/oxidize-pdf-core/src/writer/incremental_annotations.rs
@@ -33,6 +33,14 @@ pub(super) struct AnnotationSnapshot {
 
 impl AnnotationSnapshot {
     pub(super) fn parse(bytes: &[u8], target_subtype: &str, feature: &str) -> Result<Self> {
+        Self::parse_subtypes(bytes, &[target_subtype], feature)
+    }
+
+    pub(super) fn parse_subtypes(
+        bytes: &[u8],
+        target_subtypes: &[&str],
+        feature: &str,
+    ) -> Result<Self> {
         let reader = PdfReader::new(Cursor::new(bytes))
             .map_err(|e| PdfError::InvalidStructure(format!("parse base PDF: {e}")))?;
         if reader.is_encrypted() {
@@ -115,8 +123,10 @@ impl AnnotationSnapshot {
                         );
                     }
                     PdfObject::Dictionary(dictionary)
-                        if subtype(dictionary) == Some(target_subtype) =>
+                        if subtype(dictionary)
+                            .is_some_and(|value| target_subtypes.contains(&value)) =>
                     {
+                        let target_subtype = subtype(dictionary).unwrap_or("unknown");
                         return Err(PdfError::InvalidStructure(format!(
                             "inline /{target_subtype} annotations have no stable object identity"
                         )));

--- a/oxidize-pdf-core/src/writer/incremental_free_text.rs
+++ b/oxidize-pdf-core/src/writer/incremental_free_text.rs
@@ -3,8 +3,12 @@
 use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot, PageState};
 use super::incremental_update::IncrementalUpdate;
 use crate::error::{PdfError, Result};
-use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream, PdfString};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use crate::text::{escape_pdf_string_literal, TextEncoding};
 use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
 
 /// Stable indirect-object identity of a free-text annotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -161,6 +165,7 @@ impl<'a> IncrementalFreeTextEditor<'a> {
             });
         }
         validate_batch(&snapshot, mutations)?;
+        validate_policy(self.base_bytes)?;
 
         let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
         let mut changed_pages = HashSet::new();
@@ -176,8 +181,17 @@ impl<'a> IncrementalFreeTextEditor<'a> {
                     alignment,
                 } => {
                     let id = update.allocate_id()?;
-                    let dictionary =
-                        new_dictionary(*rect, contents, default_appearance, *alignment);
+                    let appearance_id = update.allocate_id()?;
+                    let appearance =
+                        build_appearance(*rect, contents, default_appearance, *alignment)?;
+                    update.replace(appearance_id, PdfObject::Stream(appearance))?;
+                    let dictionary = new_dictionary(
+                        *rect,
+                        contents,
+                        default_appearance,
+                        *alignment,
+                        appearance_id,
+                    );
                     update.replace(id, PdfObject::Dictionary(dictionary.clone()))?;
                     snapshot.pages[*page_index as usize]
                         .annotations
@@ -201,15 +215,29 @@ impl<'a> IncrementalFreeTextEditor<'a> {
                 } => {
                     let state = target(&snapshot, *id)?;
                     let mut dictionary = state.dictionary.clone();
+                    let appearance_id = update.allocate_id()?;
+                    let appearance =
+                        build_appearance(*rect, contents, default_appearance, *alignment)?;
+                    update.replace(appearance_id, PdfObject::Stream(appearance))?;
                     set_properties(
                         &mut dictionary,
                         *rect,
                         contents,
                         default_appearance,
                         *alignment,
+                        appearance_id,
                     );
                     rewritten.insert(*id, dictionary.clone());
-                    snapshot.annotations.get_mut(id).unwrap().dictionary = dictionary;
+                    snapshot
+                        .annotations
+                        .get_mut(id)
+                        .ok_or_else(|| {
+                            PdfError::InvalidStructure(format!(
+                                "annotation {} {} disappeared during batch application",
+                                id.object_number, id.generation_number
+                            ))
+                        })?
+                        .dictionary = dictionary;
                 }
                 FreeTextMutation::Remove { id } => {
                     let page_index = target(&snapshot, *id)?.page_index;
@@ -422,12 +450,7 @@ fn validate_contents(contents: &str) -> Result<()> {
 }
 
 fn validate_default_appearance(value: &str) -> Result<()> {
-    if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
-        return Err(PdfError::InvalidStructure(
-            "free-text default appearance must be non-empty ASCII and contain no NUL".to_string(),
-        ));
-    }
-    Ok(())
+    AppearanceSpec::parse(value).map(|_| ())
 }
 
 fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
@@ -473,11 +496,215 @@ fn required_text(dictionary: &PdfDictionary, key: &str) -> Result<String> {
         })
 }
 
+struct AppearanceSpec {
+    resource_name: String,
+    base_font: &'static str,
+    font_size: f64,
+}
+
+impl AppearanceSpec {
+    fn parse(value: &str) -> Result<Self> {
+        if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance must be non-empty ASCII and contain no NUL"
+                    .to_string(),
+            ));
+        }
+        let tokens: Vec<_> = value.split_whitespace().collect();
+        let font_at = tokens
+            .windows(3)
+            .position(|window| window[0].starts_with('/') && window[2] == "Tf")
+            .ok_or_else(|| {
+                PdfError::InvalidStructure(
+                    "free-text default appearance must contain '/Font size Tf'".to_string(),
+                )
+            })?;
+        let resource_name = &tokens[font_at][1..];
+        let base_font = base_font(resource_name).ok_or_else(|| {
+            PdfError::InvalidStructure(format!(
+                "free-text default appearance font /{resource_name} is not a supported non-symbolic base-14 font"
+            ))
+        })?;
+        let font_size = parse_finite(tokens[font_at + 1], "font size")?;
+        if font_size <= 0.0 {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance font size must be positive".to_string(),
+            ));
+        }
+
+        let remaining: Vec<_> = tokens
+            .iter()
+            .enumerate()
+            .filter_map(|(index, token)| {
+                (!(font_at..font_at + 3).contains(&index)).then_some(*token)
+            })
+            .collect();
+        validate_color_tokens(&remaining)?;
+        Ok(Self {
+            resource_name: resource_name.to_string(),
+            base_font,
+            font_size,
+        })
+    }
+}
+
+fn parse_finite(token: &str, description: &str) -> Result<f64> {
+    let value = token.parse::<f64>().map_err(|_| {
+        PdfError::InvalidStructure(format!(
+            "free-text default appearance {description} is not numeric"
+        ))
+    })?;
+    if !value.is_finite() {
+        return Err(PdfError::InvalidStructure(format!(
+            "free-text default appearance {description} must be finite"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_color_tokens(tokens: &[&str]) -> Result<()> {
+    let component_count = match tokens.last().copied() {
+        None => return Ok(()),
+        Some("g") if tokens.len() == 2 => 1,
+        Some("rg") if tokens.len() == 4 => 3,
+        Some("k") if tokens.len() == 5 => 4,
+        _ => {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance may contain only one base-14 font and an optional g, rg, or k color"
+                    .to_string(),
+            ))
+        }
+    };
+    for token in &tokens[..component_count] {
+        let component = parse_finite(token, "color component")?;
+        if !(0.0..=1.0).contains(&component) {
+            return Err(PdfError::InvalidStructure(
+                "free-text default appearance color components must be in the range 0..=1"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn base_font(resource_name: &str) -> Option<&'static str> {
+    match resource_name {
+        "Helv" | "Helvetica" => Some("Helvetica"),
+        "Helvetica-Bold" => Some("Helvetica-Bold"),
+        "Helvetica-Oblique" => Some("Helvetica-Oblique"),
+        "Helvetica-BoldOblique" => Some("Helvetica-BoldOblique"),
+        "Times-Roman" => Some("Times-Roman"),
+        "Times-Bold" => Some("Times-Bold"),
+        "Times-Italic" => Some("Times-Italic"),
+        "Times-BoldItalic" => Some("Times-BoldItalic"),
+        "Courier" => Some("Courier"),
+        "Courier-Bold" => Some("Courier-Bold"),
+        "Courier-Oblique" => Some("Courier-Oblique"),
+        "Courier-BoldOblique" => Some("Courier-BoldOblique"),
+        _ => None,
+    }
+}
+
+fn build_appearance(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) -> Result<PdfStream> {
+    let spec = AppearanceSpec::parse(default_appearance)?;
+    let width = rect[2] - rect[0];
+    let height = rect[3] - rect[1];
+    let padding = 2.0;
+    let line_height = spec.font_size * 1.2;
+    let mut content = format!(
+        "q\n0 0 {} {} re W n\nBT\n",
+        pdf_number(width),
+        pdf_number(height)
+    );
+    content.push_str(default_appearance);
+    content.push('\n');
+    for (line_index, line) in contents.lines().enumerate() {
+        let encoded = TextEncoding::WinAnsiEncoding.encode(line);
+        let estimated_width = encoded.len() as f64 * spec.font_size * 0.5;
+        let x = match alignment {
+            FreeTextAlignment::Left => padding,
+            FreeTextAlignment::Center => ((width - estimated_width) / 2.0).max(padding),
+            FreeTextAlignment::Right => (width - estimated_width - padding).max(padding),
+        };
+        let y = height - padding - spec.font_size - line_index as f64 * line_height;
+        if y < 0.0 {
+            break;
+        }
+        content.push_str(&format!(
+            "1 0 0 1 {} {} Tm\n({}) Tj\n",
+            pdf_number(x),
+            pdf_number(y),
+            escape_pdf_string_literal(&encoded)
+        ));
+    }
+    content.push_str("ET\nQ");
+
+    let mut font = PdfDictionary::new();
+    font.insert("Type".to_string(), name("Font"));
+    font.insert("Subtype".to_string(), name("Type1"));
+    font.insert("BaseFont".to_string(), name(spec.base_font));
+    font.insert("Encoding".to_string(), name("WinAnsiEncoding"));
+    let mut fonts = PdfDictionary::new();
+    fonts.insert(spec.resource_name, PdfObject::Dictionary(font));
+    let mut resources = PdfDictionary::new();
+    resources.insert("Font".to_string(), PdfObject::Dictionary(fonts));
+
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert("Type".to_string(), name("XObject"));
+    dictionary.insert("Subtype".to_string(), name("Form"));
+    dictionary.insert("FormType".to_string(), PdfObject::Integer(1));
+    dictionary.insert("BBox".to_string(), rectangle([0.0, 0.0, width, height]));
+    dictionary.insert("Resources".to_string(), PdfObject::Dictionary(resources));
+    Ok(PdfStream {
+        dict: dictionary,
+        data: content.into_bytes(),
+    })
+}
+
+fn pdf_number(value: f64) -> String {
+    let mut formatted = format!("{value:.6}");
+    while formatted.contains('.') && formatted.ends_with('0') {
+        formatted.pop();
+    }
+    if formatted.ends_with('.') {
+        formatted.pop();
+    }
+    if formatted == "-0" {
+        "0".to_string()
+    } else {
+        formatted
+    }
+}
+
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName(value.to_string()))
+}
+
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut reader = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| PdfError::InvalidStructure(format!("parse base PDF: {error}")))?;
+    let catalog = reader
+        .catalog()
+        .map_err(|error| PdfError::InvalidStructure(format!("read catalog: {error}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::AddAnnotation,
+    )
+}
+
 fn new_dictionary(
     rect: [f64; 4],
     contents: &str,
     default_appearance: &str,
     alignment: FreeTextAlignment,
+    appearance_id: (u32, u16),
 ) -> PdfDictionary {
     let mut dictionary = PdfDictionary::new();
     dictionary.insert(
@@ -494,6 +721,7 @@ fn new_dictionary(
         contents,
         default_appearance,
         alignment,
+        appearance_id,
     );
     dictionary
 }
@@ -504,6 +732,7 @@ fn set_properties(
     contents: &str,
     default_appearance: &str,
     alignment: FreeTextAlignment,
+    appearance_id: (u32, u16),
 ) {
     dictionary.insert("Rect".to_string(), rectangle(rect));
     dictionary.insert("Contents".to_string(), unicode_text(contents));
@@ -512,6 +741,12 @@ fn set_properties(
         PdfObject::String(PdfString(default_appearance.as_bytes().to_vec())),
     );
     dictionary.insert("Q".to_string(), PdfObject::Integer(alignment.pdf_value()));
+    let mut appearance = PdfDictionary::new();
+    appearance.insert(
+        "N".to_string(),
+        PdfObject::Reference(appearance_id.0, appearance_id.1),
+    );
+    dictionary.insert("AP".to_string(), PdfObject::Dictionary(appearance));
 }
 
 fn rectangle(rect: [f64; 4]) -> PdfObject {

--- a/oxidize-pdf-core/src/writer/incremental_free_text.rs
+++ b/oxidize-pdf-core/src/writer/incremental_free_text.rs
@@ -1,0 +1,553 @@
+//! Incremental editing of standard `/FreeText` annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot, PageState};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfString};
+use std::collections::{HashMap, HashSet};
+
+/// Stable indirect-object identity of a free-text annotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FreeTextId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl FreeTextId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// Horizontal alignment stored in a free-text annotation's `/Q` entry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FreeTextAlignment {
+    /// Left justified (`/Q 0`).
+    #[default]
+    Left,
+    /// Centered (`/Q 1`).
+    Center,
+    /// Right justified (`/Q 2`).
+    Right,
+}
+
+impl FreeTextAlignment {
+    fn from_pdf(value: i64) -> Result<Self> {
+        match value {
+            0 => Ok(Self::Left),
+            1 => Ok(Self::Center),
+            2 => Ok(Self::Right),
+            _ => Err(PdfError::InvalidStructure(format!(
+                "/FreeText annotation /Q must be 0, 1, or 2, found {value}"
+            ))),
+        }
+    }
+
+    const fn pdf_value(self) -> i64 {
+        match self {
+            Self::Left => 0,
+            Self::Center => 1,
+            Self::Right => 2,
+        }
+    }
+}
+
+/// A standard PDF free-text annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FreeText {
+    /// Stable indirect-object identity.
+    pub id: FreeTextId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Annotation rectangle `[left, bottom, right, top]`.
+    pub rect: [f64; 4],
+    /// Annotation contents decoded as Unicode.
+    pub contents: String,
+    /// Default appearance string (`/DA`).
+    pub default_appearance: String,
+    /// Horizontal text alignment.
+    pub alignment: FreeTextAlignment,
+}
+
+/// A requested change to the document's free-text annotations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FreeTextMutation {
+    /// Add a free-text annotation to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Annotation rectangle `[left, bottom, right, top]`.
+        rect: [f64; 4],
+        /// Non-empty annotation contents.
+        contents: String,
+        /// Non-empty ASCII PDF default appearance string, for example `/Helv 12 Tf 0 g`.
+        default_appearance: String,
+        /// Horizontal text alignment.
+        alignment: FreeTextAlignment,
+    },
+    /// Update an existing annotation while preserving all unrelated keys.
+    Update {
+        /// Existing free-text annotation identity.
+        id: FreeTextId,
+        /// New annotation rectangle `[left, bottom, right, top]`.
+        rect: [f64; 4],
+        /// New non-empty annotation contents.
+        contents: String,
+        /// New non-empty ASCII PDF default appearance string.
+        default_appearance: String,
+        /// New horizontal text alignment.
+        alignment: FreeTextAlignment,
+    },
+    /// Remove an existing annotation reference from its page.
+    Remove {
+        /// Existing free-text annotation identity.
+        id: FreeTextId,
+    },
+}
+
+/// Result of one atomic incremental free-text update.
+#[derive(Debug, Clone)]
+pub struct FreeTextUpdate {
+    /// Complete PDF bytes. The original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Complete current free-text set after the update.
+    pub annotations: Vec<FreeText>,
+}
+
+/// Reads and atomically edits standard free-text annotations in an existing PDF.
+pub struct IncrementalFreeTextEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalFreeTextEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/FreeText` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PDF is malformed or encrypted, or when a
+    /// free-text annotation has no stable identity or invalid properties.
+    pub fn annotations(&self) -> Result<Vec<FreeText>> {
+        Snapshot::parse(self.base_bytes)?.annotations()
+    }
+
+    /// Validate and apply a batch as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed or encrypted PDFs, invalid pages or
+    /// identities, conflicting mutations, invalid annotation properties, or
+    /// exhausted indirect-object numbers.
+    pub fn apply(&self, mutations: &[FreeTextMutation]) -> Result<FreeTextUpdate> {
+        let mut snapshot = Snapshot::parse(self.base_bytes)?;
+        if mutations.is_empty() {
+            return Ok(FreeTextUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                annotations: snapshot.annotations()?,
+            });
+        }
+        validate_batch(&snapshot, mutations)?;
+
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+        let mut rewritten = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                FreeTextMutation::Add {
+                    page_index,
+                    rect,
+                    contents,
+                    default_appearance,
+                    alignment,
+                } => {
+                    let id = update.allocate_id()?;
+                    let dictionary =
+                        new_dictionary(*rect, contents, default_appearance, *alignment);
+                    update.replace(id, PdfObject::Dictionary(dictionary.clone()))?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    snapshot.annotations.insert(
+                        FreeTextId::new(id.0, id.1),
+                        AnnotationState {
+                            page_index: *page_index,
+                            dictionary,
+                            is_free_text: true,
+                        },
+                    );
+                    changed_pages.insert(*page_index);
+                }
+                FreeTextMutation::Update {
+                    id,
+                    rect,
+                    contents,
+                    default_appearance,
+                    alignment,
+                } => {
+                    let state = target(&snapshot, *id)?;
+                    let mut dictionary = state.dictionary.clone();
+                    set_properties(
+                        &mut dictionary,
+                        *rect,
+                        contents,
+                        default_appearance,
+                        *alignment,
+                    );
+                    rewritten.insert(*id, dictionary.clone());
+                    snapshot.annotations.get_mut(id).unwrap().dictionary = dictionary;
+                }
+                FreeTextMutation::Remove { id } => {
+                    let page_index = target(&snapshot, *id)?.page_index;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    snapshot.annotations.remove(id);
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+
+        for (id, dictionary) in rewritten {
+            update.replace(id.tuple(), PdfObject::Dictionary(dictionary))?;
+        }
+        rewrite_pages(&mut update, &mut snapshot.pages, &changed_pages)?;
+        let annotations = snapshot.annotations()?;
+        Ok(FreeTextUpdate {
+            pdf_bytes: update.finish()?,
+            annotations,
+        })
+    }
+}
+
+struct AnnotationState {
+    page_index: u32,
+    dictionary: PdfDictionary,
+    is_free_text: bool,
+}
+
+struct Snapshot {
+    pages: Vec<PageState>,
+    annotations: HashMap<FreeTextId, AnnotationState>,
+}
+
+impl Snapshot {
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        let shared = AnnotationSnapshot::parse(bytes, "FreeText", "free-text annotation")?;
+        let annotations = shared
+            .annotations
+            .into_iter()
+            .map(|((number, generation), state)| {
+                (
+                    FreeTextId::new(number, generation),
+                    AnnotationState {
+                        page_index: state.page_index,
+                        is_free_text: subtype(&state.dictionary) == Some("FreeText"),
+                        dictionary: state.dictionary,
+                    },
+                )
+            })
+            .collect();
+        let snapshot = Self {
+            pages: shared.pages,
+            annotations,
+        };
+        snapshot.annotations()?;
+        Ok(snapshot)
+    }
+
+    fn annotations(&self) -> Result<Vec<FreeText>> {
+        let mut result = Vec::new();
+        for (id, state) in &self.annotations {
+            if state.is_free_text {
+                result.push(parse_annotation(
+                    *id,
+                    state,
+                    self.pages[state.page_index as usize].bounds,
+                )?);
+            }
+        }
+        result.sort_by_key(|annotation| {
+            (
+                annotation.page_index,
+                annotation.id.object_number,
+                annotation.id.generation_number,
+            )
+        });
+        Ok(result)
+    }
+}
+
+fn parse_annotation(
+    id: FreeTextId,
+    state: &AnnotationState,
+    page_bounds: [f64; 4],
+) -> Result<FreeText> {
+    let rect = parse_rectangle(&state.dictionary)?;
+    validate_rectangle(rect, page_bounds)?;
+    let contents = required_text(&state.dictionary, "Contents")?;
+    let default_appearance = required_text(&state.dictionary, "DA")?;
+    validate_contents(&contents)?;
+    validate_default_appearance(&default_appearance)?;
+    let alignment = match state.dictionary.get("Q") {
+        None => Ok(FreeTextAlignment::Left),
+        Some(PdfObject::Integer(value)) => FreeTextAlignment::from_pdf(*value),
+        Some(_) => Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Q must be an integer".to_string(),
+        )),
+    }?;
+    Ok(FreeText {
+        id,
+        page_index: state.page_index,
+        rect,
+        contents,
+        default_appearance,
+        alignment,
+    })
+}
+
+fn validate_batch(snapshot: &Snapshot, mutations: &[FreeTextMutation]) -> Result<()> {
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            FreeTextMutation::Add {
+                page_index,
+                rect,
+                contents,
+                default_appearance,
+                ..
+            } => {
+                let page = snapshot.pages.get(*page_index as usize).ok_or_else(|| {
+                    PdfError::InvalidStructure(format!("page {page_index} does not exist"))
+                })?;
+                validate_properties(*rect, contents, default_appearance, page.bounds)?;
+            }
+            FreeTextMutation::Update {
+                id,
+                rect,
+                contents,
+                default_appearance,
+                ..
+            } => {
+                ensure_unique_target(&mut targeted, *id)?;
+                let state = target(snapshot, *id)?;
+                validate_properties(
+                    *rect,
+                    contents,
+                    default_appearance,
+                    snapshot.pages[state.page_index as usize].bounds,
+                )?;
+            }
+            FreeTextMutation::Remove { id } => {
+                ensure_unique_target(&mut targeted, *id)?;
+                target(snapshot, *id)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_unique_target(targeted: &mut HashSet<FreeTextId>, id: FreeTextId) -> Result<()> {
+    if !targeted.insert(id) {
+        return Err(PdfError::InvalidStructure(format!(
+            "free-text annotation {} {} is targeted more than once",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(())
+}
+
+fn target(snapshot: &Snapshot, id: FreeTextId) -> Result<&AnnotationState> {
+    let state = snapshot.annotations.get(&id).ok_or_else(|| {
+        PdfError::InvalidStructure(format!(
+            "annotation {} {} does not exist",
+            id.object_number, id.generation_number
+        ))
+    })?;
+    if !state.is_free_text {
+        return Err(PdfError::InvalidStructure(format!(
+            "annotation {} {} is not a /FreeText annotation",
+            id.object_number, id.generation_number
+        )));
+    }
+    Ok(state)
+}
+
+fn validate_properties(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    bounds: [f64; 4],
+) -> Result<()> {
+    validate_rectangle(rect, bounds)?;
+    validate_contents(contents)?;
+    validate_default_appearance(default_appearance)
+}
+
+fn validate_rectangle(rect: [f64; 4], bounds: [f64; 4]) -> Result<()> {
+    if rect.iter().any(|value| !value.is_finite()) || rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(PdfError::InvalidStructure(
+            "free-text rectangle must contain finite, ordered coordinates".to_string(),
+        ));
+    }
+    if rect[0] < bounds[0] || rect[1] < bounds[1] || rect[2] > bounds[2] || rect[3] > bounds[3] {
+        return Err(PdfError::InvalidStructure(
+            "free-text rectangle is outside the page bounds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_contents(contents: &str) -> Result<()> {
+    if contents.trim().is_empty() {
+        return Err(PdfError::InvalidStructure(
+            "free-text contents must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_default_appearance(value: &str) -> Result<()> {
+    if value.trim().is_empty() || !value.is_ascii() || value.contains('\0') {
+        return Err(PdfError::InvalidStructure(
+            "free-text default appearance must be non-empty ASCII and contain no NUL".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_rectangle(dictionary: &PdfDictionary) -> Result<[f64; 4]> {
+    let array = dictionary
+        .get("Rect")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| {
+            PdfError::InvalidStructure("/FreeText annotation has no /Rect".to_string())
+        })?;
+    if array.0.len() != 4 {
+        return Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Rect must have four numbers".to_string(),
+        ));
+    }
+    let mut rect = [0.0; 4];
+    for (index, value) in array.0.iter().enumerate() {
+        rect[index] = match value {
+            PdfObject::Integer(value) => *value as f64,
+            PdfObject::Real(value) if value.is_finite() => *value,
+            _ => {
+                return Err(PdfError::InvalidStructure(
+                    "/FreeText annotation /Rect contains a non-finite or non-numeric value"
+                        .to_string(),
+                ))
+            }
+        };
+    }
+    if rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(PdfError::InvalidStructure(
+            "/FreeText annotation /Rect coordinates are not ordered".to_string(),
+        ));
+    }
+    Ok(rect)
+}
+
+fn required_text(dictionary: &PdfDictionary, key: &str) -> Result<String> {
+    dictionary
+        .get(key)
+        .and_then(PdfObject::as_string)
+        .map(PdfString::to_text)
+        .ok_or_else(|| {
+            PdfError::InvalidStructure(format!("/FreeText annotation /{key} must be a string"))
+        })
+}
+
+fn new_dictionary(
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) -> PdfDictionary {
+    let mut dictionary = PdfDictionary::new();
+    dictionary.insert(
+        "Type".to_string(),
+        PdfObject::Name(PdfName("Annot".to_string())),
+    );
+    dictionary.insert(
+        "Subtype".to_string(),
+        PdfObject::Name(PdfName("FreeText".to_string())),
+    );
+    set_properties(
+        &mut dictionary,
+        rect,
+        contents,
+        default_appearance,
+        alignment,
+    );
+    dictionary
+}
+
+fn set_properties(
+    dictionary: &mut PdfDictionary,
+    rect: [f64; 4],
+    contents: &str,
+    default_appearance: &str,
+    alignment: FreeTextAlignment,
+) {
+    dictionary.insert("Rect".to_string(), rectangle(rect));
+    dictionary.insert("Contents".to_string(), unicode_text(contents));
+    dictionary.insert(
+        "DA".to_string(),
+        PdfObject::String(PdfString(default_appearance.as_bytes().to_vec())),
+    );
+    dictionary.insert("Q".to_string(), PdfObject::Integer(alignment.pdf_value()));
+}
+
+fn rectangle(rect: [f64; 4]) -> PdfObject {
+    PdfObject::Array(PdfArray(rect.into_iter().map(PdfObject::Real).collect()))
+}
+
+fn unicode_text(contents: &str) -> PdfObject {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in contents.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    PdfObject::String(PdfString(bytes))
+}
+
+fn rewrite_pages(
+    update: &mut IncrementalUpdate,
+    pages: &mut [PageState],
+    changed_pages: &HashSet<u32>,
+) -> Result<()> {
+    for page_index in changed_pages {
+        let page = &mut pages[*page_index as usize];
+        match page.container {
+            AnnotationContainer::Page => {
+                page.dictionary.insert(
+                    "Annots".to_string(),
+                    PdfObject::Array(PdfArray(page.annotations.clone())),
+                );
+                update.replace(
+                    page.reference,
+                    PdfObject::Dictionary(page.dictionary.clone()),
+                )?;
+            }
+            AnnotationContainer::Indirect(id) => {
+                update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/oxidize-pdf-core/src/writer/incremental_geometric.rs
+++ b/oxidize-pdf-core/src/writer/incremental_geometric.rs
@@ -1,0 +1,1313 @@
+//! Incremental editing of standard geometric annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+
+const MAX_VERTICES: usize = 100_000;
+const MAX_APPEARANCE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Stable indirect-object identity of a geometric annotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GeometricId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl GeometricId {
+    /// Construct an identity from an indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+/// Device color used by geometric annotations.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GeometricColor {
+    /// DeviceGray.
+    Gray([f64; 1]),
+    /// DeviceRGB.
+    Rgb([f64; 3]),
+    /// DeviceCMYK.
+    Cmyk([f64; 4]),
+}
+
+impl GeometricColor {
+    /// Construct a DeviceGray color.
+    pub fn gray(value: f64) -> Result<Self> {
+        validate_unit(&[value], "gray color")?;
+        Ok(Self::Gray([value]))
+    }
+    /// Construct a DeviceRGB color.
+    pub fn rgb(values: [f64; 3]) -> Result<Self> {
+        validate_unit(&values, "RGB color")?;
+        Ok(Self::Rgb(values))
+    }
+    /// Construct a DeviceCMYK color.
+    pub fn cmyk(values: [f64; 4]) -> Result<Self> {
+        validate_unit(&values, "CMYK color")?;
+        Ok(Self::Cmyk(values))
+    }
+    fn values(self) -> Vec<f64> {
+        match self {
+            Self::Gray(v) => v.to_vec(),
+            Self::Rgb(v) => v.to_vec(),
+            Self::Cmyk(v) => v.to_vec(),
+        }
+    }
+    fn stroke_operator(self) -> String {
+        color_operator(self, true)
+    }
+    fn fill_operator(self) -> String {
+        color_operator(self, false)
+    }
+}
+
+/// Validated positive line width in user-space units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeometricWidth(f64);
+impl GeometricWidth {
+    /// Construct a positive finite width.
+    pub fn new(value: f64) -> Result<Self> {
+        if !value.is_finite() || value <= 0.0 {
+            Err(invalid("geometric width must be finite and positive"))
+        } else {
+            Ok(Self(value))
+        }
+    }
+    /// Return the width.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Validated constant opacity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeometricOpacity(f64);
+impl GeometricOpacity {
+    /// Construct an opacity in `0..=1`.
+    pub fn new(value: f64) -> Result<Self> {
+        validate_unit(&[value], "geometric opacity")?;
+        Ok(Self(value))
+    }
+    /// Return the opacity.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Validated PDF dash pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometricDashPattern(Vec<f64>);
+impl GeometricDashPattern {
+    /// Construct a non-empty finite pattern containing non-negative lengths and at least one positive length.
+    pub fn new(values: Vec<f64>) -> Result<Self> {
+        if values.is_empty()
+            || values.len() > 256
+            || values.iter().any(|v| !v.is_finite() || *v < 0.0)
+            || values.iter().all(|v| *v == 0.0)
+        {
+            return Err(invalid(
+                "dash pattern must be non-empty, finite, non-negative, bounded, and not all zero",
+            ));
+        }
+        Ok(Self(values))
+    }
+    /// Return dash lengths.
+    pub fn values(&self) -> &[f64] {
+        &self.0
+    }
+}
+
+/// Standard PDF line-ending style.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LineEnding {
+    /// No decoration.
+    #[default]
+    None,
+    /// Square.
+    Square,
+    /// Circle.
+    Circle,
+    /// Diamond.
+    Diamond,
+    /// Open arrow.
+    OpenArrow,
+    /// Closed arrow.
+    ClosedArrow,
+    /// Butt.
+    Butt,
+    /// Reverse open arrow.
+    ROpenArrow,
+    /// Reverse closed arrow.
+    RClosedArrow,
+    /// Slash.
+    Slash,
+}
+impl LineEnding {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "None" => Ok(Self::None),
+            "Square" => Ok(Self::Square),
+            "Circle" => Ok(Self::Circle),
+            "Diamond" => Ok(Self::Diamond),
+            "OpenArrow" => Ok(Self::OpenArrow),
+            "ClosedArrow" => Ok(Self::ClosedArrow),
+            "Butt" => Ok(Self::Butt),
+            "ROpenArrow" => Ok(Self::ROpenArrow),
+            "RClosedArrow" => Ok(Self::RClosedArrow),
+            "Slash" => Ok(Self::Slash),
+            _ => Err(invalid("unsupported geometric line ending")),
+        }
+    }
+    fn name(self) -> &'static str {
+        match self {
+            Self::None => "None",
+            Self::Square => "Square",
+            Self::Circle => "Circle",
+            Self::Diamond => "Diamond",
+            Self::OpenArrow => "OpenArrow",
+            Self::ClosedArrow => "ClosedArrow",
+            Self::Butt => "Butt",
+            Self::ROpenArrow => "ROpenArrow",
+            Self::RClosedArrow => "RClosedArrow",
+            Self::Slash => "Slash",
+        }
+    }
+}
+
+/// Typed geometry for a standard geometric annotation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GeometricGeometry {
+    /// `/Line` geometry.
+    Line {
+        start: Point,
+        end: Point,
+        start_ending: LineEnding,
+        end_ending: LineEnding,
+    },
+    /// `/Square` bounds.
+    Square { rect: [f64; 4] },
+    /// `/Circle` bounds.
+    Circle { rect: [f64; 4] },
+    /// Closed `/Polygon` vertices.
+    Polygon { vertices: Vec<Point> },
+    /// Open `/PolyLine` vertices and endings.
+    PolyLine {
+        vertices: Vec<Point>,
+        start_ending: LineEnding,
+        end_ending: LineEnding,
+    },
+}
+
+/// Shared stroke and fill style.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometricStyle {
+    /// Stroke color.
+    pub stroke_color: GeometricColor,
+    /// Optional fill or line-ending interior color.
+    pub fill_color: Option<GeometricColor>,
+    /// Stroke width.
+    pub width: GeometricWidth,
+    /// Optional dash pattern.
+    pub dash_pattern: Option<GeometricDashPattern>,
+    /// Optional constant opacity.
+    pub opacity: Option<GeometricOpacity>,
+}
+
+/// A geometric annotation read from a PDF.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometricAnnotation {
+    /// Stable identity.
+    pub id: GeometricId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Annotation geometry.
+    pub geometry: GeometricGeometry,
+    /// Annotation style.
+    pub style: GeometricStyle,
+}
+
+/// Atomic geometric annotation mutation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GeometricMutation {
+    /// Add an annotation.
+    Add {
+        page_index: u32,
+        geometry: GeometricGeometry,
+        style: GeometricStyle,
+    },
+    /// Update an annotation, preserving unrelated dictionary keys.
+    Update {
+        id: GeometricId,
+        geometry: GeometricGeometry,
+        style: GeometricStyle,
+    },
+    /// Remove an annotation reference.
+    Remove { id: GeometricId },
+}
+
+/// Result of an atomic incremental update.
+#[derive(Debug, Clone)]
+pub struct GeometricUpdate {
+    /// Complete PDF bytes; the input is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Current geometric annotations.
+    pub annotations: Vec<GeometricAnnotation>,
+}
+
+/// Reads and atomically edits standard geometric annotations.
+pub struct IncrementalGeometricEditor<'a> {
+    base_bytes: &'a [u8],
+}
+impl<'a> IncrementalGeometricEditor<'a> {
+    /// Create an editor over PDF bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+    /// Read all indirect Line, Square, Circle, Polygon, and PolyLine annotations.
+    pub fn annotations(&self) -> Result<Vec<GeometricAnnotation>> {
+        read_annotations(&parse_snapshot(self.base_bytes)?)
+    }
+    /// Validate and apply a batch as one incremental revision.
+    pub fn apply(&self, mutations: &[GeometricMutation]) -> Result<GeometricUpdate> {
+        let mut snapshot = parse_snapshot(self.base_bytes)?;
+        let existing = read_annotations(&snapshot)?;
+        if mutations.is_empty() {
+            return Ok(GeometricUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                annotations: existing,
+            });
+        }
+        let pages = validate_batch(&snapshot, &existing, mutations)?;
+        validate_policy(self.base_bytes)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+        let mut rewritten = HashMap::new();
+        for mutation in mutations {
+            match mutation {
+                GeometricMutation::Add {
+                    page_index,
+                    geometry,
+                    style,
+                } => {
+                    let id = update.allocate_id()?;
+                    let appearance_id = update.allocate_id()?;
+                    let rect = geometry_bounds(geometry, style.width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(geometry, style, rect)?),
+                    )?;
+                    update.replace(
+                        id,
+                        PdfObject::Dictionary(new_dictionary(geometry, style, rect, appearance_id)),
+                    )?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    changed_pages.insert(*page_index);
+                }
+                GeometricMutation::Update {
+                    id,
+                    geometry,
+                    style,
+                } => {
+                    let state = snapshot
+                        .annotations
+                        .get(&id.tuple())
+                        .ok_or_else(|| missing(*id))?;
+                    if !is_geometric(subtype(&state.dictionary)) {
+                        return Err(missing(*id));
+                    }
+                    let mut dictionary = state.dictionary.clone();
+                    let appearance_id = update.allocate_id()?;
+                    let rect = geometry_bounds(geometry, style.width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(geometry, style, rect)?),
+                    )?;
+                    set_properties(&mut dictionary, geometry, style, rect, appearance_id);
+                    rewritten.insert(id.tuple(), dictionary);
+                }
+                GeometricMutation::Remove { id } => {
+                    let page_index = *pages.get(id).ok_or_else(|| missing(*id))?;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|v| v.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+        for (id, dictionary) in rewritten {
+            update.replace(id, PdfObject::Dictionary(dictionary))?;
+        }
+        rewrite_pages(&mut update, &mut snapshot, &changed_pages)?;
+        let pdf_bytes = update.finish()?;
+        let annotations = IncrementalGeometricEditor::new(&pdf_bytes).annotations()?;
+        Ok(GeometricUpdate {
+            pdf_bytes,
+            annotations,
+        })
+    }
+}
+
+fn parse_snapshot(bytes: &[u8]) -> Result<AnnotationSnapshot> {
+    AnnotationSnapshot::parse_subtypes(
+        bytes,
+        &["Line", "Square", "Circle", "Polygon", "PolyLine"],
+        "geometric annotation",
+    )
+}
+
+fn is_geometric(value: Option<&str>) -> bool {
+    matches!(
+        value,
+        Some("Line" | "Square" | "Circle" | "Polygon" | "PolyLine")
+    )
+}
+
+fn read_annotations(snapshot: &AnnotationSnapshot) -> Result<Vec<GeometricAnnotation>> {
+    let mut result = Vec::new();
+    for (&(number, generation), state) in &snapshot.annotations {
+        if is_geometric(subtype(&state.dictionary)) {
+            result.push(parse_annotation(
+                GeometricId::new(number, generation),
+                state.page_index,
+                &state.dictionary,
+                snapshot.pages[state.page_index as usize].bounds,
+            )?);
+        }
+    }
+    result.sort_by_key(|item| {
+        (
+            item.page_index,
+            item.id.object_number,
+            item.id.generation_number,
+        )
+    });
+    Ok(result)
+}
+
+fn parse_annotation(
+    id: GeometricId,
+    page_index: u32,
+    dict: &PdfDictionary,
+    page: [f64; 4],
+) -> Result<GeometricAnnotation> {
+    let subtype = subtype(dict).ok_or_else(|| invalid("geometric annotation has no subtype"))?;
+    let declared_rect = parse_rect(dict)?;
+    let geometry = match subtype {
+        "Line" => {
+            let v = numeric_array(dict, "L", Some(4))?;
+            let (a, b) = parse_endings(dict)?;
+            GeometricGeometry::Line {
+                start: Point::new(v[0], v[1]),
+                end: Point::new(v[2], v[3]),
+                start_ending: a,
+                end_ending: b,
+            }
+        }
+        "Square" => GeometricGeometry::Square {
+            rect: parse_rect(dict)?,
+        },
+        "Circle" => GeometricGeometry::Circle {
+            rect: parse_rect(dict)?,
+        },
+        "Polygon" => GeometricGeometry::Polygon {
+            vertices: parse_vertices(dict, 3)?,
+        },
+        "PolyLine" => {
+            let (a, b) = parse_endings(dict)?;
+            GeometricGeometry::PolyLine {
+                vertices: parse_vertices(dict, 2)?,
+                start_ending: a,
+                end_ending: b,
+            }
+        }
+        _ => return Err(invalid("unsupported geometric subtype")),
+    };
+    let style = parse_style(dict)?;
+    validate_geometry(&geometry, &style, page)?;
+    let required_rect = geometry_bounds(&geometry, style.width);
+    if !rect_contains(declared_rect, required_rect) {
+        return Err(invalid(
+            "geometric /Rect does not contain its geometry and decorations",
+        ));
+    }
+    Ok(GeometricAnnotation {
+        id,
+        page_index,
+        geometry,
+        style,
+    })
+}
+
+fn parse_style(dict: &PdfDictionary) -> Result<GeometricStyle> {
+    let stroke_color = parse_color(dict, "C")?.unwrap_or(GeometricColor::Gray([0.0]));
+    let fill_color = parse_color(dict, "IC")?;
+    let (width, dash_pattern) = match dict.get("BS") {
+        None => parse_legacy_border(dict)?,
+        Some(PdfObject::Dictionary(bs)) => {
+            let width = match bs.get("W") {
+                None => 1.0,
+                Some(v) => number(v).ok_or_else(|| invalid("geometric /BS /W must be numeric"))?,
+            };
+            let dash = bs
+                .get("D")
+                .map(|_| numeric_array(bs, "D", None).and_then(GeometricDashPattern::new))
+                .transpose()?;
+            (GeometricWidth::new(width)?, dash)
+        }
+        Some(_) => return Err(invalid("geometric /BS must be a dictionary")),
+    };
+    let opacity = dict
+        .get("CA")
+        .map(|v| {
+            number(v)
+                .ok_or_else(|| invalid("geometric /CA must be numeric"))
+                .and_then(GeometricOpacity::new)
+        })
+        .transpose()?;
+    Ok(GeometricStyle {
+        stroke_color,
+        fill_color,
+        width,
+        dash_pattern,
+        opacity,
+    })
+}
+
+fn parse_legacy_border(
+    dict: &PdfDictionary,
+) -> Result<(GeometricWidth, Option<GeometricDashPattern>)> {
+    let Some(value) = dict.get("Border") else {
+        return Ok((GeometricWidth::new(1.0)?, None));
+    };
+    let border = value
+        .as_array()
+        .ok_or_else(|| invalid("geometric /Border must be an array"))?;
+    if !(3..=4).contains(&border.0.len()) {
+        return Err(invalid(
+            "geometric /Border must contain three or four values",
+        ));
+    }
+    for value in &border.0[..3] {
+        if number(value).is_none() {
+            return Err(invalid("geometric /Border dimensions must be numeric"));
+        }
+    }
+    let width = GeometricWidth::new(number(&border.0[2]).unwrap_or(1.0))?;
+    let dash = border
+        .0
+        .get(3)
+        .map(|value| {
+            let values = value
+                .as_array()
+                .ok_or_else(|| invalid("geometric /Border dash must be an array"))?
+                .0
+                .iter()
+                .map(|item| {
+                    number(item).ok_or_else(|| invalid("geometric /Border dash must be numeric"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            if values.is_empty() {
+                Ok(None)
+            } else {
+                GeometricDashPattern::new(values).map(Some)
+            }
+        })
+        .transpose()?
+        .flatten();
+    Ok((width, dash))
+}
+
+fn parse_color(dict: &PdfDictionary, key: &str) -> Result<Option<GeometricColor>> {
+    let Some(_) = dict.get(key) else {
+        return Ok(None);
+    };
+    let v = numeric_array(dict, key, None)?;
+    match v.as_slice() {
+        [g] => Ok(Some(GeometricColor::gray(*g)?)),
+        [r, g, b] => Ok(Some(GeometricColor::rgb([*r, *g, *b])?)),
+        [c, m, y, k] => Ok(Some(GeometricColor::cmyk([*c, *m, *y, *k])?)),
+        _ => Err(invalid(
+            "geometric color must have one, three, or four components",
+        )),
+    }
+}
+
+fn parse_endings(dict: &PdfDictionary) -> Result<(LineEnding, LineEnding)> {
+    let Some(value) = dict.get("LE") else {
+        return Ok((LineEnding::None, LineEnding::None));
+    };
+    let a = value
+        .as_array()
+        .ok_or_else(|| invalid("geometric /LE must be an array"))?;
+    if a.0.len() != 2 {
+        return Err(invalid("geometric /LE must have two names"));
+    }
+    let first = a.0[0]
+        .as_name()
+        .ok_or_else(|| invalid("geometric /LE must contain names"))?;
+    let second = a.0[1]
+        .as_name()
+        .ok_or_else(|| invalid("geometric /LE must contain names"))?;
+    Ok((LineEnding::parse(&first.0)?, LineEnding::parse(&second.0)?))
+}
+
+fn parse_vertices(dict: &PdfDictionary, minimum: usize) -> Result<Vec<Point>> {
+    let v = numeric_array(dict, "Vertices", None)?;
+    if v.len() % 2 != 0 || v.len() / 2 < minimum || v.len() / 2 > MAX_VERTICES {
+        return Err(invalid("geometric vertices have invalid count"));
+    }
+    Ok(v.chunks_exact(2).map(|p| Point::new(p[0], p[1])).collect())
+}
+
+fn validate_batch(
+    snapshot: &AnnotationSnapshot,
+    existing: &[GeometricAnnotation],
+    mutations: &[GeometricMutation],
+) -> Result<HashMap<GeometricId, u32>> {
+    let pages: HashMap<_, _> = existing.iter().map(|a| (a.id, a.page_index)).collect();
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            GeometricMutation::Add {
+                page_index,
+                geometry,
+                style,
+            } => {
+                let page = snapshot
+                    .pages
+                    .get(*page_index as usize)
+                    .ok_or_else(|| invalid(&format!("page {page_index} does not exist")))?;
+                validate_geometry(geometry, style, page.bounds)?;
+            }
+            GeometricMutation::Update {
+                id,
+                geometry,
+                style,
+            } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("geometric annotation is targeted more than once"));
+                }
+                let p = *pages.get(id).ok_or_else(|| missing(*id))?;
+                let original = snapshot
+                    .annotations
+                    .get(&id.tuple())
+                    .and_then(|state| subtype(&state.dictionary));
+                if original != Some(geometry_subtype(geometry)) {
+                    return Err(invalid(
+                        "geometric updates cannot change the annotation subtype",
+                    ));
+                }
+                validate_geometry(geometry, style, snapshot.pages[p as usize].bounds)?;
+            }
+            GeometricMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("geometric annotation is targeted more than once"));
+                }
+                if !pages.contains_key(id) {
+                    return Err(missing(*id));
+                }
+            }
+        }
+    }
+    Ok(pages)
+}
+
+fn validate_geometry(
+    geometry: &GeometricGeometry,
+    style: &GeometricStyle,
+    page: [f64; 4],
+) -> Result<()> {
+    let points: Vec<Point> = match geometry {
+        GeometricGeometry::Line { start, end, .. } => {
+            if start == end {
+                return Err(invalid("line endpoints must differ"));
+            }
+            vec![*start, *end]
+        }
+        GeometricGeometry::Square { rect } | GeometricGeometry::Circle { rect } => {
+            validate_rect(*rect)?;
+            if style.width.value() >= (rect[2] - rect[0]).min(rect[3] - rect[1]) {
+                return Err(invalid("geometric width is too large for the rectangle"));
+            }
+            vec![Point::new(rect[0], rect[1]), Point::new(rect[2], rect[3])]
+        }
+        GeometricGeometry::Polygon { vertices } => {
+            if vertices.len() < 3 {
+                return Err(invalid("polygon requires at least three vertices"));
+            }
+            if vertices
+                .iter()
+                .zip(vertices.iter().cycle().skip(1))
+                .any(|(first, second)| first == second)
+            {
+                return Err(invalid("polygon contains a zero-length edge"));
+            }
+            let twice_area = vertices
+                .iter()
+                .zip(vertices.iter().cycle().skip(1))
+                .map(|(first, second)| first.x * second.y - second.x * first.y)
+                .sum::<f64>();
+            if !twice_area.is_finite() || twice_area.abs() <= f64::EPSILON {
+                return Err(invalid("polygon must have a finite non-zero area"));
+            }
+            vertices.clone()
+        }
+        GeometricGeometry::PolyLine { vertices, .. } => {
+            if vertices.len() < 2 {
+                return Err(invalid("polyline requires at least two vertices"));
+            }
+            if vertices.windows(2).all(|pair| pair[0] == pair[1]) {
+                return Err(invalid("polyline requires a non-zero-length segment"));
+            }
+            vertices.clone()
+        }
+    };
+    if points.len() > MAX_VERTICES || points.iter().any(|p| !p.x.is_finite() || !p.y.is_finite()) {
+        return Err(invalid("geometric coordinates must be finite and bounded"));
+    }
+    let rect = geometry_bounds(geometry, style.width);
+    if rect[0] < page[0] || rect[1] < page[1] || rect[2] > page[2] || rect[3] > page[3] {
+        return Err(invalid("geometric annotation is outside page bounds"));
+    }
+    Ok(())
+}
+
+fn geometry_bounds(geometry: &GeometricGeometry, width: GeometricWidth) -> [f64; 4] {
+    if let GeometricGeometry::Square { rect } | GeometricGeometry::Circle { rect } = geometry {
+        return *rect;
+    }
+    let mut b = [
+        f64::INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NEG_INFINITY,
+    ];
+    let mut add = |p: Point| {
+        b[0] = b[0].min(p.x);
+        b[1] = b[1].min(p.y);
+        b[2] = b[2].max(p.x);
+        b[3] = b[3].max(p.y);
+    };
+    match geometry {
+        GeometricGeometry::Line { start, end, .. } => {
+            add(*start);
+            add(*end)
+        }
+        GeometricGeometry::Polygon { vertices } | GeometricGeometry::PolyLine { vertices, .. } => {
+            vertices.iter().for_each(|p| add(*p))
+        }
+        _ => {}
+    }
+    let has_endings = match geometry {
+        GeometricGeometry::Line {
+            start_ending,
+            end_ending,
+            ..
+        }
+        | GeometricGeometry::PolyLine {
+            start_ending,
+            end_ending,
+            ..
+        } => *start_ending != LineEnding::None || *end_ending != LineEnding::None,
+        _ => false,
+    };
+    let h = if has_endings {
+        (width.value() * 4.0).max(6.0)
+    } else {
+        width.value() / 2.0
+    };
+    [b[0] - h, b[1] - h, b[2] + h, b[3] + h]
+}
+
+fn new_dictionary(
+    geometry: &GeometricGeometry,
+    style: &GeometricStyle,
+    rect: [f64; 4],
+    ap: (u32, u16),
+) -> PdfDictionary {
+    let mut d = PdfDictionary::new();
+    d.insert("Type".into(), name("Annot"));
+    set_properties(&mut d, geometry, style, rect, ap);
+    d
+}
+
+fn geometry_subtype(geometry: &GeometricGeometry) -> &'static str {
+    match geometry {
+        GeometricGeometry::Line { .. } => "Line",
+        GeometricGeometry::Square { .. } => "Square",
+        GeometricGeometry::Circle { .. } => "Circle",
+        GeometricGeometry::Polygon { .. } => "Polygon",
+        GeometricGeometry::PolyLine { .. } => "PolyLine",
+    }
+}
+
+fn set_properties(
+    d: &mut PdfDictionary,
+    geometry: &GeometricGeometry,
+    style: &GeometricStyle,
+    rect: [f64; 4],
+    appearance: (u32, u16),
+) {
+    let subtype = geometry_subtype(geometry);
+    d.insert("Subtype".into(), name(subtype));
+    d.insert("Rect".into(), numbers(&rect));
+    d.0.remove(&PdfName("L".into()));
+    d.0.remove(&PdfName("Vertices".into()));
+    d.0.remove(&PdfName("LE".into()));
+    match geometry {
+        GeometricGeometry::Line {
+            start,
+            end,
+            start_ending,
+            end_ending,
+        } => {
+            d.insert("L".into(), numbers(&[start.x, start.y, end.x, end.y]));
+            d.insert(
+                "LE".into(),
+                names(&[start_ending.name(), end_ending.name()]),
+            );
+        }
+        GeometricGeometry::PolyLine {
+            vertices,
+            start_ending,
+            end_ending,
+        } => {
+            d.insert("Vertices".into(), points(vertices));
+            d.insert(
+                "LE".into(),
+                names(&[start_ending.name(), end_ending.name()]),
+            );
+        }
+        GeometricGeometry::Polygon { vertices } => {
+            d.insert("Vertices".into(), points(vertices));
+        }
+        _ => {}
+    }
+    d.insert("C".into(), numbers(&style.stroke_color.values()));
+    match style.fill_color {
+        Some(c) => {
+            d.insert("IC".into(), numbers(&c.values()));
+        }
+        None => {
+            d.0.remove(&PdfName("IC".into()));
+        }
+    }
+    let mut bs = match d.get("BS") {
+        Some(PdfObject::Dictionary(v)) => v.clone(),
+        _ => PdfDictionary::new(),
+    };
+    bs.insert("W".into(), PdfObject::Real(style.width.value()));
+    match &style.dash_pattern {
+        Some(v) => {
+            bs.insert("S".into(), name("D"));
+            bs.insert("D".into(), numbers(v.values()));
+        }
+        None => {
+            bs.insert("S".into(), name("S"));
+            bs.0.remove(&PdfName("D".into()));
+        }
+    }
+    d.insert("BS".into(), PdfObject::Dictionary(bs));
+    match style.opacity {
+        Some(v) => {
+            d.insert("CA".into(), PdfObject::Real(v.value()));
+        }
+        None => {
+            d.0.remove(&PdfName("CA".into()));
+        }
+    }
+    let mut ap = match d.get("AP") {
+        Some(PdfObject::Dictionary(v)) => v.clone(),
+        _ => PdfDictionary::new(),
+    };
+    ap.insert("N".into(), PdfObject::Reference(appearance.0, appearance.1));
+    d.insert("AP".into(), PdfObject::Dictionary(ap));
+}
+
+fn appearance(
+    geometry: &GeometricGeometry,
+    style: &GeometricStyle,
+    rect: [f64; 4],
+) -> Result<PdfStream> {
+    if estimate_appearance_bytes(geometry, style, rect)? > MAX_APPEARANCE_BYTES {
+        return Err(invalid("geometric appearance exceeds the byte limit"));
+    }
+    let mut s = format!(
+        "q\n{}\n{} w\n",
+        style.stroke_color.stroke_operator(),
+        pdf_number(style.width.value())
+    );
+    if let Some(d) = &style.dash_pattern {
+        s.push_str(&format!(
+            "[{}] 0 d\n",
+            d.values()
+                .iter()
+                .map(|v| pdf_number(*v))
+                .collect::<Vec<_>>()
+                .join(" ")
+        ));
+    }
+    if style.opacity.is_some() {
+        s.push_str("/GS0 gs\n");
+    }
+    s.push_str(&format!(
+        "{}\n",
+        style
+            .fill_color
+            .unwrap_or(style.stroke_color)
+            .fill_operator()
+    ));
+    let x = |v: f64| pdf_number(v - rect[0]);
+    let y = |v: f64| pdf_number(v - rect[1]);
+    match geometry {
+        GeometricGeometry::Line {
+            start,
+            end,
+            start_ending,
+            end_ending,
+        } => {
+            s.push_str(&format!(
+                "{} {} m {} {} l S\n",
+                x(start.x),
+                y(start.y),
+                x(end.x),
+                y(end.y)
+            ));
+            draw_ending(&mut s, *start, *end, *start_ending, style.width, rect);
+            draw_ending(&mut s, *end, *start, *end_ending, style.width, rect);
+        }
+        GeometricGeometry::Square { rect: r } => {
+            let inset = style.width.value() / 2.0;
+            s.push_str(&format!(
+                "{} {} {} {} re {}\n",
+                x(r[0] + inset),
+                y(r[1] + inset),
+                pdf_number(r[2] - r[0] - 2.0 * inset),
+                pdf_number(r[3] - r[1] - 2.0 * inset),
+                if style.fill_color.is_some() { "B" } else { "S" }
+            ));
+        }
+        GeometricGeometry::Circle { rect: r } => {
+            let inset = style.width.value() / 2.0;
+            let (x0, y0, x1, y1) = (
+                r[0] + inset - rect[0],
+                r[1] + inset - rect[1],
+                r[2] - inset - rect[0],
+                r[3] - inset - rect[1],
+            );
+            let (cx, cy, rx, ry) = (
+                (x0 + x1) / 2.0,
+                (y0 + y1) / 2.0,
+                (x1 - x0) / 2.0,
+                (y1 - y0) / 2.0,
+            );
+            let k = 0.5522847498;
+            s.push_str(&format!("{} {} m {} {} {} {} {} {} c {} {} {} {} {} {} c {} {} {} {} {} {} c {} {} {} {} {} {} c {}\n",pdf_number(cx+rx),pdf_number(cy),pdf_number(cx+rx),pdf_number(cy+k*ry),pdf_number(cx+k*rx),pdf_number(cy+ry),pdf_number(cx),pdf_number(cy+ry),pdf_number(cx-k*rx),pdf_number(cy+ry),pdf_number(cx-rx),pdf_number(cy+k*ry),pdf_number(cx-rx),pdf_number(cy),pdf_number(cx-rx),pdf_number(cy-k*ry),pdf_number(cx-k*rx),pdf_number(cy-ry),pdf_number(cx),pdf_number(cy-ry),pdf_number(cx+k*rx),pdf_number(cy-ry),pdf_number(cx+rx),pdf_number(cy-k*ry),pdf_number(cx+rx),pdf_number(cy),if style.fill_color.is_some(){"B"}else{"S"}));
+        }
+        GeometricGeometry::Polygon { vertices } => {
+            draw_vertices(&mut s, vertices, rect, true, style.fill_color.is_some())
+        }
+        GeometricGeometry::PolyLine {
+            vertices,
+            start_ending,
+            end_ending,
+        } => {
+            draw_vertices(&mut s, vertices, rect, false, false);
+            draw_ending(
+                &mut s,
+                vertices[0],
+                vertices[1],
+                *start_ending,
+                style.width,
+                rect,
+            );
+            let last = vertices.len() - 1;
+            draw_ending(
+                &mut s,
+                vertices[last],
+                vertices[last - 1],
+                *end_ending,
+                style.width,
+                rect,
+            );
+        }
+    }
+    s.push('Q');
+    if s.len() > MAX_APPEARANCE_BYTES {
+        return Err(invalid("geometric appearance exceeds the byte limit"));
+    }
+    let mut d = PdfDictionary::new();
+    d.insert("Type".into(), name("XObject"));
+    d.insert("Subtype".into(), name("Form"));
+    d.insert("FormType".into(), PdfObject::Integer(1));
+    d.insert(
+        "BBox".into(),
+        numbers(&[0.0, 0.0, rect[2] - rect[0], rect[3] - rect[1]]),
+    );
+    if let Some(o) = style.opacity {
+        let mut gs = PdfDictionary::new();
+        gs.insert("CA".into(), PdfObject::Real(o.value()));
+        gs.insert("ca".into(), PdfObject::Real(o.value()));
+        let mut e = PdfDictionary::new();
+        e.insert("GS0".into(), PdfObject::Dictionary(gs));
+        let mut r = PdfDictionary::new();
+        r.insert("ExtGState".into(), PdfObject::Dictionary(e));
+        d.insert("Resources".into(), PdfObject::Dictionary(r));
+    }
+    Ok(PdfStream {
+        dict: d,
+        data: s.into_bytes(),
+    })
+}
+
+fn estimate_appearance_bytes(
+    geometry: &GeometricGeometry,
+    style: &GeometricStyle,
+    rect: [f64; 4],
+) -> Result<usize> {
+    let mut size = 4096usize;
+    let mut add_point = |point: Point| -> Result<()> {
+        let coordinate_bytes = pdf_number(point.x - rect[0])
+            .len()
+            .checked_add(pdf_number(point.y - rect[1]).len())
+            .and_then(|value| value.checked_add(16))
+            .ok_or_else(|| invalid("geometric appearance size overflow"))?;
+        size = size
+            .checked_add(coordinate_bytes)
+            .ok_or_else(|| invalid("geometric appearance size overflow"))?;
+        Ok(())
+    };
+    match geometry {
+        GeometricGeometry::Line { start, end, .. } => {
+            add_point(*start)?;
+            add_point(*end)?;
+            size = size.saturating_add(4096);
+        }
+        GeometricGeometry::Square { rect } | GeometricGeometry::Circle { rect } => {
+            add_point(Point::new(rect[0], rect[1]))?;
+            add_point(Point::new(rect[2], rect[3]))?;
+        }
+        GeometricGeometry::Polygon { vertices } | GeometricGeometry::PolyLine { vertices, .. } => {
+            for point in vertices {
+                add_point(*point)?;
+            }
+            size = size.saturating_add(4096);
+        }
+    }
+    for value in style
+        .dash_pattern
+        .as_ref()
+        .into_iter()
+        .flat_map(|pattern| pattern.values())
+    {
+        size = size
+            .checked_add(pdf_number(*value).len() + 2)
+            .ok_or_else(|| invalid("geometric appearance size overflow"))?;
+    }
+    Ok(size)
+}
+
+fn draw_ending(
+    s: &mut String,
+    tip: Point,
+    neighbor: Point,
+    ending: LineEnding,
+    width: GeometricWidth,
+    rect: [f64; 4],
+) {
+    if ending == LineEnding::None {
+        return;
+    }
+    let dx = neighbor.x - tip.x;
+    let dy = neighbor.y - tip.y;
+    let length = dx.hypot(dy);
+    if length == 0.0 {
+        return;
+    }
+    let ux = dx / length;
+    let uy = dy / length;
+    let px = -uy;
+    let py = ux;
+    let size = (width.value() * 4.0).max(6.0);
+    let point = |forward: f64, side: f64| {
+        (
+            tip.x + ux * forward + px * side - rect[0],
+            tip.y + uy * forward + py * side - rect[1],
+        )
+    };
+    let (left_x, left_y) = point(size, size * 0.5);
+    let (right_x, right_y) = point(size, -size * 0.5);
+    let (tip_x, tip_y) = point(0.0, 0.0);
+    match ending {
+        LineEnding::OpenArrow => s.push_str(&format!(
+            "{} {} m {} {} l {} {} l S\n",
+            pdf_number(left_x),
+            pdf_number(left_y),
+            pdf_number(tip_x),
+            pdf_number(tip_y),
+            pdf_number(right_x),
+            pdf_number(right_y)
+        )),
+        LineEnding::ClosedArrow => s.push_str(&format!(
+            "{} {} m {} {} l {} {} l h B\n",
+            pdf_number(left_x),
+            pdf_number(left_y),
+            pdf_number(tip_x),
+            pdf_number(tip_y),
+            pdf_number(right_x),
+            pdf_number(right_y)
+        )),
+        LineEnding::ROpenArrow | LineEnding::RClosedArrow => {
+            let (apex_x, apex_y) = point(size, 0.0);
+            let (base_left_x, base_left_y) = point(0.0, size * 0.5);
+            let (base_right_x, base_right_y) = point(0.0, -size * 0.5);
+            s.push_str(&format!(
+                "{} {} m {} {} l {} {} l {}\n",
+                pdf_number(base_left_x),
+                pdf_number(base_left_y),
+                pdf_number(apex_x),
+                pdf_number(apex_y),
+                pdf_number(base_right_x),
+                pdf_number(base_right_y),
+                if ending == LineEnding::RClosedArrow {
+                    "h B"
+                } else {
+                    "S"
+                }
+            ));
+        }
+        LineEnding::Square => {
+            let half = size * 0.4;
+            let corners = [
+                point(-half, half),
+                point(half, half),
+                point(half, -half),
+                point(-half, -half),
+            ];
+            draw_closed_shape(s, &corners);
+        }
+        LineEnding::Diamond => {
+            let half = size * 0.55;
+            let corners = [
+                point(-half, 0.0),
+                point(0.0, half),
+                point(half, 0.0),
+                point(0.0, -half),
+            ];
+            draw_closed_shape(s, &corners);
+        }
+        LineEnding::Circle => {
+            let radius = size * 0.4;
+            let k = radius * 0.552_284_749_8;
+            s.push_str(&format!(
+                "{} {} m {} {} {} {} {} {} c {} {} {} {} {} {} c {} {} {} {} {} {} c {} {} {} {} {} {} c B\n",
+                pdf_number(tip_x + radius), pdf_number(tip_y),
+                pdf_number(tip_x + radius), pdf_number(tip_y + k), pdf_number(tip_x + k), pdf_number(tip_y + radius), pdf_number(tip_x), pdf_number(tip_y + radius),
+                pdf_number(tip_x - k), pdf_number(tip_y + radius), pdf_number(tip_x - radius), pdf_number(tip_y + k), pdf_number(tip_x - radius), pdf_number(tip_y),
+                pdf_number(tip_x - radius), pdf_number(tip_y - k), pdf_number(tip_x - k), pdf_number(tip_y - radius), pdf_number(tip_x), pdf_number(tip_y - radius),
+                pdf_number(tip_x + k), pdf_number(tip_y - radius), pdf_number(tip_x + radius), pdf_number(tip_y - k), pdf_number(tip_x + radius), pdf_number(tip_y)
+            ));
+        }
+        LineEnding::Butt => s.push_str(&format!(
+            "{} {} m {} {} l S\n",
+            pdf_number(tip_x - px * size * 0.5),
+            pdf_number(tip_y - py * size * 0.5),
+            pdf_number(tip_x + px * size * 0.5),
+            pdf_number(tip_y + py * size * 0.5)
+        )),
+        LineEnding::Slash => {
+            let half = size * 0.6;
+            let (first_x, first_y) = point(-half * 0.5, -half);
+            let (second_x, second_y) = point(half * 0.5, half);
+            s.push_str(&format!(
+                "{} {} m {} {} l S\n",
+                pdf_number(first_x),
+                pdf_number(first_y),
+                pdf_number(second_x),
+                pdf_number(second_y)
+            ));
+        }
+        LineEnding::None => {}
+    }
+}
+
+fn draw_closed_shape(s: &mut String, points: &[(f64, f64); 4]) {
+    s.push_str(&format!(
+        "{} {} m {} {} l {} {} l {} {} l h B\n",
+        pdf_number(points[0].0),
+        pdf_number(points[0].1),
+        pdf_number(points[1].0),
+        pdf_number(points[1].1),
+        pdf_number(points[2].0),
+        pdf_number(points[2].1),
+        pdf_number(points[3].0),
+        pdf_number(points[3].1)
+    ));
+}
+fn draw_vertices(s: &mut String, v: &[Point], r: [f64; 4], close: bool, fill: bool) {
+    s.push_str(&format!(
+        "{} {} m\n",
+        pdf_number(v[0].x - r[0]),
+        pdf_number(v[0].y - r[1])
+    ));
+    for p in &v[1..] {
+        s.push_str(&format!(
+            "{} {} l\n",
+            pdf_number(p.x - r[0]),
+            pdf_number(p.y - r[1])
+        ));
+    }
+    if close {
+        s.push_str("h\n");
+    }
+    s.push_str(if fill { "B\n" } else { "S\n" });
+}
+
+fn rewrite_pages(
+    update: &mut IncrementalUpdate,
+    snapshot: &mut AnnotationSnapshot,
+    changed: &HashSet<u32>,
+) -> Result<()> {
+    for i in changed {
+        let p = &mut snapshot.pages[*i as usize];
+        match p.container {
+            AnnotationContainer::Page => {
+                p.dictionary.insert(
+                    "Annots".into(),
+                    PdfObject::Array(PdfArray(p.annotations.clone())),
+                );
+                update.replace(p.reference, PdfObject::Dictionary(p.dictionary.clone()))?;
+            }
+            AnnotationContainer::Indirect(id) => {
+                update.replace(id, PdfObject::Array(PdfArray(p.annotations.clone())))?
+            }
+        }
+    }
+    Ok(())
+}
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut r =
+        PdfReader::new(Cursor::new(bytes)).map_err(|e| invalid(&format!("parse base PDF: {e}")))?;
+    let c = r
+        .catalog()
+        .map_err(|e| invalid(&format!("read catalog: {e}")))?
+        .clone();
+    ensure_modification_allowed(&mut r, &c, IncrementalModification::AddAnnotation)
+}
+fn parse_rect(d: &PdfDictionary) -> Result<[f64; 4]> {
+    let v = numeric_array(d, "Rect", Some(4))?;
+    let r = [v[0], v[1], v[2], v[3]];
+    validate_rect(r)?;
+    Ok(r)
+}
+fn validate_rect(r: [f64; 4]) -> Result<()> {
+    if r.iter().any(|v| !v.is_finite()) || r[0] >= r[2] || r[1] >= r[3] {
+        Err(invalid("geometric rectangle must be finite and ordered"))
+    } else {
+        Ok(())
+    }
+}
+fn rect_contains(outer: [f64; 4], inner: [f64; 4]) -> bool {
+    outer[0] <= inner[0] && outer[1] <= inner[1] && outer[2] >= inner[2] && outer[3] >= inner[3]
+}
+fn numeric_array(d: &PdfDictionary, k: &str, len: Option<usize>) -> Result<Vec<f64>> {
+    let a = d
+        .get(k)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid(&format!("geometric /{k} must be an array")))?;
+    if len.is_some_and(|n| a.0.len() != n) {
+        return Err(invalid(&format!("geometric /{k} has wrong length")));
+    }
+    a.0.iter()
+        .map(|v| {
+            number(v).ok_or_else(|| invalid(&format!("geometric /{k} contains invalid number")))
+        })
+        .collect()
+}
+fn number(v: &PdfObject) -> Option<f64> {
+    match v {
+        PdfObject::Integer(n) => Some(*n as f64),
+        PdfObject::Real(n) if n.is_finite() => Some(*n),
+        _ => None,
+    }
+}
+fn numbers(v: &[f64]) -> PdfObject {
+    PdfObject::Array(PdfArray(v.iter().copied().map(PdfObject::Real).collect()))
+}
+fn points(v: &[Point]) -> PdfObject {
+    numbers(&v.iter().flat_map(|p| [p.x, p.y]).collect::<Vec<_>>())
+}
+fn names(v: &[&str]) -> PdfObject {
+    PdfObject::Array(PdfArray(v.iter().map(|n| name(n)).collect()))
+}
+fn name(v: &str) -> PdfObject {
+    PdfObject::Name(PdfName(v.into()))
+}
+fn validate_unit(v: &[f64], label: &str) -> Result<()> {
+    if v.iter().any(|x| !x.is_finite() || !(0.0..=1.0).contains(x)) {
+        Err(invalid(&format!(
+            "{label} must be finite and between 0 and 1"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn color_operator(c: GeometricColor, stroke: bool) -> String {
+    let op = match (c, stroke) {
+        (GeometricColor::Gray(_), true) => "G",
+        (GeometricColor::Gray(_), false) => "g",
+        (GeometricColor::Rgb(_), true) => "RG",
+        (GeometricColor::Rgb(_), false) => "rg",
+        (GeometricColor::Cmyk(_), true) => "K",
+        (GeometricColor::Cmyk(_), false) => "k",
+    };
+    format!(
+        "{} {op}",
+        c.values()
+            .iter()
+            .map(|v| pdf_number(*v))
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
+}
+fn pdf_number(v: f64) -> String {
+    let mut s = format!("{v:.6}");
+    while s.contains('.') && s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    if s == "-0" {
+        "0".into()
+    } else {
+        s
+    }
+}
+fn missing(id: GeometricId) -> PdfError {
+    invalid(&format!(
+        "geometric annotation {} {} does not exist",
+        id.object_number, id.generation_number
+    ))
+}
+fn invalid(m: &str) -> PdfError {
+    PdfError::InvalidStructure(m.into())
+}

--- a/oxidize-pdf-core/src/writer/incremental_ink.rs
+++ b/oxidize-pdf-core/src/writer/incremental_ink.rs
@@ -1,0 +1,863 @@
+//! Incremental editing of standard `/Ink` annotations in existing PDFs.
+
+use super::incremental_annotations::{subtype, AnnotationContainer, AnnotationSnapshot};
+use super::incremental_update::IncrementalUpdate;
+use crate::error::{PdfError, Result};
+use crate::geometry::Point;
+use crate::parser::objects::{PdfArray, PdfDictionary, PdfName, PdfObject, PdfStream};
+use crate::parser::PdfReader;
+use crate::signatures::{ensure_modification_allowed, IncrementalModification};
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+
+const MAX_INK_STROKES: usize = 4_096;
+const MAX_INK_POINTS: usize = 1_000_000;
+const MAX_INK_APPEARANCE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Stable indirect-object identity of an Ink annotation.
+pub struct InkId {
+    /// PDF object number.
+    pub object_number: u32,
+    /// PDF generation number.
+    pub generation_number: u16,
+}
+
+impl InkId {
+    /// Construct an identity from a PDF indirect reference.
+    pub const fn new(object_number: u32, generation_number: u16) -> Self {
+        Self {
+            object_number,
+            generation_number,
+        }
+    }
+    fn tuple(self) -> (u32, u16) {
+        (self.object_number, self.generation_number)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A non-empty, finite sequence of points forming one ink stroke.
+pub struct InkStroke(Vec<Point>);
+
+impl InkStroke {
+    /// Validate and construct a stroke.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no points are supplied or a coordinate is non-finite.
+    pub fn new(points: Vec<Point>) -> Result<Self> {
+        if points.is_empty() {
+            return Err(invalid("ink stroke must contain at least one point"));
+        }
+        if points
+            .iter()
+            .any(|point| !point.x.is_finite() || !point.y.is_finite())
+        {
+            return Err(invalid("ink stroke coordinates must be finite"));
+        }
+        Ok(Self(points))
+    }
+    /// Return the stroke's points in drawing order.
+    pub fn points(&self) -> &[Point] {
+        &self.0
+    }
+}
+
+/// A validated PDF annotation color.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InkColor {
+    /// DeviceGray color with one component.
+    Gray([f64; 1]),
+    /// DeviceRGB color with three components.
+    Rgb([f64; 3]),
+    /// DeviceCMYK color with four components.
+    Cmyk([f64; 4]),
+}
+
+impl InkColor {
+    /// Construct a DeviceRGB color whose components are in `0..=1`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for non-finite or out-of-range components.
+    pub fn new(components: [f64; 3]) -> Result<Self> {
+        validate_unit(&components, "ink RGB color")?;
+        Ok(Self::Rgb(components))
+    }
+
+    /// Construct a DeviceGray color.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-finite or out-of-range component.
+    pub fn gray(component: f64) -> Result<Self> {
+        validate_unit(&[component], "ink grayscale color")?;
+        Ok(Self::Gray([component]))
+    }
+
+    /// Construct a DeviceCMYK color.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for non-finite or out-of-range components.
+    pub fn cmyk(components: [f64; 4]) -> Result<Self> {
+        validate_unit(&components, "ink CMYK color")?;
+        Ok(Self::Cmyk(components))
+    }
+
+    fn components(self) -> Vec<f64> {
+        match self {
+            Self::Gray(values) => values.to_vec(),
+            Self::Rgb(values) => values.to_vec(),
+            Self::Cmyk(values) => values.to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// A validated positive stroke width in PDF user-space units.
+pub struct InkWidth(f64);
+
+impl InkWidth {
+    /// Construct a finite, positive stroke width.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `value` is non-finite or not positive.
+    pub fn new(value: f64) -> Result<Self> {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(invalid("ink width must be finite and positive"));
+        }
+        Ok(Self(value))
+    }
+    /// Return the stroke width in user-space units.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// A validated constant opacity in the inclusive range `0..=1`.
+pub struct InkOpacity(f64);
+
+impl InkOpacity {
+    /// Construct an opacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `value` is non-finite or outside `0..=1`.
+    pub fn new(value: f64) -> Result<Self> {
+        validate_unit(&[value], "ink opacity")?;
+        Ok(Self(value))
+    }
+    /// Return the opacity value.
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A standard PDF `/Ink` annotation read from an existing document.
+pub struct Ink {
+    /// Stable indirect-object identity.
+    pub id: InkId,
+    /// Zero-based page index.
+    pub page_index: u32,
+    /// Bounding rectangle including half the stroke width.
+    pub rect: [f64; 4],
+    /// One or more strokes in page coordinates.
+    pub strokes: Vec<InkStroke>,
+    /// DeviceGray, DeviceRGB, or DeviceCMYK stroke color.
+    pub color: InkColor,
+    /// Stroke width in PDF user-space units.
+    pub width: InkWidth,
+    /// Optional constant opacity.
+    pub opacity: Option<InkOpacity>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A requested change to the document's Ink annotations.
+pub enum InkMutation {
+    /// Add an Ink annotation to a page.
+    Add {
+        /// Zero-based target page.
+        page_index: u32,
+        /// Non-empty validated strokes.
+        strokes: Vec<InkStroke>,
+        /// Stroke color.
+        color: InkColor,
+        /// Positive stroke width.
+        width: InkWidth,
+        /// Optional constant opacity.
+        opacity: Option<InkOpacity>,
+    },
+    /// Update an existing annotation while preserving unrelated keys.
+    Update {
+        /// Existing Ink annotation identity.
+        id: InkId,
+        /// Replacement strokes.
+        strokes: Vec<InkStroke>,
+        /// Replacement color.
+        color: InkColor,
+        /// Replacement stroke width.
+        width: InkWidth,
+        /// Replacement optional opacity.
+        opacity: Option<InkOpacity>,
+    },
+    /// Remove an existing annotation reference from its page.
+    Remove {
+        /// Existing Ink annotation identity.
+        id: InkId,
+    },
+}
+
+#[derive(Debug, Clone)]
+/// Result of one atomic incremental Ink update.
+pub struct InkUpdate {
+    /// Complete PDF bytes; the original document is an exact prefix.
+    pub pdf_bytes: Vec<u8>,
+    /// Complete current Ink annotation set after the update.
+    pub annotations: Vec<Ink>,
+}
+
+/// Reads and atomically edits standard Ink annotations in an existing PDF.
+pub struct IncrementalInkEditor<'a> {
+    base_bytes: &'a [u8],
+}
+
+impl<'a> IncrementalInkEditor<'a> {
+    /// Create an editor over an existing PDF's bytes.
+    pub fn new(base_bytes: &'a [u8]) -> Self {
+        Self { base_bytes }
+    }
+
+    /// Read every indirect `/Ink` annotation with its stable identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed, encrypted, inline, or resource-excessive input.
+    pub fn annotations(&self) -> Result<Vec<Ink>> {
+        let snapshot = AnnotationSnapshot::parse(self.base_bytes, "Ink", "ink annotation")?;
+        read_inks(&snapshot)
+    }
+
+    /// Validate and apply all mutations as exactly one incremental revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid geometry, pages, identities, conflicting
+    /// mutations, encryption, forbidden signature policies, or resource limits.
+    pub fn apply(&self, mutations: &[InkMutation]) -> Result<InkUpdate> {
+        let mut snapshot = AnnotationSnapshot::parse(self.base_bytes, "Ink", "ink annotation")?;
+        let existing = read_inks(&snapshot)?;
+        if mutations.is_empty() {
+            return Ok(InkUpdate {
+                pdf_bytes: self.base_bytes.to_vec(),
+                annotations: existing,
+            });
+        }
+        let pages = validate_batch(&snapshot, &existing, mutations)?;
+        validate_policy(self.base_bytes)?;
+        let mut update = IncrementalUpdate::from_base(self.base_bytes)?;
+        let mut changed_pages = HashSet::new();
+        let mut rewritten = HashMap::new();
+
+        for mutation in mutations {
+            match mutation {
+                InkMutation::Add {
+                    page_index,
+                    strokes,
+                    color,
+                    width,
+                    opacity,
+                } => {
+                    let id = update.allocate_id()?;
+                    let appearance_id = update.allocate_id()?;
+                    let rect = bounds(strokes, *width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(strokes, *color, *width, *opacity, rect)?),
+                    )?;
+                    update.replace(
+                        id,
+                        PdfObject::Dictionary(new_dictionary(
+                            strokes,
+                            *color,
+                            *width,
+                            *opacity,
+                            rect,
+                            appearance_id,
+                        )),
+                    )?;
+                    snapshot.pages[*page_index as usize]
+                        .annotations
+                        .push(PdfObject::Reference(id.0, id.1));
+                    changed_pages.insert(*page_index);
+                }
+                InkMutation::Update {
+                    id,
+                    strokes,
+                    color,
+                    width,
+                    opacity,
+                } => {
+                    let state = snapshot
+                        .annotations
+                        .get(&id.tuple())
+                        .ok_or_else(|| missing(*id))?;
+                    if subtype(&state.dictionary) != Some("Ink") {
+                        return Err(missing(*id));
+                    }
+                    let mut dictionary = state.dictionary.clone();
+                    let appearance_id = update.allocate_id()?;
+                    let rect = bounds(strokes, *width);
+                    update.replace(
+                        appearance_id,
+                        PdfObject::Stream(appearance(strokes, *color, *width, *opacity, rect)?),
+                    )?;
+                    set_properties(
+                        &mut dictionary,
+                        strokes,
+                        *color,
+                        *width,
+                        *opacity,
+                        rect,
+                        appearance_id,
+                    );
+                    rewritten.insert(id.tuple(), dictionary);
+                }
+                InkMutation::Remove { id } => {
+                    let page_index = *pages.get(id).ok_or_else(|| missing(*id))?;
+                    snapshot.pages[page_index as usize]
+                        .annotations
+                        .retain(|value| value.as_reference() != Some(id.tuple()));
+                    changed_pages.insert(page_index);
+                }
+            }
+        }
+        for (id, dictionary) in rewritten {
+            update.replace(id, PdfObject::Dictionary(dictionary))?;
+        }
+        rewrite_pages(&mut update, &mut snapshot, &changed_pages)?;
+        let pdf_bytes = update.finish()?;
+        let annotations = IncrementalInkEditor::new(&pdf_bytes).annotations()?;
+        Ok(InkUpdate {
+            pdf_bytes,
+            annotations,
+        })
+    }
+}
+
+fn read_inks(snapshot: &AnnotationSnapshot) -> Result<Vec<Ink>> {
+    let mut result = Vec::new();
+    for (&(number, generation), state) in &snapshot.annotations {
+        if subtype(&state.dictionary) == Some("Ink") {
+            let page = &snapshot.pages[state.page_index as usize];
+            result.push(parse_ink(
+                InkId::new(number, generation),
+                state.page_index,
+                &state.dictionary,
+                page.bounds,
+            )?);
+        }
+    }
+    result.sort_by_key(|ink| {
+        (
+            ink.page_index,
+            ink.id.object_number,
+            ink.id.generation_number,
+        )
+    });
+    Ok(result)
+}
+
+fn parse_ink(
+    id: InkId,
+    page_index: u32,
+    dict: &PdfDictionary,
+    page_bounds: [f64; 4],
+) -> Result<Ink> {
+    let rect_values = numeric_array(dict, "Rect", Some(4))?;
+    let rect = [
+        rect_values[0],
+        rect_values[1],
+        rect_values[2],
+        rect_values[3],
+    ];
+    if rect[0] >= rect[2] || rect[1] >= rect[3] {
+        return Err(invalid("/Ink /Rect must have positive width and height"));
+    }
+    if rect[0] < page_bounds[0]
+        || rect[1] < page_bounds[1]
+        || rect[2] > page_bounds[2]
+        || rect[3] > page_bounds[3]
+    {
+        return Err(invalid("/Ink /Rect is outside the page bounds"));
+    }
+    let lists = dict
+        .get("InkList")
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid("/Ink /InkList is missing or is not an array"))?;
+    if lists.0.is_empty() {
+        return Err(invalid("/Ink /InkList must contain at least one stroke"));
+    }
+    if lists.0.len() > MAX_INK_STROKES {
+        return Err(invalid("/Ink /InkList exceeds the stroke limit"));
+    }
+    let mut point_count = 0usize;
+    let strokes = lists
+        .0
+        .iter()
+        .map(|value| {
+            let array = value
+                .as_array()
+                .ok_or_else(|| invalid("/Ink /InkList stroke is not an array"))?;
+            if array.0.len() < 2 || array.0.len() % 2 != 0 {
+                return Err(invalid(
+                    "/Ink /InkList stroke must contain coordinate pairs",
+                ));
+            }
+            point_count = point_count
+                .checked_add(array.0.len() / 2)
+                .ok_or_else(|| invalid("/Ink /InkList point count overflows"))?;
+            if point_count > MAX_INK_POINTS {
+                return Err(invalid("/Ink /InkList exceeds the point limit"));
+            }
+            let values = array
+                .0
+                .iter()
+                .map(|value| {
+                    number(value).ok_or_else(|| {
+                        invalid("/Ink /InkList contains a non-finite or non-numeric value")
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            InkStroke::new(
+                values
+                    .chunks_exact(2)
+                    .map(|p| Point::new(p[0], p[1]))
+                    .collect(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for point in strokes.iter().flat_map(InkStroke::points) {
+        if point.x < page_bounds[0]
+            || point.x > page_bounds[2]
+            || point.y < page_bounds[1]
+            || point.y > page_bounds[3]
+        {
+            return Err(invalid(
+                "/Ink /InkList coordinates are outside the page bounds",
+            ));
+        }
+    }
+    let color = match dict.get("C") {
+        None => InkColor::Gray([0.0]),
+        Some(_) => {
+            let colors = numeric_array(dict, "C", None)?;
+            match colors.as_slice() {
+                [gray] => InkColor::gray(*gray)?,
+                [red, green, blue] => InkColor::new([*red, *green, *blue])?,
+                [cyan, magenta, yellow, black] => {
+                    InkColor::cmyk([*cyan, *magenta, *yellow, *black])?
+                }
+                _ => return Err(invalid("/Ink /C must have one, three, or four components")),
+            }
+        }
+    };
+    let width_value = match dict.get("BS") {
+        Some(PdfObject::Dictionary(bs)) => match bs.get("W") {
+            None => 1.0,
+            Some(value) => {
+                number(value).ok_or_else(|| invalid("/Ink /BS /W must be a finite number"))?
+            }
+        },
+        Some(_) => return Err(invalid("/Ink /BS must be a dictionary")),
+        None => border_width(dict)?.unwrap_or(1.0),
+    };
+    let width = InkWidth::new(width_value)?;
+    let opacity = dict
+        .get("CA")
+        .map(|value| {
+            number(value)
+                .ok_or_else(|| invalid("/Ink /CA must be a finite number"))
+                .and_then(InkOpacity::new)
+        })
+        .transpose()?;
+    Ok(Ink {
+        id,
+        page_index,
+        rect,
+        strokes,
+        color,
+        width,
+        opacity,
+    })
+}
+
+fn validate_batch(
+    snapshot: &AnnotationSnapshot,
+    existing: &[Ink],
+    mutations: &[InkMutation],
+) -> Result<HashMap<InkId, u32>> {
+    let pages: HashMap<_, _> = existing
+        .iter()
+        .map(|ink| (ink.id, ink.page_index))
+        .collect();
+    let mut targeted = HashSet::new();
+    for mutation in mutations {
+        match mutation {
+            InkMutation::Add {
+                page_index,
+                strokes,
+                width,
+                ..
+            } => {
+                let page = snapshot
+                    .pages
+                    .get(*page_index as usize)
+                    .ok_or_else(|| invalid(&format!("page {page_index} does not exist")))?;
+                validate_geometry(strokes, *width, page.bounds)?;
+            }
+            InkMutation::Update {
+                id, strokes, width, ..
+            } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("ink annotation is targeted more than once"));
+                }
+                let page_index = *pages.get(id).ok_or_else(|| missing(*id))?;
+                validate_geometry(strokes, *width, snapshot.pages[page_index as usize].bounds)?;
+            }
+            InkMutation::Remove { id } => {
+                if !targeted.insert(*id) {
+                    return Err(invalid("ink annotation is targeted more than once"));
+                }
+                if !pages.contains_key(id) {
+                    return Err(missing(*id));
+                }
+            }
+        }
+    }
+    Ok(pages)
+}
+
+fn validate_geometry(strokes: &[InkStroke], width: InkWidth, page: [f64; 4]) -> Result<()> {
+    if strokes.is_empty() {
+        return Err(invalid("ink annotation must contain at least one stroke"));
+    }
+    if strokes.len() > MAX_INK_STROKES {
+        return Err(invalid("ink annotation exceeds the stroke limit"));
+    }
+    let point_count = strokes.iter().try_fold(0usize, |count, stroke| {
+        count
+            .checked_add(stroke.points().len())
+            .ok_or_else(|| invalid("ink point count overflows"))
+    })?;
+    if point_count > MAX_INK_POINTS {
+        return Err(invalid("ink annotation exceeds the point limit"));
+    }
+    let rect = bounds(strokes, width);
+    if rect[0] < page[0] || rect[1] < page[1] || rect[2] > page[2] || rect[3] > page[3] {
+        return Err(invalid(
+            "ink stroke and width extend outside the page bounds",
+        ));
+    }
+    Ok(())
+}
+
+fn bounds(strokes: &[InkStroke], width: InkWidth) -> [f64; 4] {
+    let half = width.value() / 2.0;
+    let mut rect = [
+        f64::INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NEG_INFINITY,
+    ];
+    for point in strokes.iter().flat_map(InkStroke::points) {
+        rect[0] = rect[0].min(point.x - half);
+        rect[1] = rect[1].min(point.y - half);
+        rect[2] = rect[2].max(point.x + half);
+        rect[3] = rect[3].max(point.y + half);
+    }
+    rect
+}
+
+fn new_dictionary(
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+    appearance: (u32, u16),
+) -> PdfDictionary {
+    let mut dict = PdfDictionary::new();
+    dict.insert("Type".into(), name("Annot"));
+    dict.insert("Subtype".into(), name("Ink"));
+    set_properties(&mut dict, strokes, color, width, opacity, rect, appearance);
+    dict
+}
+
+fn set_properties(
+    dict: &mut PdfDictionary,
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+    appearance: (u32, u16),
+) {
+    dict.insert("Rect".into(), numbers(&rect));
+    dict.insert(
+        "InkList".into(),
+        PdfObject::Array(PdfArray(
+            strokes
+                .iter()
+                .map(|stroke| {
+                    numbers(
+                        &stroke
+                            .points()
+                            .iter()
+                            .flat_map(|p| [p.x, p.y])
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        )),
+    );
+    dict.insert("C".into(), numbers(&color.components()));
+    let mut bs = match dict.get("BS") {
+        Some(PdfObject::Dictionary(existing)) => existing.clone(),
+        _ => PdfDictionary::new(),
+    };
+    bs.insert("W".into(), PdfObject::Real(width.value()));
+    dict.insert("BS".into(), PdfObject::Dictionary(bs));
+    match opacity {
+        Some(value) => {
+            dict.insert("CA".into(), PdfObject::Real(value.value()));
+        }
+        None => {
+            dict.0.remove(&PdfName("CA".into()));
+        }
+    }
+    let mut ap = match dict.get("AP") {
+        Some(PdfObject::Dictionary(existing)) => existing.clone(),
+        _ => PdfDictionary::new(),
+    };
+    ap.insert("N".into(), PdfObject::Reference(appearance.0, appearance.1));
+    dict.insert("AP".into(), PdfObject::Dictionary(ap));
+}
+
+fn appearance(
+    strokes: &[InkStroke],
+    color: InkColor,
+    width: InkWidth,
+    opacity: Option<InkOpacity>,
+    rect: [f64; 4],
+) -> Result<PdfStream> {
+    let color_operator = match color {
+        InkColor::Gray([gray]) => format!("{} G", pdf_number(gray)),
+        InkColor::Rgb([red, green, blue]) => format!(
+            "{} {} {} RG",
+            pdf_number(red),
+            pdf_number(green),
+            pdf_number(blue)
+        ),
+        InkColor::Cmyk([cyan, magenta, yellow, black]) => format!(
+            "{} {} {} {} K",
+            pdf_number(cyan),
+            pdf_number(magenta),
+            pdf_number(yellow),
+            pdf_number(black)
+        ),
+    };
+    let mut data = format!(
+        "q\n{color_operator}\n{} w\n1 J\n1 j\n",
+        pdf_number(width.value())
+    );
+    if let Some(value) = opacity {
+        data.push_str("/GS0 gs\n");
+        let _ = value;
+    }
+    for stroke in strokes {
+        let points = stroke.points();
+        data.push_str(&format!(
+            "{} {} m\n",
+            pdf_number(points[0].x - rect[0]),
+            pdf_number(points[0].y - rect[1])
+        ));
+        for point in &points[1..] {
+            data.push_str(&format!(
+                "{} {} l\n",
+                pdf_number(point.x - rect[0]),
+                pdf_number(point.y - rect[1])
+            ));
+            if data.len() > MAX_INK_APPEARANCE_BYTES {
+                return Err(invalid("ink appearance exceeds the byte limit"));
+            }
+        }
+        if points.len() == 1 {
+            data.push_str(&format!(
+                "{} {} l\n",
+                pdf_number(points[0].x - rect[0]),
+                pdf_number(points[0].y - rect[1])
+            ));
+        }
+        data.push_str("S\n");
+        if data.len() > MAX_INK_APPEARANCE_BYTES {
+            return Err(invalid("ink appearance exceeds the byte limit"));
+        }
+    }
+    data.push_str("Q");
+    let mut dict = PdfDictionary::new();
+    dict.insert("Type".into(), name("XObject"));
+    dict.insert("Subtype".into(), name("Form"));
+    dict.insert("FormType".into(), PdfObject::Integer(1));
+    dict.insert(
+        "BBox".into(),
+        numbers(&[0.0, 0.0, rect[2] - rect[0], rect[3] - rect[1]]),
+    );
+    if let Some(value) = opacity {
+        let mut gs = PdfDictionary::new();
+        gs.insert("CA".into(), PdfObject::Real(value.value()));
+        gs.insert("ca".into(), PdfObject::Real(value.value()));
+        let mut resources = PdfDictionary::new();
+        resources.insert("GS0".into(), PdfObject::Dictionary(gs));
+        let mut root = PdfDictionary::new();
+        root.insert("ExtGState".into(), PdfObject::Dictionary(resources));
+        dict.insert("Resources".into(), PdfObject::Dictionary(root));
+    }
+    Ok(PdfStream {
+        dict,
+        data: data.into_bytes(),
+    })
+}
+
+fn rewrite_pages(
+    update: &mut IncrementalUpdate,
+    snapshot: &mut AnnotationSnapshot,
+    changed: &HashSet<u32>,
+) -> Result<()> {
+    for page_index in changed {
+        let page = &mut snapshot.pages[*page_index as usize];
+        match page.container {
+            AnnotationContainer::Page => {
+                page.dictionary.insert(
+                    "Annots".into(),
+                    PdfObject::Array(PdfArray(page.annotations.clone())),
+                );
+                update.replace(
+                    page.reference,
+                    PdfObject::Dictionary(page.dictionary.clone()),
+                )?;
+            }
+            AnnotationContainer::Indirect(id) => {
+                update.replace(id, PdfObject::Array(PdfArray(page.annotations.clone())))?
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_policy(bytes: &[u8]) -> Result<()> {
+    let mut reader =
+        PdfReader::new(Cursor::new(bytes)).map_err(|e| invalid(&format!("parse base PDF: {e}")))?;
+    let catalog = reader
+        .catalog()
+        .map_err(|e| invalid(&format!("read catalog: {e}")))?
+        .clone();
+    ensure_modification_allowed(
+        &mut reader,
+        &catalog,
+        IncrementalModification::AddAnnotation,
+    )
+}
+
+fn numeric_array(dict: &PdfDictionary, key: &str, length: Option<usize>) -> Result<Vec<f64>> {
+    let array = dict
+        .get(key)
+        .and_then(PdfObject::as_array)
+        .ok_or_else(|| invalid(&format!("/Ink /{key} is missing or is not an array")))?;
+    if length.is_some_and(|len| array.0.len() != len) {
+        return Err(invalid(&format!(
+            "/Ink /{key} has the wrong number of values"
+        )));
+    }
+    array
+        .0
+        .iter()
+        .map(|value| {
+            number(value).ok_or_else(|| {
+                invalid(&format!(
+                    "/Ink /{key} contains a non-finite or non-numeric value"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn border_width(dict: &PdfDictionary) -> Result<Option<f64>> {
+    let Some(value) = dict.get("Border") else {
+        return Ok(None);
+    };
+    let array = value
+        .as_array()
+        .ok_or_else(|| invalid("/Ink /Border must be an array"))?;
+    if array.0.len() < 3 {
+        return Err(invalid("/Ink /Border must contain at least three values"));
+    }
+    number(&array.0[2])
+        .ok_or_else(|| invalid("/Ink /Border width must be a finite number"))
+        .map(Some)
+}
+
+fn number(value: &PdfObject) -> Option<f64> {
+    match value {
+        PdfObject::Integer(v) => Some(*v as f64),
+        PdfObject::Real(v) if v.is_finite() => Some(*v),
+        _ => None,
+    }
+}
+fn numbers(values: &[f64]) -> PdfObject {
+    PdfObject::Array(PdfArray(
+        values.iter().copied().map(PdfObject::Real).collect(),
+    ))
+}
+fn name(value: &str) -> PdfObject {
+    PdfObject::Name(PdfName(value.into()))
+}
+fn validate_unit(values: &[f64], label: &str) -> Result<()> {
+    if values
+        .iter()
+        .any(|v| !v.is_finite() || !(0.0..=1.0).contains(v))
+    {
+        Err(invalid(&format!(
+            "{label} components must be finite and between 0 and 1"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn missing(id: InkId) -> PdfError {
+    invalid(&format!(
+        "ink annotation {} {} does not exist",
+        id.object_number, id.generation_number
+    ))
+}
+fn invalid(message: &str) -> PdfError {
+    PdfError::InvalidStructure(message.into())
+}
+fn pdf_number(value: f64) -> String {
+    let mut s = format!("{value:.6}");
+    while s.contains('.') && s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    if s == "-0" {
+        "0".into()
+    } else {
+        s
+    }
+}

--- a/oxidize-pdf-core/src/writer/incremental_update.rs
+++ b/oxidize-pdf-core/src/writer/incremental_update.rs
@@ -67,7 +67,7 @@ impl<'a> IncrementalUpdate<'a> {
         Self::from_reader(base, &reader)
     }
 
-    pub(super) fn allocate_id(&mut self) -> Result<(u32, u16)> {
+    pub(crate) fn allocate_id(&mut self) -> Result<(u32, u16)> {
         let id = (self.next_id, 0);
         self.next_id = self.next_id.checked_add(1).ok_or_else(|| {
             PdfError::InvalidStructure("PDF object number space is exhausted".to_string())

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -3,6 +3,7 @@
 mod content_stream_utils;
 mod incremental_annotations;
 mod incremental_form_fill;
+mod incremental_free_text;
 mod incremental_highlights;
 mod incremental_ocr_layer;
 mod incremental_tagged_pdf;
@@ -18,6 +19,10 @@ pub(crate) use content_stream_utils::{
     apply_font_rename_map, collision_font_mapping, rewrite_font_references, INJECTED_BASE_FONT_KEYS,
 };
 pub use incremental_form_fill::IncrementalFormFiller;
+pub use incremental_free_text::{
+    FreeText, FreeTextAlignment, FreeTextId, FreeTextMutation, FreeTextUpdate,
+    IncrementalFreeTextEditor,
+};
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
     HighlightUpdate, IncrementalHighlightEditor,

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -5,6 +5,7 @@ mod incremental_annotations;
 mod incremental_form_fill;
 mod incremental_free_text;
 mod incremental_highlights;
+mod incremental_ink;
 mod incremental_ocr_layer;
 mod incremental_tagged_pdf;
 mod incremental_text_notes;
@@ -26,6 +27,10 @@ pub use incremental_free_text::{
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,
     HighlightUpdate, IncrementalHighlightEditor,
+};
+pub use incremental_ink::{
+    IncrementalInkEditor, Ink, InkColor, InkId, InkMutation, InkOpacity, InkStroke, InkUpdate,
+    InkWidth,
 };
 pub use incremental_ocr_layer::{
     IncrementalOcrLayerEditor, OcrLayerFragment, OcrLayerPage, OcrLayerPlan, OcrLayerUpdate,

--- a/oxidize-pdf-core/src/writer/mod.rs
+++ b/oxidize-pdf-core/src/writer/mod.rs
@@ -4,6 +4,7 @@ mod content_stream_utils;
 mod incremental_annotations;
 mod incremental_form_fill;
 mod incremental_free_text;
+mod incremental_geometric;
 mod incremental_highlights;
 mod incremental_ink;
 mod incremental_ocr_layer;
@@ -23,6 +24,11 @@ pub use incremental_form_fill::IncrementalFormFiller;
 pub use incremental_free_text::{
     FreeText, FreeTextAlignment, FreeTextId, FreeTextMutation, FreeTextUpdate,
     IncrementalFreeTextEditor,
+};
+pub use incremental_geometric::{
+    GeometricAnnotation, GeometricColor, GeometricDashPattern, GeometricGeometry, GeometricId,
+    GeometricMutation, GeometricOpacity, GeometricStyle, GeometricUpdate, GeometricWidth,
+    IncrementalGeometricEditor, LineEnding,
 };
 pub use incremental_highlights::{
     Highlight, HighlightColor, HighlightId, HighlightMutation, HighlightOpacity, HighlightQuad,

--- a/oxidize-pdf-core/tests/cli_ocr_tests.rs
+++ b/oxidize-pdf-core/tests/cli_ocr_tests.rs
@@ -326,6 +326,5 @@ mod cli_ocr_disabled_tests {
     #[test]
     fn test_cli_without_ocr_feature() {
         println!("CLI OCR tests are disabled when 'ocr-tesseract' feature is not enabled");
-        assert!(true, "This is expected behavior");
     }
 }

--- a/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
@@ -11,9 +11,10 @@ fn classic_base() -> Vec<u8> {
         (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
         (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
         (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R /CustomPageKey 42 >>"),
-        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /CustomKey (preserve-me) >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /AP << /N 7 0 R >> /CustomKey (preserve-me) >>"),
         (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /CustomLinkKey 99 >>"),
         (6, b"[4 0 R 5 0 R]"),
+        (7, b"<< /Type /XObject /Subtype /Form /BBox [0 0 130 50] /Length 3 >>\nstream\nold\nendstream"),
     ])
 }
 
@@ -36,6 +37,43 @@ fn build_classic(objects: &[(u32, &[u8])]) -> Vec<u8> {
         format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
     );
     out
+}
+
+fn build_classic_generations(objects: &[(u32, u16, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap_or(0) + 1;
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[*number as usize] = Some((out.len(), *generation));
+        out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => out.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn replace_policy(source: &[u8], permission: u8) -> Vec<u8> {
+    let mut result = source.to_vec();
+    let marker = b"/P 2";
+    let offset = result
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture must contain DocMDP P=2");
+    result[offset + 3] = b'0' + permission;
+    result
 }
 
 fn xref_stream_base() -> Vec<u8> {
@@ -170,8 +208,70 @@ fn mixed_batch_is_atomic_round_trips_unicode_and_preserves_unknown_keys() {
         "preserve-me"
     );
     assert_eq!(dictionary.get("Q"), Some(&PdfObject::Integer(2)));
+    let appearance_id = dictionary
+        .get("AP")
+        .and_then(PdfObject::as_dict)
+        .and_then(|appearance| appearance.get("N"))
+        .and_then(PdfObject::as_reference)
+        .expect("updated annotation must reference a normal appearance stream");
+    assert_ne!(appearance_id, (7, 0), "stale appearance must be replaced");
+    let appearance = reader
+        .get_object(appearance_id.0, appearance_id.1)
+        .unwrap()
+        .as_stream()
+        .unwrap();
+    assert!(appearance
+        .data
+        .windows(8)
+        .any(|window| window == b"l\\355nea"));
+    assert!(appearance.dict.get("Resources").is_some());
     let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
     assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
+
+#[test]
+fn preserves_nonzero_generation_identities() {
+    let base = build_classic_generations(&[
+        (1, 0, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, 0, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, 0, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 7 R] >>"),
+        (4, 7, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (generation) /DA (/Helv 10 Tf 0 g) >>"),
+    ]);
+    let annotations = IncrementalFreeTextEditor::new(&base).annotations().unwrap();
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 7));
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[FreeTextMutation::Update {
+            id: FreeTextId::new(4, 7),
+            rect: [20.0, 30.0, 150.0, 80.0],
+            contents: "updated".to_string(),
+            default_appearance: "/Helv 11 Tf 0 g".to_string(),
+            alignment: FreeTextAlignment::Left,
+        }])
+        .unwrap();
+    assert_eq!(update.annotations[0].id, FreeTextId::new(4, 7));
+}
+
+#[test]
+fn enforces_docmdp_and_preserves_approval_signed_prefixes() {
+    let certified_p2 = include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf");
+    for source in [replace_policy(certified_p2, 1), certified_p2.to_vec()] {
+        let error = IncrementalFreeTextEditor::new(&source)
+            .apply(&[add_mutation("forbidden")])
+            .unwrap_err();
+        assert!(matches!(error, PdfError::PermissionDenied(message) if message.contains("DocMDP")));
+    }
+
+    let certified_p3 = replace_policy(certified_p2, 3);
+    let allowed = IncrementalFreeTextEditor::new(&certified_p3)
+        .apply(&[add_mutation("allowed")])
+        .unwrap();
+    assert!(allowed.pdf_bytes.starts_with(&certified_p3));
+
+    let approval = include_bytes!("fixtures/signatures/signed_rsa_incremental.pdf");
+    let approval_update = IncrementalFreeTextEditor::new(approval)
+        .apply(&[add_mutation("approval")])
+        .unwrap();
+    assert!(approval_update.pdf_bytes.starts_with(approval));
 }
 
 #[test]
@@ -302,6 +402,25 @@ fn rejects_invalid_properties_pages_stale_ids_and_conflicting_batches() {
         IncrementalFreeTextEditor::new(&base).apply(&[non_ascii_appearance]),
         "ASCII",
     );
+    for appearance in [
+        "/Unknown 10 Tf 0 g",
+        "/Helv nope Tf 0 g",
+        "/Helv 0 Tf 0 g",
+        "/Helv 10 Tf 2 0 0 rg",
+        "/Helv 10 Tf q",
+    ] {
+        let mutation = FreeTextMutation::Add {
+            page_index: 0,
+            rect: [20.0, 100.0, 180.0, 150.0],
+            contents: "valid".to_string(),
+            default_appearance: appearance.to_string(),
+            alignment: FreeTextAlignment::Left,
+        };
+        assert_invalid(
+            IncrementalFreeTextEditor::new(&base).apply(&[mutation]),
+            "default appearance",
+        );
+    }
     assert_invalid(
         IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Remove {
             id: FreeTextId::new(99, 0),

--- a/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
+++ b/oxidize-pdf-core/tests/issue_534_incremental_free_text_test.rs
@@ -1,0 +1,365 @@
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{
+    FreeTextAlignment, FreeTextId, FreeTextMutation, IncrementalFreeTextEditor,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn classic_base() -> Vec<u8> {
+    build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 6 0 R /CustomPageKey 42 >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (old) /DA (/Helv 10 Tf 0 g) /Q 0 /CustomKey (preserve-me) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /CustomLinkKey 99 >>"),
+        (6, b"[4 0 R 5 0 R]"),
+    ])
+}
+
+fn build_classic(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n".to_vec();
+    let size = objects.iter().map(|(number, _)| *number).max().unwrap_or(0) + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (number, body) in objects {
+        offsets[*number as usize] = out.len();
+        out.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = vec![0, 0, 0, 0, 0, 0xFF, 0xFF];
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn add_mutation(contents: &str) -> FreeTextMutation {
+    FreeTextMutation::Add {
+        page_index: 0,
+        rect: [20.0, 100.0, 180.0, 150.0],
+        contents: contents.to_string(),
+        default_appearance: "/Helv 12 Tf 0 0 1 rg".to_string(),
+        alignment: FreeTextAlignment::Center,
+    }
+}
+
+fn assert_invalid<T>(result: Result<T, PdfError>, expected: &str) {
+    match result {
+        Err(PdfError::InvalidStructure(message)) => assert!(
+            message.contains(expected),
+            "expected {expected:?} in {message:?}"
+        ),
+        Err(other) => panic!("expected InvalidStructure, got {other:?}"),
+        Ok(_) => panic!("expected InvalidStructure containing {expected:?}"),
+    }
+}
+
+#[test]
+fn reads_free_text_with_stable_identity_and_default_alignment() {
+    let base = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /FreeText /Rect [10 20 140 70] /Contents (hello) /DA (/Helv 10 Tf 0 g) >>"),
+    ]);
+
+    let annotations = IncrementalFreeTextEditor::new(&base).annotations().unwrap();
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 0));
+    assert_eq!(annotations[0].page_index, 0);
+    assert_eq!(annotations[0].rect, [10.0, 20.0, 140.0, 70.0]);
+    assert_eq!(annotations[0].contents, "hello");
+    assert_eq!(annotations[0].default_appearance, "/Helv 10 Tf 0 g");
+    assert_eq!(annotations[0].alignment, FreeTextAlignment::Left);
+}
+
+#[test]
+fn empty_batch_is_a_true_noop() {
+    let base = classic_base();
+    let update = IncrementalFreeTextEditor::new(&base).apply(&[]).unwrap();
+    assert_eq!(update.pdf_bytes, base);
+    assert_eq!(update.annotations.len(), 1);
+}
+
+#[test]
+fn mixed_batch_is_atomic_round_trips_unicode_and_preserves_unknown_keys() {
+    let base = classic_base();
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[
+            FreeTextMutation::Update {
+                id: FreeTextId::new(4, 0),
+                rect: [30.0, 40.0, 190.0, 100.0],
+                contents: "línea uno\nlínea dos ✓".to_string(),
+                default_appearance: "/Helv 14 Tf 1 0 0 rg".to_string(),
+                alignment: FreeTextAlignment::Right,
+            },
+            add_mutation("new annotation"),
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    assert_eq!(
+        update
+            .pdf_bytes
+            .windows(9)
+            .filter(|window| *window == b"startxref")
+            .count(),
+        2
+    );
+    assert_eq!(update.annotations.len(), 2);
+
+    let reopened = IncrementalFreeTextEditor::new(&update.pdf_bytes)
+        .annotations()
+        .unwrap();
+    let changed = reopened
+        .iter()
+        .find(|annotation| annotation.id == FreeTextId::new(4, 0))
+        .unwrap();
+    assert_eq!(changed.contents, "línea uno\nlínea dos ✓");
+    assert_eq!(changed.alignment, FreeTextAlignment::Right);
+    assert_eq!(changed.default_appearance, "/Helv 14 Tf 1 0 0 rg");
+
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let dictionary = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        dictionary
+            .get("CustomKey")
+            .and_then(PdfObject::as_string)
+            .unwrap()
+            .to_text(),
+        "preserve-me"
+    );
+    assert_eq!(dictionary.get("Q"), Some(&PdfObject::Integer(2)));
+    let link = reader.get_object(5, 0).unwrap().as_dict().unwrap();
+    assert_eq!(link.get("CustomLinkKey"), Some(&PdfObject::Integer(99)));
+}
+
+#[test]
+fn add_and_remove_update_indirect_annots_without_rewriting_other_annotations() {
+    let base = classic_base();
+    let added = IncrementalFreeTextEditor::new(&base)
+        .apply(&[add_mutation("temporary")])
+        .unwrap();
+    let new_id = added
+        .annotations
+        .iter()
+        .find(|annotation| annotation.contents == "temporary")
+        .unwrap()
+        .id;
+    let removed = IncrementalFreeTextEditor::new(&added.pdf_bytes)
+        .apply(&[FreeTextMutation::Remove { id: new_id }])
+        .unwrap();
+
+    let annotations = IncrementalFreeTextEditor::new(&removed.pdf_bytes)
+        .annotations()
+        .unwrap();
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].id, FreeTextId::new(4, 0));
+    let mut reader = PdfReader::new(Cursor::new(&removed.pdf_bytes)).unwrap();
+    assert_eq!(
+        reader
+            .get_object(5, 0)
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .get("CustomLinkKey"),
+        Some(&PdfObject::Integer(99))
+    );
+}
+
+#[test]
+fn supports_xref_stream_inputs_and_emits_a_reopenable_incremental_revision() {
+    let base = xref_stream_base();
+    let update = IncrementalFreeTextEditor::new(&base)
+        .apply(&[add_mutation("xref stream")])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&base));
+    let reopened = IncrementalFreeTextEditor::new(&update.pdf_bytes)
+        .annotations()
+        .unwrap();
+    assert_eq!(reopened.len(), 1);
+    assert_eq!(reopened[0].contents, "xref stream");
+    PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_free_text_revisions() {
+    for (name, base) in [("classic", classic_base()), ("stream", xref_stream_base())] {
+        let update = IncrementalFreeTextEditor::new(&base)
+            .apply(&[add_mutation("interop")])
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(format!("free-text-{name}.pdf"));
+        std::fs::write(&path, &update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn rejects_invalid_properties_pages_stale_ids_and_conflicting_batches() {
+    let base = classic_base();
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Add {
+            page_index: 1,
+            rect: [10.0, 10.0, 20.0, 20.0],
+            contents: "text".to_string(),
+            default_appearance: "/Helv 10 Tf".to_string(),
+            alignment: FreeTextAlignment::Left,
+        }]),
+        "page 1 does not exist",
+    );
+    for (rect, expected) in [
+        ([f64::NAN, 10.0, 20.0, 20.0], "finite, ordered"),
+        ([20.0, 10.0, 10.0, 20.0], "finite, ordered"),
+        ([10.0, 10.0, 310.0, 20.0], "outside the page"),
+    ] {
+        let mut mutation = add_mutation("text");
+        if let FreeTextMutation::Add { rect: target, .. } = &mut mutation {
+            *target = rect;
+        }
+        assert_invalid(
+            IncrementalFreeTextEditor::new(&base).apply(&[mutation]),
+            expected,
+        );
+    }
+    let mut empty_contents = add_mutation(" ");
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[empty_contents.clone()]),
+        "contents must not be empty",
+    );
+    if let FreeTextMutation::Add {
+        default_appearance, ..
+    } = &mut empty_contents
+    {
+        *default_appearance = "".to_string();
+        if let FreeTextMutation::Add { contents, .. } = &mut empty_contents {
+            *contents = "valid".to_string();
+        }
+    }
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[empty_contents]),
+        "default appearance",
+    );
+    let mut non_ascii_appearance = add_mutation("valid");
+    if let FreeTextMutation::Add {
+        default_appearance, ..
+    } = &mut non_ascii_appearance
+    {
+        *default_appearance = "/Helv 10 Tf café".to_string();
+    }
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[non_ascii_appearance]),
+        "ASCII",
+    );
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[FreeTextMutation::Remove {
+            id: FreeTextId::new(99, 0),
+        }]),
+        "does not exist",
+    );
+    assert_invalid(
+        IncrementalFreeTextEditor::new(&base).apply(&[
+            FreeTextMutation::Remove {
+                id: FreeTextId::new(4, 0),
+            },
+            FreeTextMutation::Remove {
+                id: FreeTextId::new(4, 0),
+            },
+        ]),
+        "targeted more than once",
+    );
+}
+
+#[test]
+fn rejects_malformed_inline_and_encrypted_inputs() {
+    for annotation in [
+        b"<< /Subtype /FreeText /Rect [10 10 20] /Contents (x) /DA (/Helv 10 Tf) >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents 42 /DA (/Helv 10 Tf) >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA 42 >>".as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA (/Helv 10 Tf) /Q 3 >>"
+            .as_slice(),
+        b"<< /Subtype /FreeText /Rect [10 10 310 20] /Contents (x) /DA (/Helv 10 Tf) >>".as_slice(),
+    ] {
+        let base = build_classic(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation),
+        ]);
+        assert!(IncrementalFreeTextEditor::new(&base).annotations().is_err());
+    }
+
+    let inline = build_classic(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /FreeText /Rect [10 10 20 20] /Contents (x) /DA (/Helv 10 Tf) >>] >>"),
+    ]);
+    assert!(IncrementalFreeTextEditor::new(&inline)
+        .annotations()
+        .is_err());
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    let encrypted = document.to_bytes().unwrap();
+    assert!(IncrementalFreeTextEditor::new(&encrypted)
+        .annotations()
+        .is_err());
+    assert!(IncrementalFreeTextEditor::new(&encrypted)
+        .apply(&[])
+        .is_err());
+}

--- a/oxidize-pdf-core/tests/issue_536_incremental_ink_test.rs
+++ b/oxidize-pdf-core/tests/issue_536_incremental_ink_test.rs
@@ -1,0 +1,455 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{
+    IncrementalInkEditor, InkColor, InkId, InkMutation, InkOpacity, InkStroke, InkWidth,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn build_pdf(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (number, body) in objects {
+        offsets[*number as usize] = out.len();
+        out.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn build_pdf_generations(objects: &[(u32, u16, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[*number as usize] = Some((out.len(), *generation));
+        out.extend_from_slice(format!("{number} {generation} obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                out.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => out.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn base() -> Vec<u8> {
+    build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R] /KeepPage true >>"),
+        (4, b"<< /Type /Annot /Subtype /Ink /Rect [10 10 80 60] /InkList [[10 10 20 20 30 15] [40 40 70 55]] /C [1 0 0] /BS << /W 2 /S /D /CustomBS true >> /CA 0.5 /AP << /N 6 0 R /R 6 0 R /CustomAP true >> /KeepInk (yes) >>"),
+        (5, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /KeepLink true >>"),
+        (6, b"<< /Type /XObject /Subtype /Form /BBox [10 10 80 60] /Length 0 >>\nstream\n\nendstream"),
+    ])
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = vec![0, 0, 0, 0, 0, 0xFF, 0xFF];
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn replace_policy(source: &[u8], permission: u8) -> Vec<u8> {
+    let mut result = source.to_vec();
+    let marker = b"/P 2";
+    let offset = result
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture must contain DocMDP P=2");
+    result[offset + 3] = b'0' + permission;
+    result
+}
+
+fn stroke(points: &[(f64, f64)]) -> InkStroke {
+    InkStroke::new(points.iter().map(|&(x, y)| Point::new(x, y)).collect()).unwrap()
+}
+
+fn color(rgb: [f64; 3]) -> InkColor {
+    InkColor::new(rgb).unwrap()
+}
+
+fn width(value: f64) -> InkWidth {
+    InkWidth::new(value).unwrap()
+}
+
+fn opacity(value: f64) -> InkOpacity {
+    InkOpacity::new(value).unwrap()
+}
+
+#[test]
+fn reads_updates_adds_and_removes_ink_atomically() {
+    let source = base();
+    let editor = IncrementalInkEditor::new(&source);
+    let inks = editor.annotations().unwrap();
+    assert_eq!(inks.len(), 1);
+    assert_eq!(inks[0].id, InkId::new(4, 0));
+    assert_eq!(inks[0].strokes.len(), 2);
+    assert_eq!(inks[0].color, color([1.0, 0.0, 0.0]));
+    assert_eq!(inks[0].width, width(2.0));
+    assert_eq!(inks[0].opacity, Some(opacity(0.5)));
+
+    let updated_strokes = vec![stroke(&[(20.0, 20.0), (30.0, 40.0), (50.0, 35.0)])];
+    let added_strokes = vec![
+        stroke(&[(100.0, 100.0), (120.0, 130.0)]),
+        stroke(&[(120.0, 130.0), (160.0, 110.0)]),
+    ];
+    let update = editor
+        .apply(&[
+            InkMutation::Update {
+                id: InkId::new(4, 0),
+                strokes: updated_strokes.clone(),
+                color: color([0.0, 0.0, 1.0]),
+                width: width(3.0),
+                opacity: None,
+            },
+            InkMutation::Add {
+                page_index: 0,
+                strokes: added_strokes,
+                color: color([0.0, 0.5, 0.0]),
+                width: width(1.5),
+                opacity: Some(opacity(0.75)),
+            },
+        ])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&source));
+    assert_eq!(update.annotations.len(), 2);
+    let changed = update
+        .annotations
+        .iter()
+        .find(|ink| ink.id == InkId::new(4, 0))
+        .unwrap();
+    assert_eq!(changed.strokes, updated_strokes);
+    assert_eq!(changed.rect, [18.5, 18.5, 51.5, 41.5]);
+    assert!(String::from_utf8_lossy(&update.pdf_bytes).contains("/KeepInk (yes)"));
+    assert!(String::from_utf8_lossy(&update.pdf_bytes).contains("/KeepLink true"));
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let dictionary = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    let bs = dictionary.get("BS").unwrap().as_dict().unwrap();
+    assert_eq!(bs.get("CustomBS"), Some(&PdfObject::Boolean(true)));
+    let ap = dictionary.get("AP").unwrap().as_dict().unwrap();
+    assert_eq!(ap.get("CustomAP"), Some(&PdfObject::Boolean(true)));
+    assert!(ap.get("R").is_some());
+
+    let added_id = update
+        .annotations
+        .iter()
+        .find(|ink| ink.id != InkId::new(4, 0))
+        .unwrap()
+        .id;
+    let removed = IncrementalInkEditor::new(&update.pdf_bytes)
+        .apply(&[InkMutation::Remove { id: added_id }])
+        .unwrap();
+    assert_eq!(removed.annotations.len(), 1);
+}
+
+#[test]
+fn validates_public_values_geometry_bounds_and_stale_ids() {
+    assert!(InkStroke::new(vec![]).is_err());
+    assert!(InkStroke::new(vec![Point::new(f64::NAN, 1.0)]).is_err());
+    assert!(InkColor::new([1.1, 0.0, 0.0]).is_err());
+    assert!(InkWidth::new(0.0).is_err());
+    assert!(InkOpacity::new(-0.1).is_err());
+
+    let source = base();
+    let result = IncrementalInkEditor::new(&source).apply(&[InkMutation::Add {
+        page_index: 0,
+        strokes: vec![stroke(&[(299.0, 299.0), (300.0, 300.0)])],
+        color: color([0.0, 0.0, 0.0]),
+        width: width(4.0),
+        opacity: None,
+    }]);
+    assert!(matches!(result, Err(PdfError::InvalidStructure(_))));
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Remove {
+            id: InkId::new(99, 0)
+        }])
+        .is_err());
+}
+
+#[test]
+fn rejects_malformed_ink_lists() {
+    for ink_list in ["[]", "[[10]]", "[[10 10 true 20]]"] {
+        let annotation = format!(
+            "<< /Type /Annot /Subtype /Ink /Rect [0 0 20 20] /InkList {ink_list} /C [0 0 0] /BS << /W 1 >> >>"
+        );
+        let source = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation.as_bytes()),
+        ]);
+        assert!(
+            IncrementalInkEditor::new(&source).annotations().is_err(),
+            "accepted malformed InkList {ink_list}"
+        );
+    }
+}
+
+#[test]
+fn reads_gray_and_cmyk_and_rejects_malformed_width() {
+    for (raw_color, expected) in [
+        ("[0.25]", InkColor::gray(0.25).unwrap()),
+        (
+            "[0.1 0.2 0.3 0.4]",
+            InkColor::cmyk([0.1, 0.2, 0.3, 0.4]).unwrap(),
+        ),
+    ] {
+        let annotation = format!(
+            "<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C {raw_color} /BS << /W 1 >> >>"
+        );
+        let source = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation.as_bytes()),
+        ]);
+        assert_eq!(
+            IncrementalInkEditor::new(&source).annotations().unwrap()[0].color,
+            expected
+        );
+    }
+
+    let malformed = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C [0] /BS << /W (wide) >> >>"),
+    ]);
+    assert!(IncrementalInkEditor::new(&malformed).annotations().is_err());
+}
+
+#[test]
+fn preserves_generation_and_updates_indirect_annots_array() {
+    let source = build_pdf_generations(&[
+        (1, 0, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, 0, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (
+            3,
+            0,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots 5 0 R >>",
+        ),
+        (
+            4,
+            7,
+            b"<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] /C [0] /BS << /W 1 >> >>",
+        ),
+        (5, 0, b"[4 7 R]"),
+    ]);
+    let existing = IncrementalInkEditor::new(&source).annotations().unwrap();
+    assert_eq!(existing[0].id, InkId::new(4, 7));
+    let update = IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Remove {
+            id: InkId::new(4, 7),
+        }])
+        .unwrap();
+    assert!(update.annotations.is_empty());
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    assert!(reader
+        .get_object(5, 0)
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .0
+        .is_empty());
+}
+
+#[test]
+fn rejects_excessive_strokes_and_conflicting_targets() {
+    let source = base();
+    let too_many = vec![stroke(&[(20.0, 20.0)]); 4_097];
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Add {
+            page_index: 0,
+            strokes: too_many,
+            color: color([0.0, 0.0, 0.0]),
+            width: width(1.0),
+            opacity: None,
+        }])
+        .is_err());
+    assert!(IncrementalInkEditor::new(&source)
+        .apply(&[
+            InkMutation::Remove {
+                id: InkId::new(4, 0)
+            },
+            InkMutation::Remove {
+                id: InkId::new(4, 0)
+            },
+        ])
+        .is_err());
+}
+
+#[test]
+fn rejects_inline_and_encrypted_inputs_and_enforces_docmdp() {
+    let inline = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /Ink /Rect [9 9 21 21] /InkList [[10 10 20 20]] >>] >>"),
+    ]);
+    assert!(IncrementalInkEditor::new(&inline).annotations().is_err());
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    let encrypted = document.to_bytes().unwrap();
+    assert!(IncrementalInkEditor::new(&encrypted).annotations().is_err());
+
+    let mutation = InkMutation::Add {
+        page_index: 0,
+        strokes: vec![stroke(&[(20.0, 20.0), (40.0, 40.0)])],
+        color: color([0.0, 0.0, 0.0]),
+        width: width(1.0),
+        opacity: None,
+    };
+    let certified_p2 = include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf");
+    for forbidden in [replace_policy(certified_p2, 1), certified_p2.to_vec()] {
+        assert!(matches!(
+            IncrementalInkEditor::new(&forbidden).apply(std::slice::from_ref(&mutation)),
+            Err(PdfError::PermissionDenied(_))
+        ));
+    }
+    let certified_p3 = replace_policy(certified_p2, 3);
+    assert!(IncrementalInkEditor::new(&certified_p3)
+        .apply(std::slice::from_ref(&mutation))
+        .unwrap()
+        .pdf_bytes
+        .starts_with(&certified_p3));
+    let approval = include_bytes!("fixtures/signatures/signed_rsa_incremental.pdf");
+    assert!(IncrementalInkEditor::new(approval)
+        .apply(&[mutation])
+        .unwrap()
+        .pdf_bytes
+        .starts_with(approval));
+}
+
+#[test]
+fn adds_high_point_count_ink_to_xref_stream_pdf() {
+    let source = xref_stream_base();
+    let points = (0..10_000)
+        .map(|index| Point::new(10.0 + index as f64 * 0.02, 100.0 + (index % 7) as f64))
+        .collect();
+    let update = IncrementalInkEditor::new(&source)
+        .apply(&[InkMutation::Add {
+            page_index: 0,
+            strokes: vec![InkStroke::new(points).unwrap()],
+            color: color([0.1, 0.2, 0.3]),
+            width: width(1.0),
+            opacity: Some(opacity(0.8)),
+        }])
+        .unwrap();
+
+    assert!(update.pdf_bytes.starts_with(&source));
+    assert_eq!(
+        IncrementalInkEditor::new(&update.pdf_bytes)
+            .annotations()
+            .unwrap()[0]
+            .strokes[0]
+            .points()
+            .len(),
+        10_000
+    );
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_classic_and_xref_stream_ink_revisions() {
+    for (name, source) in [("classic", base()), ("stream", xref_stream_base())] {
+        let update = IncrementalInkEditor::new(&source)
+            .apply(&[InkMutation::Add {
+                page_index: 0,
+                strokes: vec![stroke(&[(20.0, 20.0), (60.0, 80.0), (100.0, 30.0)])],
+                color: color([0.2, 0.4, 0.8]),
+                width: width(2.0),
+                opacity: Some(opacity(0.6)),
+            }])
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let raster_prefix = dir.path().join(format!("{name}-render"));
+        let render = Command::new("pdftoppm")
+            .args(["-mono", "-singlefile", "-r", "72"])
+            .arg(&path)
+            .arg(&raster_prefix)
+            .output()
+            .unwrap();
+        assert!(
+            render.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        let bitmap = std::fs::read(raster_prefix.with_extension("pbm")).unwrap();
+        let body = bitmap.splitn(3, |byte| *byte == b'\n').nth(2).unwrap();
+        assert!(
+            body.iter().any(|byte| *byte != 0),
+            "{name}: rendered page is blank"
+        );
+    }
+}

--- a/oxidize-pdf-core/tests/issue_537_incremental_geometric_test.rs
+++ b/oxidize-pdf-core/tests/issue_537_incremental_geometric_test.rs
@@ -1,0 +1,528 @@
+use oxidize_pdf::geometry::Point;
+use oxidize_pdf::parser::{objects::PdfObject, PdfReader};
+use oxidize_pdf::writer::{
+    GeometricColor, GeometricDashPattern, GeometricGeometry, GeometricId, GeometricMutation,
+    GeometricOpacity, GeometricStyle, GeometricWidth, IncrementalGeometricEditor, LineEnding,
+};
+use oxidize_pdf::{Document, Page, PdfError};
+use std::io::Cursor;
+use std::process::Command;
+
+fn build_pdf(objects: &[(u32, &[u8])]) -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let size = objects.iter().map(|item| item.0).max().unwrap() + 1;
+    let mut offsets = vec![0usize; size as usize];
+    for (number, body) in objects {
+        offsets[*number as usize] = out.len();
+        out.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets.iter().skip(1) {
+        out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn base() -> Vec<u8> {
+    build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R] /KeepPage true >>"),
+        (4, b"<< /Type /Annot /Subtype /Line /Rect [2 2 98 98] /L [10 10 90 90] /LE [/OpenArrow /ClosedArrow] /C [1 0 0] /IC [1 1 0] /BS << /W 2 /S /D /D [3 2] /KeepBS true >> /CA 0.5 /AP << /N 10 0 R /R 10 0 R >> /KeepLine true >>"),
+        (5, b"<< /Type /Annot /Subtype /Square /Rect [100 10 180 80] /C [0 1 0] /IC [0.5] /BS << /W 1 >> >>"),
+        (6, b"<< /Type /Annot /Subtype /Circle /Rect [190 10 270 80] /C [0 0 1] /BS << /W 1 >> >>"),
+        (7, b"<< /Type /Annot /Subtype /Polygon /Rect [9 99 91 181] /Vertices [10 100 90 100 50 180] /C [0 0 0] /IC [0 1 1 0] /BS << /W 2 >> >>"),
+        (8, b"<< /Type /Annot /Subtype /PolyLine /Rect [102 92 258 188] /Vertices [110 100 180 180 250 100] /LE [/None /OpenArrow] /C [0] /BS << /W 2 >> >>"),
+        (9, b"<< /Type /Annot /Subtype /Link /Rect [1 1 5 5] /KeepLink true >>"),
+        (10, b"<< /Type /XObject /Subtype /Form /BBox [0 0 82 82] /Length 0 >>\nstream\n\nendstream"),
+    ])
+}
+
+fn xref_stream_base() -> Vec<u8> {
+    let mut out = b"%PDF-1.7\n".to_vec();
+    let bodies: [&[u8]; 3] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] >>",
+    ];
+    let mut offsets = vec![0u32];
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len() as u32);
+        out.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_offset = out.len() as u32;
+    offsets.push(xref_offset);
+    let mut data = vec![0, 0, 0, 0, 0, 0xFF, 0xFF];
+    for offset in offsets.iter().skip(1) {
+        data.push(1);
+        data.extend_from_slice(&offset.to_be_bytes());
+        data.extend_from_slice(&0u16.to_be_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length {} >>\nstream\n",
+            data.len()
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(&data);
+    out.extend_from_slice(b"\nendstream\nendobj\n");
+    out.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    out
+}
+
+fn replace_policy(source: &[u8], permission: u8) -> Vec<u8> {
+    let mut result = source.to_vec();
+    let marker = b"/P 2";
+    let offset = result
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .unwrap();
+    result[offset + 3] = b'0' + permission;
+    result
+}
+
+fn rgb(values: [f64; 3]) -> GeometricColor {
+    GeometricColor::rgb(values).unwrap()
+}
+
+fn style(color: [f64; 3]) -> GeometricStyle {
+    GeometricStyle {
+        stroke_color: rgb(color),
+        fill_color: None,
+        width: GeometricWidth::new(2.0).unwrap(),
+        dash_pattern: None,
+        opacity: None,
+    }
+}
+
+#[test]
+fn reads_all_five_geometric_subtypes() {
+    let annotations = IncrementalGeometricEditor::new(&base())
+        .annotations()
+        .unwrap();
+    assert_eq!(annotations.len(), 5);
+    assert!(matches!(
+        annotations[0].geometry,
+        GeometricGeometry::Line { .. }
+    ));
+    assert!(matches!(
+        annotations[1].geometry,
+        GeometricGeometry::Square { .. }
+    ));
+    assert!(matches!(
+        annotations[2].geometry,
+        GeometricGeometry::Circle { .. }
+    ));
+    assert!(matches!(
+        annotations[3].geometry,
+        GeometricGeometry::Polygon { .. }
+    ));
+    assert!(matches!(
+        annotations[4].geometry,
+        GeometricGeometry::PolyLine { .. }
+    ));
+    assert_eq!(annotations[0].id, GeometricId::new(4, 0));
+    assert_eq!(
+        annotations[0].style.dash_pattern,
+        Some(GeometricDashPattern::new(vec![3.0, 2.0]).unwrap())
+    );
+}
+
+#[test]
+fn reads_legacy_border_and_requires_consistent_rectangles() {
+    let legacy = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>"),
+        (4, b"<< /Type /Annot /Subtype /Polygon /Rect [8 8 92 92] /Vertices [10 10 90 10 50 90] /Border [0 0 4 [5 2]] >>"),
+    ]);
+    let annotation = IncrementalGeometricEditor::new(&legacy)
+        .annotations()
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(annotation.style.width, GeometricWidth::new(4.0).unwrap());
+    assert_eq!(
+        annotation.style.dash_pattern,
+        Some(GeometricDashPattern::new(vec![5.0, 2.0]).unwrap())
+    );
+
+    let missing_rect = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+        ),
+        (4, b"<< /Type /Annot /Subtype /Line /L [10 10 20 20] >>"),
+    ]);
+    assert!(IncrementalGeometricEditor::new(&missing_rect)
+        .annotations()
+        .is_err());
+}
+
+#[test]
+fn mixed_batch_updates_adds_and_removes_atomically() {
+    let source = base();
+    let updated = GeometricGeometry::Line {
+        start: Point::new(20.0, 20.0),
+        end: Point::new(100.0, 60.0),
+        start_ending: LineEnding::Diamond,
+        end_ending: LineEnding::ClosedArrow,
+    };
+    let added = GeometricGeometry::Polygon {
+        vertices: vec![
+            Point::new(120.0, 200.0),
+            Point::new(180.0, 250.0),
+            Point::new(240.0, 200.0),
+        ],
+    };
+    let update = IncrementalGeometricEditor::new(&source)
+        .apply(&[
+            GeometricMutation::Update {
+                id: GeometricId::new(4, 0),
+                geometry: updated.clone(),
+                style: GeometricStyle {
+                    fill_color: Some(GeometricColor::gray(0.5).unwrap()),
+                    dash_pattern: Some(GeometricDashPattern::new(vec![4.0, 2.0]).unwrap()),
+                    opacity: Some(GeometricOpacity::new(0.75).unwrap()),
+                    ..style([0.0, 0.0, 1.0])
+                },
+            },
+            GeometricMutation::Remove {
+                id: GeometricId::new(5, 0),
+            },
+            GeometricMutation::Add {
+                page_index: 0,
+                geometry: added,
+                style: style([0.0, 0.0, 0.0]),
+            },
+        ])
+        .unwrap();
+    assert!(update.pdf_bytes.starts_with(&source));
+    assert_eq!(update.annotations.len(), 5);
+    assert_eq!(
+        update
+            .annotations
+            .iter()
+            .find(|item| item.id == GeometricId::new(4, 0))
+            .unwrap()
+            .geometry,
+        updated
+    );
+    let bytes = String::from_utf8_lossy(&update.pdf_bytes);
+    assert!(bytes.contains("/KeepLine true"));
+    assert!(bytes.contains("/KeepLink true"));
+    let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+    let line = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+    assert_eq!(line.get("KeepLine"), Some(&PdfObject::Boolean(true)));
+    assert_eq!(
+        line.get("BS").unwrap().as_dict().unwrap().get("KeepBS"),
+        Some(&PdfObject::Boolean(true))
+    );
+    assert!(line
+        .get("AP")
+        .unwrap()
+        .as_dict()
+        .unwrap()
+        .get("R")
+        .is_some());
+}
+
+#[test]
+fn validates_values_geometry_pages_and_stale_ids() {
+    assert!(GeometricColor::rgb([f64::NAN, 0.0, 0.0]).is_err());
+    assert!(GeometricWidth::new(0.0).is_err());
+    assert!(GeometricOpacity::new(1.1).is_err());
+    assert!(GeometricDashPattern::new(vec![]).is_err());
+    assert!(GeometricDashPattern::new(vec![1.0, -1.0]).is_err());
+    let source = base();
+    assert!(IncrementalGeometricEditor::new(&source)
+        .apply(&[GeometricMutation::Remove {
+            id: GeometricId::new(99, 0)
+        }])
+        .is_err());
+    assert!(IncrementalGeometricEditor::new(&source)
+        .apply(&[GeometricMutation::Add {
+            page_index: 0,
+            geometry: GeometricGeometry::PolyLine {
+                vertices: vec![Point::new(10.0, 10.0)],
+                start_ending: LineEnding::None,
+                end_ending: LineEnding::None,
+            },
+            style: style([0.0, 0.0, 0.0]),
+        }])
+        .is_err());
+    for geometry in [
+        GeometricGeometry::Polygon {
+            vertices: vec![
+                Point::new(10.0, 10.0),
+                Point::new(20.0, 20.0),
+                Point::new(30.0, 30.0),
+            ],
+        },
+        GeometricGeometry::PolyLine {
+            vertices: vec![Point::new(10.0, 10.0), Point::new(10.0, 10.0)],
+            start_ending: LineEnding::None,
+            end_ending: LineEnding::None,
+        },
+    ] {
+        assert!(IncrementalGeometricEditor::new(&source)
+            .apply(&[GeometricMutation::Add {
+                page_index: 0,
+                geometry,
+                style: style([0.0, 0.0, 0.0]),
+            }])
+            .is_err());
+    }
+    assert!(IncrementalGeometricEditor::new(&source)
+        .apply(&[GeometricMutation::Update {
+            id: GeometricId::new(4, 0),
+            geometry: GeometricGeometry::Square {
+                rect: [20.0, 20.0, 50.0, 50.0],
+            },
+            style: style([0.0, 0.0, 0.0]),
+        }])
+        .is_err());
+}
+
+#[test]
+fn generates_distinct_appearance_for_every_line_ending() {
+    let source = base();
+    let mut appearances = std::collections::HashSet::new();
+    for ending in [
+        LineEnding::None,
+        LineEnding::Square,
+        LineEnding::Circle,
+        LineEnding::Diamond,
+        LineEnding::OpenArrow,
+        LineEnding::ClosedArrow,
+        LineEnding::Butt,
+        LineEnding::ROpenArrow,
+        LineEnding::RClosedArrow,
+        LineEnding::Slash,
+    ] {
+        let update = IncrementalGeometricEditor::new(&source)
+            .apply(&[GeometricMutation::Update {
+                id: GeometricId::new(4, 0),
+                geometry: GeometricGeometry::Line {
+                    start: Point::new(30.0, 30.0),
+                    end: Point::new(100.0, 70.0),
+                    start_ending: ending,
+                    end_ending: LineEnding::None,
+                },
+                style: style([0.0, 0.0, 0.0]),
+            }])
+            .unwrap();
+        let mut reader = PdfReader::new(Cursor::new(&update.pdf_bytes)).unwrap();
+        let annotation = reader.get_object(4, 0).unwrap().as_dict().unwrap();
+        let appearance_id = annotation
+            .get("AP")
+            .and_then(PdfObject::as_dict)
+            .and_then(|value| value.get("N"))
+            .and_then(PdfObject::as_reference)
+            .unwrap();
+        let data = reader
+            .get_object(appearance_id.0, appearance_id.1)
+            .unwrap()
+            .as_stream()
+            .unwrap()
+            .data
+            .clone();
+        assert!(
+            appearances.insert(data),
+            "duplicate appearance for {ending:?}"
+        );
+    }
+}
+
+#[test]
+fn rejects_inline_malformed_encrypted_and_forbidden_signature_inputs() {
+    for subtype_and_geometry in [
+        "/Subtype /Line /Rect [0 0 20 20] /L [1 1 10]",
+        "/Subtype /Square /Rect [20 20 10 10]",
+        "/Subtype /Circle /Rect [0 0 20 20] /C [2 0 0]",
+        "/Subtype /Polygon /Rect [0 0 20 20] /Vertices [1 1 2 2]",
+        "/Subtype /PolyLine /Rect [0 0 20 20] /Vertices [1 1 true 2]",
+    ] {
+        let annotation = format!("<< {subtype_and_geometry} >>");
+        let source = build_pdf(&[
+            (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+            (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            (
+                3,
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [4 0 R] >>",
+            ),
+            (4, annotation.as_bytes()),
+        ]);
+        assert!(IncrementalGeometricEditor::new(&source)
+            .annotations()
+            .is_err());
+    }
+
+    let inline = build_pdf(&[
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [<< /Subtype /Square /Rect [10 10 20 20] >>] >>"),
+    ]);
+    assert!(IncrementalGeometricEditor::new(&inline)
+        .annotations()
+        .is_err());
+
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    let encrypted = document.to_bytes().unwrap();
+    assert!(IncrementalGeometricEditor::new(&encrypted)
+        .annotations()
+        .is_err());
+
+    let mutation = GeometricMutation::Add {
+        page_index: 0,
+        geometry: GeometricGeometry::Square {
+            rect: [20.0, 20.0, 50.0, 50.0],
+        },
+        style: style([0.0, 0.0, 0.0]),
+    };
+    let certified_p2 = include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf");
+    for forbidden in [replace_policy(certified_p2, 1), certified_p2.to_vec()] {
+        assert!(matches!(
+            IncrementalGeometricEditor::new(&forbidden).apply(std::slice::from_ref(&mutation)),
+            Err(PdfError::PermissionDenied(_))
+        ));
+    }
+    let certified_p3 = replace_policy(certified_p2, 3);
+    assert!(IncrementalGeometricEditor::new(&certified_p3)
+        .apply(std::slice::from_ref(&mutation))
+        .unwrap()
+        .pdf_bytes
+        .starts_with(&certified_p3));
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by interoperability CI"]
+fn qpdf_accepts_classic_and_xref_stream_geometric_revisions() {
+    for (name, source) in [("classic", base()), ("stream", xref_stream_base())] {
+        let update = IncrementalGeometricEditor::new(&source)
+            .apply(&[
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Line {
+                        start: Point::new(20.0, 20.0),
+                        end: Point::new(80.0, 50.0),
+                        start_ending: LineEnding::ROpenArrow,
+                        end_ending: LineEnding::RClosedArrow,
+                    },
+                    style: style([0.8, 0.1, 0.1]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Square {
+                        rect: [100.0, 20.0, 150.0, 70.0],
+                    },
+                    style: style([0.1, 0.8, 0.1]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Circle {
+                        rect: [170.0, 20.0, 230.0, 70.0],
+                    },
+                    style: GeometricStyle {
+                        fill_color: Some(rgb([0.8, 0.8, 0.2])),
+                        ..style([0.2, 0.2, 0.8])
+                    },
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Polygon {
+                        vertices: vec![
+                            Point::new(30.0, 120.0),
+                            Point::new(80.0, 170.0),
+                            Point::new(130.0, 120.0),
+                        ],
+                    },
+                    style: style([0.3, 0.3, 0.3]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::PolyLine {
+                        vertices: vec![
+                            Point::new(160.0, 120.0),
+                            Point::new(210.0, 170.0),
+                            Point::new(260.0, 120.0),
+                        ],
+                        start_ending: LineEnding::Butt,
+                        end_ending: LineEnding::Slash,
+                    },
+                    style: style([0.4, 0.1, 0.7]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Line {
+                        start: Point::new(30.0, 210.0),
+                        end: Point::new(100.0, 210.0),
+                        start_ending: LineEnding::Square,
+                        end_ending: LineEnding::Circle,
+                    },
+                    style: style([0.1, 0.5, 0.8]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Line {
+                        start: Point::new(140.0, 230.0),
+                        end: Point::new(240.0, 250.0),
+                        start_ending: LineEnding::Diamond,
+                        end_ending: LineEnding::OpenArrow,
+                    },
+                    style: style([0.7, 0.3, 0.1]),
+                },
+                GeometricMutation::Add {
+                    page_index: 0,
+                    geometry: GeometricGeometry::Line {
+                        start: Point::new(30.0, 270.0),
+                        end: Point::new(100.0, 270.0),
+                        start_ending: LineEnding::ClosedArrow,
+                        end_ending: LineEnding::None,
+                    },
+                    style: style([0.2, 0.6, 0.2]),
+                },
+            ])
+            .unwrap();
+        assert!(update.pdf_bytes.starts_with(&source));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, update.pdf_bytes).unwrap();
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let render_prefix = dir.path().join(format!("{name}-render"));
+        let render = Command::new("pdftoppm")
+            .args(["-f", "1", "-singlefile", "-png"])
+            .arg(&path)
+            .arg(&render_prefix)
+            .output()
+            .unwrap();
+        assert!(
+            render.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        assert!(render_prefix.with_extension("png").is_file());
+    }
+}

--- a/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
+++ b/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
@@ -255,6 +255,156 @@ fn supports_xref_stream_input_and_rejects_invalid_batches() {
 }
 
 #[test]
+fn rejects_encryption_docmdp_and_page_labels_without_replacing_output() {
+    let directory = TempDir::new().unwrap();
+    let output = directory.path().join("output.pdf");
+    fs::write(&output, b"keep").unwrap();
+
+    let encrypted = directory.path().join("encrypted.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.encrypt_with_passwords("user", "owner");
+    fs::write(&encrypted, document.to_bytes().unwrap()).unwrap();
+    let rotate = PageMutationBatch {
+        operations: vec![PageMutation::Rotate {
+            page: 0,
+            degrees: 90,
+        }],
+    };
+    let error = mutate_pdf_pages_lossless(&encrypted, &output, &rotate)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("encrypted PDFs"), "{error}");
+
+    let certified = directory.path().join("certified.pdf");
+    fs::write(
+        &certified,
+        include_bytes!("fixtures/signatures/docmdp_p2_rsa.pdf"),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(&certified, &output, &rotate)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("DocMDP"), "{error}");
+
+    let labelled = directory.path().join("labelled.pdf");
+    fs::write(
+        &labelled,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /PageLabels << /Nums [0 << /S /D >>] >> >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(
+        &labelled,
+        &output,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Delete { page: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("PageLabels"), "{error}");
+    mutate_pdf_pages_lossless(&labelled, &output, &rotate)
+        .expect("rotation does not change page-label indexes");
+}
+
+#[test]
+fn rejects_imports_with_named_destinations_or_optional_content() {
+    let directory = TempDir::new().unwrap();
+    let target = directory.path().join("target.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(&target, base_pdf("")).unwrap();
+
+    let named = directory.path().join("named.pdf");
+    fs::write(
+        &named,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Link /Rect [0 0 1 1] /Dest /chapter >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let insert = |source| PageMutationBatch {
+        operations: vec![PageMutation::Insert {
+            source,
+            page: 0,
+            at: 0,
+        }],
+    };
+    let error = plan_pdf_page_mutations(&target, &insert(named))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("named destination"), "{error}");
+
+    let ocg = directory.path().join("ocg.pdf");
+    fs::write(
+        &ocg,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [5 0 R] >> >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Resources << /Properties << /Layer 5 0 R >> >> >>"
+                .to_vec(),
+            b"null".to_vec(),
+            b"<< /Type /OCG /Name (Layer) >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = plan_pdf_page_mutations(&target, &insert(ocg))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("optional-content"), "{error}");
+    assert!(!output.exists());
+}
+
+#[test]
+fn mutates_a_nested_page_tree_and_preserves_effective_inheritance() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("nested.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(
+        &input,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>".to_vec(),
+            b"<< /Type /Pages /Parent 2 0 R /Kids [5 0 R] /Count 1 /MediaBox [0 0 100 200] >>".to_vec(),
+            b"<< /Type /Pages /Parent 2 0 R /Kids [6 0 R] /Count 1 /MediaBox [0 0 300 400] /Rotate 90 >>".to_vec(),
+            b"<< /Type /Page /Parent 3 0 R >>".to_vec(),
+            b"<< /Type /Page /Parent 4 0 R >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    mutate_pdf_pages_lossless(
+        &input,
+        &output,
+        &PageMutationBatch {
+            operations: vec![
+                PageMutation::Move { from: 1, to: 0 },
+                PageMutation::Rotate {
+                    page: 0,
+                    degrees: 90,
+                },
+            ],
+        },
+    )
+    .unwrap();
+    let bytes = fs::read(output).unwrap();
+    assert_eq!(page_refs(&bytes), vec![(6, 0), (5, 0)]);
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let page = reader.get_object(6, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        page.get("Rotate").and_then(PdfObject::as_integer),
+        Some(180)
+    );
+    assert!(page.contains_key("MediaBox"));
+}
+
+#[test]
 #[ignore = "requires qpdf and Poppler command-line tools"]
 fn qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations() {
     for (name, config) in [

--- a/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
+++ b/oxidize-pdf-core/tests/issue_538_page_tree_mutations_test.rs
@@ -1,0 +1,312 @@
+//! Regression coverage for issue #538: mixed page-tree changes are one
+//! lossless, validated incremental revision.
+
+mod common;
+
+use common::pdf_assembler::{assemble_pdf, stream_obj};
+use oxidize_pdf::operations::{
+    mutate_pdf_pages_lossless, plan_pdf_page_mutations, PageMutation, PageMutationBatch,
+};
+use oxidize_pdf::parser::{PdfObject, PdfReader};
+use oxidize_pdf::writer::WriterConfig;
+use oxidize_pdf::{Document, Page};
+use std::fs;
+use std::io::Cursor;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn base_pdf(catalog_extra: &str) -> Vec<u8> {
+    assemble_pdf(&[
+        format!("<< /Type /Catalog /Pages 2 0 R {catalog_extra} >>").into_bytes(),
+        b"<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 /MediaBox [0 0 200 300] /Resources 9 0 R >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 6 0 R /Annots [10 0 R] >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 7 0 R /Rotate 90 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>".to_vec(),
+        stream_obj("", b"first"),
+        stream_obj("", b"second"),
+        stream_obj("", b"third"),
+        b"<< /ProcSet [/PDF] >>".to_vec(),
+        b"<< /Type /Annot /Subtype /Text /P 3 0 R /Rect [0 0 10 10] /Contents (note) >>".to_vec(),
+        b"<< /Dests << /third [5 0 R /Fit] >> >>".to_vec(),
+    ])
+}
+
+fn page_refs(bytes: &[u8]) -> Vec<(u32, u16)> {
+    let document = PdfReader::new(Cursor::new(bytes)).unwrap().into_document();
+    (0..document.page_count().unwrap())
+        .map(|index| document.get_page(index).unwrap().obj_ref)
+        .collect()
+}
+
+#[test]
+fn applies_mixed_move_rotate_delete_and_duplicate_atomically() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = base_pdf("");
+    fs::write(&input, &source).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![
+            PageMutation::Move { from: 2, to: 0 },
+            PageMutation::Rotate {
+                page: 1,
+                degrees: 90,
+            },
+            PageMutation::Duplicate { page: 1, at: 2 },
+            PageMutation::Delete { page: 3 },
+        ],
+    };
+
+    let planned = plan_pdf_page_mutations(&input, &batch).unwrap();
+    assert_eq!(planned.page_count, 3);
+    assert_eq!(planned.unreachable_objects, vec![(4, 0), (7, 0)]);
+    let report = mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    assert_eq!(report, planned);
+
+    let bytes = fs::read(output).unwrap();
+    assert!(bytes.starts_with(&source));
+    let refs = page_refs(&bytes);
+    assert_eq!(refs[0], (5, 0));
+    assert_eq!(refs[1], (3, 0));
+    assert_ne!(refs[2], (3, 0));
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let original = reader.get_object(3, 0).unwrap().as_dict().unwrap();
+    assert_eq!(
+        original.get("Rotate").and_then(PdfObject::as_integer),
+        Some(90)
+    );
+    let duplicate = reader
+        .get_object(refs[2].0, refs[2].1)
+        .unwrap()
+        .as_dict()
+        .unwrap();
+    assert_eq!(
+        duplicate.get("Rotate").and_then(PdfObject::as_integer),
+        Some(90)
+    );
+    assert_ne!(
+        duplicate
+            .get("Annots")
+            .and_then(PdfObject::as_array)
+            .unwrap()
+            .0[0]
+            .as_reference(),
+        Some((10, 0)),
+        "duplicate annotations must have independent identities"
+    );
+}
+
+#[test]
+fn imports_a_page_and_its_reachable_object_graph() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let imported = directory.path().join("imported.pdf");
+    let output = directory.path().join("output.pdf");
+    let source = base_pdf("");
+    fs::write(&input, &source).unwrap();
+    fs::write(&imported, base_pdf("")).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Insert {
+            source: imported,
+            page: 1,
+            at: 1,
+        }],
+    };
+
+    let report = mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    assert_eq!(report.page_count, 4);
+    assert!(!report.added_objects.is_empty());
+    let bytes = fs::read(output).unwrap();
+    assert!(bytes.starts_with(&source));
+    let refs = page_refs(&bytes);
+    assert_eq!(&refs[0..1], &[(3, 0)]);
+    assert_ne!(refs[1], (4, 0));
+    let mut reader = PdfReader::new(Cursor::new(bytes)).unwrap();
+    let page = reader
+        .get_object(refs[1].0, refs[1].1)
+        .unwrap()
+        .as_dict()
+        .unwrap();
+    assert_eq!(page.get("Rotate").and_then(PdfObject::as_integer), Some(90));
+    let contents = page
+        .get("Contents")
+        .and_then(PdfObject::as_reference)
+        .unwrap();
+    assert!(reader
+        .get_object(contents.0, contents.1)
+        .unwrap()
+        .as_stream()
+        .is_some());
+}
+
+#[test]
+fn rejects_deletion_referenced_by_catalog_semantics_without_touching_destination() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("input.pdf");
+    let output = directory.path().join("output.pdf");
+    fs::write(&input, base_pdf("/Names 11 0 R")).unwrap();
+    fs::write(&output, b"keep destination").unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Delete { page: 2 }],
+    };
+
+    let error = mutate_pdf_pages_lossless(&input, &output, &batch)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("catalog-level structure references it"),
+        "{error}"
+    );
+    assert_eq!(fs::read(output).unwrap(), b"keep destination");
+}
+
+#[test]
+fn rejects_dangling_page_links_and_unsupported_widget_duplication() {
+    let directory = TempDir::new().unwrap();
+    let output = directory.path().join("output.pdf");
+    let linked = directory.path().join("linked.pdf");
+    fs::write(
+        &linked,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [5 0 R] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Link /Rect [0 0 1 1] /Dest [4 0 R /Fit] >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = plan_pdf_page_mutations(
+        &linked,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Delete { page: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        error.contains("retained page structure references it"),
+        "{error}"
+    );
+
+    let widget = directory.path().join("widget.pdf");
+    fs::write(
+        &widget,
+        assemble_pdf(&[
+            b"<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>".to_vec(),
+            b"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 10 10] >>".to_vec(),
+            b"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".to_vec(),
+            b"<< /Type /Annot /Subtype /Widget /FT /Tx /P 3 0 R /Rect [0 0 1 1] >>".to_vec(),
+            b"<< /Fields [4 0 R] >>".to_vec(),
+        ]),
+    )
+    .unwrap();
+    let error = mutate_pdf_pages_lossless(
+        &widget,
+        &output,
+        &PageMutationBatch {
+            operations: vec![PageMutation::Duplicate { page: 0, at: 1 }],
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("AcroForm field tree"), "{error}");
+    assert!(!output.exists());
+}
+
+#[test]
+fn supports_xref_stream_input_and_rejects_invalid_batches() {
+    let directory = TempDir::new().unwrap();
+    let input = directory.path().join("modern.pdf");
+    let output = directory.path().join("output.pdf");
+    let mut document = Document::new();
+    document.add_page(Page::a4());
+    document.add_page(Page::letter());
+    let source = document
+        .to_bytes_with_config(WriterConfig::modern())
+        .unwrap();
+    fs::write(&input, &source).unwrap();
+    let batch = PageMutationBatch {
+        operations: vec![PageMutation::Rotate {
+            page: 0,
+            degrees: -90,
+        }],
+    };
+    mutate_pdf_pages_lossless(&input, &output, &batch).unwrap();
+    let bytes = fs::read(&output).unwrap();
+    assert!(bytes.starts_with(&source));
+    assert!(bytes
+        .windows(b"/Type /XRef".len())
+        .any(|window| window == b"/Type /XRef"));
+
+    for operations in [
+        vec![],
+        vec![PageMutation::Rotate {
+            page: 0,
+            degrees: 45,
+        }],
+        vec![
+            PageMutation::Delete { page: 0 },
+            PageMutation::Delete { page: 0 },
+        ],
+    ] {
+        assert!(plan_pdf_page_mutations(&input, &PageMutationBatch { operations }).is_err());
+    }
+}
+
+#[test]
+#[ignore = "requires qpdf and Poppler command-line tools"]
+fn qpdf_and_poppler_accept_classic_and_xref_stream_page_mutations() {
+    for (name, config) in [
+        ("classic", WriterConfig::default()),
+        ("xref-stream", WriterConfig::modern()),
+    ] {
+        let directory = TempDir::new().unwrap();
+        let input = directory.path().join(format!("{name}-input.pdf"));
+        let output = directory.path().join(format!("{name}-output.pdf"));
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.add_page(Page::letter());
+        let source = document.to_bytes_with_config(config).unwrap();
+        fs::write(&input, source).unwrap();
+        mutate_pdf_pages_lossless(
+            &input,
+            &output,
+            &PageMutationBatch {
+                operations: vec![
+                    PageMutation::Duplicate { page: 0, at: 1 },
+                    PageMutation::Rotate {
+                        page: 1,
+                        degrees: 90,
+                    },
+                    PageMutation::Delete { page: 2 },
+                ],
+            },
+        )
+        .unwrap();
+
+        let check = Command::new("qpdf")
+            .arg("--check")
+            .arg(&output)
+            .output()
+            .unwrap();
+        assert!(
+            check.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&check.stderr)
+        );
+        let render_prefix = directory.path().join(format!("{name}-render"));
+        let render = Command::new("pdftoppm")
+            .args(["-f", "1", "-singlefile", "-png"])
+            .arg(&output)
+            .arg(&render_prefix)
+            .output()
+            .unwrap();
+        assert!(
+            render.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        assert!(render_prefix.with_extension("png").is_file());
+    }
+}

--- a/oxidize-pdf-core/tests/issue_539_semantic_preservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_539_semantic_preservation_test.rs
@@ -1,0 +1,191 @@
+use oxidize_pdf::operations::{
+    extract_pdf_pages_lossless, merge_pdfs_lossless, plan_extract_pdf_pages_lossless,
+    plan_merge_pdfs_lossless, split_pdf_lossless, DocumentStructure, LosslessMergeInput, PageRange,
+    StructureDisposition,
+};
+use oxidize_pdf::page_labels::{PageLabel, PageLabelTree};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::text::TextExtractor;
+use oxidize_pdf::{Document, Page};
+use std::fs;
+
+fn write_pdf(path: &std::path::Path, pages: usize) {
+    let mut document = Document::new();
+    for index in 0..pages {
+        let mut page = Page::a4();
+        page.text()
+            .at(40.0, 750.0)
+            .write(&format!("page {}", index + 1))
+            .unwrap();
+        document.add_page(page);
+    }
+    document.save(path).unwrap();
+}
+
+fn page_texts(path: &std::path::Path) -> Vec<String> {
+    let document = PdfReader::open_document(path).unwrap();
+    let count = document.page_count().unwrap();
+    let mut extractor = TextExtractor::new();
+    (0..count)
+        .map(|page| {
+            extractor
+                .extract_from_page(&document, page)
+                .unwrap()
+                .text
+                .trim()
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn sparse_extraction_is_planned_and_keeps_the_source_prefix() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let output = directory.path().join("output.pdf");
+    write_pdf(&source, 3);
+
+    let planned = plan_extract_pdf_pages_lossless(&source, &[2, 0]).unwrap();
+    let written = extract_pdf_pages_lossless(&source, &output, &[2, 0]).unwrap();
+
+    assert_eq!(planned, written);
+    assert_eq!(written.mutation.page_count, 2);
+    assert!(fs::read(&output)
+        .unwrap()
+        .starts_with(&fs::read(&source).unwrap()));
+    assert_eq!(PdfReader::open(&output).unwrap().page_count().unwrap(), 2);
+    assert_eq!(page_texts(&output), ["page 3", "page 1"]);
+}
+
+#[test]
+fn merge_preserves_base_and_imports_self_contained_pages() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("second.pdf");
+    let output = directory.path().join("merged.pdf");
+    write_pdf(&first, 2);
+    write_pdf(&second, 2);
+    let inputs = vec![
+        LosslessMergeInput::new(&first),
+        LosslessMergeInput::new(&second),
+    ];
+
+    let planned = plan_merge_pdfs_lossless(&inputs).unwrap();
+    let written = merge_pdfs_lossless(&inputs, &output).unwrap();
+
+    assert_eq!(planned, written);
+    assert_eq!(written.mutation.page_count, 4);
+    assert!(written.inputs[1].structures.iter().any(|entry| {
+        entry.structure == DocumentStructure::MetadataStream
+            && entry.disposition == StructureDisposition::FirstInputWins
+    }));
+    assert!(fs::read(&output)
+        .unwrap()
+        .starts_with(&fs::read(&first).unwrap()));
+    assert_eq!(PdfReader::open(&output).unwrap().page_count().unwrap(), 4);
+    assert_eq!(
+        page_texts(&output),
+        ["page 1", "page 2", "page 1", "page 2"]
+    );
+}
+
+#[test]
+fn split_plans_every_output_before_atomic_publication() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let first = directory.path().join("part-a.pdf");
+    let second = directory.path().join("part-b.pdf");
+    write_pdf(&source, 3);
+
+    let reports = split_pdf_lossless(
+        &source,
+        &[PageRange::List(vec![0, 2]), PageRange::Single(1)],
+        &[first.clone(), second.clone()],
+    )
+    .unwrap();
+
+    assert_eq!(reports.len(), 2);
+    assert_eq!(PdfReader::open(first).unwrap().page_count().unwrap(), 2);
+    assert_eq!(PdfReader::open(second).unwrap().page_count().unwrap(), 1);
+}
+
+#[test]
+fn extraction_honors_requested_order_and_duplicates() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let output = directory.path().join("selected.pdf");
+    write_pdf(&source, 3);
+
+    let report = extract_pdf_pages_lossless(&source, &output, &[2, 0, 2]).unwrap();
+
+    assert_eq!(report.mutation.page_count, 3);
+    assert!(!report.mutation.added_objects.is_empty());
+    assert_eq!(PdfReader::open(&output).unwrap().page_count().unwrap(), 3);
+    assert_eq!(page_texts(&output), ["page 3", "page 1", "page 3"]);
+}
+
+#[test]
+fn split_rejects_duplicate_and_input_alias_paths_before_writing() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let output = directory.path().join("part.pdf");
+    write_pdf(&source, 2);
+    let ranges = [PageRange::Single(0), PageRange::Single(1)];
+
+    let duplicate = split_pdf_lossless(&source, &ranges, &[output.clone(), output.clone()]);
+    assert!(duplicate.unwrap_err().to_string().contains("duplicate"));
+    assert!(!output.exists());
+
+    let alias = split_pdf_lossless(
+        &source,
+        &[PageRange::Single(0)],
+        std::slice::from_ref(&source),
+    );
+    assert!(alias.unwrap_err().to_string().contains("aliases the input"));
+    assert_eq!(page_texts(&source), ["page 1", "page 2"]);
+}
+
+#[test]
+fn split_stages_every_destination_before_replacing_any_output() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let first = directory.path().join("existing.pdf");
+    let invalid_second = directory.path().join("directory-output");
+    write_pdf(&source, 2);
+    fs::write(&first, b"keep me").unwrap();
+    fs::create_dir(&invalid_second).unwrap();
+
+    let result = split_pdf_lossless(
+        &source,
+        &[PageRange::Single(0), PageRange::Single(1)],
+        &[first.clone(), invalid_second],
+    );
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(first).unwrap(), b"keep me");
+}
+
+#[test]
+fn merge_rejects_secondary_catalog_semantics_before_writing() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("labeled.pdf");
+    let output = directory.path().join("existing.pdf");
+    write_pdf(&first, 1);
+    let mut labeled = Document::new();
+    labeled.add_page(Page::a4());
+    let mut labels = PageLabelTree::new();
+    labels.add_range(0, PageLabel::roman_lowercase());
+    labeled.set_page_labels(labels);
+    labeled.save(&second).unwrap();
+    fs::write(&output, b"do not replace").unwrap();
+    let inputs = vec![
+        LosslessMergeInput::new(&first),
+        LosslessMergeInput::new(&second),
+    ];
+
+    let error = plan_merge_pdfs_lossless(&inputs).unwrap_err();
+
+    assert!(error.to_string().contains("PageLabels"));
+    assert_eq!(fs::read(output).unwrap(), b"do not replace");
+}

--- a/oxidize-pdf-core/tests/issue_540_incremental_signing_test.rs
+++ b/oxidize-pdf-core/tests/issue_540_incremental_signing_test.rs
@@ -1,0 +1,362 @@
+use oxidize_pdf::parser::objects::{PdfDictionary, PdfObject, PdfString};
+use oxidize_pdf::signatures::{
+    prepare_incremental_signature, CertificationPermission, FieldLock, SignaturePreparationOptions,
+    SignatureRect, SignatureTarget,
+};
+use oxidize_pdf::{Document, Page};
+use std::process::Command;
+
+fn base_pdf(xref_stream: bool) -> Vec<u8> {
+    let mut document = Document::new();
+    document.enable_xref_streams(xref_stream);
+    document.add_page(Page::a4());
+    document.to_bytes().unwrap()
+}
+
+fn deterministic_cms() -> &'static [u8] {
+    // DER ContentInfo wrapping SignedData with deterministic empty sets. It is
+    // structurally valid CMS but intentionally carries no trust assertion.
+    b"\x30\x23\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02\xA0\x16\x30\x14\x02\x01\x01\x31\x00\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x01\x31\x00"
+}
+
+fn classic_with_fields(fields: &[(u32, u16, &str)]) -> Vec<u8> {
+    let references = fields
+        .iter()
+        .map(|(number, generation, _)| format!("{number} {generation} R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut objects = vec![
+        (
+            1,
+            0,
+            format!("<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [{references}] >> >>"),
+        ),
+        (
+            2,
+            0,
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        ),
+        (
+            3,
+            0,
+            format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [{references}] >>"
+            ),
+        ),
+    ];
+    objects.extend(fields.iter().map(|(number, generation, name)| {
+        (
+            *number,
+            *generation,
+            format!(
+                "<< /Type /Annot /Subtype /Widget /FT /Sig /T ({name}) /Rect [0 0 0 0] /P 3 0 R >>"
+            ),
+        )
+    }));
+    build_classic_objects(objects)
+}
+
+fn hierarchical_field() -> Vec<u8> {
+    build_classic_objects(vec![
+        (
+            1,
+            0,
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields 4 0 R >> >>".to_string(),
+        ),
+        (
+            2,
+            0,
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        ),
+        (
+            3,
+            0,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Annots [9 0 R] >>".to_string(),
+        ),
+        (4, 0, "[5 0 R]".to_string()),
+        (5, 0, "<< /FT /Sig /T (Parent) /Kids 6 0 R >>".to_string()),
+        (6, 0, "[7 0 R]".to_string()),
+        (
+            7,
+            0,
+            "<< /T (Child) /Parent 5 0 R /Kids 8 0 R >>".to_string(),
+        ),
+        (8, 0, "[9 0 R]".to_string()),
+        (
+            9,
+            0,
+            "<< /Type /Annot /Subtype /Widget /Parent 7 0 R /Rect [0 0 0 0] /P 3 0 R >>"
+                .to_string(),
+        ),
+    ])
+}
+
+fn build_classic_objects(mut objects: Vec<(u32, u16, String)>) -> Vec<u8> {
+    objects.sort_by_key(|(number, _, _)| *number);
+    let size = objects.iter().map(|(number, _, _)| *number).max().unwrap() + 1;
+    let mut output = b"%PDF-1.7\n".to_vec();
+    let mut entries = vec![None; size as usize];
+    for (number, generation, body) in objects {
+        entries[number as usize] = Some((output.len(), generation));
+        output.extend_from_slice(format!("{number} {generation} obj\n{body}\nendobj\n").as_bytes());
+    }
+    let xref = output.len();
+    output.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for entry in entries.into_iter().skip(1) {
+        match entry {
+            Some((offset, generation)) => {
+                output.extend_from_slice(format!("{offset:010} {generation:05} n \n").as_bytes())
+            }
+            None => output.extend_from_slice(b"0000000000 00000 f \n"),
+        }
+    }
+    output.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    output
+}
+
+#[test]
+fn two_phase_signing_preserves_the_source_and_exact_byte_range() {
+    let source = base_pdf(false);
+    let prepared = prepare_incremental_signature(
+        &source,
+        &SignaturePreparationOptions::invisible("Approval.1"),
+    )
+    .unwrap();
+    assert!(prepared.prepared_pdf().starts_with(&source));
+    prepared.byte_range().validate().unwrap();
+
+    let expected: Vec<_> = prepared
+        .byte_range()
+        .ranges()
+        .iter()
+        .flat_map(|&(offset, length)| {
+            prepared.prepared_pdf()[offset as usize..(offset + length) as usize]
+                .iter()
+                .copied()
+        })
+        .collect();
+    assert_eq!(prepared.bytes_to_digest(), expected);
+
+    let signed = prepared.finalize(deterministic_cms()).unwrap();
+    assert!(signed.starts_with(&source));
+    assert!(signed.windows(8).any(|bytes| bytes == b"30230609"));
+}
+
+#[test]
+fn visible_and_successive_signatures_are_incremental_for_both_xref_formats() {
+    for xref_stream in [false, true] {
+        let source = base_pdf(xref_stream);
+        let mut first = SignaturePreparationOptions::invisible("Approval.1");
+        first.target = SignatureTarget::New {
+            field_name: "Approval.1".to_string(),
+            page_index: 0,
+            rect: Some(SignatureRect {
+                left: 40.0,
+                bottom: 40.0,
+                right: 180.0,
+                top: 90.0,
+            }),
+        };
+        let signed_once = prepare_incremental_signature(&source, &first)
+            .unwrap()
+            .finalize(deterministic_cms())
+            .unwrap();
+        assert!(signed_once.windows(3).any(|bytes| bytes == b"/AP"));
+
+        let signed_twice = prepare_incremental_signature(
+            &signed_once,
+            &SignaturePreparationOptions::invisible("Approval.2"),
+        )
+        .unwrap()
+        .finalize(deterministic_cms())
+        .unwrap();
+        assert!(signed_twice.starts_with(&signed_once));
+        assert_eq!(
+            signed_twice
+                .windows(b"/ByteRange".len())
+                .filter(|value| *value == b"/ByteRange")
+                .count(),
+            2
+        );
+    }
+}
+
+#[test]
+fn profile_extensions_and_mdp_transforms_are_serialized() {
+    let source = base_pdf(false);
+    let mut options = SignaturePreparationOptions::invisible("Certification");
+    options.sub_filter = "ETSI.CAdES.detached".to_string();
+    options.certification = Some(CertificationPermission::FormFillAndSign);
+    options.field_lock = Some(FieldLock::Include(vec!["Approval.2".to_string()]));
+    options.additional_signature_entries.insert(
+        "ProfileMarker".to_string(),
+        PdfObject::String(PdfString::new(b"private-extension".to_vec())),
+    );
+    let prepared = prepare_incremental_signature(&source, &options).unwrap();
+    let text = String::from_utf8_lossy(prepared.prepared_pdf());
+    assert!(text.contains("/SubFilter /ETSI.CAdES.detached"));
+    assert!(text.contains("/TransformMethod /DocMDP"));
+    assert!(text.contains("/TransformMethod /FieldMDP"));
+    assert!(text.contains("/ProfileMarker"));
+}
+
+#[test]
+fn malformed_inputs_and_unsafe_extension_overrides_fail_closed() {
+    let source = base_pdf(false);
+    assert!(prepare_incremental_signature(
+        b"not a PDF",
+        &SignaturePreparationOptions::invisible("Approval")
+    )
+    .is_err());
+    let mut encrypted = Document::new();
+    encrypted.add_page(Page::a4());
+    encrypted.encrypt_with_passwords("user", "owner");
+    let encrypted = encrypted.to_bytes().unwrap();
+    assert!(prepare_incremental_signature(
+        &encrypted,
+        &SignaturePreparationOptions::invisible("Approval")
+    )
+    .is_err());
+    let prepared =
+        prepare_incremental_signature(&source, &SignaturePreparationOptions::invisible("Approval"))
+            .unwrap();
+    assert!(prepared.finalize(b"not DER CMS").is_err());
+
+    let mut options = SignaturePreparationOptions::invisible("Approval");
+    options.additional_signature_entries = PdfDictionary::new();
+    options.additional_signature_entries.insert(
+        "Contents".to_string(),
+        PdfObject::String(PdfString::new(vec![1, 2, 3])),
+    );
+    assert!(prepare_incremental_signature(&source, &options).is_err());
+
+    let mut small = SignaturePreparationOptions::invisible("Approval");
+    small.placeholder_bytes = 256;
+    let prepared = prepare_incremental_signature(&source, &small).unwrap();
+    let mut oversized_cms = vec![0x30, 0x82, 0x01, 0x2c];
+    oversized_cms.extend(vec![0x01; 300]);
+    assert!(prepared.finalize(&oversized_cms).is_err());
+}
+
+#[test]
+fn docmdp_and_fieldmdp_are_enforced_on_later_signatures() {
+    let source = base_pdf(false);
+    let mut no_changes = SignaturePreparationOptions::invisible("Certification");
+    no_changes.certification = Some(CertificationPermission::NoChanges);
+    let certified = prepare_incremental_signature(&source, &no_changes)
+        .unwrap()
+        .finalize(deterministic_cms())
+        .unwrap();
+    assert!(prepare_incremental_signature(
+        &certified,
+        &SignaturePreparationOptions::invisible("Approval")
+    )
+    .is_err());
+
+    let mut locked = SignaturePreparationOptions::invisible("Certification");
+    locked.certification = Some(CertificationPermission::FormFillAndSign);
+    locked.field_lock = Some(FieldLock::Include(vec!["Approval".to_string()]));
+    let certified = prepare_incremental_signature(&source, &locked)
+        .unwrap()
+        .finalize(deterministic_cms())
+        .unwrap();
+    assert!(prepare_incremental_signature(
+        &certified,
+        &SignaturePreparationOptions::invisible("Approval")
+    )
+    .is_err());
+    assert!(prepare_incremental_signature(
+        &certified,
+        &SignaturePreparationOptions::invisible("Unrestricted")
+    )
+    .is_ok());
+}
+
+#[test]
+fn selects_indirect_existing_fields_with_nonzero_generations_and_rejects_ambiguity() {
+    let source = classic_with_fields(&[(4, 7, "Existing")]);
+    let mut options = SignaturePreparationOptions::invisible("unused");
+    options.target = SignatureTarget::Existing {
+        field_name: "Existing".to_string(),
+        widget_index: None,
+        rect: None,
+    };
+    let signed = prepare_incremental_signature(&source, &options)
+        .unwrap()
+        .finalize(deterministic_cms())
+        .unwrap();
+    assert!(signed.starts_with(&source));
+    assert!(
+        signed
+            .windows(b"4 7 obj".len())
+            .filter(|window| *window == b"4 7 obj")
+            .count()
+            >= 2
+    );
+
+    let ambiguous = classic_with_fields(&[(4, 0, "Duplicate"), (5, 0, "Duplicate")]);
+    options.target = SignatureTarget::Existing {
+        field_name: "Duplicate".to_string(),
+        widget_index: None,
+        rect: None,
+    };
+    assert!(prepare_incremental_signature(&ambiguous, &options).is_err());
+
+    let hierarchical = hierarchical_field();
+    options.target = SignatureTarget::Existing {
+        field_name: "Parent.Child".to_string(),
+        widget_index: Some(0),
+        rect: Some(SignatureRect {
+            left: 10.0,
+            bottom: 10.0,
+            right: 100.0,
+            top: 40.0,
+        }),
+    };
+    let prepared = prepare_incremental_signature(&hierarchical, &options).unwrap();
+    let text = String::from_utf8_lossy(prepared.prepared_pdf());
+    assert!(text.contains("/AP"));
+    assert!(text.contains("/Rect [10 10 100 40]"));
+}
+
+#[test]
+#[ignore = "requires qpdf; exercised by the Ubuntu CI interoperability step"]
+fn qpdf_accepts_finalized_signatures_for_both_xref_formats() {
+    for (name, xref_stream) in [("classic", false), ("xref-stream", true)] {
+        let signed = prepare_incremental_signature(
+            &base_pdf(xref_stream),
+            &SignaturePreparationOptions::invisible("Approval"),
+        )
+        .unwrap()
+        .finalize(deterministic_cms())
+        .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(format!("{name}.pdf"));
+        std::fs::write(&path, signed).unwrap();
+        let cms_path = directory.path().join("fixture.cms");
+        std::fs::write(&cms_path, deterministic_cms()).unwrap();
+        let cms_output = Command::new("openssl")
+            .args(["cms", "-cmsout", "-inform", "DER", "-in"])
+            .arg(&cms_path)
+            .arg("-noout")
+            .output()
+            .unwrap();
+        assert!(
+            cms_output.status.success(),
+            "deterministic CMS fixture: {}",
+            String::from_utf8_lossy(&cms_output.stderr)
+        );
+        let output = Command::new("qpdf")
+            .arg("--check")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- bump the maintained `oxidize-pdf` crate to 4.9.0
- document the additive features merged in PRs #553 through #558
- update the README dependency example
- record retirement of the obsolete CLI/API release artifacts from #552

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo package -p oxidize-pdf --allow-dirty`
- pre-commit formatting, Clippy, and build checks

The tag must only be created from `main` after this PR and all required CI checks are green.