### PR TITLE
Make OmniDocBench native reading-order scope reproducible

### DIFF
--- a/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
+++ b/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
@@ -10,16 +10,30 @@ Date: 2026-09-02 (UTC)
 - Evaluator: official `end2end_eval` with `quick_match`
 - OCR: disabled
 
-The reported 0.31034257473747384 baseline averages every page for which the
+The unfiltered 0.31034257473747384 diagnostic averages every page for which the
 official evaluator emits a reading-order result. That population includes 113
-pages without native text, principally scanned notes. Those pages score 1.0
-when OCR is disabled and contribute 0.1227 to the global average, but issue
-#565 explicitly excludes OCR, image-only notes, and fuzzy scans.
+pages labelled `data_source: note` and another 28 pages labelled `fuzzy_scan`
+under `special_issue` by the pinned dataset. Notes score 1.0 when OCR is
+disabled and contribute 0.1227 to the unfiltered average, but issue #565
+explicitly excludes image-only notes, fuzzy scans, and OCR.
 
-Filtering the completed official per-page artifact by the pinned dataset's
-`page_attribute` metadata leaves 808 native-text pages. Their official
-reading-order edit distance is **0.21389295957080867**, below the issue's 0.25
-acceptance ceiling. No OCR feature is enabled or required.
+The repository's native-scope aggregator filters the completed official
+per-page artifact using those explicit metadata labels. It leaves 780 native-text
+pages with a scoped official reading-order edit distance of
+**0.18610108290582916**, below the issue's 0.25 acceptance ceiling. No OCR
+feature is enabled or required.
+
+Reproduce the scoped artifact with:
+
+```bash
+python3 tools/benchmarks/omnidocbench_native_reading_order.py \
+  /path/to/pinned/OmniDocBench.json \
+  /path/to/official_reading_order_per_page_edit.json \
+  --output native-reading-order.json
+```
+
+The output records the protocol, exact exclusion predicate, official scored
+population, excluded and retained counts, global value, and category values.
 
 ## Native-text results
 
@@ -27,22 +41,22 @@ Lower edit distance is better.
 
 | Category | Pages | Edit distance |
 |---|---:|---:|
-| Global native text | 808 | **0.21389** |
-| English | 275 | 0.07897 |
-| Simplified Chinese | 502 | 0.26020 |
-| English/Chinese mixed | 31 | 0.66092 |
-| Single column | 313 | 0.20288 |
-| Double column | 123 | 0.25292 |
-| One-or-more column | 120 | 0.19934 |
+| Global native text | 780 | **0.18610** |
+| English | 271 | 0.06537 |
+| Simplified Chinese | 480 | 0.22699 |
+| English/Chinese mixed | 29 | 0.63754 |
+| Single column | 302 | 0.17384 |
+| Double column | 113 | 0.18680 |
+| One-or-more column | 119 | 0.19261 |
 | Three column | 45 | 0.13632 |
-| Other layout | 207 | 0.23266 |
+| Other layout | 201 | 0.21141 |
 | Academic literature | 122 | 0.03815 |
-| Books | 83 | 0.08700 |
-| Colorful textbooks | 93 | 0.56693 |
-| Exam papers | 113 | 0.63776 |
-| Magazines | 92 | 0.13655 |
+| Books | 82 | 0.07586 |
+| Colorful textbooks | 81 | 0.50277 |
+| Exam papers | 101 | 0.59472 |
+| Magazines | 91 | 0.12706 |
 | Newspapers | 111 | 0.02294 |
-| PPT-to-PDF | 128 | 0.08633 |
+| PPT-to-PDF | 126 | 0.07447 |
 | Research reports | 66 | 0.15152 |
 
 ## Strategy experiments
@@ -50,12 +64,12 @@ Lower edit distance is better.
 Experiments were evaluated with the same pinned official protocol before being
 rejected:
 
-| Strategy | Text edit | Reading-order edit | Decision |
-|---|---:|---:|---|
-| Published v5.0.0 emission order | 0.51741 | 0.31034 | Native baseline |
-| Layout reconstruction from #564 | 0.38886 | 0.38785 | Reject for ordering |
-| Layout plus automatic line joining | 0.48547 | 0.34643 | Reject globally |
-| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | Reject globally |
+| Strategy | Text edit (all) | Reading edit (all) | Reading edit (native) | Decision |
+|---|---:|---:|---:|---|
+| Published v5.0.0 emission order | 0.51741 | 0.31034 | **0.18610** | Retain |
+| Layout reconstruction from #564 | 0.38886 | 0.38785 | 0.27744 | Reject for ordering |
+| Layout plus automatic line joining | 0.48547 | 0.34643 | 0.22872 | Reject globally |
+| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | 0.22534 | Reject globally |
 
 The alternatives improve selected categories but worsen the official global
 reading-order metric. The current emission-order default is therefore retained;
@@ -68,9 +82,11 @@ positioned `Tj` and `TJ` label/value cells and verifies that values and labels
 are not glued across rows.
 
 - `cargo test -p oxidize-pdf --test issue_495_flat_grid_order_test`: 3 passed
-- Existing corpus baseline: zero parser panics
-- Source changes: none
+- `python3 -m unittest tools/benchmarks/omnidocbench_native_reading_order_test.py`: 7 passed
+- Aggregator failure coverage: unknown and duplicate pages, invalid, non-finite and out-of-range scores, and empty native population
+- Production extraction source changes: none
 
-The original 0.31034 and scoped 0.21389 figures come from the same official
-per-page result artifact. The change is the population required by #565's
-native-text scope, not a replacement metric or evaluator.
+The unfiltered 0.31034 diagnostic and scoped 0.18610 acceptance figure come
+from the same official per-page result artifact. The versioned aggregator and
+its focused tests make the native-text population explicit and reproducible;
+they do not replace or approximate the upstream metric.

--- a/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
+++ b/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
@@ -1,0 +1,76 @@
+# Issue #565 — OmniDocBench native-text reading order
+
+Date: 2026-09-02 (UTC)
+
+## Protocol audit
+
+- oxidize-pdf baseline: 5.0.0
+- Dataset revision: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- Upstream evaluator revision: `337cc26965893db3ef53ddc119a6d6bb5bde096f`
+- Evaluator: official `end2end_eval` with `quick_match`
+- OCR: disabled
+
+The reported 0.31034257473747384 baseline averages every page for which the
+official evaluator emits a reading-order result. That population includes 113
+pages without native text, principally scanned notes. Those pages score 1.0
+when OCR is disabled and contribute 0.1227 to the global average, but issue
+#565 explicitly excludes OCR, image-only notes, and fuzzy scans.
+
+Filtering the completed official per-page artifact by the pinned dataset's
+`page_attribute` metadata leaves 808 native-text pages. Their official
+reading-order edit distance is **0.21389295957080867**, below the issue's 0.25
+acceptance ceiling. No OCR feature is enabled or required.
+
+## Native-text results
+
+Lower edit distance is better.
+
+| Category | Pages | Edit distance |
+|---|---:|---:|
+| Global native text | 808 | **0.21389** |
+| English | 275 | 0.07897 |
+| Simplified Chinese | 502 | 0.26020 |
+| English/Chinese mixed | 31 | 0.66092 |
+| Single column | 313 | 0.20288 |
+| Double column | 123 | 0.25292 |
+| One-or-more column | 120 | 0.19934 |
+| Three column | 45 | 0.13632 |
+| Other layout | 207 | 0.23266 |
+| Academic literature | 122 | 0.03815 |
+| Books | 83 | 0.08700 |
+| Colorful textbooks | 93 | 0.56693 |
+| Exam papers | 113 | 0.63776 |
+| Magazines | 92 | 0.13655 |
+| Newspapers | 111 | 0.02294 |
+| PPT-to-PDF | 128 | 0.08633 |
+| Research reports | 66 | 0.15152 |
+
+## Strategy experiments
+
+Experiments were evaluated with the same pinned official protocol before being
+rejected:
+
+| Strategy | Text edit | Reading-order edit | Decision |
+|---|---:|---:|---|
+| Published v5.0.0 emission order | 0.51741 | 0.31034 | Native baseline |
+| Layout reconstruction from #564 | 0.38886 | 0.38785 | Reject for ordering |
+| Layout plus automatic line joining | 0.48547 | 0.34643 | Reject globally |
+| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | Reject globally |
+
+The alternatives improve selected categories but worsen the official global
+reading-order metric. The current emission-order default is therefore retained;
+no benchmark-specific classifier or OCR dependency is introduced.
+
+## Issue #495 and validation
+
+Issue #495 is fixed. `issue_495_flat_grid_order_test` covers independently
+positioned `Tj` and `TJ` label/value cells and verifies that values and labels
+are not glued across rows.
+
+- `cargo test -p oxidize-pdf --test issue_495_flat_grid_order_test`: 3 passed
+- Existing corpus baseline: zero parser panics
+- Source changes: none
+
+The original 0.31034 and scoped 0.21389 figures come from the same official
+per-page result artifact. The change is the population required by #565's
+native-text scope, not a replacement metric or evaluator.

--- a/tools/benchmarks/omnidocbench_native_reading_order.py
+++ b/tools/benchmarks/omnidocbench_native_reading_order.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Aggregate official OmniDocBench reading-order scores for native-text pages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+EXCLUDED_DATA_SOURCES = frozenset({"note"})
+EXCLUDED_SPECIAL_ISSUES = frozenset({"fuzzy_scan"})
+DIMENSIONS = ("data_source", "layout", "language")
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def aggregate_native_scores(
+    dataset: list[dict[str, Any]], scores: dict[str, float]
+) -> dict[str, Any]:
+    """Return native-only averages from an official per-page score artifact."""
+    metadata = {}
+    for page in dataset:
+        name = Path(page["page_info"]["image_path"]).name
+        if name in metadata:
+            raise ValueError(f"duplicate dataset page basename: {name}")
+        metadata[name] = page["page_info"]["page_attribute"]
+    missing = sorted(set(scores) - set(metadata))
+    if missing:
+        raise ValueError(f"scores reference {len(missing)} unknown pages; first: {missing[0]}")
+
+    selected: list[tuple[str, float, dict[str, Any]]] = []
+    excluded = 0
+    for name, score in scores.items():
+        if (
+            not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not math.isfinite(score)
+            or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError(f"invalid edit-distance score for {name}: {score!r}")
+        attributes = metadata[name]
+        special_issues = set(attributes.get("special_issue", []))
+        if (
+            attributes.get("data_source") in EXCLUDED_DATA_SOURCES
+            or special_issues & EXCLUDED_SPECIAL_ISSUES
+        ):
+            excluded += 1
+            continue
+        selected.append((name, float(score), attributes))
+
+    if not selected:
+        raise ValueError("no native-text pages remain after filtering")
+
+    categories: dict[str, dict[str, dict[str, float | int]]] = {}
+    for dimension in DIMENSIONS:
+        groups: dict[str, list[float]] = defaultdict(list)
+        for _, score, attributes in selected:
+            groups[str(attributes.get(dimension, "unknown"))].append(score)
+        categories[dimension] = {
+            label: {"pages": len(values), "edit_distance": sum(values) / len(values)}
+            for label, values in sorted(groups.items())
+        }
+
+    values = [score for _, score, _ in selected]
+    return {
+        "protocol": "OmniDocBench end2end_eval/quick_match per-page reading-order Edit_dist",
+        "filter": {
+            "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
+            "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+        },
+        "official_scored_pages": len(scores),
+        "excluded_pages": excluded,
+        "native_pages": len(values),
+        "native_edit_distance": sum(values) / len(values),
+        "categories": categories,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset", type=Path, help="Pinned OmniDocBench.json")
+    parser.add_argument("scores", type=Path, help="Official reading_order_per_page_edit.json")
+    parser.add_argument("--output", type=Path, help="Write JSON here instead of stdout")
+    args = parser.parse_args()
+
+    result = aggregate_native_scores(_load_json(args.dataset), _load_json(args.scores))
+    rendered = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmarks/omnidocbench_native_reading_order_test.py
+++ b/tools/benchmarks/omnidocbench_native_reading_order_test.py
@@ -1,0 +1,94 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("omnidocbench_native_reading_order.py")
+SPEC = importlib.util.spec_from_file_location("native_reading_order", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def page(
+    name: str,
+    source: str,
+    layout: str = "single_column",
+    language: str = "english",
+    special_issue=None,
+):
+    return {
+        "page_info": {
+            "image_path": f"images/{name}",
+            "page_attribute": {
+                "data_source": source,
+                "layout": layout,
+                "language": language,
+                "special_issue": special_issue or ["None"],
+            },
+        }
+    }
+
+
+class NativeReadingOrderAggregationTests(unittest.TestCase):
+    def test_excludes_notes_and_fuzzy_scans_and_aggregates_categories(self):
+        dataset = [
+            page("book.jpg", "book", "double_column"),
+            page("paper.jpg", "academic_literature"),
+            page("scan.jpg", "note"),
+            page("fuzzy.jpg", "book", special_issue=["fuzzy_scan"]),
+        ]
+        result = MODULE.aggregate_native_scores(
+            dataset,
+            {"book.jpg": 0.4, "paper.jpg": 0.2, "scan.jpg": 1.0, "fuzzy.jpg": 0.8},
+        )
+
+        self.assertEqual(result["official_scored_pages"], 4)
+        self.assertEqual(result["excluded_pages"], 2)
+        self.assertEqual(result["native_pages"], 2)
+        self.assertAlmostEqual(result["native_edit_distance"], 0.3)
+        self.assertEqual(
+            result["categories"]["layout"]["double_column"],
+            {"pages": 1, "edit_distance": 0.4},
+        )
+
+    def test_rejects_unknown_score_pages(self):
+        with self.assertRaisesRegex(ValueError, "unknown pages"):
+            MODULE.aggregate_native_scores(
+                [page("known.jpg", "book")], {"missing.jpg": 0.1}
+            )
+
+    def test_rejects_non_numeric_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": "0.1"}
+            )
+
+    def test_rejects_non_finite_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": float("nan")}
+            )
+
+    def test_rejects_out_of_range_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": 1.01}
+            )
+
+    def test_rejects_duplicate_dataset_basenames(self):
+        with self.assertRaisesRegex(ValueError, "duplicate dataset page basename"):
+            MODULE.aggregate_native_scores(
+                [page("same.jpg", "book"), page("same.jpg", "academic_literature")],
+                {"same.jpg": 0.1},
+            )
+
+    def test_rejects_an_empty_native_population(self):
+        with self.assertRaisesRegex(ValueError, "no native-text pages"):
+            MODULE.aggregate_native_scores(
+                [page("scan.jpg", "note")], {"scan.jpg": 1.0}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a versioned native-text aggregator over the official OmniDocBench per-page reading-order artifact
- exclude the issue-scoped `note` and `fuzzy_scan` populations explicitly and report category metrics
- document the reproducible 780-page result: 0.18610 edit distance
- add focused validation and failure-path tests

## Validation
- Formal QR: approved, no findings
- `python3 -m unittest tools/benchmarks/omnidocbench_native_reading_order_test.py` (7 passed)
- `cargo test -p oxidize-pdf --test issue_495_flat_grid_order_test` (3 passed)
- pre-commit: formatting, clippy, build, and library tests (6777 passed, 3 ignored)
- Kripteia security: no issues

Closes #565