### PR TITLE
Fix OmniDocBench text quality regression

### DIFF
--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -1,0 +1,36 @@
+# Issue #564 — text-quality correction (TDD trace)
+
+## Red
+
+- [x] Add a focused regression proving that layout-aware plain text follows
+  column reading order when content streams interleave the two columns.
+- [x] Confirm the regression fails with the reviewed `detect_columns = false`
+  configuration.
+
+## Green
+
+- [x] Reject direct column reconstruction after it reached 61.10% text similarity
+  but regressed native reading-order edit distance to 0.27748.
+- [x] Use the existing scale-relative XY-Cut orderer without restoring the
+  rejected error-swallowing fallback.
+- [x] Pass the focused #564 tests and neighboring #477, #495, and #521 tests
+  (4 + 5 + 3 + 1 passed).
+- [x] Pass the library suite (6,777 passed, 3 ignored), Clippy, formatting,
+  T0 (21 passed, 3 ignored), and T1 (22 passed).
+
+## Benchmark acceptance
+
+- [x] Generate predictions from the candidate with OCR disabled and without
+  flattening line breaks (981 written, 1 known invalid-filter failure).
+- [x] Run pinned OmniDocBench `end2end_eval` / `quick_match`.
+- [x] Confirm official global text similarity is at least 55% (60.01%).
+- [ ] Re-run the benchmark from the final clean commit and seal its manifest.
+- [ ] Attach global, native-text, category, extraction-error, and reading-order
+  before/after metrics.
+- [ ] Keep the issue open if the exact committed candidate misses any criterion.
+
+## Quality review and delivery
+
+- [ ] Run the formal QR, including Kripteia test-quality and security analysis.
+- [ ] Correct every finding and repeat affected checks.
+- [ ] Open a PR only after the QR has no remaining findings.

--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -24,13 +24,14 @@
   flattening line breaks (981 written, 1 known invalid-filter failure).
 - [x] Run pinned OmniDocBench `end2end_eval` / `quick_match`.
 - [x] Confirm official global text similarity is at least 55% (60.01%).
-- [ ] Re-run the benchmark from the final clean commit and seal its manifest.
-- [ ] Attach global, native-text, category, extraction-error, and reading-order
+- [x] Re-run the benchmark from clean implementation commit `36a9d11c` and
+  seal its manifest and summary.
+- [x] Attach global, native-text, category, extraction-error, and reading-order
   before/after metrics.
-- [ ] Keep the issue open if the exact committed candidate misses any criterion.
+- [x] Confirm the exact committed candidate misses no acceptance criterion.
 
 ## Quality review and delivery
 
-- [ ] Run the formal QR, including Kripteia test-quality and security analysis.
-- [ ] Correct every finding and repeat affected checks.
+- [x] Run the formal QR, including Kripteia test-quality and security analysis.
+- [x] Correct every confirmed finding and repeat affected checks.
 - [ ] Open a PR only after the QR has no remaining findings.

--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -34,4 +34,4 @@
 
 - [x] Run the formal QR, including Kripteia test-quality and security analysis.
 - [x] Correct every confirmed finding and repeat affected checks.
-- [ ] Open a PR only after the QR has no remaining findings.
+- [x] Open PR #570 only after the QR has no remaining findings.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -38,6 +38,12 @@ The official text artifact contains 945 scored text entries; the official
 reading-order artifact contains 921 pages, of which the versioned #565 filter
 classifies 780 as native text.
 
+The clean implementation commit is
+`36a9d11c7da38e3b959171cfad06840cc5ff724e`. Its prediction-tree SHA-256 is
+`6a9240ec5b3a8a800a5f8813942edd2ee51eabed85d33f98e9c3f0d6ce3abedf` and
+the sealed summary SHA-256 is
+`431f967ef1f64ac66cc74ddc62d304164452f10cf29be97eadd080a0081c59a0`.
+
 ## Reproducibility correction
 
 The first rerun incorrectly used the historical comparison runner, which
@@ -48,5 +54,26 @@ back to a combined source PDF (`source.pdf`, page index N-1). Its exporter write
 the extracted text unchanged, preserving the line structure used by the
 official evaluator.
 
-Final clean-commit validation and formal quality review remain pending; no PR
-will be opened before both complete.
+The final gate also verifies materialized Git LFS objects by their committed
+SHA-256 and size when `git-lfs` is unavailable, rejects altered objects, accepts
+the evaluator's prediction-dependent optional text pages only when they belong
+to the pinned dataset, and seals the exact scored-page population in the
+summary.
+
+## Validation and quality review
+
+- Library suite: 6,777 passed, 3 ignored.
+- Focused #564: 4 passed; neighboring #477/#495/#521: 9 passed.
+- T0: 21 passed, 3 maintenance generators ignored; T1: 22 passed.
+- Exporter tests: 2 passed; benchmark gate: 21 passed.
+- Formatting, Clippy, build and `git diff --check`: passed.
+- Kripteia Rust: 94/100 globally; focused #564 tests: 90/100.
+- Kripteia Python: no tests discovered; the 21 `unittest` cases above are the
+  direct test evidence.
+- Kripteia security: no issues in either Rust or Python scope.
+
+The review found and corrected misleading cross-revision extraction metadata,
+missing split-PDF resolution, Git LFS provenance handling and incomplete
+official score-population handling. A proposed `page_no` validation finding was
+disproved against the pinned dataset and was not retained. The repeated final
+review has no remaining findings. No PR was opened during validation.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -104,3 +104,8 @@ bytes were reclaimed. Six project-scoped benchmark paths under `/tmp` were
 inspected (about 1.83 GB total). All were created on 2026-09-03, are newer than
 the five-day cutoff, and include evidence referenced above, so all six were
 preserved. No uncertain cleanup candidates were deleted.
+
+## Delivery
+
+PR #570 was opened against `develop` after the quality review completed with no
+remaining findings: https://github.com/bzsanti/oxidizePdf/pull/570

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -1,0 +1,52 @@
+# Issue #564 — text-quality correction
+
+Date: 2026-09-03 (UTC)
+
+## Outcome
+
+`PlainTextExtractor::preserve_layout()` now uses the complete text engine and
+orders its line groups with the existing scale-relative XY-Cut implementation.
+This retains `/ActualText`, artifact filtering, font metrics and error
+propagation while satisfying both the text-quality gate from #564 and the
+native reading-order gate from #565.
+
+The first correction candidate enabled fragment-level column reconstruction.
+It reached 61.10% text similarity, but was rejected because its native
+reading-order edit distance was 0.27748, above #565's maximum of 0.25.
+
+## Pinned protocol
+
+- Dataset revision: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- Evaluator revision: `337cc26965893db3ef53ddc119a6d6bb5bde096f`
+- Evaluator: official `end2end_eval` / `quick_match`
+- OCR: disabled
+- Predictions written: 981
+- Extraction failures: 1 (`Invalid Filter type`, also present in the baseline)
+
+## Candidate measurements
+
+Lower edit distance and higher similarity are better.
+
+| Metric | v5.0.0 baseline | Candidate | Acceptance |
+|---|---:|---:|---:|
+| Global text edit distance | 0.51741 | **0.39994** | — |
+| Global text similarity | 48.26% | **60.01%** | ≥55% |
+| Global reading-order edit distance | 0.31034 | 0.34447 | diagnostic |
+| Native reading-order edit distance | 0.18610 | **0.22639** | ≤0.25 |
+
+The official text artifact contains 945 scored text entries; the official
+reading-order artifact contains 921 pages, of which the versioned #565 filter
+classifies 780 as native text.
+
+## Reproducibility correction
+
+The first rerun incorrectly used the historical comparison runner, which
+normalizes whitespace before writing Markdown predictions and therefore
+reported only 49.14% similarity. The versioned gate now prefers exact
+page-specific PDFs (`source.pdf_N.pdf`, page index zero) when present and falls
+back to a combined source PDF (`source.pdf`, page index N-1). Its exporter writes
+the extracted text unchanged, preserving the line structure used by the
+official evaluator.
+
+Final clean-commit validation and formal quality review remain pending; no PR
+will be opened before both complete.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -77,3 +77,30 @@ missing split-PDF resolution, Git LFS provenance handling and incomplete
 official score-population handling. A proposed `page_no` validation finding was
 disproved against the pinned dataset and was not retained. The repeated final
 review has no remaining findings. No PR was opened during validation.
+
+## Session handoff
+
+The session closed on branch `fix/issue-564-omnidocbench-text-quality` at
+`472f4fbc3b6ad26d3919170d62c9b444cfc7dc0b`, after refreshing
+`origin/develop` to `d1a1ab0e99098e01cc51a04aa5ee315f5772ab4d`. The diff
+against that base contains only the six #564 files listed in this report and
+plan. The quality review is complete; the only unchecked acceptance item is
+opening the PR.
+
+The worktree also contains pre-existing or user-owned changes in `README.md`,
+`docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md`,
+`oxidize-pdf-core/Cargo.toml`, and eight untracked handoff reports dated
+2026-08-25 through 2026-09-01. They are unrelated to #564 and must not be
+staged with this branch.
+
+To continue, first verify `git diff --check` and
+`git diff --name-status origin/develop...HEAD`; then push only
+`fix/issue-564-omnidocbench-text-quality` and open a PR against `develop`.
+After the PR exists, mark the final checklist item and report its CI status.
+
+For cleanup, `cargo-sweep 0.8.0` was run with both `--dry-run --time 5` and
+`--time 5` against this workspace; both reported nothing eligible, so zero
+bytes were reclaimed. Six project-scoped benchmark paths under `/tmp` were
+inspected (about 1.83 GB total). All were created on 2026-09-03, are newer than
+the five-day cutoff, and include evidence referenced above, so all six were
+preserved. No uncertain cleanup candidates were deleted.

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -224,13 +224,16 @@ impl PlainTextExtractor {
         page_index: u32,
     ) -> ParseResult<PlainTextResult> {
         // Layout-aware plain text needs the same font metrics, graphics-state
-        // handling, marked-content filtering and geometric reconstruction as
-        // the position-bearing extractor. Keeping a second partial
-        // implementation here made `preserve_layout()` less accurate than the
-        // lower-level API it is intended to simplify.
+        // handling and marked-content filtering as the position-bearing
+        // extractor. Rebuild the full engine's flat text with its scale-relative
+        // XY-cut orderer: fragment-level column reconstruction recovers slightly
+        // more benchmark text, but regresses the native reading-order gate.
         if self.config.preserve_layout {
             let options = ExtractionOptions {
-                preserve_layout: true,
+                // The public facade still preserves line structure. This flag
+                // selects the full engine's flat reconstruction so XY-cut can
+                // order complete line groups without exposing fragments.
+                preserve_layout: false,
                 space_threshold: self.config.space_threshold,
                 tj_space_threshold: self.config.tj_space_threshold,
                 newline_threshold: self.config.newline_threshold,
@@ -242,8 +245,9 @@ impl PlainTextExtractor {
                 ),
                 ..Default::default()
             };
-            let extracted =
-                TextExtractor::with_options(options).extract_from_page(document, page_index)?;
+            let extracted = TextExtractor::with_options(options)
+                .with_reading_order(true)
+                .extract_from_page(document, page_index)?;
             return Ok(PlainTextResult::new(
                 self.apply_line_break_mode(&extracted.text),
             ));

--- a/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
+++ b/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
@@ -54,3 +54,21 @@ fn layout_plaintext_propagates_extraction_errors() {
         "Syntax error at position 0: Page index 1 out of range (document has 1 pages)"
     );
 }
+
+#[test]
+fn layout_plaintext_reads_interleaved_columns_left_then_right() {
+    let text = extract(
+        b"BT\n/F1 10 Tf\n\
+          1 0 0 1 330 700 Tm\n(right one) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 700 Tm\n(left one) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 330 680 Tm\n(right two) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 680 Tm\n(left two) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 330 660 Tm\n(right three) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 660 Tm\n(left three) Tj\nET\n",
+    );
+
+    assert_eq!(
+        text.trim_end(),
+        "left one\nleft two\nleft three\nright one\nright two\nright three"
+    );
+}

--- a/tools/benchmarks/omnidocbench_gate.py
+++ b/tools/benchmarks/omnidocbench_gate.py
@@ -84,13 +84,48 @@ def git_output(*args: str) -> str:
     ).stdout.rstrip("\n")
 
 
+def _matches_lfs_pointer(root: Path, relative: str) -> bool:
+    path = root / relative
+    if not path.is_file():
+        return False
+    pointer = subprocess.run(
+        ["git", "-C", str(root), "show", f"HEAD:{relative}"],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    lines = pointer.decode("ascii", errors="replace").splitlines()
+    if len(lines) != 3 or lines[0] != "version https://git-lfs.github.com/spec/v1":
+        return False
+    if not lines[1].startswith("oid sha256:") or not lines[2].startswith("size "):
+        return False
+    expected_hash = lines[1].removeprefix("oid sha256:")
+    try:
+        expected_size = int(lines[2].removeprefix("size "))
+    except ValueError:
+        return False
+    return path.stat().st_size == expected_size and file_hash(path) == expected_hash
+
+
 def git_provenance(allow_dirty: bool, source_root: Path | None = None) -> dict[str, Any]:
     prefix = ("-C", str(source_root.resolve())) if source_root else ()
+    root = source_root.resolve() if source_root else Path.cwd()
     sha = git_output(*prefix, "rev-parse", "HEAD")
-    status = git_output(*prefix, "status", "--porcelain=v1", "--untracked-files=all")
+    raw_status = git_output(
+        *prefix, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    )
+    entries = [entry for entry in raw_status.split("\0") if entry]
+    materialized_lfs = [
+        entry[3:]
+        for entry in entries
+        if entry.startswith(" M ") and _matches_lfs_pointer(root, entry[3:])
+    ]
+    remaining = [entry for entry in entries if entry[3:] not in materialized_lfs]
+    status = "\0".join(remaining)
     if status and not allow_dirty:
         raise ValueError("dirty worktree cannot be labelled as a clean commit; pass --allow-dirty")
     result: dict[str, Any] = {"git_sha": sha, "worktree_clean": not bool(status)}
+    if materialized_lfs:
+        result["verified_materialized_lfs_files"] = len(materialized_lfs)
     if status:
         diff = git_output(*prefix, "diff", "--binary", "HEAD")
         untracked = git_output(*prefix, "ls-files", "--others", "--exclude-standard", "-z")
@@ -191,7 +226,7 @@ def summarize_scores(
         raise ValueError("scores JSON must be an object")
     metadata = _dataset_metadata(dataset)
     expected = {name for name, item in metadata.items() if item["text_scorable"]}
-    unknown = sorted(set(scores) - expected)
+    unknown = sorted(set(scores) - set(metadata))
     missing = sorted(expected - set(scores))
     if unknown:
         raise ValueError(f"scores reference {len(unknown)} unknown pages; first: {unknown[0]}")
@@ -200,7 +235,7 @@ def summarize_scores(
 
     native: list[float] = []
     global_values: list[float] = []
-    for name in sorted(expected):
+    for name in sorted(scores):
         score = scores[name]
         if (
             not isinstance(score, (int, float))
@@ -225,6 +260,7 @@ def summarize_scores(
             "version": POPULATION_VERSION,
             "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
             "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+            "scored_pages_sha256": canonical_hash(sorted(scores)),
         },
         "counts": {
             "dataset": len(metadata),
@@ -270,6 +306,10 @@ def compare_summaries(baseline: dict[str, Any], candidate: dict[str, Any]) -> di
     ]
     if count_mismatches:
         raise ValueError(f"incompatible benchmark population counts: {', '.join(count_mismatches)}")
+    left_pages = baseline.get("population", {}).get("scored_pages_sha256")
+    right_pages = candidate.get("population", {}).get("scored_pages_sha256")
+    if not left_pages or left_pages != right_pages:
+        raise ValueError("incompatible scored-page population")
     before = baseline["metrics"]
     after = candidate["metrics"]
     return {
@@ -293,6 +333,23 @@ def source_pdf_identity(entry: dict[str, Any]) -> tuple[str, int]:
     if not source.lower().endswith(".pdf"):
         source += ".pdf"
     return source, page_no - 1
+
+
+def resolve_source_pdf(
+    entry: dict[str, Any], pdfs: dict[str, Path]
+) -> tuple[Path, int]:
+    image_name = Path(entry["page_info"]["image_path"]).name
+    split_name = f"{Path(image_name).stem}.pdf"
+    split_pdf = pdfs.get(split_name.casefold())
+    if split_pdf is not None:
+        return split_pdf, 0
+    source_name, page_index = source_pdf_identity(entry)
+    source = pdfs.get(source_name.casefold())
+    if source is None:
+        raise ValueError(
+            f"missing source PDF: tried {split_name} and {source_name}"
+        )
+    return source, page_index
 
 
 def _write_json(path: Path, value: Any) -> None:
@@ -330,10 +387,7 @@ def export_predictions(args: argparse.Namespace) -> None:
     pdfs = _pdf_index(args.pdf_root)
     jobs = []
     for entry in sorted(dataset, key=lambda item: Path(item["page_info"]["image_path"]).name):
-        source_name, page_index = source_pdf_identity(entry)
-        source = pdfs.get(source_name.casefold())
-        if source is None:
-            raise ValueError(f"missing source PDF: {source_name}")
+        source, page_index = resolve_source_pdf(entry, pdfs)
         image_name = Path(entry["page_info"]["image_path"]).name
         jobs.append({"prediction_name": str(Path(image_name).with_suffix(".md")), "pdf_path": str(source), "page_index": page_index})
 

--- a/tools/benchmarks/omnidocbench_gate_test.py
+++ b/tools/benchmarks/omnidocbench_gate_test.py
@@ -1,4 +1,5 @@
 import importlib.util
+import hashlib
 import json
 import argparse
 import shutil
@@ -35,6 +36,7 @@ def page(name, source="book", special=None, page_no=1):
 def sealed_summary(identity=None, dataset_count=1, similarity=0.5):
     value = {
         "identity": identity or GATE.identity_fixture(),
+        "population": {"scored_pages_sha256": "pages"},
         "provenance": {"worktree_clean": True},
         "artifacts": {
             "dataset_sha256": "dataset",
@@ -92,6 +94,13 @@ class JsonAndPopulationTests(unittest.TestCase):
         entry["layout_dets"] = [{"category_type": "code_txt_caption", "text": "caption"}]
         result = GATE.summarize_scores([entry], {"caption.jpg": 0.25})
         self.assertEqual(result["counts"]["official_text_scorable"], 1)
+
+    def test_accepts_evaluator_score_for_known_page_furniture_only_page(self):
+        entry = page("header.jpg")
+        entry["layout_dets"] = [{"category_type": "header", "text": "running title"}]
+        result = GATE.summarize_scores([entry], {"header.jpg": 0.25})
+        self.assertEqual(result["counts"]["official_text_scorable"], 0)
+        self.assertEqual(result["counts"]["scored"], 1)
 
     def test_reports_distinct_global_and_native_populations(self):
         dataset = [
@@ -154,10 +163,46 @@ class IdentityAndHashTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "dirty worktree"):
                 GATE.verified_revision(root, revision, "fixture")
 
+    def test_verified_revision_accepts_only_matching_materialized_lfs_objects(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+            content = b"materialized lfs payload"
+            pointer = (
+                "version https://git-lfs.github.com/spec/v1\n"
+                f"oid sha256:{hashlib.sha256(content).hexdigest()}\n"
+                f"size {len(content)}\n"
+            )
+            (root / "asset.bin").write_text(pointer, encoding="ascii")
+            subprocess.run(["git", "-C", str(root), "add", "asset.bin"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"], check=True)
+            revision = GATE.git_output("-C", str(root), "rev-parse", "HEAD")
+
+            (root / "asset.bin").write_bytes(content)
+            provenance = GATE.verified_revision(root, revision, "fixture")
+            self.assertTrue(provenance["worktree_clean"])
+            self.assertEqual(provenance["verified_materialized_lfs_files"], 1)
+
+            (root / "asset.bin").write_bytes(content + b"tampered")
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.verified_revision(root, revision, "fixture")
+
     def test_population_count_mismatch_is_not_comparable(self):
         baseline = sealed_summary(dataset_count=2)
         candidate = sealed_summary(dataset_count=3)
         with self.assertRaisesRegex(ValueError, "population counts"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_scored_page_population_mismatch_is_not_comparable(self):
+        baseline = sealed_summary()
+        candidate = sealed_summary()
+        candidate["population"]["scored_pages_sha256"] = "different-pages"
+        candidate["summary_sha256"] = GATE.canonical_hash(
+            {key: value for key, value in candidate.items() if key != "summary_sha256"}
+        )
+        with self.assertRaisesRegex(ValueError, "scored-page population"):
             GATE.compare_summaries(baseline, candidate)
 
     def test_compare_rejects_tampered_or_dirty_summaries(self):
@@ -176,6 +221,17 @@ class IdentityAndHashTests(unittest.TestCase):
 
 
 class PdfResolutionTests(unittest.TestCase):
+    def test_prefers_page_specific_pdf_when_dataset_stores_split_pages(self):
+        entry = page("source.pdf_7.jpg", page_no=7)
+        split_pdf = Path("/dataset/ori_pdfs/source.pdf_7.pdf")
+        combined_pdf = Path("/dataset/ori_pdfs/source.pdf")
+        pdfs = {
+            split_pdf.name.casefold(): split_pdf,
+            combined_pdf.name.casefold(): combined_pdf,
+        }
+
+        self.assertEqual(GATE.resolve_source_pdf(entry, pdfs), (split_pdf, 0))
+
     def test_resolves_pdf_suffix_and_one_based_page(self):
         self.assertEqual(
             GATE.source_pdf_identity(page("source.pdf_7.jpg", page_no=7)),


### PR DESCRIPTION
## Summary
- route layout-preserving plaintext extraction through the complete text engine and XY-Cut reading order
- add the issue #564 regression test and harden the reproducible OmniDocBench gate
- document the TDD trace, sealed benchmark evidence, and completed quality review

## Measurement
- global text similarity: 48.26% -> 60.01% (target >=55%)
- global text edit distance: 0.51741 -> 0.39994
- native reading-order edit distance: 0.22639 (limit <=0.25)
- 981 predictions, 1 known baseline Invalid Filter failure

## Validation
- cargo test --lib: 6,777 passed, 3 ignored
- focused #564 tests: 4 passed
- neighboring #477/#495/#521 tests: 9 passed
- T0: 21 passed, 3 ignored; T1: 22 passed
- exporter tests: 2 passed; benchmark gate tests: 21 passed
- formatting, Clippy, build, diff check, and formal QR passed

Closes #564