### PR TITLE
quality(benchmark): add reproducible OmniDocBench gate

### DIFF
--- a/docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md
+++ b/docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md
@@ -1,0 +1,57 @@
+# Issue #568 — reproducible OmniDocBench gate (TDD plan)
+
+This checklist is the implementation trace. A checked item has a corresponding
+automated test or an explicitly recorded external validation requirement.
+
+## Red: specify observable behavior
+
+- [x] Reject duplicate JSON object keys instead of silently overwriting scores.
+- [x] Reject duplicate dataset page names and unknown, missing, non-finite, or
+  out-of-range page scores.
+- [x] Keep official-global and native-text populations separate, with explicit
+  included, excluded, missing, duplicate, and failed counts.
+- [x] Version the `note` / `fuzzy_scan` native-text exclusion predicate.
+- [x] Canonicalize JSON before hashing so input ordering cannot change hashes.
+- [x] Reject baseline/candidate comparisons when their protocol identity differs.
+- [x] Refuse clean-commit provenance for a dirty worktree unless dirty provenance
+  is explicitly requested and includes a diff hash.
+- [x] Resolve OmniDocBench image names to source PDFs and page indices
+  deterministically.
+
+## Green: minimal implementation
+
+- [x] Add a repository-owned Rust prediction exporter using the public native-text
+  extraction API and a fixed, serialized extraction configuration.
+- [x] Add a Python gate that validates official per-page text scores, emits a
+  versioned summary, and compares compatible baseline/candidate summaries.
+- [x] Record Git SHA, worktree state, extraction configuration, dataset and
+  evaluator revisions, protocol, OCR state, population definition, and artifact
+  hashes.
+- [x] Add one documented command for prediction export and summary generation
+  from externally supplied PDFs, dataset metadata, and official score artifact.
+- [x] Make failures and empty predictions explicit without introducing OCR.
+- [x] Build from a temporary `git archive` with the evaluated commit's own
+  locked dependencies; no auxiliary relative path dependency is used.
+- [x] Verify dataset/evaluator Git revisions and record the Rust/Cargo toolchain.
+- [x] Re-hash predictions during summary and reject tampered or dirty summaries.
+- [x] Serialize effective extraction configuration from Rust, group pages by
+  source PDF, and publish the prediction tree atomically.
+
+## Refactor and verification
+
+- [x] Run the focused Python suite and Rust exporter tests (17 gate tests and
+  2 focused Rust exporter tests; native-reading-order regressions run separately).
+- [x] Run formatting, clippy for the exporter, and `git diff --check`.
+- [x] Verify two synthetic repeated runs produce identical prediction hashes.
+- [x] Feed the existing pinned official `d5e2d0b` score artifact through the gate:
+  921 global pages at `0.5085693812417305` edit distance and 780 native pages
+  at `0.41990107039261854`.
+- [ ] External: run the pinned OmniDocBench dataset/evaluator and confirm commit
+  `d5e2d0ba5073f28ef56cf13a32871236cff6e11f` reports global edit distance
+  approximately `0.50856938` (similarity `49.1431%`) within `1e-8`.
+- [ ] External: create the v5.0.0 baseline with this same gate/schema and retain
+  both immutable summary artifacts for future comparisons.
+
+The two external items deliberately remain unchecked until the non-redistributable
+dataset and pinned evaluator are supplied. Synthetic tests do not claim benchmark
+acceptance.

--- a/docs/reports/2026-09-03-issue-568-omnidocbench-gate.md
+++ b/docs/reports/2026-09-03-issue-568-omnidocbench-gate.md
@@ -1,0 +1,102 @@
+# Issue #568 — reproducible OmniDocBench gate
+
+## Contract
+
+The repository owns both sides of the measurement boundary:
+
+- `omnidocbench_export.rs` extracts every dataset page through
+  `PlainTextExtractor::preserve_layout()` with OCR disabled. It writes an empty
+  prediction for a failed page and records that failure instead of silently
+  dropping the page.
+- `omnidocbench_gate.py` resolves source PDFs, records provenance and hashes,
+  validates the official per-page text artifact, reports global and native-text
+  populations separately, and rejects incompatible comparisons.
+
+The gate creates a temporary `git archive` of `--source-root`, adds the same
+versioned exporter to that archive, and compiles it with the archived commit's
+own workspace manifest and lockfile using `--locked --offline`. This measures a
+clean `v5.0.0` worktree and a clean candidate without modifying either checkout
+or introducing a separate path dependency.
+
+## Reproduction identity
+
+- Schema: `oxidize-pdf-omnidocbench-gate/v1`
+- Dataset and evaluator revisions: verified against clean Git checkouts
+- Protocol: official `end2end_eval` / `quick_match` / `text`
+- OCR: disabled; it is neither configured nor linked by the exporter
+- Native population: `native-text-v1`, excluding `data_source == note` and any
+  page whose `special_issue` contains `fuzzy_scan`
+- Extraction configuration: serialized by the Rust exporter from the effective
+  `PlainTextConfig::preserve_layout()` values
+- Build identity: archived `Cargo.lock` hash plus `rustc -Vv` and `cargo -V`
+
+The official text population is derived from the evaluator's versioned text
+categories (`text_block`, `title`, `code_txt`, and `reference`). With the pinned
+dataset this identifies 921 text-scorable pages and 60 pages containing only
+non-text/ignored categories.
+
+## Commands
+
+From this repository, generate predictions and their provenance manifest in one
+command. `PDF_ROOT` may contain nested directories, but source PDF basenames
+must be unique. The dataset image name and `page_no` resolve the source name and
+zero-based page index (for example `paper.pdf_7.jpg` becomes page 6 of
+`paper.pdf`).
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py export \
+  --source-root /path/to/clean/oxidize-pdf-checkout \
+  --dataset-root /data/omnidocbench \
+  --evaluator-root /path/to/clean/evaluator-checkout \
+  --dataset /data/omnidocbench/OmniDocBench.json \
+  --pdf-root /data/source-pdfs \
+  --predictions /artifacts/predictions \
+  --manifest /artifacts/run-manifest.json \
+  --dataset-revision f5f559bddf50e36f7f9899d842d0006f13ce8afc \
+  --evaluator-revision 337cc26965893db3ef53ddc119a6d6bb5bde096f
+```
+
+The command refuses a dirty source checkout by default. `--allow-dirty` is for
+experiments only and records a dirty-state hash; such a run is not labelled as
+the clean Git commit.
+
+Run the pinned upstream evaluator over the generated Markdown directory. Then
+validate its `*_quick_match_text_block_per_page_edit.json` artifact:
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py summarize \
+  --dataset /data/omnidocbench/OmniDocBench.json \
+  --scores /artifacts/model_quick_match_text_block_per_page_edit.json \
+  --predictions /artifacts/predictions \
+  --evaluator-root /path/to/clean/evaluator-checkout \
+  --manifest /artifacts/run-manifest.json \
+  --output /artifacts/summary.json
+```
+
+The summary recomputes the prediction-tree hash and re-verifies the evaluator
+revision. Compare clean, untampered baseline and candidate summaries only when
+their machine-readable identities and population counts agree:
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py compare \
+  --baseline /artifacts/v5.0.0-summary.json \
+  --candidate /artifacts/candidate-summary.json \
+  --output /artifacts/comparison.json
+```
+
+## Reproduced final #564 result
+
+Feeding the pinned official per-page artifact for `d5e2d0b` through the gate
+produces:
+
+| Population | Pages | Edit distance | Similarity |
+|---|---:|---:|---:|
+| Official global text | 921 | 0.5085693812417305 | 49.1430618758% |
+| Native text v1 | 780 | 0.41990107039261854 | 58.0098929607% |
+
+This reproduces the final commit rather than the earlier 61.11% experimental
+artifact. The 60 non-scorable dataset pages are reported separately; all 981
+pages must still have prediction files.
+
+The implementation checklist and remaining external full-run validation are in
+`docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md`.

--- a/oxidize-pdf-core/examples/omnidocbench_export.rs
+++ b/oxidize-pdf-core/examples/omnidocbench_export.rs
@@ -1,0 +1,211 @@
+//! Deterministic native-text prediction exporter for OmniDocBench.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::plaintext::{PlainTextConfig, PlainTextExtractor};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct Job {
+    prediction_name: String,
+    pdf_path: PathBuf,
+    page_index: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct Counts {
+    attempted: usize,
+    written: usize,
+    failed: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct Failure {
+    prediction_name: String,
+    error: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ExtractionConfig {
+    api: &'static str,
+    preserve_layout: bool,
+    line_break_mode: &'static str,
+    space_threshold: f64,
+    tj_space_threshold: f64,
+    newline_threshold: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    counts: Counts,
+    failures: Vec<Failure>,
+    extraction_config: ExtractionConfig,
+}
+
+fn prediction_path(output: &Path, name: &str) -> Result<PathBuf, String> {
+    let path = Path::new(name);
+    if path.components().count() != 1
+        || path.extension().and_then(|part| part.to_str()) != Some("md")
+    {
+        return Err(format!("invalid prediction filename: {name}"));
+    }
+    Ok(output.join(path))
+}
+
+fn extraction_config() -> ExtractionConfig {
+    let config = PlainTextConfig::preserve_layout();
+    ExtractionConfig {
+        api: "PlainTextExtractor::preserve_layout",
+        preserve_layout: config.preserve_layout,
+        line_break_mode: "PreserveAll",
+        space_threshold: config.space_threshold,
+        tj_space_threshold: config.tj_space_threshold,
+        newline_threshold: config.newline_threshold,
+    }
+}
+
+fn temporary_output_path(output: &Path) -> Result<PathBuf, String> {
+    let name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("invalid prediction directory: {}", output.display()))?;
+    Ok(output.with_file_name(format!(".{name}.tmp-{}", std::process::id())))
+}
+
+fn write_predictions(jobs: &[Job], staging: &Path) -> Result<Vec<Failure>, String> {
+    let mut jobs_by_pdf: BTreeMap<&Path, Vec<&Job>> = BTreeMap::new();
+    for job in jobs {
+        jobs_by_pdf.entry(&job.pdf_path).or_default().push(job);
+    }
+    let mut failures = Vec::new();
+    for (pdf_path, pdf_jobs) in jobs_by_pdf {
+        let document = PdfReader::open(pdf_path)
+            .map(PdfDocument::new)
+            .map_err(|error| error.to_string());
+        let page_count = document
+            .as_ref()
+            .map_err(Clone::clone)
+            .and_then(|document| document.page_count().map_err(|error| error.to_string()));
+        let mut extractor = PlainTextExtractor::with_config(PlainTextConfig::preserve_layout());
+        for job in pdf_jobs {
+            let destination = prediction_path(staging, &job.prediction_name)?;
+            let extracted = match (&document, &page_count) {
+                (Ok(document), Ok(count)) if job.page_index < *count => extractor
+                    .extract(document, job.page_index)
+                    .map(|result| result.text)
+                    .map_err(|error| error.to_string()),
+                (Ok(_), Ok(count)) => Err(format!(
+                    "page index {} outside document with {} pages",
+                    job.page_index, count
+                )),
+                (Err(error), _) | (_, Err(error)) => Err(error.clone()),
+            };
+            match extracted {
+                Ok(text) => {
+                    fs::write(destination, text.as_bytes()).map_err(|error| error.to_string())?
+                }
+                Err(error) => {
+                    fs::write(destination, []).map_err(|write_error| write_error.to_string())?;
+                    failures.push(Failure {
+                        prediction_name: job.prediction_name.clone(),
+                        error,
+                    });
+                }
+            }
+        }
+    }
+    Ok(failures)
+}
+
+fn run(jobs_path: &Path, output: &Path, report_path: &Path) -> Result<(), String> {
+    let jobs: Vec<Job> = serde_json::from_slice(
+        &fs::read(jobs_path).map_err(|error| format!("read jobs: {error}"))?,
+    )
+    .map_err(|error| format!("parse jobs: {error}"))?;
+    if jobs.is_empty() {
+        return Err("job population is empty".to_string());
+    }
+    if output.exists() {
+        return Err(format!(
+            "prediction directory already exists: {}",
+            output.display()
+        ));
+    }
+    let staging = temporary_output_path(output)?;
+    if staging.exists() {
+        return Err(format!(
+            "staging directory already exists: {}",
+            staging.display()
+        ));
+    }
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    fs::create_dir(&staging).map_err(|error| error.to_string())?;
+    let mut failures = match write_predictions(&jobs, &staging) {
+        Ok(failures) => failures,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(error);
+        }
+    };
+    failures.sort_by(|left, right| left.prediction_name.cmp(&right.prediction_name));
+    let report = Report {
+        counts: Counts {
+            attempted: jobs.len(),
+            written: jobs.len(),
+            failed: failures.len(),
+        },
+        failures,
+        extraction_config: extraction_config(),
+    };
+    let mut rendered = serde_json::to_vec_pretty(&report).map_err(|error| error.to_string())?;
+    rendered.push(b'\n');
+    fs::write(report_path, rendered).map_err(|error| error.to_string())?;
+    fs::rename(staging, output).map_err(|error| error.to_string())
+}
+
+fn main() {
+    let args: Vec<_> = env::args_os().collect();
+    if args.len() != 4 {
+        eprintln!("usage: omnidocbench_export <jobs.json> <predictions-dir> <report.json>");
+        std::process::exit(2);
+    }
+    if let Err(error) = run(
+        Path::new(&args[1]),
+        Path::new(&args[2]),
+        Path::new(&args[3]),
+    ) {
+        eprintln!("error: {error}");
+        std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prediction_names_are_flat_markdown_files() {
+        let output = Path::new("predictions");
+        assert_eq!(
+            prediction_path(output, "source.pdf_7.md").unwrap(),
+            output.join("source.pdf_7.md")
+        );
+        assert!(prediction_path(output, "../escape.md").is_err());
+        assert!(prediction_path(output, "page.txt").is_err());
+    }
+
+    #[test]
+    fn effective_configuration_is_reportable() {
+        let config = extraction_config();
+        assert!(config.preserve_layout);
+        assert_eq!(config.line_break_mode, "PreserveAll");
+        assert_eq!(config.space_threshold, 0.3);
+        assert_eq!(config.tj_space_threshold, 0.2);
+        assert_eq!(config.newline_threshold, 10.0);
+    }
+}

--- a/tools/benchmarks/omnidocbench_gate.py
+++ b/tools/benchmarks/omnidocbench_gate.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Reproducible prediction and score gate for OmniDocBench native PDF text."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "oxidize-pdf-omnidocbench-gate/v1"
+POPULATION_VERSION = "native-text-v1"
+PROTOCOL = "OmniDocBench/end2end_eval/quick_match/text"
+EXCLUDED_DATA_SOURCES = frozenset({"note"})
+EXCLUDED_SPECIAL_ISSUES = frozenset({"fuzzy_scan"})
+OFFICIAL_TEXT_CATEGORIES = frozenset(
+    {"text_block", "title", "code_txt", "code_txt_caption", "reference"}
+)
+IDENTITY_FIELDS = (
+    "schema_version",
+    "dataset_revision",
+    "evaluator_revision",
+    "protocol",
+    "ocr_enabled",
+    "population_version",
+    "extraction_config",
+    "exporter_sha256",
+    "source_lock_sha256",
+    "rustc_version",
+    "cargo_version",
+)
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_object)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"invalid JSON in {path}: {error}") from error
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tree_hash(directory: Path, suffix: str = ".md") -> str:
+    entries = []
+    for path in sorted(directory.rglob(f"*{suffix}"), key=lambda item: item.relative_to(directory).as_posix()):
+        entries.append({"path": path.relative_to(directory).as_posix(), "sha256": file_hash(path)})
+    return canonical_hash(entries)
+
+
+def git_output(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, stdout=subprocess.PIPE, text=True
+    ).stdout.rstrip("\n")
+
+
+def git_provenance(allow_dirty: bool, source_root: Path | None = None) -> dict[str, Any]:
+    prefix = ("-C", str(source_root.resolve())) if source_root else ()
+    sha = git_output(*prefix, "rev-parse", "HEAD")
+    status = git_output(*prefix, "status", "--porcelain=v1", "--untracked-files=all")
+    if status and not allow_dirty:
+        raise ValueError("dirty worktree cannot be labelled as a clean commit; pass --allow-dirty")
+    result: dict[str, Any] = {"git_sha": sha, "worktree_clean": not bool(status)}
+    if status:
+        diff = git_output(*prefix, "diff", "--binary", "HEAD")
+        untracked = git_output(*prefix, "ls-files", "--others", "--exclude-standard", "-z")
+        dirty = hashlib.sha256()
+        dirty.update(status.encode())
+        dirty.update(b"\0")
+        dirty.update(diff.encode())
+        dirty.update(b"\0")
+        dirty.update(untracked.encode())
+        for name in sorted(filter(None, untracked.split("\0"))):
+            path = (source_root / name) if source_root else Path(name)
+            if path.is_file():
+                dirty.update(name.encode())
+                dirty.update(bytes.fromhex(file_hash(path)))
+        result["dirty_state_sha256"] = dirty.hexdigest()
+    return result
+
+
+def verified_revision(root: Path, expected: str, label: str) -> dict[str, Any]:
+    provenance = git_provenance(False, root)
+    if provenance["git_sha"] != expected:
+        raise ValueError(
+            f"{label} revision mismatch: expected {expected}, found {provenance['git_sha']}"
+        )
+    return provenance
+
+
+def command_version(*command: str) -> str:
+    return subprocess.run(
+        list(command), check=True, stdout=subprocess.PIPE, text=True
+    ).stdout.strip()
+
+
+def identity_fixture(**overrides: Any) -> dict[str, Any]:
+    identity = {
+        "schema_version": SCHEMA_VERSION,
+        "dataset_revision": "dataset",
+        "evaluator_revision": "evaluator",
+        "protocol": PROTOCOL,
+        "ocr_enabled": False,
+        "population_version": POPULATION_VERSION,
+        "extraction_config": {
+            "api": "PlainTextExtractor::preserve_layout",
+            "preserve_layout": True,
+            "line_break_mode": "PreserveAll",
+            "space_threshold": 0.3,
+            "tj_space_threshold": 0.2,
+            "newline_threshold": 10.0,
+        },
+        "exporter_sha256": "exporter",
+        "source_lock_sha256": "lock",
+        "rustc_version": "rustc",
+        "cargo_version": "cargo",
+    }
+    identity.update(overrides)
+    return identity
+
+
+def _dataset_metadata(dataset: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    if not isinstance(dataset, list):
+        raise ValueError("dataset JSON must be an array")
+    metadata: dict[str, dict[str, Any]] = {}
+    for entry in dataset:
+        if not isinstance(entry, dict):
+            raise ValueError("each dataset page must be an object")
+        try:
+            info = entry["page_info"]
+            name = Path(info["image_path"]).name
+            attributes = info["page_attribute"]
+        except (KeyError, TypeError) as error:
+            raise ValueError(f"malformed dataset page: {error}") from error
+        if name in metadata:
+            raise ValueError(f"duplicate dataset page: {name}")
+        if not isinstance(attributes, dict):
+            raise ValueError(f"page attributes must be an object: {name}")
+        special = attributes.get("special_issue", [])
+        if not isinstance(special, list) or not all(isinstance(item, str) for item in special):
+            raise ValueError(f"special_issue must be an array of strings: {name}")
+        layout = entry.get("layout_dets", [])
+        if not isinstance(layout, list) or not all(isinstance(item, dict) for item in layout):
+            raise ValueError(f"layout_dets must be an array of objects: {name}")
+        scorable = any(
+            item.get("category_type") in OFFICIAL_TEXT_CATEGORIES
+            and str(item.get("text", "")).strip()
+            and not item.get("ignore", False)
+            for item in layout
+        )
+        metadata[name] = {"attributes": attributes, "text_scorable": scorable}
+    if not metadata:
+        raise ValueError("dataset population is empty")
+    return metadata
+
+
+def summarize_scores(
+    dataset: list[dict[str, Any]], scores: dict[str, Any], failed_pages: int = 0
+) -> dict[str, Any]:
+    if not isinstance(scores, dict):
+        raise ValueError("scores JSON must be an object")
+    metadata = _dataset_metadata(dataset)
+    expected = {name for name, item in metadata.items() if item["text_scorable"]}
+    unknown = sorted(set(scores) - expected)
+    missing = sorted(expected - set(scores))
+    if unknown:
+        raise ValueError(f"scores reference {len(unknown)} unknown pages; first: {unknown[0]}")
+    if missing:
+        raise ValueError(f"missing scores for {len(missing)} pages; first: {missing[0]}")
+
+    native: list[float] = []
+    global_values: list[float] = []
+    for name in sorted(expected):
+        score = scores[name]
+        if (
+            not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not math.isfinite(score)
+            or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError(f"invalid score for {name}: {score!r}")
+        value = float(score)
+        global_values.append(value)
+        attrs = metadata[name]["attributes"]
+        special = set(attrs.get("special_issue", []))
+        if attrs.get("data_source") not in EXCLUDED_DATA_SOURCES and not special.intersection(EXCLUDED_SPECIAL_ISSUES):
+            native.append(value)
+    if not native:
+        raise ValueError("native-text population is empty")
+
+    global_edit = math.fsum(global_values) / len(global_values)
+    native_edit = math.fsum(native) / len(native)
+    return {
+        "population": {
+            "version": POPULATION_VERSION,
+            "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
+            "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+        },
+        "counts": {
+            "dataset": len(metadata),
+            "official_text_scorable": len(expected),
+            "official_text_unscored": len(metadata) - len(expected),
+            "scored": len(scores),
+            "included_native": len(native),
+            "excluded_native": len(global_values) - len(native),
+            "missing": 0,
+            "duplicate": 0,
+            "failed": failed_pages,
+        },
+        "metrics": {
+            "official_global_text_edit_distance": global_edit,
+            "official_global_text_similarity": 1.0 - global_edit,
+            "native_text_edit_distance": native_edit,
+            "native_text_similarity": 1.0 - native_edit,
+        },
+    }
+
+
+def compare_summaries(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    for label, summary in (("baseline", baseline), ("candidate", candidate)):
+        recorded_hash = summary.get("summary_sha256")
+        unhashed = {key: value for key, value in summary.items() if key != "summary_sha256"}
+        if recorded_hash != canonical_hash(unhashed):
+            raise ValueError(f"{label} summary hash is invalid")
+        if summary.get("provenance", {}).get("worktree_clean") is not True:
+            raise ValueError(f"{label} summary is not from a clean worktree")
+        artifacts = summary.get("artifacts", {})
+        if not all(artifacts.get(name) for name in ("dataset_sha256", "scores_sha256", "predictions_sha256")):
+            raise ValueError(f"{label} artifact identity is incomplete")
+    left = baseline.get("identity", {})
+    right = candidate.get("identity", {})
+    mismatches = [field for field in IDENTITY_FIELDS if left.get(field) != right.get(field)]
+    if mismatches:
+        raise ValueError(f"incompatible benchmark identity: {', '.join(mismatches)}")
+    population_counts = ("dataset", "official_text_scorable", "included_native", "excluded_native")
+    count_mismatches = [
+        name
+        for name in population_counts
+        if baseline.get("counts", {}).get(name) != candidate.get("counts", {}).get(name)
+    ]
+    if count_mismatches:
+        raise ValueError(f"incompatible benchmark population counts: {', '.join(count_mismatches)}")
+    before = baseline["metrics"]
+    after = candidate["metrics"]
+    return {
+        "identity_sha256": canonical_hash(left),
+        "official_global_text_similarity_delta": after["official_global_text_similarity"] - before["official_global_text_similarity"],
+        "native_text_similarity_delta": after["native_text_similarity"] - before["native_text_similarity"],
+    }
+
+
+def source_pdf_identity(entry: dict[str, Any]) -> tuple[str, int]:
+    info = entry["page_info"]
+    image_name = Path(info["image_path"]).name
+    page_no = info["page_no"]
+    if not isinstance(page_no, int) or isinstance(page_no, bool) or page_no < 1:
+        raise ValueError(f"invalid page_no for {image_name}: {page_no!r}")
+    stem = Path(image_name).stem
+    suffix = f"_{page_no}"
+    if not stem.endswith(suffix):
+        raise ValueError(f"image name does not end in _<page_no>: {image_name}")
+    source = stem[: -len(suffix)]
+    if not source.lower().endswith(".pdf"):
+        source += ".pdf"
+    return source, page_no - 1
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_json(value))
+
+
+def _pdf_index(root: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() != ".pdf":
+            continue
+        key = path.name.casefold()
+        if key in result:
+            raise ValueError(f"duplicate source PDF basename: {path.name}")
+        result[key] = path.resolve()
+    return result
+
+
+def export_predictions(args: argparse.Namespace) -> None:
+    dataset = load_json(args.dataset)
+    _dataset_metadata(dataset)
+    dataset_root = args.dataset_root.resolve()
+    evaluator_root = args.evaluator_root.resolve()
+    try:
+        args.dataset.resolve().relative_to(dataset_root)
+    except ValueError as error:
+        raise ValueError("--dataset must be inside --dataset-root") from error
+    dataset_provenance = verified_revision(
+        dataset_root, args.dataset_revision, "dataset"
+    )
+    evaluator_provenance = verified_revision(
+        evaluator_root, args.evaluator_revision, "evaluator"
+    )
+    pdfs = _pdf_index(args.pdf_root)
+    jobs = []
+    for entry in sorted(dataset, key=lambda item: Path(item["page_info"]["image_path"]).name):
+        source_name, page_index = source_pdf_identity(entry)
+        source = pdfs.get(source_name.casefold())
+        if source is None:
+            raise ValueError(f"missing source PDF: {source_name}")
+        image_name = Path(entry["page_info"]["image_path"]).name
+        jobs.append({"prediction_name": str(Path(image_name).with_suffix(".md")), "pdf_path": str(source), "page_index": page_index})
+
+    source_root = args.source_root.resolve()
+    provenance = git_provenance(args.allow_dirty, source_root)
+    provenance["dataset_repository"] = dataset_provenance
+    provenance["evaluator_repository"] = evaluator_provenance
+    exporter = Path(__file__).resolve().parents[2] / "oxidize-pdf-core/examples/omnidocbench_export.rs"
+    source_lock = source_root / "Cargo.lock"
+    if not source_lock.is_file():
+        raise ValueError(f"source checkout has no Cargo.lock: {source_root}")
+    with tempfile.TemporaryDirectory(prefix="oxidize-omnidocbench-") as directory:
+        harness = Path(directory)
+        archived_source = harness / "source"
+        jobs_path = harness / "jobs.json"
+        report_path = harness / "export-report.json"
+        core_path = archived_source / "oxidize-pdf-core"
+        if not (source_root / "oxidize-pdf-core/Cargo.toml").is_file():
+            raise ValueError(f"source checkout has no oxidize-pdf-core crate: {source_root}")
+        archive_path = harness / "source.tar"
+        subprocess.run(
+            ["git", "-C", str(source_root), "archive", "--format=tar", f"--output={archive_path}", "HEAD"],
+            check=True,
+        )
+        archived_source.mkdir()
+        with tarfile.open(archive_path) as archive:
+            archive.extractall(archived_source, filter="data")
+        examples = core_path / "examples"
+        examples.mkdir(exist_ok=True)
+        (examples / "omnidocbench_export.rs").write_bytes(exporter.read_bytes())
+        _write_json(jobs_path, jobs)
+        command_env = os.environ.copy()
+        command_env.setdefault(
+            "CARGO_TARGET_DIR",
+            str(Path(__file__).resolve().parents[2] / "target/omnidocbench-gate"),
+        )
+        subprocess.run(
+            ["cargo", "run", "--locked", "--offline", "--quiet", "--release", "--manifest-path", str(archived_source / "Cargo.toml"), "-p", "oxidize-pdf", "--example", "omnidocbench_export", "--", str(jobs_path), str(args.predictions), str(report_path)],
+            check=True,
+            env=command_env,
+        )
+        report = load_json(report_path)
+        archived_lock_sha256 = file_hash(archived_source / "Cargo.lock")
+    identity = identity_fixture(
+        dataset_revision=args.dataset_revision,
+        evaluator_revision=args.evaluator_revision,
+        extraction_config=report["extraction_config"],
+        exporter_sha256=file_hash(exporter),
+        source_lock_sha256=archived_lock_sha256,
+        rustc_version=command_version("rustc", "-Vv"),
+        cargo_version=command_version("cargo", "-V"),
+    )
+    manifest = {
+        "identity": identity,
+        "provenance": provenance,
+        "dataset_sha256": file_hash(args.dataset),
+        "predictions_sha256": tree_hash(args.predictions),
+        "counts": report["counts"],
+        "failures": report["failures"],
+    }
+    _write_json(args.manifest, manifest)
+
+
+def summarize_command(args: argparse.Namespace) -> None:
+    dataset = load_json(args.dataset)
+    scores = load_json(args.scores)
+    manifest = load_json(args.manifest)
+    dataset_sha256 = file_hash(args.dataset)
+    if manifest.get("dataset_sha256") != dataset_sha256:
+        raise ValueError("manifest dataset hash does not match --dataset")
+    dataset_pages = len(_dataset_metadata(dataset))
+    export_counts = manifest.get("counts", {})
+    if export_counts.get("attempted") != dataset_pages or export_counts.get("written") != dataset_pages:
+        raise ValueError("incomplete prediction manifest")
+    if export_counts.get("failed") != len(manifest.get("failures", [])):
+        raise ValueError("prediction failure count does not match failure records")
+    identity = manifest.get("identity", {})
+    missing_identity = [field for field in IDENTITY_FIELDS if field not in identity]
+    if missing_identity:
+        raise ValueError(f"manifest identity is incomplete: {', '.join(missing_identity)}")
+    if identity["ocr_enabled"] is not False or identity["protocol"] != PROTOCOL:
+        raise ValueError("manifest does not describe the supported OCR-free protocol")
+    verified_revision(args.evaluator_root, identity["evaluator_revision"], "evaluator")
+    predictions_sha256 = tree_hash(args.predictions)
+    if manifest.get("predictions_sha256") != predictions_sha256:
+        raise ValueError("prediction tree hash does not match manifest")
+    prediction_count = sum(1 for path in args.predictions.rglob("*.md") if path.is_file())
+    if prediction_count != dataset_pages:
+        raise ValueError("prediction directory is incomplete")
+    result = summarize_scores(dataset, scores, manifest["counts"]["failed"])
+    result["identity"] = manifest["identity"]
+    result["provenance"] = manifest["provenance"]
+    result["artifacts"] = {
+        "dataset_sha256": dataset_sha256,
+        "scores_sha256": canonical_hash(scores),
+        "predictions_sha256": predictions_sha256,
+    }
+    result["summary_sha256"] = canonical_hash(result)
+    _write_json(args.output, result)
+
+
+def compare_command(args: argparse.Namespace) -> None:
+    result = compare_summaries(load_json(args.baseline), load_json(args.candidate))
+    _write_json(args.output, result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    export = commands.add_parser("export", help="generate deterministic Markdown predictions")
+    export.add_argument("--dataset", type=Path, required=True)
+    export.add_argument("--dataset-root", type=Path, required=True, help="clean Git checkout containing the dataset")
+    export.add_argument("--evaluator-root", type=Path, required=True, help="clean pinned evaluator Git checkout")
+    export.add_argument("--pdf-root", type=Path, required=True)
+    export.add_argument("--source-root", type=Path, default=Path.cwd(), help="clean oxidize-pdf checkout to evaluate")
+    export.add_argument("--predictions", type=Path, required=True)
+    export.add_argument("--manifest", type=Path, required=True)
+    export.add_argument("--dataset-revision", required=True)
+    export.add_argument("--evaluator-revision", required=True)
+    export.add_argument("--allow-dirty", action="store_true")
+    export.set_defaults(handler=export_predictions)
+    summary = commands.add_parser("summarize", help="validate official per-page text scores")
+    summary.add_argument("--dataset", type=Path, required=True)
+    summary.add_argument("--scores", type=Path, required=True)
+    summary.add_argument("--predictions", type=Path, required=True)
+    summary.add_argument("--evaluator-root", type=Path, required=True)
+    summary.add_argument("--manifest", type=Path, required=True)
+    summary.add_argument("--output", type=Path, required=True)
+    summary.set_defaults(handler=summarize_command)
+    compare = commands.add_parser("compare", help="compare compatible summaries")
+    compare.add_argument("--baseline", type=Path, required=True)
+    compare.add_argument("--candidate", type=Path, required=True)
+    compare.add_argument("--output", type=Path, required=True)
+    compare.set_defaults(handler=compare_command)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    try:
+        args.handler(args)
+    except (ValueError, KeyError, OSError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmarks/omnidocbench_gate_test.py
+++ b/tools/benchmarks/omnidocbench_gate_test.py
@@ -1,0 +1,255 @@
+import importlib.util
+import json
+import argparse
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("omnidocbench_gate.py")
+SPEC = importlib.util.spec_from_file_location("omnidocbench_gate", MODULE_PATH)
+assert SPEC and SPEC.loader
+GATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GATE)
+
+
+def page(name, source="book", special=None, page_no=1):
+    return {
+        "layout_dets": [{"category_type": "text_block", "text": "text"}],
+        "page_info": {
+            "image_path": f"images/{name}",
+            "page_no": page_no,
+            "page_attribute": {
+                "data_source": source,
+                "special_issue": special or ["None"],
+                "layout": "single_column",
+                "language": "english",
+            },
+        }
+    }
+
+
+def sealed_summary(identity=None, dataset_count=1, similarity=0.5):
+    value = {
+        "identity": identity or GATE.identity_fixture(),
+        "provenance": {"worktree_clean": True},
+        "artifacts": {
+            "dataset_sha256": "dataset",
+            "scores_sha256": "scores",
+            "predictions_sha256": "predictions",
+        },
+        "counts": {
+            "dataset": dataset_count,
+            "official_text_scorable": dataset_count,
+            "included_native": dataset_count,
+            "excluded_native": 0,
+        },
+        "metrics": {
+            "official_global_text_similarity": similarity,
+            "native_text_similarity": similarity,
+        },
+    }
+    value["summary_sha256"] = GATE.canonical_hash(value)
+    return value
+
+
+class JsonAndPopulationTests(unittest.TestCase):
+    def test_rejects_duplicate_json_keys(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scores.json"
+            path.write_text('{"a.jpg": 0.1, "a.jpg": 0.2}', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate JSON key"):
+                GATE.load_json(path)
+
+    def test_rejects_missing_unknown_and_duplicate_dataset_pages(self):
+        with self.assertRaisesRegex(ValueError, "missing scores"):
+            GATE.summarize_scores([page("a.jpg"), page("b.jpg")], {"a.jpg": 0.1})
+        with self.assertRaisesRegex(ValueError, "unknown pages"):
+            GATE.summarize_scores([page("a.jpg")], {"a.jpg": 0.1, "x.jpg": 0.2})
+        with self.assertRaisesRegex(ValueError, "duplicate dataset page"):
+            GATE.summarize_scores([page("a.jpg"), page("a.jpg")], {"a.jpg": 0.1})
+
+    def test_rejects_invalid_scores(self):
+        for value in (float("nan"), float("inf"), -0.1, 1.1, True, "0.1"):
+            with self.subTest(value=value), self.assertRaisesRegex(ValueError, "invalid score"):
+                GATE.summarize_scores([page("a.jpg")], {"a.jpg": value})
+
+    def test_rejects_malformed_dataset_and_score_shapes(self):
+        with self.assertRaisesRegex(ValueError, "dataset JSON must be an array"):
+            GATE.summarize_scores({}, {})
+        with self.assertRaisesRegex(ValueError, "scores JSON must be an object"):
+            GATE.summarize_scores([page("a.jpg")], [])
+        malformed = page("a.jpg")
+        malformed["page_info"]["page_attribute"]["special_issue"] = "fuzzy_scan"
+        with self.assertRaisesRegex(ValueError, "array of strings"):
+            GATE.summarize_scores([malformed], {"a.jpg": 0.1})
+
+    def test_code_text_caption_is_officially_scorable(self):
+        entry = page("caption.jpg")
+        entry["layout_dets"] = [{"category_type": "code_txt_caption", "text": "caption"}]
+        result = GATE.summarize_scores([entry], {"caption.jpg": 0.25})
+        self.assertEqual(result["counts"]["official_text_scorable"], 1)
+
+    def test_reports_distinct_global_and_native_populations(self):
+        dataset = [
+            page("native.jpg"),
+            page("note.jpg", source="note"),
+            page("fuzzy.jpg", special=["fuzzy_scan"]),
+        ]
+        result = GATE.summarize_scores(
+            dataset, {"native.jpg": 0.2, "note.jpg": 1.0, "fuzzy.jpg": 0.8}, failed_pages=1
+        )
+        self.assertEqual(result["counts"], {
+            "dataset": 3, "official_text_scorable": 3,
+            "official_text_unscored": 0, "scored": 3, "included_native": 1,
+            "excluded_native": 2, "missing": 0, "duplicate": 0, "failed": 1,
+        })
+        self.assertAlmostEqual(result["metrics"]["official_global_text_similarity"], 1 - 2 / 3)
+        self.assertAlmostEqual(result["metrics"]["native_text_similarity"], 0.8)
+
+
+class IdentityAndHashTests(unittest.TestCase):
+    def test_canonical_hash_ignores_mapping_order(self):
+        self.assertEqual(GATE.canonical_hash({"b": 2, "a": 1}), GATE.canonical_hash({"a": 1, "b": 2}))
+
+    def test_compare_rejects_incompatible_identity(self):
+        baseline = sealed_summary(GATE.identity_fixture(dataset_revision="old"))
+        candidate = sealed_summary(GATE.identity_fixture(dataset_revision="new"))
+        with self.assertRaisesRegex(ValueError, "incompatible.*dataset_revision"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_summary_hash_is_repeatable(self):
+        dataset = [page("b.jpg"), page("a.jpg")]
+        first = GATE.summarize_scores(dataset, {"a.jpg": 0.1, "b.jpg": 0.2})
+        second = GATE.summarize_scores(list(reversed(dataset)), {"b.jpg": 0.2, "a.jpg": 0.1})
+        self.assertEqual(GATE.canonical_hash(first), GATE.canonical_hash(second))
+
+    def test_dirty_checkout_requires_explicit_provenance(self):
+        with mock.patch.object(GATE, "git_output", side_effect=["abc123", " M file"]):
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.git_provenance(False)
+
+    def test_dirty_provenance_has_diff_hash(self):
+        with mock.patch.object(GATE, "git_output", side_effect=["abc123", " M file", "diff", "file\0"]):
+            result = GATE.git_provenance(True)
+        self.assertEqual(result["git_sha"], "abc123")
+        self.assertFalse(result["worktree_clean"])
+        self.assertRegex(result["dirty_state_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_verified_revision_uses_real_temporary_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+            (root / "tracked").write_text("content", encoding="utf-8")
+            subprocess.run(["git", "-C", str(root), "add", "tracked"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"], check=True)
+            revision = GATE.git_output("-C", str(root), "rev-parse", "HEAD")
+            self.assertEqual(GATE.verified_revision(root, revision, "fixture")["git_sha"], revision)
+            (root / "tracked").write_text("changed", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.verified_revision(root, revision, "fixture")
+
+    def test_population_count_mismatch_is_not_comparable(self):
+        baseline = sealed_summary(dataset_count=2)
+        candidate = sealed_summary(dataset_count=3)
+        with self.assertRaisesRegex(ValueError, "population counts"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_compare_rejects_tampered_or_dirty_summaries(self):
+        baseline = sealed_summary()
+        candidate = sealed_summary(similarity=0.6)
+        candidate["metrics"]["native_text_similarity"] = 0.9
+        with self.assertRaisesRegex(ValueError, "summary hash"):
+            GATE.compare_summaries(baseline, candidate)
+        candidate = sealed_summary(similarity=0.6)
+        candidate["provenance"]["worktree_clean"] = False
+        candidate["summary_sha256"] = GATE.canonical_hash(
+            {key: value for key, value in candidate.items() if key != "summary_sha256"}
+        )
+        with self.assertRaisesRegex(ValueError, "clean worktree"):
+            GATE.compare_summaries(baseline, candidate)
+
+
+class PdfResolutionTests(unittest.TestCase):
+    def test_resolves_pdf_suffix_and_one_based_page(self):
+        self.assertEqual(
+            GATE.source_pdf_identity(page("source.pdf_7.jpg", page_no=7)),
+            ("source.pdf", 6),
+        )
+
+    def test_resolves_source_without_pdf_in_image_stem(self):
+        self.assertEqual(
+            GATE.source_pdf_identity(page("slides_455.jpg", page_no=455)),
+            ("slides.pdf", 454),
+        )
+
+    def test_exporter_writes_prediction_and_manifest(self):
+        repository = MODULE_PATH.parents[2]
+        fixture = repository / "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pdf_root = root / "pdfs"
+            pdf_root.mkdir()
+            shutil.copy2(fixture, pdf_root / "source.pdf")
+            dataset = root / "dataset.json"
+            dataset.write_text(json.dumps([page("source.pdf_1.jpg")]), encoding="utf-8")
+            predictions = root / "predictions"
+            manifest = root / "manifest.json"
+            args = argparse.Namespace(
+                dataset=dataset,
+                dataset_root=root,
+                evaluator_root=repository,
+                pdf_root=pdf_root,
+                source_root=repository,
+                predictions=predictions,
+                manifest=manifest,
+                dataset_revision="dataset-rev",
+                evaluator_revision="evaluator-rev",
+                allow_dirty=True,
+            )
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), mock.patch.object(
+                GATE, "git_provenance", return_value={"git_sha": "candidate", "worktree_clean": True}
+            ):
+                GATE.export_predictions(args)
+            recorded = GATE.load_json(manifest)
+            self.assertTrue((predictions / "source.pdf_1.md").is_file())
+            self.assertEqual(recorded["counts"], {"attempted": 1, "failed": 0, "written": 1})
+            self.assertEqual(recorded["predictions_sha256"], GATE.tree_hash(predictions))
+
+            scores = root / "scores.json"
+            scores.write_text('{"source.pdf_1.jpg":0.25}', encoding="utf-8")
+            summary = root / "summary.json"
+            summary_args = argparse.Namespace(
+                dataset=dataset,
+                scores=scores,
+                predictions=predictions,
+                evaluator_root=repository,
+                manifest=manifest,
+                output=summary,
+            )
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}):
+                GATE.summarize_command(summary_args)
+            self.assertEqual(GATE.load_json(summary)["metrics"]["official_global_text_similarity"], 0.75)
+            (predictions / "source.pdf_1.md").write_text("tampered", encoding="utf-8")
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), self.assertRaisesRegex(ValueError, "prediction tree hash"):
+                GATE.summarize_command(summary_args)
+
+            second_predictions = root / "predictions-second"
+            second_manifest = root / "manifest-second.json"
+            args.predictions = second_predictions
+            args.manifest = second_manifest
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), mock.patch.object(
+                GATE, "git_provenance", return_value={"git_sha": "candidate", "worktree_clean": True}
+            ):
+                GATE.export_predictions(args)
+            repeated = GATE.load_json(second_manifest)
+            self.assertEqual(recorded["predictions_sha256"], repeated["predictions_sha256"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a repository-owned Rust exporter for the supported native-text extraction path
- add a provenance-aware gate for official global and native-text OmniDocBench metrics
- reject dirty, incompatible, incomplete, malformed, or tampered benchmark artifacts
- build an archived exact commit with its own locked dependency graph and no auxiliary path dependency
- document the reproducible commands and TDD implementation trace

## Validation

- 24 focused Python tests passed
- 2 focused Rust exporter tests passed
- full pre-commit suite: 6,777 passed, 3 ignored
- clippy, formatting, build, and diff checks passed
- existing pinned d5e2d0b artifact reproduces 0.5085693812417305 global text edit distance (49.1431% similarity) and 0.41990107039261854 native-text edit distance over 780 pages

## External follow-up

The non-redistributable full dataset run and immutable v5.0.0 baseline generation remain explicitly unchecked in the implementation checklist until the external source-PDF corpus and pinned evaluator are supplied.

Closes #568