### PR TITLE
feat(operations): unify existing PDF operation policies

### DIFF
--- a/docs/migration/v5-existing-pdf-operations.md
+++ b/docs/migration/v5-existing-pdf-operations.md
@@ -1,0 +1,95 @@
+# Existing-PDF operations in v5
+
+This v4 preview is available under `operations::existing_document`. Version 5
+will promote it to the primary split, extraction, and
+merge APIs. The old reconstruction APIs copied page content into a new
+`Document`; callers could therefore lose annotations or document-level
+structures without selecting a lossy policy.
+
+The primary functions are now:
+
+- `plan_merge_pdfs` and `merge_pdfs`
+- `plan_extract_pdf_pages` and `extract_pdf_pages`
+- `plan_split_pdf` and `split_pdf`
+
+Every function requires an `ExistingDocumentPolicy`. There is no default
+policy. The policy is an enum whose variants carry only options supported by
+their engine, so contradictory combinations cannot be constructed.
+`ExistingDocumentPolicy::preserve_base()` keeps the first input as an exact byte
+prefix and rejects structures from secondary merge inputs that cannot be
+combined safely. It does not claim to merge those structures.
+
+`ExistingDocumentPolicy::reconstruct()` deliberately selects the page-content
+reconstruction engine. Planning marks every detected catalog structure as
+`Discarded`, and execution returns that same report. This is the explicit lossy
+path inside the unified family.
+`reconstruct_with_metadata_from_first()` is the separate, explicit choice for
+copying trailer `/Info` metadata from the first input.
+
+```rust
+use oxidize_pdf::operations::existing_document::{
+    merge_pdfs, ExistingDocumentMergeInput, ExistingDocumentPolicy,
+};
+
+let inputs = [
+    ExistingDocumentMergeInput::new("first.pdf"),
+    ExistingDocumentMergeInput::new("second.pdf"),
+];
+
+let report = merge_pdfs(
+    &inputs,
+    "merged.pdf",
+    ExistingDocumentPolicy::preserve_base(),
+)?;
+# Ok::<(), oxidize_pdf::operations::OperationError>(())
+```
+
+Planning returns the same machine-readable `SemanticPreservationReport` as
+execution. `ExistingDocumentExecutionPlan::Incremental` carries the exact
+object mutation, while `ExistingDocumentExecutionPlan::Reconstruct` carries
+the reconstructed output page count without pretending that an incremental
+mutation occurred. Applications should display or persist this report when users need
+to understand which input is the preserved base and which document structures
+use a deterministic policy such as `FirstInputWins`.
+
+## Legacy reconstruction
+
+The v4 `PdfMerger`, `PdfSplitter`, `PageExtractor`, `MergeOptions`, and
+`SplitOptions` model a different operation: reconstructing a new PDF from page
+content. They remain public throughout v4, as do the `*_lossless` entry points.
+Version 5 will remove those ambiguous names. The narrower
+`operations::reconstruct` namespace is also available for code that wants to
+make accepted semantic loss visible at the call site.
+
+The compatibility implementation and its operation-specific module paths stay
+public until the major transition. The batch worker already uses the preview
+API with an explicit policy.
+
+| v4 entry point | v5-preview replacement |
+| --- | --- |
+| `merge_pdfs`, `PdfMerger`, `merge_pdf_files` | `existing_document::merge_pdfs` with `ExistingDocumentPolicy::reconstruct()` |
+| `split_pdf`, `PdfSplitter`, `split_into_pages` | `existing_document::split_pdf` with `ExistingDocumentPolicy::reconstruct()` |
+| `PageExtractor`, `extract_page`, `extract_pages`, `extract_page_range` and their `*_to_file` forms | `existing_document::extract_pdf_pages` with `ExistingDocumentPolicy::reconstruct()` |
+| `merge_pdfs_lossless` | `existing_document::merge_pdfs` with `ExistingDocumentPolicy::preserve_base()` |
+| `split_pdf_lossless` | `existing_document::split_pdf` with `ExistingDocumentPolicy::preserve_base()` |
+| `extract_pdf_pages_lossless` | `existing_document::extract_pdf_pages` with `ExistingDocumentPolicy::preserve_base()` |
+| Every `plan_*_lossless` function | Corresponding `existing_document::plan_*` function with `ExistingDocumentPolicy::preserve_base()` |
+
+The v5-preview replacement returns a machine-readable report in both modes;
+legacy reconstructive functions return only their historical result types.
+
+## Merge limitation
+
+`ExistingDocumentPolicy::preserve_base()` is base-preserving, not a complete semantic
+union of arbitrary PDFs. Forms, outlines, destinations, optional-content
+groups, tagged structure, attachments, and page labels found in a secondary
+input cause planning to fail. Metadata uses a documented first-input-wins
+policy. A future policy may support typed remapping, but it must not silently
+change the behavior of this policy.
+
+Digital signatures are inventoried independently from AcroForm. Page
+annotations and trailer `/Info` metadata are also inventoried, so reconstructive
+loss is visible in the report. Encryption has its own semantic category and
+encrypted inputs currently fail during planning
+because neither engine accepts credentials through this API; the error names
+the selected encryption disposition.

--- a/oxidize-pdf-core/examples/analyze_table.rs
+++ b/oxidize-pdf-core/examples/analyze_table.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Lines found: {}", graphics.lines.len());
     if !graphics.lines.is_empty() {
         println!("Sample lines (first 5):");
-        for (_i, line) in graphics.lines.iter().take(5).enumerate() {
+        for line in graphics.lines.iter().take(5) {
             println!("  {:?}", line.orientation);
         }
     }
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nText fragments: {}", text.fragments.len());
     if !text.fragments.is_empty() {
         println!("Sample text (first 5):");
-        for (_i, frag) in text.fragments.iter().take(5).enumerate() {
+        for frag in text.fragments.iter().take(5) {
             let preview: String = frag.text.chars().take(30).collect();
             println!("  '{}' at ({:.0},{:.0})", preview, frag.x, frag.y);
         }

--- a/oxidize-pdf-core/examples/batch_processing_advanced.rs
+++ b/oxidize-pdf-core/examples/batch_processing_advanced.rs
@@ -207,7 +207,7 @@ impl AdvancedBatchProcessor {
             println!(
                 "Processing chunk {} of {} ({} files)",
                 chunk_idx + 1,
-                (pdf_files.len() + chunk_size - 1) / chunk_size,
+                pdf_files.len().div_ceil(chunk_size),
                 chunk.len()
             );
 

--- a/oxidize-pdf-core/examples/diagnose_failures.rs
+++ b/oxidize-pdf-core/examples/diagnose_failures.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut pdf_files: Vec<_> = fs::read_dir(failures_dir)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == "pdf"))
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "pdf"))
         .collect();
 
     pdf_files.sort_by_key(|e| e.path());
@@ -109,7 +109,7 @@ fn main() {
     println!("\n=== ERROR CATEGORIES ===\n");
 
     let mut categories: Vec<_> = error_categories.iter().collect();
-    categories.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    categories.sort_by_key(|category| std::cmp::Reverse(category.1.len()));
 
     for (category, files) in categories {
         println!("[{}] ({} files)", category, files.len());

--- a/oxidize-pdf-core/examples/generate_synthetic_slide_deck.rs
+++ b/oxidize-pdf-core/examples/generate_synthetic_slide_deck.rs
@@ -153,9 +153,7 @@ fn summary(doc: &mut Document) -> Result<(), Box<dyn std::error::Error>> {
     let mut y = 440.0;
     for para in paragraphs.iter() {
         wrap_cell_text(&mut p, para, 60.0, y, 840.0)?;
-        let lines = ((para.len() as f64) / ((840.0 / 6.0) as f64))
-            .ceil()
-            .max(1.0);
+        let lines = ((para.len() as f64) / (840.0 / 6.0)).ceil().max(1.0);
         y -= lines * 14.0 + 8.0;
     }
     doc.add_page(p);

--- a/oxidize-pdf-core/examples/invoice_complete.rs
+++ b/oxidize-pdf-core/examples/invoice_complete.rs
@@ -120,7 +120,7 @@ impl Default for InvoiceStyle {
 /// Generate a complete PDF invoice
 pub fn generate_invoice(invoice: &Invoice, style: &InvoiceStyle) -> Result<Document> {
     let mut doc = Document::new();
-    doc.set_title(&format!("Invoice {}", invoice.invoice_number));
+    doc.set_title(format!("Invoice {}", invoice.invoice_number));
 
     let mut page = Page::a4();
     let mut y = 780.0;

--- a/oxidize-pdf-core/examples/random_pdf_test.rs
+++ b/oxidize-pdf-core/examples/random_pdf_test.rs
@@ -144,11 +144,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     );
 
-    if successful_extractions > 0 {
-        println!(
-            "📏 Average chars per extraction: {}",
-            total_chars_extracted / successful_extractions
-        );
+    if let Some(average) = total_chars_extracted.checked_div(successful_extractions) {
+        println!("📏 Average chars per extraction: {average}");
     }
 
     Ok(())

--- a/oxidize-pdf-core/examples/realistic_document_benchmark.rs
+++ b/oxidize-pdf-core/examples/realistic_document_benchmark.rs
@@ -67,13 +67,10 @@ fn generate_paragraph(page_num: usize, para_idx: usize) -> String {
     let outcome_idx = (page_num * 13 + para_idx * 7) % outcomes.len();
 
     format!(
-        "{}, {} {}, {}",
+        "{}, {} with quantifiable metrics showing {}% improvement, {}",
         contexts[context_idx],
         topics[topic_idx],
-        format!(
-            "with quantifiable metrics showing {}% improvement",
-            5 + ((page_num + para_idx) * 7) % 45
-        ),
+        5 + ((page_num + para_idx) * 7) % 45,
         outcomes[outcome_idx]
     )
 }

--- a/oxidize-pdf-core/examples/transfer_functions.rs
+++ b/oxidize-pdf-core/examples/transfer_functions.rs
@@ -160,7 +160,7 @@ fn main() -> Result<()> {
 
     for (i, (color, _name)) in colors.iter().enumerate() {
         page.graphics()
-            .set_fill_color(color.clone())
+            .set_fill_color(*color)
             .rect(50.0 + i as f64 * 45.0, 380.0, 40.0, 30.0)
             .fill();
     }

--- a/oxidize-pdf-core/src/batch/mod.rs
+++ b/oxidize-pdf-core/src/batch/mod.rs
@@ -301,14 +301,18 @@ pub fn batch_split_pdfs<P: AsRef<Path>>(
 
     for file in files {
         let path = file.as_ref();
+        let output_name = format!(
+            "{}_page_%d.pdf",
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("output")
+        );
         processor.add_job(BatchJob::Split {
             input: path.to_path_buf(),
-            output_pattern: format!(
-                "{}_page_%d.pdf",
-                path.file_stem()
-                    .and_then(|stem| stem.to_str())
-                    .unwrap_or("output")
-            ),
+            output_pattern: path
+                .with_file_name(output_name)
+                .to_string_lossy()
+                .into_owned(),
             pages_per_file,
         });
     }

--- a/oxidize-pdf-core/src/batch/worker.rs
+++ b/oxidize-pdf-core/src/batch/worker.rs
@@ -2,8 +2,12 @@
 
 use crate::batch::{BatchJob, BatchProgress, JobResult};
 use crate::error::PdfError;
-use crate::operations::page_extraction::extract_pages_to_file;
-use crate::operations::{merge_pdfs, split_pdf};
+use crate::operations::existing_document::{
+    extract_pdf_pages, merge_pdfs, split_pdf, ExistingDocumentMergeInput, ExistingDocumentPolicy,
+};
+use crate::operations::OperationError;
+use crate::operations::PageRange;
+use crate::parser::PdfReader;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -293,28 +297,52 @@ fn execute_job(job: BatchJob) -> std::result::Result<Vec<PathBuf>, PdfError> {
             output_pattern,
             pages_per_file,
         } => {
-            // Create split options
-            let options = crate::operations::SplitOptions {
-                mode: crate::operations::SplitMode::ChunkSize(pages_per_file),
-                output_pattern,
-                preserve_metadata: true,
-                optimize: false,
-            };
-
-            split_pdf(&input, options).map_err(|e| PdfError::InvalidStructure(e.to_string()))?;
-
-            // Return generated files (simplified - would need to track actual outputs)
-            Ok(vec![])
+            if pages_per_file == 0 {
+                return Err(PdfError::InvalidStructure(
+                    "pages_per_file must be greater than zero".to_string(),
+                ));
+            }
+            let page_count = PdfReader::open(&input)?.page_count()? as usize;
+            if page_count == 0 {
+                return Err(PdfError::InvalidStructure(
+                    "cannot split a PDF with no pages".to_string(),
+                ));
+            }
+            let mut ranges = Vec::new();
+            let mut outputs = Vec::new();
+            for (index, start) in (0..page_count).step_by(pages_per_file).enumerate() {
+                let end = (start + pages_per_file - 1).min(page_count - 1);
+                ranges.push(PageRange::Range(start, end));
+                outputs.push(PathBuf::from(
+                    output_pattern
+                        .replace("%d", &(index + 1).to_string())
+                        .replace("{}", &format!("{}-{}", start + 1, end + 1))
+                        .replace("{n}", &(index + 1).to_string())
+                        .replace("{start}", &(start + 1).to_string())
+                        .replace("{end}", &(end + 1).to_string()),
+                ));
+            }
+            split_pdf(
+                &input,
+                &ranges,
+                &outputs,
+                ExistingDocumentPolicy::preserve_base(),
+            )
+            .map_err(operation_error_to_pdf_error)?;
+            Ok(outputs)
         }
 
         BatchJob::Merge { inputs, output } => {
             let merge_inputs: Vec<_> = inputs
                 .into_iter()
-                .map(crate::operations::MergeInput::new)
+                .map(ExistingDocumentMergeInput::new)
                 .collect();
-            let options = crate::operations::MergeOptions::default();
-            merge_pdfs(merge_inputs, &output, options)
-                .map_err(|e| PdfError::InvalidStructure(e.to_string()))?;
+            merge_pdfs(
+                &merge_inputs,
+                &output,
+                ExistingDocumentPolicy::preserve_base(),
+            )
+            .map_err(operation_error_to_pdf_error)?;
             Ok(vec![output])
         }
 
@@ -334,8 +362,13 @@ fn execute_job(job: BatchJob) -> std::result::Result<Vec<PathBuf>, PdfError> {
             output,
             pages,
         } => {
-            extract_pages_to_file(&input, &pages, &output)
-                .map_err(|e| PdfError::InvalidStructure(e.to_string()))?;
+            extract_pdf_pages(
+                &input,
+                &output,
+                &pages,
+                ExistingDocumentPolicy::preserve_base(),
+            )
+            .map_err(operation_error_to_pdf_error)?;
             Ok(vec![output])
         }
 
@@ -355,9 +388,87 @@ fn execute_job(job: BatchJob) -> std::result::Result<Vec<PathBuf>, PdfError> {
     }
 }
 
+fn operation_error_to_pdf_error(error: OperationError) -> PdfError {
+    match error {
+        OperationError::Io(error) => PdfError::Io(error),
+        OperationError::PdfError(error) => error,
+        OperationError::ParseError(message) => PdfError::ParseError(message),
+        OperationError::InvalidPath { reason }
+        | OperationError::InvalidPageRange(reason)
+        | OperationError::ResourceConflict(reason)
+        | OperationError::ProcessingError(reason) => PdfError::InvalidOperation(reason),
+        OperationError::PageIndexOutOfBounds(page, _) => u32::try_from(page)
+            .map(PdfError::InvalidPageNumber)
+            .unwrap_or_else(|_| {
+                PdfError::InvalidOperation(format!("page index {page} is too large"))
+            }),
+        OperationError::NoPagesToProcess => {
+            PdfError::InvalidOperation("no pages to process".to_string())
+        }
+        OperationError::InvalidRotation(rotation) => {
+            PdfError::InvalidOperation(format!("invalid rotation angle {rotation}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Document, Page};
+
+    #[test]
+    fn batch_extraction_uses_the_fail_closed_preserving_engine() {
+        let directory = tempfile::tempdir().unwrap();
+        let input = directory.path().join("source.pdf");
+        let output = directory.path().join("extracted.pdf");
+        let mut document = Document::new();
+        document.add_page(Page::a4());
+        document.add_page(Page::a4());
+        document.save(&input).unwrap();
+        let source = std::fs::read(&input).unwrap();
+
+        execute_job(BatchJob::Extract {
+            input,
+            output: output.clone(),
+            pages: vec![0],
+        })
+        .unwrap();
+
+        assert!(std::fs::read(output).unwrap().starts_with(&source));
+    }
+
+    #[test]
+    fn operation_errors_keep_their_public_category() {
+        let io = operation_error_to_pdf_error(OperationError::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "denied",
+        )));
+        let parse = operation_error_to_pdf_error(OperationError::ParseError("broken".into()));
+        let permission = operation_error_to_pdf_error(OperationError::PdfError(
+            PdfError::PermissionDenied("locked".into()),
+        ));
+
+        assert!(matches!(io, PdfError::Io(_)));
+        assert!(matches!(parse, PdfError::ParseError(_)));
+        assert!(matches!(permission, PdfError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn split_rejects_a_zero_page_pdf() {
+        let directory = tempfile::tempdir().unwrap();
+        let input = directory.path().join("empty.pdf");
+        let bytes = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\nxref\n0 3\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n110\n%%EOF\n";
+        std::fs::write(&input, bytes).unwrap();
+
+        let error = execute_job(BatchJob::Split {
+            input,
+            output_pattern: directory.path().join("page_%d.pdf").display().to_string(),
+            pages_per_file: 1,
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("no pages"));
+    }
 
     #[test]
     fn test_worker_pool_creation() {

--- a/oxidize-pdf-core/src/lib.rs
+++ b/oxidize-pdf-core/src/lib.rs
@@ -307,11 +307,13 @@ pub use operations::{
     plan_extract_pdf_pages_lossless, plan_merge_pdfs_lossless, plan_pdf_page_mutations,
     plan_split_pdf_lossless, reorder_pdf_pages, reorder_pdf_pages_lossless, reverse_pdf_pages,
     rotate_pdf_pages, split_pdf, split_pdf_lossless, swap_pdf_pages, DocumentStructure,
-    ExtractImagesOptions, ExtractedImage, ExtractedImageData, ImageExtractionError,
-    ImageExtractionLimits, ImageExtractionResult, ImageExtractor, InputSemanticReport,
-    InputSemanticRole, LosslessMergeInput, OverlayOptions, OverlayPosition, PageMutation,
-    PageMutationBatch, PageMutationReport, ReorderOptions, SemanticPreservationReport,
-    StructureDisposition, StructureSemanticReport,
+    DocumentStructurePolicy, ExistingDocumentEngine, ExistingDocumentExecutionPlan,
+    ExistingDocumentMergeInput, ExistingDocumentPolicy, ExtractImagesOptions, ExtractedImage,
+    ExtractedImageData, ImageExtractionError, ImageExtractionLimits, ImageExtractionResult,
+    ImageExtractor, InputSemanticReport, InputSemanticRole, LosslessMergeInput, OverlayOptions,
+    OverlayPosition, PageMutation, PageMutationBatch, PageMutationReport, PreserveBasePolicy,
+    ReconstructMetadataPolicy, ReconstructPolicy, ReorderOptions, SecondaryStructurePolicy,
+    SemanticPreservationReport, StructureDisposition, StructureSemanticReport,
 };
 
 // Re-export dashboard types

--- a/oxidize-pdf-core/src/operations/merge.rs
+++ b/oxidize-pdf-core/src/operations/merge.rs
@@ -10,22 +10,11 @@ use std::path::{Path, PathBuf};
 
 /// Options for PDF merging
 #[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct MergeOptions {
-    /// Page ranges to include from each input file
     pub page_ranges: Option<Vec<PageRange>>,
-    /// Unsupported legacy request to preserve bookmarks/outlines.
-    ///
-    /// The `Document` reconstruction API cannot preserve arbitrary source
-    /// outline graphs. Setting this to `true` returns an error; use
-    /// `plan_merge_pdfs_lossless` and `merge_pdfs_lossless` instead.
     pub preserve_bookmarks: bool,
-    /// Unsupported legacy request to preserve form fields.
-    ///
-    /// The `Document` reconstruction API cannot preserve arbitrary source
-    /// field trees. Setting this to `true` returns an error; use the lossless
-    /// merge API when forms must be retained.
     pub preserve_forms: bool,
-    /// Whether to optimize the output
     pub optimize: bool,
     /// How to handle metadata
     pub metadata_mode: MetadataMode,
@@ -104,6 +93,7 @@ impl PdfMerger {
     }
 
     /// Add an input file to merge
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn add_input(&mut self, input: MergeInput) {
         self.inputs.push(input);
     }
@@ -117,8 +107,7 @@ impl PdfMerger {
     pub fn merge(&mut self) -> OperationResult<Document> {
         if self.options.preserve_bookmarks || self.options.preserve_forms {
             return Err(OperationError::ProcessingError(
-                "legacy Document reconstruction cannot honor preserve_bookmarks or preserve_forms; use merge_pdfs_lossless"
-                    .to_string(),
+                "reconstruction cannot preserve bookmarks or forms".to_string(),
             ));
         }
         if self.inputs.is_empty() {
@@ -279,7 +268,9 @@ mod tests {
             Ok(_) => panic!("legacy preservation flag must be rejected"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("merge_pdfs_lossless"));
+        assert!(error
+            .to_string()
+            .contains("cannot preserve bookmarks or forms"));
     }
 
     #[test]

--- a/oxidize-pdf-core/src/operations/mod.rs
+++ b/oxidize-pdf-core/src/operations/mod.rs
@@ -12,7 +12,7 @@ pub mod page_extraction;
 pub mod pdf_ocr_converter;
 pub mod reorder;
 pub mod rotate;
-pub mod semantic_preservation;
+mod semantic_preservation;
 pub mod semantic_redactor;
 pub mod source_highlighter;
 pub mod split;
@@ -40,8 +40,11 @@ pub use rotate::{rotate_all_pages, rotate_pdf_pages, PageRotator, RotateOptions,
 pub use semantic_preservation::{
     extract_pdf_pages_lossless, merge_pdfs_lossless, plan_extract_pdf_pages_lossless,
     plan_merge_pdfs_lossless, plan_split_pdf_lossless, split_pdf_lossless, DocumentStructure,
-    InputSemanticReport, InputSemanticRole, LosslessMergeInput, SemanticPreservationReport,
-    StructureDisposition, StructureSemanticReport,
+    DocumentStructurePolicy, ExistingDocumentEngine, ExistingDocumentExecutionPlan,
+    ExistingDocumentMergeInput, ExistingDocumentPolicy, InputSemanticReport, InputSemanticRole,
+    LosslessMergeInput, PreserveBasePolicy, ReconstructMetadataPolicy, ReconstructPolicy,
+    SecondaryStructurePolicy, SemanticPreservationReport, StructureDisposition,
+    StructureSemanticReport,
 };
 pub use semantic_redactor::{
     RedactionConfig, RedactionEntry, RedactionMode, RedactionReport, RedactionStyle,
@@ -52,6 +55,72 @@ pub use source_highlighter::{
     SourceHighlighterError, SourceHighlighterResult, TextPositionIndex,
 };
 pub use split::{split_into_pages, split_pdf, PdfSplitter, SplitMode, SplitOptions};
+
+/// Preview of the unified existing-document API planned for the next major.
+///
+/// Keeping the preview in a namespace preserves every v4 entry point. The
+/// next major can promote these functions after removing their ambiguous
+/// legacy names.
+pub mod existing_document {
+    pub use super::semantic_preservation::{
+        extract_pdf_pages, merge_pdfs, plan_extract_pdf_pages, plan_merge_pdfs, plan_split_pdf,
+        split_pdf, DocumentStructure, DocumentStructurePolicy, ExistingDocumentEngine,
+        ExistingDocumentExecutionPlan, ExistingDocumentMergeInput, ExistingDocumentPolicy,
+        InputSemanticReport, InputSemanticRole, PreserveBasePolicy, ReconstructMetadataPolicy,
+        ReconstructPolicy, SecondaryStructurePolicy, SemanticPreservationReport,
+        StructureDisposition, StructureSemanticReport,
+    };
+}
+
+/// Deliberately reconstructive operations for callers that accept semantic loss.
+///
+/// These APIs are isolated from the primary preservation-first operations so
+/// selecting reconstruction is visible at every call site.
+pub mod reconstruct {
+    pub use super::merge::{merge_pdf_files, MergeInput, MetadataMode};
+    pub use super::page_extraction::{
+        extract_page, extract_page_range, extract_page_range_to_file, extract_page_to_file,
+        extract_pages, extract_pages_to_file,
+    };
+    pub use super::split::{split_into_pages, SplitMode};
+
+    use super::{merge, split, OperationResult};
+    use std::path::{Path, PathBuf};
+
+    /// Reconstruct several PDFs, deliberately accepting semantic loss.
+    pub fn merge_pdfs(
+        inputs: Vec<MergeInput>,
+        output: impl AsRef<Path>,
+        metadata_mode: MetadataMode,
+    ) -> OperationResult<()> {
+        merge::merge_pdfs(
+            inputs,
+            output,
+            merge::MergeOptions {
+                metadata_mode,
+                ..merge::MergeOptions::default()
+            },
+        )
+    }
+
+    /// Reconstruct split outputs, deliberately accepting semantic loss.
+    pub fn split_pdf(
+        input: impl AsRef<Path>,
+        mode: SplitMode,
+        output_pattern: impl Into<String>,
+        preserve_metadata: bool,
+    ) -> OperationResult<Vec<PathBuf>> {
+        split::split_pdf(
+            input,
+            split::SplitOptions {
+                mode,
+                output_pattern: output_pattern.into(),
+                preserve_metadata,
+                optimize: false,
+            },
+        )
+    }
+}
 
 use crate::error::PdfError;
 

--- a/oxidize-pdf-core/src/operations/page_extraction.rs
+++ b/oxidize-pdf-core/src/operations/page_extraction.rs
@@ -5,7 +5,7 @@
 //! API specifically for page extraction use cases.
 //!
 //! This legacy API returns a reconstructed [`crate::Document`]. Use
-//! [`super::extract_pdf_pages_lossless`] when annotations and document-level
+//! [`super::existing_document::extract_pdf_pages`] when annotations and document-level
 //! structures must be retained or rejected explicitly before writing.
 
 use super::{OperationError, OperationResult, PageRange};
@@ -16,14 +16,12 @@ use std::path::Path;
 
 /// Options for page extraction
 #[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct PageExtractionOptions {
     /// Whether to preserve document metadata
     pub preserve_metadata: bool,
-    /// Whether to preserve annotations
     pub preserve_annotations: bool,
-    /// Whether to preserve form fields
     pub preserve_forms: bool,
-    /// Whether to optimize the extracted pages
     pub optimize: bool,
 }
 
@@ -54,6 +52,7 @@ impl PageExtractor {
     }
 
     /// Create a new page extractor with custom options
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn with_options(document: PdfDocument<File>, options: PageExtractionOptions) -> Self {
         Self { document, options }
     }

--- a/oxidize-pdf-core/src/operations/semantic_preservation.rs
+++ b/oxidize-pdf-core/src/operations/semantic_preservation.rs
@@ -47,6 +47,14 @@ pub enum DocumentStructure {
     MetadataStream,
     /// Page-label number tree.
     PageLabels,
+    /// Digital signature fields with a signature value.
+    DigitalSignatures,
+    /// Trailer-level encryption dictionary.
+    Encryption,
+    /// Page annotations reachable from selected pages.
+    Annotations,
+    /// Trailer `/Info` document metadata.
+    DocumentInfo,
 }
 
 /// Policy applied to a detected document structure.
@@ -58,6 +66,17 @@ pub enum StructureDisposition {
     FirstInputWins,
     /// The combination cannot be represented safely and planning fails.
     Rejected,
+    /// Deliberately omitted by the selected reconstructive engine.
+    Discarded,
+}
+
+/// Engine selected for an existing-document operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingDocumentEngine {
+    /// Preserve the first input as an exact byte prefix and mutate incrementally.
+    PreserveBase,
+    /// Rebuild page appearance/content and explicitly discard catalog semantics.
+    Reconstruct,
 }
 
 /// One detected structure and its explicit operation policy.
@@ -76,6 +95,8 @@ pub enum InputSemanticRole {
     PreservedBase,
     /// The input contributes cloned page graphs.
     ImportedPages,
+    /// The input contributes page appearance/content through reconstruction.
+    ReconstructedPages,
 }
 
 /// Semantic inventory for one input.
@@ -94,22 +115,234 @@ pub struct InputSemanticReport {
 /// Exact dry-run report returned before a lossless operation writes output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticPreservationReport {
+    /// Engine that will execute, or executed, the operation.
+    pub engine: ExistingDocumentEngine,
     /// Per-input semantic inventory and policy.
     pub inputs: Vec<InputSemanticReport>,
-    /// Exact object-level page mutation plan.
-    pub mutation: PageMutationReport,
+    /// Concrete execution plan, whose shape identifies the selected engine.
+    pub plan: ExistingDocumentExecutionPlan,
 }
 
-/// Input to a lossless merge.
+/// Engine-specific plan for an existing-document operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExistingDocumentExecutionPlan {
+    /// Exact object-level incremental mutation.
+    Incremental(PageMutationReport),
+    /// Reconstruct selected page appearance/content into a new document.
+    Reconstruct {
+        /// Number of pages in the reconstructed output.
+        page_count: usize,
+    },
+}
+
+impl ExistingDocumentExecutionPlan {
+    /// Number of pages in the planned output.
+    pub const fn page_count(&self) -> usize {
+        match self {
+            Self::Incremental(report) => report.page_count,
+            Self::Reconstruct { page_count } => *page_count,
+        }
+    }
+}
+
+/// Policy for one detected document-level structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocumentStructurePolicy {
+    /// Reject the operation before writing output.
+    Reject,
+    /// Keep the first input's value and deliberately ignore the secondary value.
+    FirstInputWins,
+}
+
+/// v4-preview compatibility name for [`DocumentStructurePolicy`].
+pub type SecondaryStructurePolicy = DocumentStructurePolicy;
+
+/// Policies for structures detected in secondary inputs of a preserving merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreserveBasePolicy {
+    /// Interactive forms.
+    forms: DocumentStructurePolicy,
+    /// Outline tree.
+    outlines: DocumentStructurePolicy,
+    /// Name trees and attachments.
+    names_and_attachments: DocumentStructurePolicy,
+    /// Legacy named destinations.
+    named_destinations: DocumentStructurePolicy,
+    /// Optional-content configuration.
+    optional_content: DocumentStructurePolicy,
+    /// Tagged-PDF structure tree.
+    structure_tree: DocumentStructurePolicy,
+    /// Catalog metadata stream.
+    metadata: DocumentStructurePolicy,
+    /// Page labels.
+    page_labels: DocumentStructurePolicy,
+    /// Digital signatures.
+    digital_signatures: DocumentStructurePolicy,
+    /// Encryption.
+    encryption: DocumentStructurePolicy,
+    /// Page annotations.
+    annotations: DocumentStructurePolicy,
+    /// Trailer document information.
+    document_info: DocumentStructurePolicy,
+}
+
+impl PreserveBasePolicy {
+    const fn fail_closed() -> Self {
+        Self {
+            forms: DocumentStructurePolicy::Reject,
+            outlines: DocumentStructurePolicy::Reject,
+            names_and_attachments: DocumentStructurePolicy::Reject,
+            named_destinations: DocumentStructurePolicy::Reject,
+            optional_content: DocumentStructurePolicy::Reject,
+            structure_tree: DocumentStructurePolicy::Reject,
+            metadata: DocumentStructurePolicy::FirstInputWins,
+            page_labels: DocumentStructurePolicy::Reject,
+            digital_signatures: DocumentStructurePolicy::Reject,
+            encryption: DocumentStructurePolicy::Reject,
+            annotations: DocumentStructurePolicy::Reject,
+            document_info: DocumentStructurePolicy::FirstInputWins,
+        }
+    }
+
+    /// Set the policy for page labels found in secondary merge inputs.
+    pub const fn with_page_labels(mut self, policy: DocumentStructurePolicy) -> Self {
+        self.page_labels = policy;
+        self
+    }
+
+    fn disposition(self, structure: DocumentStructure) -> StructureDisposition {
+        let policy = match structure {
+            DocumentStructure::Forms => self.forms,
+            DocumentStructure::Outlines => self.outlines,
+            DocumentStructure::NamesAndAttachments => self.names_and_attachments,
+            DocumentStructure::NamedDestinations => self.named_destinations,
+            DocumentStructure::OptionalContent => self.optional_content,
+            DocumentStructure::StructureTree => self.structure_tree,
+            DocumentStructure::MetadataStream => self.metadata,
+            DocumentStructure::PageLabels => self.page_labels,
+            DocumentStructure::DigitalSignatures => self.digital_signatures,
+            DocumentStructure::Encryption => self.encryption,
+            DocumentStructure::Annotations => self.annotations,
+            DocumentStructure::DocumentInfo => self.document_info,
+        };
+        match policy {
+            DocumentStructurePolicy::Reject => StructureDisposition::Rejected,
+            DocumentStructurePolicy::FirstInputWins => StructureDisposition::FirstInputWins,
+        }
+    }
+}
+
+/// Metadata handling supported by the reconstructive engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconstructMetadataPolicy {
+    /// Discard document information metadata.
+    Discard,
+    /// Copy document information metadata from the first input.
+    FirstInputWins,
+}
+
+/// Valid policy for the reconstructive engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconstructPolicy {
+    metadata: ReconstructMetadataPolicy,
+}
+
+impl ReconstructPolicy {
+    /// Metadata policy selected for reconstruction.
+    pub const fn metadata(self) -> ReconstructMetadataPolicy {
+        self.metadata
+    }
+}
+
+/// Explicit, type-safe policy for existing-document operations.
+///
+/// There is deliberately no [`Default`] implementation: every call site must
+/// choose preservation or reconstruction. Engine-specific policy values also
+/// cannot be assembled from arbitrary structure dispositions.
+///
+/// ```compile_fail
+/// use oxidize_pdf::operations::ExistingDocumentPolicy;
+///
+/// let policy = ExistingDocumentPolicy::default();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingDocumentPolicy {
+    /// Preserve the first input byte-for-byte and control secondary structures.
+    PreserveBase(PreserveBasePolicy),
+    /// Reconstruct page appearance/content and deliberately lose other semantics.
+    Reconstruct(ReconstructPolicy),
+}
+
+impl ExistingDocumentPolicy {
+    /// Preserve the base and reject ambiguous secondary structures.
+    pub const fn preserve_base() -> Self {
+        Self::PreserveBase(PreserveBasePolicy::fail_closed())
+    }
+
+    /// Reconstruct page appearance/content and explicitly discard every
+    /// detected document-level structure.
+    pub const fn reconstruct() -> Self {
+        Self::Reconstruct(ReconstructPolicy {
+            metadata: ReconstructMetadataPolicy::Discard,
+        })
+    }
+
+    /// Reconstruct pages while copying document information from the first input.
+    pub const fn reconstruct_with_metadata_from_first() -> Self {
+        Self::Reconstruct(ReconstructPolicy {
+            metadata: ReconstructMetadataPolicy::FirstInputWins,
+        })
+    }
+
+    /// Return the selected execution engine.
+    pub const fn engine(self) -> ExistingDocumentEngine {
+        match self {
+            Self::PreserveBase(_) => ExistingDocumentEngine::PreserveBase,
+            Self::Reconstruct(_) => ExistingDocumentEngine::Reconstruct,
+        }
+    }
+
+    /// Configure page labels in secondary inputs of a preserving merge.
+    /// Reconstructive policies are unchanged because they always discard them.
+    pub const fn with_page_labels(self, policy: DocumentStructurePolicy) -> Self {
+        match self {
+            Self::PreserveBase(preserve) => Self::PreserveBase(preserve.with_page_labels(policy)),
+            reconstruct @ Self::Reconstruct(_) => reconstruct,
+        }
+    }
+
+    fn disposition(
+        self,
+        role: InputSemanticRole,
+        structure: DocumentStructure,
+    ) -> StructureDisposition {
+        match self {
+            Self::PreserveBase(_) if role == InputSemanticRole::PreservedBase => {
+                StructureDisposition::Preserved
+            }
+            Self::PreserveBase(policy) => policy.disposition(structure),
+            Self::Reconstruct(policy) => match structure {
+                DocumentStructure::DocumentInfo
+                    if policy.metadata == ReconstructMetadataPolicy::FirstInputWins =>
+                {
+                    StructureDisposition::FirstInputWins
+                }
+                _ => StructureDisposition::Discarded,
+            },
+        }
+    }
+}
+
+/// Input to a semantic merge of existing PDF documents.
 #[derive(Debug, Clone)]
-pub struct LosslessMergeInput {
+pub struct ExistingDocumentMergeInput {
     /// PDF path.
     pub path: PathBuf,
     /// Pages to include, or all pages when omitted.
     pub pages: Option<PageRange>,
 }
 
-impl LosslessMergeInput {
+impl ExistingDocumentMergeInput {
     /// Include every page from `path`.
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
@@ -127,20 +360,25 @@ impl LosslessMergeInput {
     }
 }
 
+/// v4 compatibility name for a preservation-first merge input.
+pub type LosslessMergeInput = ExistingDocumentMergeInput;
+
 fn inspect_input_bytes(
     path: &Path,
     bytes: &[u8],
     role: InputSemanticRole,
     range: Option<&PageRange>,
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<InputSemanticReport> {
     let mut reader = PdfReader::new(Cursor::new(bytes)).map_err(|error| {
         OperationError::ParseError(format!("open snapshot of {}: {error}", path.display()))
     })?;
     if reader.is_encrypted() {
+        let disposition = policy.disposition(role, DocumentStructure::Encryption);
         return Err(OperationError::PdfError(crate::PdfError::PermissionDenied(
             format!(
-                "lossless semantic operations do not support encrypted PDF {}",
-                path.display()
+                "existing-document operation cannot process encrypted PDF {} (policy disposition: {:?})",
+                path.display(), disposition
             ),
         )));
     }
@@ -154,25 +392,53 @@ fn inspect_input_bytes(
     let catalog = reader.catalog().map_err(|error| {
         OperationError::ParseError(format!("read catalog in {}: {error}", path.display()))
     })?;
-    let structures = DOCUMENT_STRUCTURES
+    let mut structures: Vec<_> = DOCUMENT_STRUCTURES
         .iter()
         .filter_map(|(key, structure)| {
             catalog
                 .contains_key(key)
                 .then_some(StructureSemanticReport {
                     structure: *structure,
-                    disposition: match role {
-                        InputSemanticRole::PreservedBase => StructureDisposition::Preserved,
-                        InputSemanticRole::ImportedPages
-                            if *structure == DocumentStructure::MetadataStream =>
-                        {
-                            StructureDisposition::FirstInputWins
-                        }
-                        InputSemanticRole::ImportedPages => StructureDisposition::Rejected,
-                    },
+                    disposition: policy.disposition(role, *structure),
                 })
         })
         .collect();
+    let signatures = crate::signatures::detect_signature_fields(&mut reader).map_err(|error| {
+        OperationError::ParseError(format!("inspect signatures in {}: {error}", path.display()))
+    })?;
+    if !signatures.is_empty() {
+        structures.push(StructureSemanticReport {
+            structure: DocumentStructure::DigitalSignatures,
+            disposition: policy.disposition(role, DocumentStructure::DigitalSignatures),
+        });
+    }
+    if reader.trailer().info().is_some() {
+        structures.push(StructureSemanticReport {
+            structure: DocumentStructure::DocumentInfo,
+            disposition: policy.disposition(role, DocumentStructure::DocumentInfo),
+        });
+    }
+    let document = PdfReader::new(Cursor::new(bytes))
+        .map_err(|error| OperationError::ParseError(error.to_string()))?
+        .into_document();
+    let has_annotations = selected_pages.iter().try_fold(false, |found, page| {
+        if found {
+            return Ok(true);
+        }
+        document
+            .get_page(*page as u32)
+            .map(|page| {
+                page.get_annotations()
+                    .is_some_and(|annots| !annots.is_empty())
+            })
+            .map_err(|error| OperationError::ParseError(error.to_string()))
+    })?;
+    if has_annotations {
+        structures.push(StructureSemanticReport {
+            structure: DocumentStructure::Annotations,
+            disposition: policy.disposition(role, DocumentStructure::Annotations),
+        });
+    }
     Ok(InputSemanticReport {
         path: path.to_path_buf(),
         role,
@@ -318,9 +584,10 @@ fn materialize_batch(
 ///
 /// Returns an error for invalid page indexes, encrypted or restricted inputs,
 /// and catalog/page structures that reference pages being removed.
-pub fn plan_extract_pdf_pages_lossless(
+fn plan_extract_pdf_pages_preserving(
     input: impl AsRef<Path>,
     pages: &[usize],
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<SemanticPreservationReport> {
     let input = input.as_ref();
     if pages.is_empty() {
@@ -328,7 +595,13 @@ pub fn plan_extract_pdf_pages_lossless(
     }
     let range = PageRange::List(pages.to_vec());
     let base = read_snapshot(input)?;
-    let report = inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(&range))?;
+    let report = inspect_input_bytes(
+        input,
+        &base,
+        InputSemanticRole::PreservedBase,
+        Some(&range),
+        policy,
+    )?;
     let page_count = PdfReader::new(Cursor::new(&base))
         .map_err(|error| OperationError::ParseError(error.to_string()))?
         .page_count()
@@ -337,8 +610,9 @@ pub fn plan_extract_pdf_pages_lossless(
     let batch = selection_batch(page_count, &report.selected_pages)?;
     let mutation = plan_batch(&base, &batch, page_count)?;
     Ok(SemanticPreservationReport {
+        engine: ExistingDocumentEngine::PreserveBase,
         inputs: vec![report],
-        mutation,
+        plan: ExistingDocumentExecutionPlan::Incremental(mutation),
     })
 }
 
@@ -350,18 +624,24 @@ pub fn plan_extract_pdf_pages_lossless(
 /// # Errors
 ///
 /// Returns an error under the same conditions as
-/// [`plan_extract_pdf_pages_lossless`], or when atomic publication fails.
-pub fn extract_pdf_pages_lossless(
+/// [`plan_extract_pdf_pages_preserving`], or when atomic publication fails.
+fn extract_pdf_pages_preserving(
     input: impl AsRef<Path>,
     output: impl AsRef<Path>,
     pages: &[usize],
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<SemanticPreservationReport> {
     let input = input.as_ref();
     let output = output.as_ref();
     let base = read_snapshot(input)?;
     let range = PageRange::List(pages.to_vec());
-    let input_report =
-        inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(&range))?;
+    let input_report = inspect_input_bytes(
+        input,
+        &base,
+        InputSemanticRole::PreservedBase,
+        Some(&range),
+        policy,
+    )?;
     let actual_count = PdfReader::new(Cursor::new(&base))
         .map_err(|error| OperationError::ParseError(error.to_string()))?
         .page_count()
@@ -381,8 +661,9 @@ pub fn extract_pdf_pages_lossless(
         .persist(output)
         .map_err(|error| OperationError::Io(error.error))?;
     let report = SemanticPreservationReport {
+        engine: ExistingDocumentEngine::PreserveBase,
         inputs: vec![input_report],
-        mutation: planned,
+        plan: ExistingDocumentExecutionPlan::Incremental(planned),
     };
     Ok(report)
 }
@@ -393,9 +674,10 @@ pub fn extract_pdf_pages_lossless(
 ///
 /// Returns an error when a range is empty or cannot be represented while
 /// preserving the source's reachable document semantics.
-pub fn plan_split_pdf_lossless(
+fn plan_split_pdf_preserving(
     input: impl AsRef<Path>,
     ranges: &[PageRange],
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<Vec<SemanticPreservationReport>> {
     let input = input.as_ref();
     if ranges.is_empty() {
@@ -412,13 +694,19 @@ pub fn plan_split_pdf_lossless(
         .iter()
         .map(|range| {
             let pages = range.get_indices(page_count)?;
-            let report =
-                inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(range))?;
+            let report = inspect_input_bytes(
+                input,
+                &base,
+                InputSemanticRole::PreservedBase,
+                Some(range),
+                policy,
+            )?;
             let batch = selection_batch(page_count, &pages)?;
             let mutation = plan_batch(&base, &batch, page_count)?;
             Ok(SemanticPreservationReport {
+                engine: ExistingDocumentEngine::PreserveBase,
                 inputs: vec![report],
-                mutation,
+                plan: ExistingDocumentExecutionPlan::Incremental(mutation),
             })
         })
         .collect()
@@ -435,10 +723,11 @@ pub fn plan_split_pdf_lossless(
 ///
 /// Returns an error when the range/output counts differ, paths alias, any dry
 /// run fails, or an output cannot be validated and transactionally published.
-pub fn split_pdf_lossless(
+fn split_pdf_preserving(
     input: impl AsRef<Path>,
     ranges: &[PageRange],
     outputs: &[PathBuf],
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<Vec<SemanticPreservationReport>> {
     if ranges.len() != outputs.len() {
         return Err(OperationError::InvalidPath {
@@ -476,8 +765,13 @@ pub fn split_pdf_lossless(
     let mut materialized = Vec::with_capacity(ranges.len());
     for range in ranges {
         let pages = range.get_indices(page_count)?;
-        let input_report =
-            inspect_input_bytes(input, &base, InputSemanticRole::PreservedBase, Some(range))?;
+        let input_report = inspect_input_bytes(
+            input,
+            &base,
+            InputSemanticRole::PreservedBase,
+            Some(range),
+            policy,
+        )?;
         let batch = selection_batch(page_count, &pages)?;
         let planned = plan_batch(&base, &batch, page_count)?;
         let (bytes, written) = materialize_batch(&base, &batch, page_count)?;
@@ -488,8 +782,9 @@ pub fn split_pdf_lossless(
             ));
         }
         reports.push(SemanticPreservationReport {
+            engine: ExistingDocumentEngine::PreserveBase,
             inputs: vec![input_report],
-            mutation: planned,
+            plan: ExistingDocumentExecutionPlan::Incremental(planned),
         });
         materialized.push(bytes);
     }
@@ -541,8 +836,9 @@ pub fn split_pdf_lossless(
 /// Returns an error for fewer than one input, invalid selections, encrypted or
 /// restricted PDFs, unsupported imported page graphs, or secondary document
 /// structures that cannot be combined safely.
-pub fn plan_merge_pdfs_lossless(
-    inputs: &[LosslessMergeInput],
+fn plan_merge_pdfs_preserving(
+    inputs: &[ExistingDocumentMergeInput],
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<SemanticPreservationReport> {
     let Some(first) = inputs.first() else {
         return Err(OperationError::NoPagesToProcess);
@@ -551,11 +847,13 @@ pub fn plan_merge_pdfs_lossless(
         .iter()
         .map(|input| read_snapshot(&input.path))
         .collect::<OperationResult<Vec<_>>>()?;
+    let snapshot_files = snapshot_files(&snapshots)?;
     let base = inspect_input_bytes(
         &first.path,
         &snapshots[0],
         InputSemanticRole::PreservedBase,
         first.pages.as_ref(),
+        policy,
     )?;
     let base_count = PdfReader::new(Cursor::new(&snapshots[0]))
         .map_err(|error| OperationError::ParseError(error.to_string()))?
@@ -565,17 +863,18 @@ pub fn plan_merge_pdfs_lossless(
     let mut batch = selection_batch(base_count, &base.selected_pages)?;
     let mut reports = vec![base];
     let mut insertion_index = reports[0].selected_pages.len();
-    for (input, snapshot) in inputs.iter().skip(1).zip(snapshots.iter().skip(1)) {
+    for (index, (input, snapshot)) in inputs.iter().zip(&snapshots).enumerate().skip(1) {
         let report = inspect_input_bytes(
             &input.path,
             snapshot,
             InputSemanticRole::ImportedPages,
             input.pages.as_ref(),
+            policy,
         )?;
         reject_secondary_document_structures(&report)?;
         for &page in &report.selected_pages {
             batch.operations.push(PageMutation::Insert {
-                source: input.path.clone(),
+                source: snapshot_files[index].path().to_path_buf(),
                 page,
                 at: insertion_index,
             });
@@ -588,8 +887,9 @@ pub fn plan_merge_pdfs_lossless(
         ensure_snapshot_unchanged(&input.path, snapshot)?;
     }
     Ok(SemanticPreservationReport {
+        engine: ExistingDocumentEngine::PreserveBase,
         inputs: reports,
-        mutation,
+        plan: ExistingDocumentExecutionPlan::Incremental(mutation),
     })
 }
 
@@ -597,11 +897,12 @@ pub fn plan_merge_pdfs_lossless(
 ///
 /// # Errors
 ///
-/// Returns an error under the same conditions as [`plan_merge_pdfs_lossless`],
+/// Returns an error under the same conditions as [`plan_merge_pdfs_preserving`],
 /// or when atomic publication or output validation fails.
-pub fn merge_pdfs_lossless(
-    inputs: &[LosslessMergeInput],
+fn merge_pdfs_preserving(
+    inputs: &[ExistingDocumentMergeInput],
     output: impl AsRef<Path>,
+    policy: ExistingDocumentPolicy,
 ) -> OperationResult<SemanticPreservationReport> {
     let Some(first) = inputs.first() else {
         return Err(OperationError::NoPagesToProcess);
@@ -610,11 +911,13 @@ pub fn merge_pdfs_lossless(
         .iter()
         .map(|input| read_snapshot(&input.path))
         .collect::<OperationResult<Vec<_>>>()?;
+    let snapshot_files = snapshot_files(&snapshots)?;
     let base_report = inspect_input_bytes(
         &first.path,
         &snapshots[0],
         InputSemanticRole::PreservedBase,
         first.pages.as_ref(),
+        policy,
     )?;
     let base_count = PdfReader::new(Cursor::new(&snapshots[0]))
         .map_err(|error| OperationError::ParseError(error.to_string()))?
@@ -624,17 +927,18 @@ pub fn merge_pdfs_lossless(
     let mut batch = selection_batch(base_count, &base_report.selected_pages)?;
     let mut reports = vec![base_report];
     let mut at = reports[0].selected_pages.len();
-    for (input, snapshot) in inputs.iter().zip(&snapshots).skip(1) {
+    for (index, (input, snapshot)) in inputs.iter().zip(&snapshots).enumerate().skip(1) {
         let input_report = inspect_input_bytes(
             &input.path,
             snapshot,
             InputSemanticRole::ImportedPages,
             input.pages.as_ref(),
+            policy,
         )?;
         reject_secondary_document_structures(&input_report)?;
         for &page in &input_report.selected_pages {
             batch.operations.push(PageMutation::Insert {
-                source: input.path.clone(),
+                source: snapshot_files[index].path().to_path_buf(),
                 page,
                 at,
             });
@@ -658,10 +962,449 @@ pub fn merge_pdfs_lossless(
         .persist(output)
         .map_err(|error| OperationError::Io(error.error))?;
     let report = SemanticPreservationReport {
+        engine: ExistingDocumentEngine::PreserveBase,
         inputs: reports,
-        mutation: planned,
+        plan: ExistingDocumentExecutionPlan::Incremental(planned),
     };
     Ok(report)
+}
+
+fn reconstructive_report(
+    inputs: &[ExistingDocumentMergeInput],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    let snapshots = inputs
+        .iter()
+        .map(|input| read_snapshot(&input.path))
+        .collect::<OperationResult<Vec<_>>>()?;
+    reconstructive_report_from_snapshots(inputs, &snapshots, policy)
+}
+
+fn reconstructive_report_from_snapshots(
+    inputs: &[ExistingDocumentMergeInput],
+    snapshots: &[Vec<u8>],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    let mut reports = Vec::with_capacity(inputs.len());
+    let mut page_count = 0usize;
+    for (input, bytes) in inputs.iter().zip(snapshots) {
+        let report = inspect_input_bytes(
+            &input.path,
+            bytes,
+            InputSemanticRole::ReconstructedPages,
+            input.pages.as_ref(),
+            policy,
+        )?;
+        page_count = page_count
+            .checked_add(report.selected_pages.len())
+            .ok_or_else(|| OperationError::ProcessingError("page count overflow".to_string()))?;
+        reports.push(report);
+    }
+    if reports.is_empty() || page_count == 0 {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    Ok(SemanticPreservationReport {
+        engine: ExistingDocumentEngine::Reconstruct,
+        inputs: reports,
+        plan: ExistingDocumentExecutionPlan::Reconstruct { page_count },
+    })
+}
+
+fn reject_output_aliases(output: &Path, inputs: &[&Path]) -> OperationResult<()> {
+    let normalized_output = normalized_path(output)?;
+    for input in inputs {
+        if normalized_output == normalized_path(input)? {
+            return Err(OperationError::InvalidPath {
+                reason: format!(
+                    "output {} aliases input {}",
+                    output.display(),
+                    input.display()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn snapshot_files(snapshots: &[Vec<u8>]) -> OperationResult<Vec<tempfile::NamedTempFile>> {
+    snapshots
+        .iter()
+        .map(|bytes| stage_output(Path::new("snapshot.pdf"), bytes))
+        .collect()
+}
+
+fn reconstructive_extract_report(
+    input: &Path,
+    pages: &[usize],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    if pages.is_empty() {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    reconstructive_report(
+        &[ExistingDocumentMergeInput::with_pages(
+            input,
+            PageRange::List(pages.to_vec()),
+        )],
+        policy,
+    )
+}
+
+/// Plan a semantic merge using an explicit preservation policy.
+///
+/// Unlike the legacy reconstruction API, this operation cannot silently
+/// discard document semantics.
+///
+/// # Errors
+///
+/// Returns an error for missing inputs, invalid selections, encrypted or
+/// restricted PDFs, unsafe imported graphs, or policy-rejected structures.
+pub fn plan_merge_pdfs(
+    inputs: &[ExistingDocumentMergeInput],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => plan_merge_pdfs_preserving(inputs, policy),
+        ExistingDocumentPolicy::Reconstruct(_) => reconstructive_report(inputs, policy),
+    }
+}
+
+/// Merge existing PDFs using an explicit preservation policy.
+///
+/// # Errors
+///
+/// Returns the planning errors described by [`plan_merge_pdfs`], or an error
+/// if validation or atomic publication fails. No output is published on error.
+pub fn merge_pdfs(
+    inputs: &[ExistingDocumentMergeInput],
+    output: impl AsRef<Path>,
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    let output = output.as_ref();
+    let input_paths: Vec<_> = inputs.iter().map(|input| input.path.as_path()).collect();
+    reject_output_aliases(output, &input_paths)?;
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => merge_pdfs_preserving(inputs, output, policy),
+        ExistingDocumentPolicy::Reconstruct(reconstruct) => {
+            let snapshots = inputs
+                .iter()
+                .map(|input| read_snapshot(&input.path))
+                .collect::<OperationResult<Vec<_>>>()?;
+            let report = reconstructive_report_from_snapshots(inputs, &snapshots, policy)?;
+            let snapshot_files = snapshot_files(&snapshots)?;
+            let legacy_inputs = inputs
+                .iter()
+                .zip(&snapshot_files)
+                .map(|(input, snapshot)| super::merge::MergeInput {
+                    path: snapshot.path().to_path_buf(),
+                    pages: input.pages.clone(),
+                })
+                .collect();
+            let metadata_mode = match reconstruct.metadata() {
+                ReconstructMetadataPolicy::Discard => super::merge::MetadataMode::None,
+                ReconstructMetadataPolicy::FirstInputWins => super::merge::MetadataMode::FromFirst,
+            };
+            let temporary = tempfile::NamedTempFile::new_in(
+                output
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new(".")),
+            )?;
+            super::merge::merge_pdfs(
+                legacy_inputs,
+                temporary.path(),
+                super::merge::MergeOptions {
+                    metadata_mode,
+                    ..super::merge::MergeOptions::default()
+                },
+            )?;
+            temporary.as_file().sync_all()?;
+            temporary
+                .persist(output)
+                .map_err(|error| OperationError::Io(error.error))?;
+            Ok(report)
+        }
+    }
+}
+
+/// Plan sparse extraction using an explicit preservation policy.
+///
+/// # Errors
+///
+/// Returns an error for an empty or invalid page selection, encrypted or
+/// restricted input, or references that make removing pages unsafe.
+pub fn plan_extract_pdf_pages(
+    input: impl AsRef<Path>,
+    pages: &[usize],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => {
+            plan_extract_pdf_pages_preserving(input, pages, policy)
+        }
+        ExistingDocumentPolicy::Reconstruct(_) => {
+            reconstructive_extract_report(input.as_ref(), pages, policy)
+        }
+    }
+}
+
+/// Extract pages from an existing PDF using an explicit preservation policy.
+///
+/// # Errors
+///
+/// Returns the planning errors described by [`plan_extract_pdf_pages`], or an
+/// error if the source changes, validation fails, or publication fails.
+pub fn extract_pdf_pages(
+    input: impl AsRef<Path>,
+    output: impl AsRef<Path>,
+    pages: &[usize],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<SemanticPreservationReport> {
+    let input = input.as_ref();
+    let output = output.as_ref();
+    reject_output_aliases(output, &[input])?;
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => {
+            extract_pdf_pages_preserving(input, output, pages, policy)
+        }
+        ExistingDocumentPolicy::Reconstruct(_) => {
+            let snapshot = read_snapshot(input)?;
+            let merge_input =
+                ExistingDocumentMergeInput::with_pages(input, PageRange::List(pages.to_vec()));
+            let report = reconstructive_report_from_snapshots(
+                std::slice::from_ref(&merge_input),
+                std::slice::from_ref(&snapshot),
+                policy,
+            )?;
+            let snapshot_file = stage_output(Path::new("snapshot.pdf"), &snapshot)?;
+            let temporary = tempfile::NamedTempFile::new_in(
+                output
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new(".")),
+            )?;
+            super::page_extraction::extract_pages_to_file(
+                snapshot_file.path(),
+                pages,
+                temporary.path(),
+            )?;
+            temporary.as_file().sync_all()?;
+            temporary
+                .persist(output)
+                .map_err(|error| OperationError::Io(error.error))?;
+            Ok(report)
+        }
+    }
+}
+
+/// Plan a split using an explicit preservation policy.
+///
+/// # Errors
+///
+/// Returns an error for empty or invalid ranges, encrypted or restricted input,
+/// or retained structures that reference pages removed from an output.
+pub fn plan_split_pdf(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => plan_split_pdf_preserving(input, ranges, policy),
+        ExistingDocumentPolicy::Reconstruct(_) => {
+            if ranges.is_empty() {
+                return Err(OperationError::NoPagesToProcess);
+            }
+            let input = input.as_ref();
+            let snapshot = read_snapshot(input)?;
+            let mut reader = PdfReader::new(Cursor::new(&snapshot))
+                .map_err(|error| OperationError::ParseError(error.to_string()))?;
+            let page_count = reader
+                .page_count()
+                .map_err(|error| OperationError::ParseError(error.to_string()))?
+                as usize;
+            ranges
+                .iter()
+                .map(|range| {
+                    let pages = range.get_indices(page_count)?;
+                    let merge_input =
+                        ExistingDocumentMergeInput::with_pages(input, PageRange::List(pages));
+                    reconstructive_report_from_snapshots(
+                        std::slice::from_ref(&merge_input),
+                        std::slice::from_ref(&snapshot),
+                        policy,
+                    )
+                })
+                .collect()
+        }
+    }
+}
+
+/// Split an existing PDF using an explicit preservation policy.
+///
+/// # Errors
+///
+/// Returns the planning errors described by [`plan_split_pdf`], mismatched or
+/// aliased paths, validation failures, or transactional publication failures.
+pub fn split_pdf(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+    outputs: &[PathBuf],
+    policy: ExistingDocumentPolicy,
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    if ranges.is_empty() {
+        return Err(OperationError::NoPagesToProcess);
+    }
+    match policy {
+        ExistingDocumentPolicy::PreserveBase(_) => {
+            split_pdf_preserving(input, ranges, outputs, policy)
+        }
+        ExistingDocumentPolicy::Reconstruct(_) => {
+            if ranges.len() != outputs.len() {
+                return Err(OperationError::InvalidPath {
+                    reason: format!(
+                        "split has {} ranges but {} output paths",
+                        ranges.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            let input = input.as_ref();
+            let normalized_input = normalized_path(input)?;
+            let mut normalized_outputs = BTreeSet::new();
+            for output in outputs {
+                let normalized = normalized_path(output)?;
+                if normalized == normalized_input || !normalized_outputs.insert(normalized) {
+                    return Err(OperationError::InvalidPath {
+                        reason: format!("invalid or duplicate split output {}", output.display()),
+                    });
+                }
+            }
+            let snapshot = read_snapshot(input)?;
+            let mut reader = PdfReader::new(Cursor::new(&snapshot))
+                .map_err(|error| OperationError::ParseError(error.to_string()))?;
+            let page_count = reader
+                .page_count()
+                .map_err(|error| OperationError::ParseError(error.to_string()))?
+                as usize;
+            let reports = ranges
+                .iter()
+                .map(|range| {
+                    let pages = range.get_indices(page_count)?;
+                    let merge_input =
+                        ExistingDocumentMergeInput::with_pages(input, PageRange::List(pages));
+                    reconstructive_report_from_snapshots(
+                        std::slice::from_ref(&merge_input),
+                        std::slice::from_ref(&snapshot),
+                        policy,
+                    )
+                })
+                .collect::<OperationResult<Vec<_>>>()?;
+            let snapshot_file = stage_output(Path::new("snapshot.pdf"), &snapshot)?;
+            let mut staged = Vec::with_capacity(outputs.len());
+            for (report, output) in reports.iter().zip(outputs) {
+                let parent = output
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+                let temporary = tempfile::NamedTempFile::new_in(parent)?;
+                super::page_extraction::extract_pages_to_file(
+                    snapshot_file.path(),
+                    &report.inputs[0].selected_pages,
+                    temporary.path(),
+                )?;
+                temporary.as_file().sync_all()?;
+                staged.push(temporary);
+            }
+            let backups = outputs
+                .iter()
+                .map(|path| {
+                    if path.exists() {
+                        std::fs::read(path).map(Some)
+                    } else {
+                        Ok(None)
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            for index in 0..staged.len() {
+                let temporary = staged.remove(0);
+                if let Err(error) = temporary.persist(&outputs[index]) {
+                    for rollback in 0..index {
+                        match &backups[rollback] {
+                            Some(bytes) => {
+                                stage_output(&outputs[rollback], bytes)?
+                                    .persist(&outputs[rollback])
+                                    .map_err(|persist| OperationError::Io(persist.error))?;
+                            }
+                            None => {
+                                let _ = std::fs::remove_file(&outputs[rollback]);
+                            }
+                        }
+                    }
+                    return Err(OperationError::Io(error.error));
+                }
+            }
+            Ok(reports)
+        }
+    }
+}
+
+/// Plan a v4 preservation-first extraction.
+pub fn plan_extract_pdf_pages_lossless(
+    input: impl AsRef<Path>,
+    pages: &[usize],
+) -> OperationResult<SemanticPreservationReport> {
+    plan_extract_pdf_pages(input, pages, ExistingDocumentPolicy::preserve_base())
+}
+
+/// Execute a v4 preservation-first extraction.
+pub fn extract_pdf_pages_lossless(
+    input: impl AsRef<Path>,
+    output: impl AsRef<Path>,
+    pages: &[usize],
+) -> OperationResult<SemanticPreservationReport> {
+    extract_pdf_pages(
+        input,
+        output,
+        pages,
+        ExistingDocumentPolicy::preserve_base(),
+    )
+}
+
+/// Plan a v4 preservation-first split.
+pub fn plan_split_pdf_lossless(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    plan_split_pdf(input, ranges, ExistingDocumentPolicy::preserve_base())
+}
+
+/// Execute a v4 preservation-first split.
+pub fn split_pdf_lossless(
+    input: impl AsRef<Path>,
+    ranges: &[PageRange],
+    outputs: &[PathBuf],
+) -> OperationResult<Vec<SemanticPreservationReport>> {
+    split_pdf(
+        input,
+        ranges,
+        outputs,
+        ExistingDocumentPolicy::preserve_base(),
+    )
+}
+
+/// Plan a v4 preservation-first merge.
+pub fn plan_merge_pdfs_lossless(
+    inputs: &[LosslessMergeInput],
+) -> OperationResult<SemanticPreservationReport> {
+    plan_merge_pdfs(inputs, ExistingDocumentPolicy::preserve_base())
+}
+
+/// Execute a v4 preservation-first merge.
+pub fn merge_pdfs_lossless(
+    inputs: &[LosslessMergeInput],
+    output: impl AsRef<Path>,
+) -> OperationResult<SemanticPreservationReport> {
+    merge_pdfs(inputs, output, ExistingDocumentPolicy::preserve_base())
 }
 
 #[cfg(test)]
@@ -669,13 +1412,19 @@ mod tests {
     use super::*;
 
     fn semantic_fixture() -> Vec<u8> {
+        semantic_fixture_with_field(
+            b"<< /Type /Annot /Subtype /Widget /FT /Tx /T (field) /P 3 0 R /Rect [0 0 10 10] >>",
+        )
+    }
+
+    fn semantic_fixture_with_field(field: &[u8]) -> Vec<u8> {
         let objects = [
             b"<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [6 0 R] >> /Outlines << /Type /Outlines /Count 0 >> /Names << /EmbeddedFiles << /Names [(attachment.txt) << /F (attachment.txt) >>] >> >> /Dests << >> /OCProperties << /OCGs [] /D << >> >> /StructTreeRoot << /Type /StructTreeRoot /K [] >> /Metadata 4 0 R /PageLabels << /Nums [] >> >>".as_slice(),
             b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".as_slice(),
             b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << >> /StructParents 0 /Annots [5 0 R 6 0 R] >>".as_slice(),
             b"<< /Type /Metadata /Subtype /XML /Length 0 >>\nstream\n\nendstream".as_slice(),
             b"<< /Type /Annot /Subtype /Link /Rect [0 0 10 10] /Dest [3 0 R /Fit] >>".as_slice(),
-            b"<< /Type /Annot /Subtype /Widget /FT /Tx /T (field) /P 3 0 R /Rect [0 0 10 10] >>".as_slice(),
+            field,
         ];
         let mut bytes = b"%PDF-1.7\n".to_vec();
         let mut offsets = Vec::new();
@@ -697,20 +1446,77 @@ mod tests {
     }
 
     #[test]
+    fn inventories_digital_signatures_separately_from_forms() {
+        let bytes = semantic_fixture_with_field(
+            b"<< /Type /Annot /Subtype /Widget /FT /Sig /T (signature) /P 3 0 R /Rect [0 0 10 10] /V << /Type /Sig /Filter /Adobe.PPKLite /ByteRange [0 0 0 0] /Contents () >> >>",
+        );
+        let report = inspect_input_bytes(
+            Path::new("signed.pdf"),
+            &bytes,
+            InputSemanticRole::PreservedBase,
+            None,
+            ExistingDocumentPolicy::preserve_base(),
+        )
+        .unwrap();
+
+        assert!(report.structures.iter().any(|entry| {
+            entry.structure == DocumentStructure::DigitalSignatures
+                && entry.disposition == StructureDisposition::Preserved
+        }));
+    }
+
+    #[test]
+    fn empty_annotations_array_is_not_reported_as_document_semantics() {
+        let fixture = String::from_utf8(semantic_fixture()).unwrap();
+        let bytes = fixture
+            .replace("/Annots [5 0 R 6 0 R]", "/Annots []")
+            .into_bytes();
+        let report = inspect_input_bytes(
+            Path::new("empty-annots.pdf"),
+            &bytes,
+            InputSemanticRole::ImportedPages,
+            None,
+            ExistingDocumentPolicy::preserve_base(),
+        )
+        .unwrap();
+
+        assert!(!report
+            .structures
+            .iter()
+            .any(|entry| entry.structure == DocumentStructure::Annotations));
+    }
+
+    #[test]
     fn inventories_every_required_catalog_structure_with_explicit_dispositions() {
         let bytes = semantic_fixture();
         let path = Path::new("semantic-fixture.pdf");
-        let base =
-            inspect_input_bytes(path, &bytes, InputSemanticRole::PreservedBase, None).unwrap();
-        assert_eq!(base.structures.len(), DOCUMENT_STRUCTURES.len());
+        let base = inspect_input_bytes(
+            path,
+            &bytes,
+            InputSemanticRole::PreservedBase,
+            None,
+            ExistingDocumentPolicy::preserve_base(),
+        )
+        .unwrap();
+        assert_eq!(base.structures.len(), DOCUMENT_STRUCTURES.len() + 1);
         assert!(base
             .structures
             .iter()
             .all(|entry| entry.disposition == StructureDisposition::Preserved));
 
-        let imported =
-            inspect_input_bytes(path, &bytes, InputSemanticRole::ImportedPages, None).unwrap();
-        assert_eq!(imported.structures.len(), DOCUMENT_STRUCTURES.len());
+        let imported = inspect_input_bytes(
+            path,
+            &bytes,
+            InputSemanticRole::ImportedPages,
+            None,
+            ExistingDocumentPolicy::preserve_base(),
+        )
+        .unwrap();
+        assert_eq!(imported.structures.len(), DOCUMENT_STRUCTURES.len() + 1);
+        assert!(imported.structures.iter().any(|entry| {
+            entry.structure == DocumentStructure::Annotations
+                && entry.disposition == StructureDisposition::Rejected
+        }));
         assert!(imported
             .structures
             .iter()
@@ -722,7 +1528,7 @@ mod tests {
                 .iter()
                 .filter(|entry| entry.disposition == StructureDisposition::Rejected)
                 .count(),
-            DOCUMENT_STRUCTURES.len() - 1
+            DOCUMENT_STRUCTURES.len()
         );
     }
 

--- a/oxidize-pdf-core/src/operations/split.rs
+++ b/oxidize-pdf-core/src/operations/split.rs
@@ -4,7 +4,7 @@
 //! based on page ranges or other criteria.
 //!
 //! This legacy API reconstructs a new [`crate::Document`]. Use
-//! [`super::split_pdf_lossless`] when complete reachable source semantics must
+//! the policy-driven [`super::existing_document::split_pdf`] when complete reachable source semantics must
 //! be retained or rejected explicitly through a dry-run report.
 
 use super::{OperationError, OperationResult, PageRange};
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 /// Options for PDF splitting
 #[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct SplitOptions {
     /// How to split the document
     pub mode: SplitMode,
@@ -23,7 +24,6 @@ pub struct SplitOptions {
     pub output_pattern: String,
     /// Whether to preserve document metadata
     pub preserve_metadata: bool,
-    /// Whether to optimize output files
     pub optimize: bool,
 }
 

--- a/oxidize-pdf-core/tests/batch_processing_tests.rs
+++ b/oxidize-pdf-core/tests/batch_processing_tests.rs
@@ -94,8 +94,13 @@ fn test_batch_split_pdfs() {
     assert_eq!(summary.successful, 3);
     assert_eq!(summary.failed, 0);
 
-    // The batch_split_pdfs function creates split files in the current directory
-    // We can verify the operation succeeded by checking the summary
+    let outputs = summary.output_files();
+    assert_eq!(outputs.len(), 12);
+    for output in outputs {
+        assert!(output.exists(), "missing split output {}", output.display());
+        let document = oxidize_pdf::parser::PdfReader::open_document(output).unwrap();
+        assert_eq!(document.page_count().unwrap(), 1);
+    }
     assert_eq!(summary.success_rate(), 100.0);
 }
 

--- a/oxidize-pdf-core/tests/encryption_basic_test.rs
+++ b/oxidize-pdf-core/tests/encryption_basic_test.rs
@@ -102,8 +102,7 @@ fn test_aes_encryption_decryption_128() {
     let aes = Aes::new(key.clone());
     let result = aes.encrypt_cbc(plaintext, &iv);
 
-    if result.is_ok() {
-        let ciphertext = result.unwrap();
+    if let Ok(ciphertext) = result {
         assert_ne!(ciphertext, plaintext);
         assert!(ciphertext.len() >= plaintext.len());
 
@@ -111,8 +110,7 @@ fn test_aes_encryption_decryption_128() {
         let aes_decrypt = Aes::new(key);
         let decrypt_result = aes_decrypt.decrypt_cbc(&ciphertext, &iv);
 
-        if decrypt_result.is_ok() {
-            let decrypted = decrypt_result.unwrap();
+        if let Ok(decrypted) = decrypt_result {
             // Compare only the original plaintext bytes (16 bytes)
             // The rest may be PKCS7 padding (values 1-16, not null bytes)
             let original_len = plaintext.len();
@@ -157,16 +155,14 @@ fn test_aes_encryption_decryption_256() {
     let aes = Aes::new(key.clone());
     let result = aes.encrypt_cbc(plaintext, &iv);
 
-    if result.is_ok() {
-        let ciphertext = result.unwrap();
+    if let Ok(ciphertext) = result {
         assert_ne!(ciphertext, plaintext);
         assert!(ciphertext.len() >= plaintext.len());
 
         let aes_decrypt = Aes::new(key);
         let decrypt_result = aes_decrypt.decrypt_cbc(&ciphertext, &iv);
 
-        if decrypt_result.is_ok() {
-            let decrypted = decrypt_result.unwrap();
+        if let Ok(decrypted) = decrypt_result {
             // Compare only the original plaintext bytes (16 bytes)
             // The rest may be PKCS7 padding (values 1-16, not null bytes)
             let original_len = plaintext.len();
@@ -360,10 +356,12 @@ fn test_permissions_creation() {
 
 #[test]
 fn test_permissions_from_flags() {
-    let mut flags = PermissionFlags::default();
-    flags.print = true;
-    flags.modify_contents = true;
-    flags.copy = true;
+    let flags = PermissionFlags {
+        print: true,
+        modify_contents: true,
+        copy: true,
+        ..PermissionFlags::default()
+    };
 
     let permissions = Permissions::from_flags(flags);
 
@@ -535,8 +533,7 @@ fn test_full_aes_workflow() {
     let plaintext = b"AES encrypted   "; // 16 bytes
     let encrypt_result = aes.encrypt_cbc(plaintext, &iv);
 
-    if encrypt_result.is_ok() {
-        let ciphertext = encrypt_result.unwrap();
+    if let Ok(ciphertext) = encrypt_result {
         assert_ne!(ciphertext, plaintext);
         assert!(ciphertext.len() >= plaintext.len());
 
@@ -544,8 +541,7 @@ fn test_full_aes_workflow() {
         let aes_decrypt = Aes::new(aes_key);
         let decrypt_result = aes_decrypt.decrypt_cbc(&ciphertext, &iv);
 
-        if decrypt_result.is_ok() {
-            let decrypted = decrypt_result.unwrap();
+        if let Ok(decrypted) = decrypt_result {
             // Remove potential padding for comparison
             let trimmed: Vec<u8> = decrypted.iter().take_while(|&&b| b != 0).cloned().collect();
             assert!(trimmed.starts_with(b"AES encrypted"));

--- a/oxidize-pdf-core/tests/encryption_cross_validation_test.rs
+++ b/oxidize-pdf-core/tests/encryption_cross_validation_test.rs
@@ -27,9 +27,9 @@ fn extract_u_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
             let start = pos + pattern.len() - 1;
             let rest = &pdf_str[start..];
 
-            if rest.starts_with('<') {
-                if let Some(end) = rest[1..].find('>') {
-                    let hex = &rest[1..end + 1];
+            if let Some(stripped) = rest.strip_prefix('<') {
+                if let Some(end) = stripped.find('>') {
+                    let hex = &stripped[..end];
                     return Some(hex_to_bytes(hex));
                 }
             } else if rest.starts_with('(') {
@@ -49,9 +49,9 @@ fn extract_ue_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
             let start = pos + pattern.len() - 1;
             let rest = &pdf_str[start..];
 
-            if rest.starts_with('<') {
-                if let Some(end) = rest[1..].find('>') {
-                    let hex = &rest[1..end + 1];
+            if let Some(stripped) = rest.strip_prefix('<') {
+                if let Some(end) = stripped.find('>') {
+                    let hex = &stripped[..end];
                     return Some(hex_to_bytes(hex));
                 }
             } else if rest.starts_with('(') {
@@ -71,9 +71,9 @@ fn extract_perms_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
             let start = pos + pattern.len() - 1;
             let rest = &pdf_str[start..];
 
-            if rest.starts_with('<') {
-                if let Some(end) = rest[1..].find('>') {
-                    let hex = &rest[1..end + 1];
+            if let Some(stripped) = rest.strip_prefix('<') {
+                if let Some(end) = stripped.find('>') {
+                    let hex = &stripped[..end];
                     return Some(hex_to_bytes(hex));
                 }
             } else if rest.starts_with('(') {

--- a/oxidize-pdf-core/tests/encryption_r5_real_pdf_test.rs
+++ b/oxidize-pdf-core/tests/encryption_r5_real_pdf_test.rs
@@ -14,7 +14,7 @@ const FIXTURES_DIR: &str = "tests/fixtures";
 /// Test helper to read PDF bytes
 fn read_pdf_bytes(filename: &str) -> Vec<u8> {
     let path = format!("{}/{}", FIXTURES_DIR, filename);
-    std::fs::read(&path).expect(&format!("Failed to read {}", path))
+    std::fs::read(&path).unwrap_or_else(|_| panic!("Failed to read {path}"))
 }
 
 /// Extract U entry bytes from PDF (48 bytes for R5/R6)
@@ -36,7 +36,7 @@ fn extract_u_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
             }
         } else if rest.starts_with('(') {
             // Literal string - more complex due to escapes
-            return extract_literal_string(&rest);
+            return extract_literal_string(rest);
         }
     }
     None
@@ -56,7 +56,7 @@ fn extract_ue_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
                 return Some(hex_to_bytes(hex));
             }
         } else if rest.starts_with('(') {
-            return extract_literal_string(&rest);
+            return extract_literal_string(rest);
         }
     }
     None

--- a/oxidize-pdf-core/tests/encryption_r6_real_pdf_test.rs
+++ b/oxidize-pdf-core/tests/encryption_r6_real_pdf_test.rs
@@ -14,7 +14,7 @@ const FIXTURES_DIR: &str = "tests/fixtures";
 /// Test helper to read PDF bytes
 fn read_pdf_bytes(filename: &str) -> Vec<u8> {
     let path = format!("{}/{}", FIXTURES_DIR, filename);
-    std::fs::read(&path).expect(&format!("Failed to read {}", path))
+    std::fs::read(&path).unwrap_or_else(|_| panic!("Failed to read {}", path))
 }
 
 /// Extract U entry bytes from PDF (48 bytes for R5/R6)
@@ -31,7 +31,7 @@ fn extract_u_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
                 return Some(hex_to_bytes(hex));
             }
         } else if rest.starts_with('(') {
-            return extract_literal_string(&rest);
+            return extract_literal_string(rest);
         }
     }
     None
@@ -51,7 +51,7 @@ fn extract_ue_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
                 return Some(hex_to_bytes(hex));
             }
         } else if rest.starts_with('(') {
-            return extract_literal_string(&rest);
+            return extract_literal_string(rest);
         }
     }
     None
@@ -71,7 +71,7 @@ fn extract_perms_entry(pdf_bytes: &[u8]) -> Option<Vec<u8>> {
                 return Some(hex_to_bytes(hex));
             }
         } else if rest.starts_with('(') {
-            return extract_literal_string(&rest);
+            return extract_literal_string(rest);
         }
     }
     None

--- a/oxidize-pdf-core/tests/end_to_end_test.rs
+++ b/oxidize-pdf-core/tests/end_to_end_test.rs
@@ -2,8 +2,8 @@
 //! Tests complete workflows from PDF creation to parsing and manipulation
 
 use oxidize_pdf::graphics::Color;
-use oxidize_pdf::operations::{
-    merge_pdfs, split_pdf, MergeInput, MergeOptions, SplitMode, SplitOptions,
+use oxidize_pdf::operations::reconstruct::{
+    merge_pdfs, split_pdf, MergeInput, MetadataMode, SplitMode,
 };
 use oxidize_pdf::parser::PdfReader;
 use oxidize_pdf::text::Font;
@@ -219,18 +219,12 @@ fn test_split_pdf() -> std::result::Result<(), Box<dyn std::error::Error>> {
     fs::write(&input_path, pdf_bytes)?;
 
     // Split into individual pages
-    let options = SplitOptions {
-        mode: SplitMode::SinglePages,
-        output_pattern: temp_dir
-            .path()
-            .join("page_{}.pdf")
-            .to_string_lossy()
-            .to_string(),
-        preserve_metadata: true,
-        optimize: false,
-    };
-
-    split_pdf(&input_path, options)?;
+    split_pdf(
+        &input_path,
+        SplitMode::SinglePages,
+        temp_dir.path().join("page_{}.pdf").to_string_lossy(),
+        true,
+    )?;
 
     // Verify output files
     for i in 1..=6 {
@@ -270,9 +264,7 @@ fn test_merge_pdfs() -> std::result::Result<(), Box<dyn std::error::Error>> {
     ];
 
     let output_path = temp_dir.path().join("merged.pdf");
-    let options = MergeOptions::default();
-
-    merge_pdfs(inputs, &output_path, options)?;
+    merge_pdfs(inputs, &output_path, MetadataMode::FromFirst)?;
 
     // Verify merged PDF
     assert!(output_path.exists());
@@ -422,18 +414,12 @@ fn test_complex_document_workflow() -> std::result::Result<(), Box<dyn std::erro
     writer.write_document(&mut document)?;
 
     // Step 3: Split into chunks
-    let split_options = SplitOptions {
-        mode: SplitMode::ChunkSize(3),
-        output_pattern: temp_dir
-            .path()
-            .join("chunk_{}.pdf")
-            .to_string_lossy()
-            .to_string(),
-        preserve_metadata: true,
-        optimize: false,
-    };
-
-    let split_files = split_pdf(&original_path, split_options)?;
+    let split_files = split_pdf(
+        &original_path,
+        SplitMode::ChunkSize(3),
+        temp_dir.path().join("chunk_{}.pdf").to_string_lossy(),
+        true,
+    )?;
 
     // Step 4: Merge some chunks
     // Use the actual file names created
@@ -452,7 +438,7 @@ fn test_complex_document_workflow() -> std::result::Result<(), Box<dyn std::erro
     let merge_inputs = vec![MergeInput::new(chunk1), MergeInput::new(chunk2)];
 
     let merged_path = temp_dir.path().join("merged_chunks.pdf");
-    merge_pdfs(merge_inputs, &merged_path, MergeOptions::default())?;
+    merge_pdfs(merge_inputs, &merged_path, MetadataMode::FromFirst)?;
 
     // Step 5: Verify final result
     assert!(merged_path.exists());

--- a/oxidize-pdf-core/tests/extraction_actualtext_test.rs
+++ b/oxidize-pdf-core/tests/extraction_actualtext_test.rs
@@ -35,12 +35,12 @@ fn literal_actualtext_overrides_decoded_glyphs() {
     let frags = extract(content);
     let texts: Vec<&str> = frags.iter().map(|f| f.text.as_str()).collect();
     assert!(
-        texts.iter().any(|t| *t == "fi"),
+        texts.contains(&"fi"),
         "fragment must be ActualText 'fi', not glyph 'xy'; got {:?}",
         texts
     );
     assert!(
-        !texts.iter().any(|t| *t == "xy"),
+        !texts.contains(&"xy"),
         "raw glyph 'xy' must not be emitted under ActualText scope"
     );
 }
@@ -56,11 +56,11 @@ fn utf16be_actualtext_overrides_decoded_glyphs() {
     let frags = extract(content);
     let texts: Vec<&str> = frags.iter().map(|f| f.text.as_str()).collect();
     assert!(
-        texts.iter().any(|t| *t == "fi"),
+        texts.contains(&"fi"),
         "UTF-16BE ActualText must decode to 'fi'; got {:?}",
         texts
     );
-    assert!(!texts.iter().any(|t| *t == "junk"));
+    assert!(!texts.contains(&"junk"));
 }
 
 #[test]
@@ -80,6 +80,6 @@ fn actualtext_collapses_multi_tj_run_to_single_fragment() {
         "expected exactly one 'ff' fragment, got {:?}",
         texts
     );
-    assert!(!texts.iter().any(|t| *t == "f"));
-    assert!(!texts.iter().any(|t| *t == "i"));
+    assert!(!texts.contains(&"f"));
+    assert!(!texts.contains(&"i"));
 }

--- a/oxidize-pdf-core/tests/field_appearance_tests.rs
+++ b/oxidize-pdf-core/tests/field_appearance_tests.rs
@@ -21,12 +21,14 @@ fn test_appearance_characteristics_default() {
 
 #[test]
 fn test_appearance_characteristics_to_dict() {
-    let mut chars = AppearanceCharacteristics::default();
-    chars.rotation = 90;
-    chars.border_color = Some(Color::rgb(0.0, 0.0, 1.0)); // Blue
-    chars.background_color = Some(Color::rgb(1.0, 1.0, 1.0)); // White
-    chars.normal_caption = Some("Click Me".to_string());
-    chars.text_position = TextPosition::CaptionBelowIcon;
+    let chars = AppearanceCharacteristics {
+        rotation: 90,
+        border_color: Some(Color::rgb(0.0, 0.0, 1.0)), // Blue
+        background_color: Some(Color::rgb(1.0, 1.0, 1.0)), // White
+        normal_caption: Some("Click Me".to_string()),
+        text_position: TextPosition::CaptionBelowIcon,
+        ..AppearanceCharacteristics::default()
+    };
 
     let dict = chars.to_dict();
 

--- a/oxidize-pdf-core/tests/forms_cross_module_integration_test.rs
+++ b/oxidize-pdf-core/tests/forms_cross_module_integration_test.rs
@@ -94,7 +94,7 @@ fn test_forms_graphics_integration() {
     let mut form_manager = FormManager::new();
 
     // Create form fields with various graphic appearances
-    let color_test_cases = vec![
+    let color_test_cases = [
         (
             "rgb_field",
             Color::rgb(1.0, 0.0, 0.0),
@@ -653,7 +653,7 @@ fn test_forms_pdf_objects_integration() {
     additional_dict.set("CustomProperty", Object::String("Custom Value".to_string()));
     additional_dict.set("NumericProperty", Object::Integer(42));
     additional_dict.set("BooleanProperty", Object::Boolean(true));
-    additional_dict.set("RealProperty", Object::Real(3.14159));
+    additional_dict.set("RealProperty", Object::Real(3.125));
 
     // Create array with mixed object types
     let mixed_array = vec![
@@ -705,10 +705,7 @@ fn test_forms_pdf_objects_integration() {
             custom_dict.get("BooleanProperty"),
             Some(&Object::Boolean(true))
         );
-        assert_eq!(
-            custom_dict.get("RealProperty"),
-            Some(&Object::Real(3.14159))
-        );
+        assert_eq!(custom_dict.get("RealProperty"), Some(&Object::Real(3.125)));
 
         // Mixed array should be preserved
         if let Some(Object::Array(mixed_arr)) = custom_dict.get("MixedArray") {

--- a/oxidize-pdf-core/tests/forms_document_integration_test.rs
+++ b/oxidize-pdf-core/tests/forms_document_integration_test.rs
@@ -1357,7 +1357,7 @@ fn test_international_form_support() {
     let mut form_manager = FormManager::new();
 
     // Test with various international characters
-    let international_texts = vec![
+    let international_texts = [
         ("chinese", "你好世界"),
         ("arabic", "مرحبا بالعالم"),
         ("spanish", "Hola Mundo ñáéíóú"),

--- a/oxidize-pdf-core/tests/forms_error_handling_test.rs
+++ b/oxidize-pdf-core/tests/forms_error_handling_test.rs
@@ -226,7 +226,7 @@ fn test_invalid_choice_field_configurations() {
     let mut form_manager = FormManager::new();
 
     // Test RadioButton with invalid selections
-    let invalid_radio_tests = vec![
+    let invalid_radio_tests = [
         // Selection index out of bounds
         (vec![("A", "Option A"), ("B", "Option B")], Some(5)), // Index 5 invalid
         (vec![("A", "Option A")], Some(10)),                   // Index 10 invalid for single option
@@ -278,7 +278,7 @@ fn test_invalid_choice_field_configurations() {
     }
 
     // Test ListBox with invalid selections
-    let invalid_list_tests = vec![
+    let invalid_list_tests = [
         // Multiple selections with some invalid indices
         (
             vec![("A", "Option A"), ("B", "Option B")],
@@ -461,7 +461,7 @@ fn test_circular_reference_detection() {
 fn test_invalid_appearance_configurations() {
     // Test widget appearances with invalid or extreme values
 
-    let invalid_appearances = vec![
+    let invalid_appearances = [
         // Extreme border widths
         WidgetAppearance {
             border_color: Some(Color::black()),
@@ -594,7 +594,7 @@ fn test_invalid_field_flags_combinations() {
     let mut form_manager = FormManager::new();
 
     // Test with contradictory or problematic flag combinations
-    let problematic_options = vec![
+    let problematic_options = [
         // Read-only but required (user can't fill required field)
         FieldOptions {
             flags: FieldFlags {
@@ -979,7 +979,7 @@ fn test_invalid_widget_operations() {
     let base_rect = Rectangle::new(Point::new(100.0, 100.0), Point::new(200.0, 120.0));
 
     // Test 1: Widget with extreme appearance values
-    let extreme_appearances = vec![
+    let extreme_appearances = [
         WidgetAppearance {
             border_color: None,
             background_color: None,

--- a/oxidize-pdf-core/tests/forms_parser_integration_test.rs
+++ b/oxidize-pdf-core/tests/forms_parser_integration_test.rs
@@ -557,7 +557,7 @@ fn test_parse_field_flags() {
 /// Test 10: Parse malformed form dictionaries gracefully
 #[test]
 fn test_parse_malformed_form_dictionaries() {
-    let malformed_cases = vec![
+    let malformed_cases = [
         // Case 1: Missing field type
         {
             let mut dict = Dictionary::new();
@@ -670,7 +670,7 @@ fn test_parse_form_field_options() {
     choice_dict.set("T", Object::String("test_choices".to_string()));
 
     // Test different option formats
-    let option_formats = vec![
+    let option_formats = [
         // Format 1: Simple string array
         vec![
             Object::String("Option1".to_string()),

--- a/oxidize-pdf-core/tests/incremental_form_fill_test.rs
+++ b/oxidize-pdf-core/tests/incremental_form_fill_test.rs
@@ -159,7 +159,7 @@ fn base_startxref(bytes: &[u8]) -> u64 {
 /// Base trailer `/Size` (= the first object id a fresh appearance stream takes).
 fn base_size(bytes: &[u8]) -> u32 {
     let reader = PdfReader::new(Cursor::new(bytes)).expect("parse");
-    reader.trailer().size().expect("base /Size") as u32
+    reader.trailer().size().expect("base /Size")
 }
 
 /// Object ids of the first page's widget annotations (the bearers of /AP after

--- a/oxidize-pdf-core/tests/inline_font_resources_test.rs
+++ b/oxidize-pdf-core/tests/inline_font_resources_test.rs
@@ -18,7 +18,7 @@
 mod common;
 
 use common::pdf_assembler::{assemble_pdf, stream_obj};
-use oxidize_pdf::operations::{merge_pdfs, MergeInput, MergeOptions};
+use oxidize_pdf::operations::reconstruct::{merge_pdfs, MergeInput, MetadataMode};
 use oxidize_pdf::parser::{ParseOptions, PdfDocument, PdfReader};
 use oxidize_pdf::text::{ExtractionOptions, PlainTextExtractor, TextExtractor};
 use std::io::Cursor;
@@ -168,7 +168,7 @@ fn a_document_written_by_this_library_stays_readable_to_this_library() {
     merge_pdfs(
         vec![MergeInput::new(input)],
         &output,
-        MergeOptions::default(),
+        MetadataMode::FromFirst,
     )
     .expect("merge writes the document");
 

--- a/oxidize-pdf-core/tests/iso_curation_validation_tests.rs
+++ b/oxidize-pdf-core/tests/iso_curation_validation_tests.rs
@@ -222,10 +222,11 @@ mod curation {
         if DATE_PARENS_PATTERN.is_match(text) && ORG_PATTERN.is_match(text) {
             return true;
         }
-        if ORG_PATTERN.is_match(text) && !NORMATIVE_PATTERN.is_match(text) {
-            if text.trim().ends_with('.') || text.trim().ends_with("Incorporated") {
-                return true;
-            }
+        if ORG_PATTERN.is_match(text)
+            && !NORMATIVE_PATTERN.is_match(text)
+            && (text.trim().ends_with('.') || text.trim().ends_with("Incorporated"))
+        {
+            return true;
         }
         false
     }

--- a/oxidize-pdf-core/tests/issue_240_text_flow_encoding_test.rs
+++ b/oxidize-pdf-core/tests/issue_240_text_flow_encoding_test.rs
@@ -183,13 +183,11 @@ fn count_tj_operators(pdf: &[u8]) -> usize {
 fn write_wrapped_wraps_by_char_width_not_by_utf8_byte_length() {
     let n_words = 30;
     // "naïve" = 5 chars, 6 bytes UTF-8 (`ï` = 0xC3 0xAF in UTF-8).
-    let unicode_line: String = std::iter::repeat("naïve")
-        .take(n_words)
+    let unicode_line: String = std::iter::repeat_n("naïve", n_words)
         .collect::<Vec<_>>()
         .join(" ");
     // "naive" = 5 chars, 5 bytes UTF-8.
-    let ascii_line: String = std::iter::repeat("naive")
-        .take(n_words)
+    let ascii_line: String = std::iter::repeat_n("naive", n_words)
         .collect::<Vec<_>>()
         .join(" ");
 
@@ -235,7 +233,7 @@ fn text_at_and_text_flow_at_emit_identical_show_text_bytes() {
 
 /// Integración E2E #240: round-trip a través del parser. Emitir `€ — ±`
 /// vía `text_flow().write_wrapped(...)`, parsear el PDF con `PdfReader`
-/// + `TextExtractor` y verificar que cada character especial sobrevive
+/// mediante `TextExtractor` y verificar que cada character especial sobrevive
 /// la decodificación WinAnsi → UTF-8. Pre-fix, el extractor leía los
 /// bytes UTF-8 raw como tres chars Windows-1252 separados produciendo
 /// mojibake (`€` → `â‚¬`).

--- a/oxidize-pdf-core/tests/issue_286_high_compression_image_test.rs
+++ b/oxidize-pdf-core/tests/issue_286_high_compression_image_test.rs
@@ -46,7 +46,6 @@ fn options(out: std::path::PathBuf) -> ExtractImagesOptions {
             force_grayscale: false,
             ..Default::default()
         },
-        ..Default::default()
     }
 }
 
@@ -56,7 +55,7 @@ fn test_high_compression_images_all_extract() {
     // ("expected 1085400, got 0") and aborted the whole batch.
     let out = std::env::temp_dir().join("oxidize_issue286_hc_all");
     let _ = std::fs::remove_dir_all(&out);
-    let images = extract_images_from_pdf(&fixture(), options(out))
+    let images = extract_images_from_pdf(fixture(), options(out))
         .expect("extraction must not fail on highly-compressible images");
     assert_eq!(
         images.len(),
@@ -73,8 +72,7 @@ fn test_high_ratio_image_decodes_full_size_not_empty() {
     // bytes. The bug produced 0 bytes; a truncated decode would produce fewer.
     let out = std::env::temp_dir().join("oxidize_issue286_hc_pixels");
     let _ = std::fs::remove_dir_all(&out);
-    let images =
-        extract_images_from_pdf(&fixture(), options(out)).expect("extraction must succeed");
+    let images = extract_images_from_pdf(fixture(), options(out)).expect("extraction must succeed");
 
     let big = images
         .iter()
@@ -241,14 +239,13 @@ fn test_smask_composited_into_rgba_alpha() {
     // The mask is a real shape, not a constant: it has both transparent and
     // opaque pixels.
     assert!(
-        expected_alpha.iter().any(|&a| a == 0) && expected_alpha.iter().any(|&a| a == 255),
+        expected_alpha.contains(&0) && expected_alpha.contains(&255),
         "SMask must carry a real shape (both 0 and 255 present)"
     );
 
     let out = std::env::temp_dir().join("oxidize_issue286_smask");
     let _ = std::fs::remove_dir_all(&out);
-    let images =
-        extract_images_from_pdf(&fixture(), options(out)).expect("extraction must succeed");
+    let images = extract_images_from_pdf(fixture(), options(out)).expect("extraction must succeed");
     let big = images
         .iter()
         .find(|img| img.width == 600 && img.height == 603)

--- a/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
+++ b/oxidize-pdf-core/tests/issue_286_indexed_image_test.rs
@@ -47,7 +47,7 @@ fn test_indexed_image_extraction_does_not_fail_with_size_error() {
         ..Default::default()
     };
 
-    let images = extract_images_from_pdf(&fixture(), options)
+    let images = extract_images_from_pdf(fixture(), options)
         .expect("extraction must not fail on Indexed colour space");
 
     // The five pages reference 28 image XObjects (6+6+6+7+3), all above the
@@ -75,7 +75,7 @@ fn test_indexed_image_is_expanded_to_rgb_png() {
         ..Default::default()
     };
 
-    let images = extract_images_from_pdf(&fixture(), options).expect("extraction must succeed");
+    let images = extract_images_from_pdf(fixture(), options).expect("extraction must succeed");
 
     // The Indexed image is 600x603.
     let indexed = images
@@ -289,9 +289,8 @@ fn test_indexed_image_matches_independent_decode() {
             force_grayscale: false,
             ..Default::default()
         },
-        ..Default::default()
     };
-    let images = extract_images_from_pdf(&fixture(), options).expect("extraction must succeed");
+    let images = extract_images_from_pdf(fixture(), options).expect("extraction must succeed");
     let indexed = images
         .iter()
         .find(|img| img.width == 600 && img.height == 603)

--- a/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_merged_cells_detect_test.rs
@@ -40,7 +40,7 @@ fn frag(t: &str, x: f64, y: f64) -> TextFragment {
 
 fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
     let mut g = ExtractedGraphics::new();
-    for line in h.into_iter().chain(v.into_iter()) {
+    for line in h.into_iter().chain(v) {
         g.add_line(line);
     }
     g

--- a/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
+++ b/oxidize-pdf-core/tests/issue_375_multi_level_header_test.rs
@@ -39,7 +39,7 @@ fn frag(t: &str, x: f64, y: f64) -> TextFragment {
 
 fn build_graphics(h: Vec<VectorLine>, v: Vec<VectorLine>) -> ExtractedGraphics {
     let mut g = ExtractedGraphics::new();
-    for line in h.into_iter().chain(v.into_iter()) {
+    for line in h.into_iter().chain(v) {
         g.add_line(line);
     }
     g

--- a/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
+++ b/oxidize-pdf-core/tests/issue_382_extract_page_byte_limit.rs
@@ -374,14 +374,16 @@ fn test_actualtext_scope_respects_budget() {
 
     for (label, base) in [
         ("preserve_layout", {
-            let mut o = ExtractionOptions::default();
-            o.preserve_layout = true;
-            o
+            ExtractionOptions {
+                preserve_layout: true,
+                ..ExtractionOptions::default()
+            }
         }),
         ("reorder_columns", {
-            let mut o = ExtractionOptions::default();
-            o.reorder_columns = true;
-            o
+            ExtractionOptions {
+                reorder_columns: true,
+                ..ExtractionOptions::default()
+            }
         }),
     ] {
         // Unbounded: the ActualText override does surface (sanity that the

--- a/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
+++ b/oxidize-pdf-core/tests/issue_453_page_ops_preserve_content_test.rs
@@ -13,11 +13,9 @@
 //! crate's own extractor: it reads the *bytes we wrote*, so a passing test means
 //! the written PDF is correct for any reader, not just ours.
 
+use oxidize_pdf::operations::reconstruct::{extract_page_to_file, split_into_pages};
 use oxidize_pdf::operations::PageRange;
-use oxidize_pdf::operations::{
-    extract_page_to_file, reorder_pdf_pages, rotate_pdf_pages, split_into_pages, RotateOptions,
-    RotationAngle,
-};
+use oxidize_pdf::operations::{reorder_pdf_pages, rotate_pdf_pages, RotateOptions, RotationAngle};
 use std::path::Path;
 use std::process::Command;
 

--- a/oxidize-pdf-core/tests/issue_465_smask_preservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_465_smask_preservation_test.rs
@@ -16,9 +16,10 @@
 //! Fixture: `Cold_Email_Hacks.pdf` page 16 (1-based) carries one image with a
 //! soft mask (poppler: one `smask` row, object 31). The other pages are plain.
 
-use oxidize_pdf::operations::{
-    extract_page_to_file, merge_pdfs, split_into_pages, MergeInput, MergeOptions, PageRange,
+use oxidize_pdf::operations::reconstruct::{
+    extract_page_to_file, merge_pdfs, split_into_pages, MergeInput, MetadataMode,
 };
+use oxidize_pdf::operations::PageRange;
 use std::path::Path;
 use std::process::Command;
 
@@ -100,7 +101,7 @@ fn merge_preserves_smask() {
         MergeInput::with_pages(src, PageRange::Single(SMASK_PAGE_0BASED)),
     ];
     let out = std::env::temp_dir().join("issue465_merge.pdf");
-    merge_pdfs(inputs, &out, MergeOptions::default()).expect("merge");
+    merge_pdfs(inputs, &out, MetadataMode::FromFirst).expect("merge");
 
     let got = poppler_smask_count(&out, 2, 2).expect("output smask");
     assert_eq!(

--- a/oxidize-pdf-core/tests/issue_539_semantic_preservation_test.rs
+++ b/oxidize-pdf-core/tests/issue_539_semantic_preservation_test.rs
@@ -1,8 +1,9 @@
-use oxidize_pdf::operations::{
-    extract_pdf_pages_lossless, merge_pdfs_lossless, plan_extract_pdf_pages_lossless,
-    plan_merge_pdfs_lossless, split_pdf_lossless, DocumentStructure, LosslessMergeInput, PageRange,
-    StructureDisposition,
+use oxidize_pdf::operations::existing_document::{
+    extract_pdf_pages, merge_pdfs, plan_extract_pdf_pages, plan_merge_pdfs, split_pdf,
+    DocumentStructure, ExistingDocumentEngine, ExistingDocumentMergeInput, ExistingDocumentPolicy,
+    SecondaryStructurePolicy, StructureDisposition,
 };
+use oxidize_pdf::operations::PageRange;
 use oxidize_pdf::page_labels::{PageLabel, PageLabelTree};
 use oxidize_pdf::parser::PdfReader;
 use oxidize_pdf::text::TextExtractor;
@@ -45,11 +46,12 @@ fn sparse_extraction_is_planned_and_keeps_the_source_prefix() {
     let output = directory.path().join("output.pdf");
     write_pdf(&source, 3);
 
-    let planned = plan_extract_pdf_pages_lossless(&source, &[2, 0]).unwrap();
-    let written = extract_pdf_pages_lossless(&source, &output, &[2, 0]).unwrap();
+    let policy = ExistingDocumentPolicy::preserve_base();
+    let planned = plan_extract_pdf_pages(&source, &[2, 0], policy).unwrap();
+    let written = extract_pdf_pages(&source, &output, &[2, 0], policy).unwrap();
 
     assert_eq!(planned, written);
-    assert_eq!(written.mutation.page_count, 2);
+    assert_eq!(written.plan.page_count(), 2);
     assert!(fs::read(&output)
         .unwrap()
         .starts_with(&fs::read(&source).unwrap()));
@@ -66,15 +68,16 @@ fn merge_preserves_base_and_imports_self_contained_pages() {
     write_pdf(&first, 2);
     write_pdf(&second, 2);
     let inputs = vec![
-        LosslessMergeInput::new(&first),
-        LosslessMergeInput::new(&second),
+        ExistingDocumentMergeInput::new(&first),
+        ExistingDocumentMergeInput::new(&second),
     ];
 
-    let planned = plan_merge_pdfs_lossless(&inputs).unwrap();
-    let written = merge_pdfs_lossless(&inputs, &output).unwrap();
+    let policy = ExistingDocumentPolicy::preserve_base();
+    let planned = plan_merge_pdfs(&inputs, policy).unwrap();
+    let written = merge_pdfs(&inputs, &output, policy).unwrap();
 
     assert_eq!(planned, written);
-    assert_eq!(written.mutation.page_count, 4);
+    assert_eq!(written.plan.page_count(), 4);
     assert!(written.inputs[1].structures.iter().any(|entry| {
         entry.structure == DocumentStructure::MetadataStream
             && entry.disposition == StructureDisposition::FirstInputWins
@@ -97,10 +100,11 @@ fn split_plans_every_output_before_atomic_publication() {
     let second = directory.path().join("part-b.pdf");
     write_pdf(&source, 3);
 
-    let reports = split_pdf_lossless(
+    let reports = split_pdf(
         &source,
         &[PageRange::List(vec![0, 2]), PageRange::Single(1)],
         &[first.clone(), second.clone()],
+        ExistingDocumentPolicy::preserve_base(),
     )
     .unwrap();
 
@@ -116,10 +120,22 @@ fn extraction_honors_requested_order_and_duplicates() {
     let output = directory.path().join("selected.pdf");
     write_pdf(&source, 3);
 
-    let report = extract_pdf_pages_lossless(&source, &output, &[2, 0, 2]).unwrap();
+    let report = extract_pdf_pages(
+        &source,
+        &output,
+        &[2, 0, 2],
+        ExistingDocumentPolicy::preserve_base(),
+    )
+    .unwrap();
 
-    assert_eq!(report.mutation.page_count, 3);
-    assert!(!report.mutation.added_objects.is_empty());
+    assert_eq!(report.plan.page_count(), 3);
+    let oxidize_pdf::operations::existing_document::ExistingDocumentExecutionPlan::Incremental(
+        mutation,
+    ) = &report.plan
+    else {
+        panic!("preserving extraction must use an incremental plan");
+    };
+    assert!(!mutation.added_objects.is_empty());
     assert_eq!(PdfReader::open(&output).unwrap().page_count().unwrap(), 3);
     assert_eq!(page_texts(&output), ["page 3", "page 1", "page 3"]);
 }
@@ -132,14 +148,20 @@ fn split_rejects_duplicate_and_input_alias_paths_before_writing() {
     write_pdf(&source, 2);
     let ranges = [PageRange::Single(0), PageRange::Single(1)];
 
-    let duplicate = split_pdf_lossless(&source, &ranges, &[output.clone(), output.clone()]);
+    let duplicate = split_pdf(
+        &source,
+        &ranges,
+        &[output.clone(), output.clone()],
+        ExistingDocumentPolicy::preserve_base(),
+    );
     assert!(duplicate.unwrap_err().to_string().contains("duplicate"));
     assert!(!output.exists());
 
-    let alias = split_pdf_lossless(
+    let alias = split_pdf(
         &source,
         &[PageRange::Single(0)],
         std::slice::from_ref(&source),
+        ExistingDocumentPolicy::preserve_base(),
     );
     assert!(alias.unwrap_err().to_string().contains("aliases the input"));
     assert_eq!(page_texts(&source), ["page 1", "page 2"]);
@@ -155,14 +177,21 @@ fn split_stages_every_destination_before_replacing_any_output() {
     fs::write(&first, b"keep me").unwrap();
     fs::create_dir(&invalid_second).unwrap();
 
-    let result = split_pdf_lossless(
-        &source,
-        &[PageRange::Single(0), PageRange::Single(1)],
-        &[first.clone(), invalid_second],
-    );
+    for policy in [
+        ExistingDocumentPolicy::preserve_base(),
+        ExistingDocumentPolicy::reconstruct(),
+    ] {
+        fs::write(&first, b"keep me").unwrap();
+        let result = split_pdf(
+            &source,
+            &[PageRange::Single(0), PageRange::Single(1)],
+            &[first.clone(), invalid_second.clone()],
+            policy,
+        );
 
-    assert!(result.is_err());
-    assert_eq!(fs::read(first).unwrap(), b"keep me");
+        assert!(result.is_err());
+        assert_eq!(fs::read(&first).unwrap(), b"keep me");
+    }
 }
 
 #[test]
@@ -180,12 +209,220 @@ fn merge_rejects_secondary_catalog_semantics_before_writing() {
     labeled.save(&second).unwrap();
     fs::write(&output, b"do not replace").unwrap();
     let inputs = vec![
-        LosslessMergeInput::new(&first),
-        LosslessMergeInput::new(&second),
+        ExistingDocumentMergeInput::new(&first),
+        ExistingDocumentMergeInput::new(&second),
     ];
 
-    let error = plan_merge_pdfs_lossless(&inputs).unwrap_err();
+    let error = plan_merge_pdfs(&inputs, ExistingDocumentPolicy::preserve_base()).unwrap_err();
 
     assert!(error.to_string().contains("PageLabels"));
     assert_eq!(fs::read(output).unwrap(), b"do not replace");
+}
+
+#[test]
+fn merge_policy_explicitly_controls_each_secondary_structure() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("labeled.pdf");
+    write_pdf(&first, 1);
+    let mut labeled = Document::new();
+    labeled.add_page(Page::a4());
+    let mut labels = PageLabelTree::new();
+    labels.add_range(0, PageLabel::roman_lowercase());
+    labeled.set_page_labels(labels);
+    labeled.save(&second).unwrap();
+    let inputs = [
+        ExistingDocumentMergeInput::new(first),
+        ExistingDocumentMergeInput::new(second),
+    ];
+    let policy = ExistingDocumentPolicy::preserve_base()
+        .with_page_labels(SecondaryStructurePolicy::FirstInputWins);
+
+    let report = plan_merge_pdfs(&inputs, policy).unwrap();
+
+    assert!(report.inputs[1].structures.iter().any(|entry| {
+        entry.structure == DocumentStructure::PageLabels
+            && entry.disposition == StructureDisposition::FirstInputWins
+    }));
+}
+
+#[test]
+fn reconstructive_policy_is_explicit_and_reports_discarded_semantics() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("labeled.pdf");
+    let output = directory.path().join("merged.pdf");
+    write_pdf(&first, 1);
+    let mut labeled = Document::new();
+    labeled.add_page(Page::a4());
+    let mut labels = PageLabelTree::new();
+    labels.add_range(0, PageLabel::roman_lowercase());
+    labeled.set_page_labels(labels);
+    labeled.save(&second).unwrap();
+    let inputs = [
+        ExistingDocumentMergeInput::new(&first),
+        ExistingDocumentMergeInput::new(&second),
+    ];
+
+    let policy = ExistingDocumentPolicy::reconstruct();
+    let planned = plan_merge_pdfs(&inputs, policy).unwrap();
+    let written = merge_pdfs(&inputs, &output, policy).unwrap();
+
+    assert_eq!(planned, written);
+    assert_eq!(written.engine, ExistingDocumentEngine::Reconstruct);
+    assert!(written.inputs[1].structures.iter().any(|entry| {
+        entry.structure == DocumentStructure::PageLabels
+            && entry.disposition == StructureDisposition::Discarded
+    }));
+    assert!(!fs::read(&output)
+        .unwrap()
+        .starts_with(&fs::read(first).unwrap()));
+    assert_eq!(PdfReader::open(output).unwrap().page_count().unwrap(), 2);
+}
+
+#[test]
+fn reconstructive_extract_and_split_preserve_selected_content_and_order() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let extracted = directory.path().join("extracted.pdf");
+    let first = directory.path().join("first.pdf");
+    let second = directory.path().join("second.pdf");
+    write_pdf(&source, 3);
+
+    let extraction = extract_pdf_pages(
+        &source,
+        &extracted,
+        &[2, 0, 2],
+        ExistingDocumentPolicy::reconstruct(),
+    )
+    .unwrap();
+    assert_eq!(extraction.plan.page_count(), 3);
+    assert_eq!(page_texts(&extracted), ["page 3", "page 1", "page 3"]);
+
+    let reports = split_pdf(
+        &source,
+        &[PageRange::List(vec![2, 0]), PageRange::Single(1)],
+        &[first.clone(), second.clone()],
+        ExistingDocumentPolicy::reconstruct(),
+    )
+    .unwrap();
+    assert_eq!(reports.len(), 2);
+    assert_eq!(page_texts(&first), ["page 3", "page 1"]);
+    assert_eq!(page_texts(&second), ["page 2"]);
+}
+
+#[test]
+fn merge_and_extract_reject_input_aliases_for_both_engines() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    write_pdf(&source, 2);
+    let original = fs::read(&source).unwrap();
+    let inputs = [ExistingDocumentMergeInput::new(&source)];
+
+    for policy in [
+        ExistingDocumentPolicy::preserve_base(),
+        ExistingDocumentPolicy::reconstruct(),
+    ] {
+        assert!(merge_pdfs(&inputs, &source, policy)
+            .unwrap_err()
+            .to_string()
+            .contains("aliases input"));
+        assert!(extract_pdf_pages(&source, &source, &[0], policy)
+            .unwrap_err()
+            .to_string()
+            .contains("aliases input"));
+        assert_eq!(fs::read(&source).unwrap(), original);
+    }
+}
+
+#[test]
+fn reconstructive_failures_do_not_replace_existing_outputs() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let output = directory.path().join("existing.pdf");
+    write_pdf(&source, 1);
+    fs::write(&output, b"keep me").unwrap();
+
+    let result = extract_pdf_pages(
+        &source,
+        &output,
+        &[99],
+        ExistingDocumentPolicy::reconstruct(),
+    );
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(output).unwrap(), b"keep me");
+}
+
+#[test]
+fn reconstructive_metadata_policy_matches_the_report_and_output() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    let discarded = directory.path().join("discarded.pdf");
+    let retained = directory.path().join("retained.pdf");
+    let mut document = Document::new();
+    document.set_title("source title");
+    document.add_page(Page::a4());
+    document.save(&source).unwrap();
+    let inputs = [ExistingDocumentMergeInput::new(&source)];
+
+    let discarded_report =
+        merge_pdfs(&inputs, &discarded, ExistingDocumentPolicy::reconstruct()).unwrap();
+    let retained_report = merge_pdfs(
+        &inputs,
+        &retained,
+        ExistingDocumentPolicy::reconstruct_with_metadata_from_first(),
+    )
+    .unwrap();
+
+    assert!(discarded_report.inputs[0].structures.iter().any(|entry| {
+        entry.structure == DocumentStructure::DocumentInfo
+            && entry.disposition == StructureDisposition::Discarded
+    }));
+    assert!(retained_report.inputs[0].structures.iter().any(|entry| {
+        entry.structure == DocumentStructure::DocumentInfo
+            && entry.disposition == StructureDisposition::FirstInputWins
+    }));
+    assert_eq!(
+        PdfReader::open_document(&discarded)
+            .unwrap()
+            .metadata()
+            .unwrap()
+            .title,
+        None
+    );
+    assert_eq!(
+        PdfReader::open_document(&retained)
+            .unwrap()
+            .metadata()
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("source title")
+    );
+}
+
+#[test]
+fn empty_split_is_rejected_consistently_by_plan_and_execution() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("source.pdf");
+    write_pdf(&source, 1);
+
+    for policy in [
+        ExistingDocumentPolicy::preserve_base(),
+        ExistingDocumentPolicy::reconstruct(),
+    ] {
+        let planned =
+            oxidize_pdf::operations::existing_document::plan_split_pdf(&source, &[], policy);
+        let executed = split_pdf(&source, &[], &[], policy);
+
+        assert!(matches!(
+            planned,
+            Err(oxidize_pdf::operations::OperationError::NoPagesToProcess)
+        ));
+        assert!(matches!(
+            executed,
+            Err(oxidize_pdf::operations::OperationError::NoPagesToProcess)
+        ));
+    }
 }

--- a/oxidize-pdf-core/tests/issue_560_v4_api_compatibility_test.rs
+++ b/oxidize-pdf-core/tests/issue_560_v4_api_compatibility_test.rs
@@ -1,0 +1,176 @@
+use oxidize_pdf::operations::split as legacy_split;
+use oxidize_pdf::operations::{
+    extract_page, extract_page_range, extract_page_range_to_file, extract_page_to_file,
+    extract_pages, extract_pages_to_file, extract_pdf_pages_lossless, merge_pdf_files, merge_pdfs,
+    merge_pdfs_lossless, plan_extract_pdf_pages_lossless, plan_merge_pdfs_lossless,
+    plan_split_pdf_lossless, split_into_pages, split_pdf, split_pdf_lossless, LosslessMergeInput,
+    MergeInput, MergeOptions, PageExtractionOptions, PageExtractor, PageRange, PdfMerger,
+    PdfSplitter, SplitMode, SplitOptions,
+};
+use oxidize_pdf::operations::{merge as legacy_merge, page_extraction as legacy_extraction};
+use oxidize_pdf::parser::PdfReader;
+use oxidize_pdf::{Document, Page};
+
+fn write_pdf(path: &std::path::Path, pages: usize) {
+    let mut document = Document::new();
+    for _ in 0..pages {
+        document.add_page(Page::a4());
+    }
+    document
+        .save(path)
+        .expect("compatibility fixture must be writable");
+}
+
+#[test]
+fn every_v4_operation_family_remains_reachable_during_the_preview() {
+    let directory = tempfile::tempdir().expect("compatibility tempdir must be creatable");
+    let source = directory.path().join("source.pdf");
+    let reconstructed_page = directory.path().join("reconstructed-page.pdf");
+    let reconstructed_merge = directory.path().join("reconstructed-merge.pdf");
+    write_pdf(&source, 2);
+
+    extract_page_to_file(&source, 0, &reconstructed_page)
+        .expect("v4 extract_page_to_file must remain callable");
+    assert_eq!(
+        extract_page(&source, 0)
+            .expect("v4 extract_page must remain callable")
+            .pages()
+            .len(),
+        1
+    );
+    assert_eq!(
+        extract_pages(&source, &[1, 0])
+            .expect("v4 extract_pages must remain callable")
+            .pages()
+            .len(),
+        2
+    );
+    assert_eq!(
+        extract_page_range(&source, &PageRange::Range(0, 1))
+            .expect("v4 extract_page_range must remain callable")
+            .pages()
+            .len(),
+        2
+    );
+    extract_pages_to_file(
+        &source,
+        &[1, 0],
+        directory.path().join("reconstructed-pages.pdf"),
+    )
+    .expect("v4 extract_pages_to_file must remain callable");
+    extract_page_range_to_file(
+        &source,
+        &PageRange::Range(0, 1),
+        directory.path().join("reconstructed-range.pdf"),
+    )
+    .expect("v4 extract_page_range_to_file must remain callable");
+    let mut extractor = PageExtractor::new(
+        PdfReader::open_document(&source).expect("v4 extractor input must open"),
+    );
+    assert_eq!(
+        extractor
+            .extract_pages(&[0, 1])
+            .expect("v4 PageExtractor must remain callable")
+            .pages()
+            .len(),
+        2
+    );
+    let mut configured_extractor = legacy_extraction::PageExtractor::with_options(
+        PdfReader::open_document(&source).expect("v4 extractor input must open"),
+        PageExtractionOptions::default(),
+    );
+    assert_eq!(
+        configured_extractor
+            .extract_page(0)
+            .expect("v4 module-path extractor must remain callable")
+            .pages()
+            .len(),
+        1
+    );
+    merge_pdfs(
+        vec![MergeInput::new(&source)],
+        &reconstructed_merge,
+        MergeOptions::default(),
+    )
+    .expect("v4 merge_pdfs must remain callable");
+    merge_pdf_files(
+        &[&source],
+        directory.path().join("reconstructed-simple-merge.pdf"),
+    )
+    .expect("v4 merge_pdf_files must remain callable");
+    let mut merger = PdfMerger::new(MergeOptions::default());
+    merger.add_input(MergeInput::new(&source));
+    assert_eq!(
+        merger
+            .merge()
+            .expect("v4 PdfMerger must remain callable")
+            .pages()
+            .len(),
+        2
+    );
+    let mut module_merger = legacy_merge::PdfMerger::new(legacy_merge::MergeOptions::default());
+    module_merger.add_inputs([legacy_merge::MergeInput::new(&source)]);
+    module_merger
+        .merge_to_file(directory.path().join("module-path-merge.pdf"))
+        .expect("v4 module-path merger must remain callable");
+    let split_outputs = split_pdf(
+        &source,
+        SplitOptions {
+            mode: SplitMode::ChunkSize(1),
+            output_pattern: directory.path().join("legacy_{}.pdf").display().to_string(),
+            ..SplitOptions::default()
+        },
+    )
+    .expect("v4 split_pdf must remain callable");
+    assert_eq!(split_outputs.len(), 2);
+    let single_pattern = directory.path().join("single_{}.pdf").display().to_string();
+    assert_eq!(
+        split_into_pages(&source, &single_pattern)
+            .expect("v4 split_into_pages must remain callable")
+            .len(),
+        2
+    );
+    let module_pattern = directory.path().join("module_{}.pdf").display().to_string();
+    assert_eq!(
+        legacy_split::split_into_pages(&source, &module_pattern)
+            .expect("v4 module-path split must remain callable")
+            .len(),
+        2
+    );
+    let mut splitter = PdfSplitter::new(
+        PdfReader::open_document(&source).expect("v4 splitter input must open"),
+        SplitOptions {
+            output_pattern: directory.path().join("object_{}.pdf").display().to_string(),
+            ..SplitOptions::default()
+        },
+    );
+    assert_eq!(
+        splitter
+            .split()
+            .expect("v4 PdfSplitter must remain callable")
+            .len(),
+        2
+    );
+
+    let preserved_extract = directory.path().join("preserved-extract.pdf");
+    let preserved_merge = directory.path().join("preserved-merge.pdf");
+    let preserved_split = directory.path().join("preserved-split.pdf");
+    let inputs = [LosslessMergeInput::new(&source)];
+    assert_eq!(
+        plan_extract_pdf_pages_lossless(&source, &[0])
+            .expect("v4 lossless extract plan must remain callable"),
+        extract_pdf_pages_lossless(&source, &preserved_extract, &[0])
+            .expect("v4 lossless extract must remain callable")
+    );
+    assert_eq!(
+        plan_merge_pdfs_lossless(&inputs).expect("v4 lossless merge plan must remain callable"),
+        merge_pdfs_lossless(&inputs, &preserved_merge)
+            .expect("v4 lossless merge must remain callable")
+    );
+    assert_eq!(
+        plan_split_pdf_lossless(&source, &[PageRange::Single(0)])
+            .expect("v4 lossless split plan must remain callable"),
+        split_pdf_lossless(&source, &[PageRange::Single(0)], &[preserved_split])
+            .expect("v4 lossless split must remain callable")
+    );
+}

--- a/oxidize-pdf-core/tests/jpeg_extraction_regression_test.rs
+++ b/oxidize-pdf-core/tests/jpeg_extraction_regression_test.rs
@@ -56,53 +56,50 @@ fn test_jpeg_extraction_no_byte_duplication() {
             let mut found_jpeg = false;
             for results_dir in &results_dirs {
                 if let Ok(entries) = std::fs::read_dir(results_dir) {
-                    for entry in entries {
-                        if let Ok(entry) = entry {
-                            let path = entry.path();
-                            if path.extension().and_then(|s| s.to_str()) == Some("jpg") {
-                                if let Some(filename) = path.file_name().and_then(|s| s.to_str()) {
-                                    if filename.starts_with("extracted_") {
-                                        found_jpeg = true;
-                                        // Validate the JPEG file to ensure no byte duplication bug
-                                        let jpeg_data = std::fs::read(&path)
-                                            .expect("Failed to read extracted JPEG");
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.extension().and_then(|s| s.to_str()) == Some("jpg") {
+                            if let Some(filename) = path.file_name().and_then(|s| s.to_str()) {
+                                if filename.starts_with("extracted_") {
+                                    found_jpeg = true;
+                                    // Validate the JPEG file to ensure no byte duplication bug
+                                    let jpeg_data = std::fs::read(&path)
+                                        .expect("Failed to read extracted JPEG");
 
-                                        // Check basic JPEG structure
-                                        if jpeg_data.len() > 4 {
-                                            assert_eq!(
-                                                jpeg_data[0], 0xFF,
-                                                "Missing JPEG SOI marker (FF)"
-                                            );
-                                            assert_eq!(
-                                                jpeg_data[1], 0xD8,
-                                                "Missing JPEG SOI marker (D8)"
-                                            );
+                                    // Check basic JPEG structure
+                                    if jpeg_data.len() > 4 {
+                                        assert_eq!(
+                                            jpeg_data[0], 0xFF,
+                                            "Missing JPEG SOI marker (FF)"
+                                        );
+                                        assert_eq!(
+                                            jpeg_data[1], 0xD8,
+                                            "Missing JPEG SOI marker (D8)"
+                                        );
 
-                                            // Count the specific 17-byte pattern that was being duplicated
-                                            let problematic_pattern = [
-                                                0x1a, 0x1f, 0x28, 0x42, 0x2b, 0x28, 0x24, 0x24,
-                                                0x28, 0x51, 0x3a, 0x3d, 0x30, 0x42, 0x60, 0x55,
-                                                0x64,
-                                            ];
+                                        // Count the specific 17-byte pattern that was being duplicated
+                                        let problematic_pattern = [
+                                            0x1a, 0x1f, 0x28, 0x42, 0x2b, 0x28, 0x24, 0x24, 0x28,
+                                            0x51, 0x3a, 0x3d, 0x30, 0x42, 0x60, 0x55, 0x64,
+                                        ];
 
-                                            let mut occurrences = 0;
-                                            for window in jpeg_data.windows(17) {
-                                                if window == problematic_pattern {
-                                                    occurrences += 1;
-                                                }
+                                        let mut occurrences = 0;
+                                        for window in jpeg_data.windows(17) {
+                                            if window == problematic_pattern {
+                                                occurrences += 1;
                                             }
+                                        }
 
-                                            // This is the key test: the pattern should appear at most once
-                                            // If it appears more than once, it suggests the byte duplication bug
-                                            assert!(
+                                        // This is the key test: the pattern should appear at most once
+                                        // If it appears more than once, it suggests the byte duplication bug
+                                        assert!(
                                                 occurrences <= 1,
                                                 "The problematic 17-byte pattern appears {} times in {:?}, but should appear at most once. \
                                                  Multiple occurrences indicate the byte duplication bug has returned!",
                                                 occurrences, path
                                             );
 
-                                            println!("✅ JPEG validation passed for {:?} - pattern appears {} times", path, occurrences);
-                                        }
+                                        println!("✅ JPEG validation passed for {:?} - pattern appears {} times", path, occurrences);
                                     }
                                 }
                             }

--- a/oxidize-pdf-core/tests/memory_optimization_integration.rs
+++ b/oxidize-pdf-core/tests/memory_optimization_integration.rs
@@ -111,9 +111,7 @@ fn test_optimized_reader_memory_workflows() -> Result<()> {
         let reader_result =
             OptimizedPdfReader::new_with_options(cursor, parse_options, memory_options.clone());
 
-        if reader_result.is_ok() {
-            let reader = reader_result.unwrap();
-
+        if let Ok(reader) = reader_result {
             // Test memory statistics
             let stats = reader.memory_stats();
             assert_eq!(stats.cache_hits, 0); // Initial state
@@ -336,7 +334,8 @@ fn test_content_type_memory_optimization() -> Result<()> {
         Ok(())
     }
 
-    let content_types: Vec<(&str, fn(&mut Page) -> Result<()>)> = vec![
+    type ContentSetup = fn(&mut Page) -> Result<()>;
+    let content_types: Vec<(&str, ContentSetup)> = vec![
         ("text_heavy", setup_text_heavy),
         ("graphics_heavy", setup_graphics_heavy),
         ("mixed_content", setup_mixed_content),

--- a/oxidize-pdf-core/tests/merge_font_mapping_test.rs
+++ b/oxidize-pdf-core/tests/merge_font_mapping_test.rs
@@ -1,7 +1,6 @@
 //! Tests for font and XObject mapping in merge operations
 
-use oxidize_pdf::operations::merge::MetadataMode;
-use oxidize_pdf::operations::{merge_pdfs, MergeInput, MergeOptions};
+use oxidize_pdf::operations::reconstruct::{merge_pdfs, MergeInput, MetadataMode};
 use oxidize_pdf::{Document, Page};
 use std::fs;
 use tempfile::TempDir;
@@ -52,16 +51,8 @@ fn test_font_mapping_in_merge() {
 
     // Merge the PDFs
     let output_path = temp_dir.path().join("merged.pdf");
-    let options = MergeOptions {
-        preserve_bookmarks: false,
-        preserve_forms: false,
-        optimize: false,
-        metadata_mode: MetadataMode::FromFirst,
-        page_ranges: None,
-    };
-
     let inputs = vec![MergeInput::new(pdf1_path), MergeInput::new(pdf2_path)];
-    merge_pdfs(inputs, &output_path, options).unwrap();
+    merge_pdfs(inputs, &output_path, MetadataMode::FromFirst).unwrap();
 
     // Verify the merged PDF exists and has 2 pages
     assert!(output_path.exists());
@@ -86,10 +77,8 @@ fn test_xobject_mapping_placeholder() {
 
     // Merge with itself to test XObject mapping
     let output_path = temp_dir.path().join("merged_xobject.pdf");
-    let options = MergeOptions::default();
-
     let inputs = vec![MergeInput::new(pdf_path.clone()), MergeInput::new(pdf_path)];
-    merge_pdfs(inputs, &output_path, options).unwrap();
+    merge_pdfs(inputs, &output_path, MetadataMode::FromFirst).unwrap();
 
     // Verify the merge completed
     assert!(output_path.exists());

--- a/oxidize-pdf-core/tests/new_architecture_test.rs
+++ b/oxidize-pdf-core/tests/new_architecture_test.rs
@@ -1,7 +1,9 @@
 //! Integration test for the new PdfDocument architecture
 
-use oxidize_pdf::operations::{merge_pdf_files, rotate_pdf_pages, split_pdf};
-use oxidize_pdf::operations::{RotateOptions, RotationAngle, SplitMode, SplitOptions};
+use oxidize_pdf::operations::existing_document::{
+    merge_pdfs, split_pdf, ExistingDocumentMergeInput, ExistingDocumentPolicy,
+};
+use oxidize_pdf::operations::{rotate_pdf_pages, PageRange, RotateOptions, RotationAngle};
 use oxidize_pdf::parser::PdfReader;
 use oxidize_pdf::{Document, Page};
 use tempfile::TempDir;
@@ -76,13 +78,17 @@ fn test_split_operation_with_new_architecture() {
         .to_str()
         .unwrap()
         .to_string();
-    let options = SplitOptions {
-        mode: SplitMode::SinglePages,
-        output_pattern,
-        ..Default::default()
-    };
-
-    let output_files = split_pdf(&test_pdf, options).unwrap();
+    let ranges: Vec<_> = (0..5).map(PageRange::Single).collect();
+    let output_files: Vec<_> = (1..=5)
+        .map(|page| std::path::PathBuf::from(output_pattern.replace("{}", &page.to_string())))
+        .collect();
+    split_pdf(
+        &test_pdf,
+        &ranges,
+        &output_files,
+        ExistingDocumentPolicy::preserve_base(),
+    )
+    .unwrap();
     assert_eq!(output_files.len(), 5);
 
     // Verify each output file exists
@@ -124,7 +130,17 @@ fn test_merge_operation_with_new_architecture() {
 
     // Merge them
     let output_pdf = temp_dir.path().join("merged.pdf");
-    merge_pdf_files(&input_files, &output_pdf).unwrap();
+    let merge_inputs: Vec<_> = input_files
+        .iter()
+        .map(ExistingDocumentMergeInput::new)
+        .collect();
+    let report = merge_pdfs(
+        &merge_inputs,
+        &output_pdf,
+        ExistingDocumentPolicy::preserve_base(),
+    )
+    .unwrap();
+    assert_eq!(report.plan.page_count(), 6);
 
     // Verify the merged PDF
     let document = PdfReader::open_document(&output_pdf).unwrap();

--- a/oxidize-pdf-core/tests/ocr_tests.rs
+++ b/oxidize-pdf-core/tests/ocr_tests.rs
@@ -316,6 +316,6 @@ mod ocr_disabled_tests {
         // When OCR feature is disabled, we should still be able to compile
         // but OCR functionality won't be available
         println!("OCR features are disabled - this is expected when 'ocr-tesseract' feature is not enabled");
-        assert!(true, "Compilation successful without OCR features");
+        // Reaching this branch confirms compilation without OCR features.
     }
 }

--- a/oxidize-pdf-core/tests/operations_test.rs
+++ b/oxidize-pdf-core/tests/operations_test.rs
@@ -1,8 +1,7 @@
 //! Integration tests for PDF operations
 
-use oxidize_pdf::operations::{
-    merge_pdf_files, rotate_all_pages, split_into_pages, PageRange, RotationAngle,
-};
+use oxidize_pdf::operations::reconstruct::{merge_pdf_files, split_into_pages};
+use oxidize_pdf::operations::{rotate_all_pages, PageRange, RotationAngle};
 use oxidize_pdf::{Document, Page};
 use std::path::Path;
 use tempfile::TempDir;

--- a/oxidize-pdf-core/tests/parser_comprehensive_test.rs
+++ b/oxidize-pdf-core/tests/parser_comprehensive_test.rs
@@ -114,10 +114,9 @@ mod content_parser_tests {
         let ops = ContentParser::parse(content).unwrap();
 
         // Should contain Do operation
-        assert!(ops.iter().any(|op| match op {
-            ContentOperation::PaintXObject(_) => true,
-            _ => false,
-        }));
+        assert!(ops
+            .iter()
+            .any(|op| matches!(op, ContentOperation::PaintXObject(_))));
     }
 
     #[test]
@@ -228,7 +227,7 @@ mod objects_parser_tests {
     fn test_pdf_object_conversion() {
         // Test object type conversions
         let int_obj = PdfObject::Integer(42);
-        let real_obj = PdfObject::Real(3.14);
+        let real_obj = PdfObject::Real(3.125);
         let bool_obj = PdfObject::Boolean(true);
         let null_obj = PdfObject::Null;
 
@@ -239,7 +238,7 @@ mod objects_parser_tests {
         }
 
         match real_obj {
-            PdfObject::Real(val) => assert!((val - 3.14).abs() < 0.001),
+            PdfObject::Real(val) => assert!((val - 3.125).abs() < 0.001),
             _ => panic!("Wrong type"),
         }
 

--- a/oxidize-pdf-core/tests/parser_edge_cases_integration.rs
+++ b/oxidize-pdf-core/tests/parser_edge_cases_integration.rs
@@ -91,7 +91,7 @@ fn test_invalid_pdf_header() {
 /// Test parsing file with truncated content after valid header
 #[test]
 fn test_truncated_after_header() {
-    let truncated_files = vec![
+    let truncated_files = [
         b"%PDF-1.4\n%".to_vec(),                      // Truncated comment
         b"%PDF-1.4\n%%EOF".to_vec(),                  // Missing xref
         b"%PDF-1.4\n1 0 obj\n".to_vec(),              // Truncated object
@@ -124,7 +124,7 @@ fn test_truncated_after_header() {
 /// Test parsing with malformed xref table
 #[test]
 fn test_malformed_xref_table() {
-    let malformed_xrefs = vec![
+    let malformed_xrefs = [
         // Missing xref keyword
         create_pdf_with_xref(""),
         // Invalid xref format
@@ -184,24 +184,8 @@ fn test_circular_references() {
             let start = std::time::Instant::now();
             let timeout = std::time::Duration::from_secs(5);
 
-            let mut object_accessed = false;
-            while start.elapsed() < timeout {
-                // Try to read some objects
-                match reader.get_object(1, 0) {
-                    Ok(_) => {
-                        object_accessed = true;
-                        break;
-                    }
-                    Err(_) => {
-                        // Try next object
-                        if reader.get_object(2, 0).is_ok() {
-                            object_accessed = true;
-                            break;
-                        }
-                        break; // Give up after trying a couple objects
-                    }
-                }
-            }
+            let object_accessed =
+                reader.get_object(1, 0).is_ok() || reader.get_object(2, 0).is_ok();
 
             if start.elapsed() >= timeout {
                 panic!("Timeout accessing objects - possible infinite loop");
@@ -219,7 +203,7 @@ fn test_circular_references() {
 #[test]
 fn test_memory_exhaustion_protection() {
     // Create PDF with extremely large objects
-    let large_object_pdfs = vec![
+    let large_object_pdfs = [
         create_pdf_with_large_string(1_000_000), // 1MB string
         create_pdf_with_large_array(100_000),    // 100K array elements
         create_pdf_with_large_stream(5_000_000), // 5MB stream
@@ -349,7 +333,7 @@ fn test_malformed_arrays() {
 /// Test with invalid character encodings
 #[test]
 fn test_invalid_encodings() {
-    let invalid_encodings = vec![
+    let invalid_encodings = [
         // Invalid UTF-8 sequences
         create_pdf_with_string(vec![0xFF, 0xFE, 0xFD]),
         create_pdf_with_string(vec![0x80, 0x81, 0x82]),
@@ -396,7 +380,7 @@ fn test_invalid_encodings() {
 /// Test parser limits and boundary conditions
 #[test]
 fn test_parser_limits() {
-    let limit_cases = vec![
+    let limit_cases = [
         // Maximum nesting depth
         create_deeply_nested_pdf(1000),
         // Very long names
@@ -446,7 +430,7 @@ fn test_parser_limits() {
 /// Test error recovery scenarios
 #[test]
 fn test_error_recovery() {
-    let recovery_cases = vec![
+    let recovery_cases = [
         // Partially valid PDF with some bad objects
         create_pdf_with_mixed_validity(),
         // PDF with recoverable xref issues
@@ -510,7 +494,7 @@ fn test_real_world_corrupted_samples() {
     // Read the valid PDF and create corrupted versions
     let valid_data = fs::read(&valid_path).unwrap();
 
-    let corrupted_versions = vec![
+    let corrupted_versions = [
         corrupt_pdf_header(&valid_data),
         corrupt_pdf_xref(&valid_data),
         corrupt_pdf_objects(&valid_data),

--- a/oxidize-pdf-core/tests/parser_objects_coverage.rs
+++ b/oxidize-pdf-core/tests/parser_objects_coverage.rs
@@ -47,7 +47,7 @@ fn test_as_integer_with_integer() {
 
 #[test]
 fn test_as_integer_with_non_integer() {
-    let obj = PdfObject::Real(3.14);
+    let obj = PdfObject::Real(3.125);
     assert_eq!(obj.as_integer(), None);
 
     let obj = PdfObject::Boolean(true);
@@ -56,8 +56,8 @@ fn test_as_integer_with_non_integer() {
 
 #[test]
 fn test_as_real_with_real() {
-    let obj = PdfObject::Real(3.14159);
-    assert_eq!(obj.as_real(), Some(3.14159));
+    let obj = PdfObject::Real(3.125);
+    assert_eq!(obj.as_real(), Some(3.125));
 }
 
 #[test]
@@ -454,13 +454,13 @@ fn test_parse_null() {
 
 #[test]
 fn test_parse_real_number() {
-    let data = b"3.14159";
+    let data = b"3.125";
     let cursor = Cursor::new(data);
     let mut lexer = Lexer::new(cursor);
 
     let result = PdfObject::parse(&mut lexer);
     assert!(result.is_ok());
-    assert_eq!(result.unwrap().as_real(), Some(3.14159));
+    assert_eq!(result.unwrap().as_real(), Some(3.125));
 }
 
 #[test]

--- a/oxidize-pdf-core/tests/parser_reader_coverage.rs
+++ b/oxidize-pdf-core/tests/parser_reader_coverage.rs
@@ -143,7 +143,7 @@ fn test_unlock_with_password_on_unencrypted_pdf() {
         // Unlocking unencrypted PDF should return Ok(true)
         let result = reader.unlock_with_password("any_password");
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 }
 
@@ -156,7 +156,7 @@ fn test_try_empty_password_on_unencrypted_pdf() {
         // Trying empty password on unencrypted PDF should return Ok(true)
         let result = reader.try_empty_password();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 }
 
@@ -522,7 +522,7 @@ fn test_open_and_parse_unicode_pdf() {
         // Exercise get_all_pages
         let pages_result = reader.get_all_pages();
         if let Ok(pages) = pages_result {
-            assert!(pages.len() >= 1, "Should have at least 1 page");
+            assert!(!pages.is_empty(), "Should have at least 1 page");
         }
 
         // Exercise object retrieval
@@ -603,10 +603,10 @@ fn test_parse_complex_pdf_with_many_objects() {
         // Exercise get_all_pages with many pages
         let pages_result = reader.get_all_pages();
         if let Ok(pages) = pages_result {
-            assert!(pages.len() > 0, "Should return page array");
+            assert!(!pages.is_empty(), "Should return page array");
 
             // Exercise get_page for first page
-            if pages.len() > 0 {
+            if !pages.is_empty() {
                 let page_result = reader.get_page(0);
                 let _ = page_result; // May succeed or fail, but exercises code
             }

--- a/oxidize-pdf-core/tests/partition_confidence_test.rs
+++ b/oxidize-pdf-core/tests/partition_confidence_test.rs
@@ -112,7 +112,7 @@ fn test_title_confidence_lower_near_threshold() {
     if !titles.is_empty() {
         let c = titles[0].metadata().confidence;
         assert!(
-            c >= 0.5 && c < 0.9,
+            (0.5..0.9).contains(&c),
             "Title cerca del threshold debe tener confidence 0.5..0.9, got {}",
             c
         );

--- a/oxidize-pdf-core/tests/t2_realworld.rs
+++ b/oxidize-pdf-core/tests/t2_realworld.rs
@@ -264,7 +264,7 @@ fn t2_generator_diversity() {
     if !report.by_generator.is_empty() {
         println!("\n=== T2 Generator Diversity ===");
         let mut generators: Vec<_> = report.by_generator.iter().collect();
-        generators.sort_by(|a, b| b.1.total.cmp(&a.1.total));
+        generators.sort_by_key(|generator| std::cmp::Reverse(generator.1.total));
 
         let top_n = 20.min(generators.len());
         for (gen, stats) in generators.iter().take(top_n) {

--- a/oxidize-pdf-core/tests/table_integration_test.rs
+++ b/oxidize-pdf-core/tests/table_integration_test.rs
@@ -80,21 +80,21 @@ fn test_table_with_custom_options() -> Result<()> {
     table.set_position(50.0, 650.0);
 
     // Custom table options
-    let mut options = TableOptions::default();
-    options.border_width = 2.0;
-    options.border_color = Color::rgb(0.2, 0.3, 0.5);
-    options.cell_padding = 8.0;
-    options.font = Font::TimesRoman;
-    options.font_size = 11.0;
-    options.text_color = Color::rgb(0.1, 0.1, 0.1);
-
-    // Header style
-    options.header_style = Some(HeaderStyle {
-        background_color: Color::rgb(0.9, 0.9, 0.95),
-        text_color: Color::rgb(0.0, 0.0, 0.5),
-        font: Font::TimesBold,
-        bold: true,
-    });
+    let options = TableOptions {
+        border_width: 2.0,
+        border_color: Color::rgb(0.2, 0.3, 0.5),
+        cell_padding: 8.0,
+        font: Font::TimesRoman,
+        font_size: 11.0,
+        text_color: Color::rgb(0.1, 0.1, 0.1),
+        header_style: Some(HeaderStyle {
+            background_color: Color::rgb(0.9, 0.9, 0.95),
+            text_color: Color::rgb(0.0, 0.0, 0.5),
+            font: Font::TimesBold,
+            bold: true,
+        }),
+        ..TableOptions::default()
+    };
 
     table.set_options(options);
 
@@ -262,9 +262,11 @@ fn test_multiple_tables_on_page() -> Result<()> {
     let mut table2 = Table::new(vec![80.0, 120.0, 100.0, 80.0]);
     table2.set_position(50.0, 600.0);
 
-    let mut options = TableOptions::default();
-    options.border_color = Color::rgb(0.8, 0.2, 0.2);
-    options.font_size = 9.0;
+    let options = TableOptions {
+        border_color: Color::rgb(0.8, 0.2, 0.2),
+        font_size: 9.0,
+        ..TableOptions::default()
+    };
     table2.set_options(options);
 
     table2.add_header_row(vec![
@@ -326,8 +328,10 @@ fn test_table_dimensions() -> Result<()> {
     assert_eq!(table.get_height(), 40.0);
 
     // Test with custom row height
-    let mut options = TableOptions::default();
-    options.row_height = 30.0;
+    let options = TableOptions {
+        row_height: 30.0,
+        ..TableOptions::default()
+    };
     table.set_options(options);
 
     assert_eq!(table.get_height(), 60.0);
@@ -351,16 +355,17 @@ fn test_table_with_custom_fonts() -> Result<()> {
     table.set_position(50.0, 700.0);
 
     // Use different fonts for header and content
-    let mut options = TableOptions::default();
-    options.font = Font::Courier;
-    options.font_size = 10.0;
-
-    options.header_style = Some(HeaderStyle {
-        background_color: Color::gray(0.85),
-        text_color: Color::black(),
-        font: Font::CourierBold,
-        bold: true,
-    });
+    let options = TableOptions {
+        font: Font::Courier,
+        font_size: 10.0,
+        header_style: Some(HeaderStyle {
+            background_color: Color::gray(0.85),
+            text_color: Color::black(),
+            font: Font::CourierBold,
+            bold: true,
+        }),
+        ..TableOptions::default()
+    };
 
     table.set_options(options);
 
@@ -404,9 +409,11 @@ fn test_table_with_custom_font_uses_hex_encoding() -> Result<()> {
     let mut table = Table::new(vec![200.0, 200.0]);
     table.set_position(50.0, 700.0);
 
-    let mut options = TableOptions::default();
-    options.font = Font::Custom("NotoSansCJK".to_string());
-    options.font_size = 12.0;
+    let options = TableOptions {
+        font: Font::Custom("NotoSansCJK".to_string()),
+        font_size: 12.0,
+        ..TableOptions::default()
+    };
     table.set_options(options);
 
     // Add row with CJK text: 你好 (U+4F60 U+597D)

--- a/oxidize-pdf-core/tests/tagged_pdf_integration_test.rs
+++ b/oxidize-pdf-core/tests/tagged_pdf_integration_test.rs
@@ -311,14 +311,11 @@ fn test_marked_content_with_different_tags() {
     let _tree = StructTree::new();
 
     let tags = vec!["H1", "P", "Div", "Span", "Figure"];
-    let mut mcid_counter = 0;
-
-    for tag in tags {
+    for (expected_mcid, tag) in tags.into_iter().enumerate() {
         let mcid = page
             .begin_marked_content(tag)
             .expect("Failed to begin marked content");
-        assert_eq!(mcid, mcid_counter);
-        mcid_counter += 1;
+        assert_eq!(mcid as usize, expected_mcid);
 
         page.text()
             .set_font(Font::Helvetica, 12.0)

--- a/oxidize-pdf-core/tests/test_hybrid_reference_pdfs.rs
+++ b/oxidize-pdf-core/tests/test_hybrid_reference_pdfs.rs
@@ -12,9 +12,11 @@ const COLD_EMAIL_HACKS_PDF: &str = "tests/fixtures/Cold_Email_Hacks.pdf";
 
 #[test]
 fn test_hybrid_reference_pdf_opens() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let result = PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options);
     assert!(result.is_ok(), "Failed to open hybrid-reference PDF");
@@ -22,9 +24,11 @@ fn test_hybrid_reference_pdf_opens() {
 
 #[test]
 fn test_hybrid_reference_pdf_page_count() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -36,9 +40,11 @@ fn test_hybrid_reference_pdf_page_count() {
 
 #[test]
 fn test_hybrid_reference_pdf_all_pages_accessible() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -60,9 +66,11 @@ fn test_hybrid_reference_pdf_all_pages_accessible() {
 
 #[test]
 fn test_hybrid_reference_pdf_text_extraction() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -126,9 +134,11 @@ fn test_hybrid_reference_pdf_text_extraction() {
 
 #[test]
 fn test_hybrid_reference_pdf_object_reconstruction() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let mut reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -157,9 +167,11 @@ fn test_hybrid_reference_pdf_object_reconstruction() {
 
 #[test]
 fn test_hybrid_reference_pdf_xref_chain() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -173,9 +185,11 @@ fn test_hybrid_reference_pdf_xref_chain() {
 
 #[test]
 fn test_hybrid_reference_pdf_type_inference() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -199,9 +213,11 @@ fn test_hybrid_reference_pdf_type_inference() {
 
 #[test]
 fn test_hybrid_reference_pdf_random_page_access() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");
@@ -246,9 +262,11 @@ fn test_hybrid_reference_pdf_random_page_access() {
 
 #[test]
 fn test_hybrid_reference_pdf_metadata() {
-    let mut options = ParseOptions::default();
-    options.collect_warnings = true;
-    options.lenient_syntax = true;
+    let options = ParseOptions {
+        collect_warnings: true,
+        lenient_syntax: true,
+        ..ParseOptions::default()
+    };
 
     let reader =
         PdfReader::open_with_options(COLD_EMAIL_HACKS_PDF, options).expect("Failed to open PDF");

--- a/oxidize-pdf-core/tests/text_validation_coverage.rs
+++ b/oxidize-pdf-core/tests/text_validation_coverage.rs
@@ -198,7 +198,7 @@ fn test_extract_key_info_comprehensive() {
     // Should extract organizations (2 orgs: "Acme Corporation" and "BelowZero Solutions LLC")
     assert!(extracted.contains_key("organizations"));
     let orgs = &extracted["organizations"];
-    assert!(orgs.len() >= 1); // At least 1 organization (lowered from 2 to be safe)
+    assert!(!orgs.is_empty()); // At least 1 organization (lowered from 2 to be safe)
 }
 
 #[test]
@@ -220,13 +220,11 @@ fn test_extract_key_info_no_patterns() {
     let extracted = validator.extract_key_info(text);
 
     // Should return empty or minimal map
-    assert!(extracted.get("dates").map_or(true, |v| v.is_empty()));
+    assert!(extracted.get("dates").is_none_or(|v| v.is_empty()));
     assert!(extracted
         .get("monetary_amounts")
-        .map_or(true, |v| v.is_empty()));
-    assert!(extracted
-        .get("organizations")
-        .map_or(true, |v| v.is_empty()));
+        .is_none_or(|v| v.is_empty()));
+    assert!(extracted.get("organizations").is_none_or(|v| v.is_empty()));
 }
 
 // ============================================================================

--- a/oxidize-pdf-core/tests/tracing_infrastructure.rs
+++ b/oxidize-pdf-core/tests/tracing_infrastructure.rs
@@ -22,7 +22,6 @@ fn test_tracing_subscriber_init() {
     tracing::info!("Test info log");
 
     // If we get here without panicking, tracing infrastructure works
-    assert!(true);
 }
 
 #[test]
@@ -40,8 +39,6 @@ fn test_tracing_with_env_filter() {
 
     tracing::debug!(target: "oxidize_pdf::parser", "Parser debug log");
     tracing::info!(target: "oxidize_pdf::text", "Text info log");
-
-    assert!(true);
 }
 
 #[test]
@@ -58,5 +55,4 @@ fn test_verbose_debug_feature_enabled() {
 fn test_verbose_debug_feature_disabled() {
     // This test runs when verbose-debug is NOT enabled (default)
     // Debug logs should still work via runtime filtering, but can be compiled out
-    assert!(true, "verbose-debug feature is disabled (default)");
 }


### PR DESCRIPTION
## Summary

- unify merge, split, and extract under the public existing-document operations API
- add explicit preserve/reconstruct policies with planning and applied-operation reports
- migrate batch processing fail-closed and document the v5 migration path
- preserve v4 API compatibility and add regression coverage for the corrected edge cases

## Validation

- issue 539 integration: 14 passed
- issue 560 compatibility: 1 passed
- batch worker: 13 passed
- batch public API: 13 passed
- semantic internal: 4 passed
- doctests: 216 passed, 26 ignored
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check

Closes #560