### PR TITLE
chore: prepare release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased]
 
+## [5.0.1] - 2026-09-04
+
+### Fixed
+
+- **Layout-preserving plaintext extraction restores document reading quality**
+  (#564, #570). `PlainTextExtractor::preserve_layout()` now uses the complete
+  text engine and its scale-relative XY-Cut reading order, retaining
+  `/ActualText`, artifact filtering, font metrics, and error propagation. On
+  the pinned OmniDocBench protocol, global text similarity improves from
+  48.26% in v5.0.0 to 60.01%, above the 55% acceptance threshold, while native
+  reading-order edit distance remains within its 0.25 limit at 0.22639.
+
+### Changed
+
+- **OmniDocBench quality measurements are reproducible** (#565, #568). The
+  versioned gate pins dataset, evaluator, source, extraction configuration, and
+  scored-page population provenance, validates materialized Git LFS objects,
+  supports split-page PDFs, and seals prediction and summary hashes.
+
 ## [5.0.0] - 2026-09-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxidize-pdf"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 rust-version = "1.88"  # MSRV - dependency floor: subprocess (let-chains), image 0.25.10, time 0.3.47 all require 1.88
 authors = ["Santiago Fernández Muñoz"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most PDF libraries give you a wall of text. oxidize-pdf gives you **structured, 
 
 ```toml
 [dependencies]
-oxidize-pdf = "5.0.0"
+oxidize-pdf = "5.0.1"
 ```
 
 ### RAG Pipeline -- One Liner

--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -1,0 +1,36 @@
+# Issue #564 — text-quality correction (TDD trace)
+
+## Red
+
+- [x] Add a focused regression proving that layout-aware plain text follows
+  column reading order when content streams interleave the two columns.
+- [x] Confirm the regression fails with the reviewed `detect_columns = false`
+  configuration.
+
+## Green
+
+- [x] Reject direct column reconstruction after it reached 61.10% text similarity
+  but regressed native reading-order edit distance to 0.27748.
+- [x] Use the existing scale-relative XY-Cut orderer without restoring the
+  rejected error-swallowing fallback.
+- [x] Pass the focused #564 tests and neighboring #477, #495, and #521 tests
+  (4 + 5 + 3 + 1 passed).
+- [x] Pass the library suite (6,777 passed, 3 ignored), Clippy, formatting,
+  T0 (21 passed, 3 ignored), and T1 (22 passed).
+
+## Benchmark acceptance
+
+- [x] Generate predictions from the candidate with OCR disabled and without
+  flattening line breaks (981 written, 1 known invalid-filter failure).
+- [x] Run pinned OmniDocBench `end2end_eval` / `quick_match`.
+- [x] Confirm official global text similarity is at least 55% (60.01%).
+- [ ] Re-run the benchmark from the final clean commit and seal its manifest.
+- [ ] Attach global, native-text, category, extraction-error, and reading-order
+  before/after metrics.
+- [ ] Keep the issue open if the exact committed candidate misses any criterion.
+
+## Quality review and delivery
+
+- [ ] Run the formal QR, including Kripteia test-quality and security analysis.
+- [ ] Correct every finding and repeat affected checks.
+- [ ] Open a PR only after the QR has no remaining findings.

--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -24,13 +24,14 @@
   flattening line breaks (981 written, 1 known invalid-filter failure).
 - [x] Run pinned OmniDocBench `end2end_eval` / `quick_match`.
 - [x] Confirm official global text similarity is at least 55% (60.01%).
-- [ ] Re-run the benchmark from the final clean commit and seal its manifest.
-- [ ] Attach global, native-text, category, extraction-error, and reading-order
+- [x] Re-run the benchmark from clean implementation commit `36a9d11c` and
+  seal its manifest and summary.
+- [x] Attach global, native-text, category, extraction-error, and reading-order
   before/after metrics.
-- [ ] Keep the issue open if the exact committed candidate misses any criterion.
+- [x] Confirm the exact committed candidate misses no acceptance criterion.
 
 ## Quality review and delivery
 
-- [ ] Run the formal QR, including Kripteia test-quality and security analysis.
-- [ ] Correct every finding and repeat affected checks.
+- [x] Run the formal QR, including Kripteia test-quality and security analysis.
+- [x] Correct every confirmed finding and repeat affected checks.
 - [ ] Open a PR only after the QR has no remaining findings.

--- a/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
+++ b/docs/plans/2026-09-03-issue-564-text-quality-correction-tdd.md
@@ -34,4 +34,4 @@
 
 - [x] Run the formal QR, including Kripteia test-quality and security analysis.
 - [x] Correct every confirmed finding and repeat affected checks.
-- [ ] Open a PR only after the QR has no remaining findings.
+- [x] Open PR #570 only after the QR has no remaining findings.

--- a/docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md
+++ b/docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md
@@ -1,0 +1,57 @@
+# Issue #568 — reproducible OmniDocBench gate (TDD plan)
+
+This checklist is the implementation trace. A checked item has a corresponding
+automated test or an explicitly recorded external validation requirement.
+
+## Red: specify observable behavior
+
+- [x] Reject duplicate JSON object keys instead of silently overwriting scores.
+- [x] Reject duplicate dataset page names and unknown, missing, non-finite, or
+  out-of-range page scores.
+- [x] Keep official-global and native-text populations separate, with explicit
+  included, excluded, missing, duplicate, and failed counts.
+- [x] Version the `note` / `fuzzy_scan` native-text exclusion predicate.
+- [x] Canonicalize JSON before hashing so input ordering cannot change hashes.
+- [x] Reject baseline/candidate comparisons when their protocol identity differs.
+- [x] Refuse clean-commit provenance for a dirty worktree unless dirty provenance
+  is explicitly requested and includes a diff hash.
+- [x] Resolve OmniDocBench image names to source PDFs and page indices
+  deterministically.
+
+## Green: minimal implementation
+
+- [x] Add a repository-owned Rust prediction exporter using the public native-text
+  extraction API and a fixed, serialized extraction configuration.
+- [x] Add a Python gate that validates official per-page text scores, emits a
+  versioned summary, and compares compatible baseline/candidate summaries.
+- [x] Record Git SHA, worktree state, extraction configuration, dataset and
+  evaluator revisions, protocol, OCR state, population definition, and artifact
+  hashes.
+- [x] Add one documented command for prediction export and summary generation
+  from externally supplied PDFs, dataset metadata, and official score artifact.
+- [x] Make failures and empty predictions explicit without introducing OCR.
+- [x] Build from a temporary `git archive` with the evaluated commit's own
+  locked dependencies; no auxiliary relative path dependency is used.
+- [x] Verify dataset/evaluator Git revisions and record the Rust/Cargo toolchain.
+- [x] Re-hash predictions during summary and reject tampered or dirty summaries.
+- [x] Serialize effective extraction configuration from Rust, group pages by
+  source PDF, and publish the prediction tree atomically.
+
+## Refactor and verification
+
+- [x] Run the focused Python suite and Rust exporter tests (17 gate tests and
+  2 focused Rust exporter tests; native-reading-order regressions run separately).
+- [x] Run formatting, clippy for the exporter, and `git diff --check`.
+- [x] Verify two synthetic repeated runs produce identical prediction hashes.
+- [x] Feed the existing pinned official `d5e2d0b` score artifact through the gate:
+  921 global pages at `0.5085693812417305` edit distance and 780 native pages
+  at `0.41990107039261854`.
+- [ ] External: run the pinned OmniDocBench dataset/evaluator and confirm commit
+  `d5e2d0ba5073f28ef56cf13a32871236cff6e11f` reports global edit distance
+  approximately `0.50856938` (similarity `49.1431%`) within `1e-8`.
+- [ ] External: create the v5.0.0 baseline with this same gate/schema and retain
+  both immutable summary artifacts for future comparisons.
+
+The two external items deliberately remain unchecked until the non-redistributable
+dataset and pinned evaluator are supplied. Synthetic tests do not claim benchmark
+acceptance.

--- a/docs/reports/2026-09-02-issue-564-omnidocbench-text-quality.md
+++ b/docs/reports/2026-09-02-issue-564-omnidocbench-text-quality.md
@@ -1,0 +1,71 @@
+# Issue #564 — OmniDocBench native-text quality
+
+Date: 2026-09-02 (UTC)
+
+## Protocol
+
+- oxidize-pdf baseline: 5.0.0
+- Dataset revision: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- Upstream evaluator revision: `337cc26965893db3ef53ddc119a6d6bb5bde096f`
+- Evaluator: official `end2end_eval` with `quick_match`
+- Pages: 981
+- OCR: disabled
+- Extraction errors: 0 before and after
+
+One malformed corpus file fails during document opening with `Invalid Filter
+type` in both runs. It is represented by an empty prediction, as in the
+baseline, and is not an extraction-stage regression.
+
+## Change
+
+`PlainTextExtractor::preserve_layout()` now delegates to the complete
+position-bearing text engine. This removes the independent partial extraction
+path for layout-aware calls and makes the plain-text facade inherit its font
+metrics, form/content traversal, graphics-state handling, `/ActualText`
+substitution, `/Artifact` filtering, and geometric reconstruction.
+
+The lightweight non-layout path remains unchanged.
+
+## Official results
+
+Lower edit distance and higher similarity are better.
+
+| Metric/category | Baseline edit | New edit | Baseline similarity | New similarity |
+|---|---:|---:|---:|---:|
+| Global text | 0.51741 | **0.38902** | 48.26% | **61.10%** |
+| English | 0.26885 | **0.19930** | 73.12% | **80.07%** |
+| Simplified Chinese | 0.58763 | **0.41624** | 41.24% | **58.38%** |
+| English/Chinese mixed | 0.88236 | **0.87599** | 11.76% | **12.40%** |
+| Academic literature | 0.31317 | **0.20967** | 68.68% | **79.03%** |
+| PPT-to-PDF | 0.32537 | **0.23464** | 67.46% | **76.54%** |
+| Books | 0.36134 | **0.30993** | 63.87% | **69.01%** |
+| Magazines | 0.35673 | **0.21462** | 64.33% | **78.54%** |
+| Newspapers | 0.40844 | **0.11743** | 59.16% | **88.26%** |
+
+The official global acceptance threshold is 55% similarity. The measured
+result is 61.10%, 6.10 percentage points above the threshold and 12.84 points
+above the v5.0.0 baseline.
+
+The evaluator wrote the complete metric JSON before its optional display step
+failed against NumPy 2 (`np.NaN` was removed). The figures above come directly
+from that completed official metric artifact.
+
+The official reading-order edit distance changed from 0.31034 to 0.38788.
+Reading-order strategy selection and correction are deliberately tracked by
+#565; this issue changes text recovery and reconstruction, and does not claim a
+reading-order improvement.
+
+## Validation
+
+- `cargo clippy -p oxidize-pdf --lib --test issue_564_plaintext_quality_test -- -D warnings`
+- `cargo test -p oxidize-pdf --lib`: 6,777 passed, 3 ignored
+- Focused #564 tests: 2 passed
+- Neighbor regressions #477, #495, and #521: 9 passed
+- T0 regression corpus: 21 passed, 3 maintenance generators ignored
+- T1 spec corpus: 22 passed
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+The focused regressions prove that layout-aware plain text filters marked
+artifacts, applies `/ActualText`, and uses Standard-14 AFM advances for
+contiguous positioned runs.

--- a/docs/reports/2026-09-02-issue-564-omnidocbench-text-quality.md
+++ b/docs/reports/2026-09-02-issue-564-omnidocbench-text-quality.md
@@ -32,34 +32,36 @@ Lower edit distance and higher similarity are better.
 
 | Metric/category | Baseline edit | New edit | Baseline similarity | New similarity |
 |---|---:|---:|---:|---:|
-| Global text | 0.51741 | **0.38902** | 48.26% | **61.10%** |
-| English | 0.26885 | **0.19930** | 73.12% | **80.07%** |
-| Simplified Chinese | 0.58763 | **0.41624** | 41.24% | **58.38%** |
+| Global text | 0.51741 | **0.38886** | 48.26% | **61.11%** |
+| English | 0.26885 | **0.19880** | 73.12% | **80.12%** |
+| Simplified Chinese | 0.58763 | **0.41622** | 41.24% | **58.38%** |
 | English/Chinese mixed | 0.88236 | **0.87599** | 11.76% | **12.40%** |
-| Academic literature | 0.31317 | **0.20967** | 68.68% | **79.03%** |
+| Academic literature | 0.31317 | **0.20835** | 68.68% | **79.16%** |
 | PPT-to-PDF | 0.32537 | **0.23464** | 67.46% | **76.54%** |
-| Books | 0.36134 | **0.30993** | 63.87% | **69.01%** |
+| Books | 0.36134 | **0.31019** | 63.87% | **68.98%** |
 | Magazines | 0.35673 | **0.21462** | 64.33% | **78.54%** |
 | Newspapers | 0.40844 | **0.11743** | 59.16% | **88.26%** |
 
 The official global acceptance threshold is 55% similarity. The measured
-result is 61.10%, 6.10 percentage points above the threshold and 12.84 points
+result is 61.11%, 6.11 percentage points above the threshold and 12.85 points
 above the v5.0.0 baseline.
 
 The evaluator wrote the complete metric JSON before its optional display step
 failed against NumPy 2 (`np.NaN` was removed). The figures above come directly
 from that completed official metric artifact.
 
-The official reading-order edit distance changed from 0.31034 to 0.38788.
-Reading-order strategy selection and correction are deliberately tracked by
-#565; this issue changes text recovery and reconstruction, and does not claim a
-reading-order improvement.
+The official reading-order edit distance changed from 0.31034 to 0.38785.
+An official A/B run with geometric sorting disabled measured 0.38819, showing
+that sorting and column detection do not account for this change. Reading-order
+strategy selection and correction are deliberately tracked by #565; this issue
+changes text recovery and reconstruction, and does not claim a reading-order
+improvement.
 
 ## Validation
 
 - `cargo clippy -p oxidize-pdf --lib --test issue_564_plaintext_quality_test -- -D warnings`
 - `cargo test -p oxidize-pdf --lib`: 6,777 passed, 3 ignored
-- Focused #564 tests: 2 passed
+- Focused #564 tests: 3 passed
 - Neighbor regressions #477, #495, and #521: 9 passed
 - T0 regression corpus: 21 passed, 3 maintenance generators ignored
 - T1 spec corpus: 22 passed
@@ -67,5 +69,6 @@ reading-order improvement.
 - `git diff --check`
 
 The focused regressions prove that layout-aware plain text filters marked
-artifacts, applies `/ActualText`, and uses Standard-14 AFM advances for
-contiguous positioned runs.
+artifacts, applies `/ActualText`, uses Standard-14 AFM advances for contiguous
+positioned runs, and propagates extraction errors without silently downgrading
+to the legacy parser.

--- a/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
+++ b/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
@@ -10,16 +10,30 @@ Date: 2026-09-02 (UTC)
 - Evaluator: official `end2end_eval` with `quick_match`
 - OCR: disabled
 
-The reported 0.31034257473747384 baseline averages every page for which the
+The unfiltered 0.31034257473747384 diagnostic averages every page for which the
 official evaluator emits a reading-order result. That population includes 113
-pages without native text, principally scanned notes. Those pages score 1.0
-when OCR is disabled and contribute 0.1227 to the global average, but issue
-#565 explicitly excludes OCR, image-only notes, and fuzzy scans.
+pages labelled `data_source: note` and another 28 pages labelled `fuzzy_scan`
+under `special_issue` by the pinned dataset. Notes score 1.0 when OCR is
+disabled and contribute 0.1227 to the unfiltered average, but issue #565
+explicitly excludes image-only notes, fuzzy scans, and OCR.
 
-Filtering the completed official per-page artifact by the pinned dataset's
-`page_attribute` metadata leaves 808 native-text pages. Their official
-reading-order edit distance is **0.21389295957080867**, below the issue's 0.25
-acceptance ceiling. No OCR feature is enabled or required.
+The repository's native-scope aggregator filters the completed official
+per-page artifact using those explicit metadata labels. It leaves 780 native-text
+pages with a scoped official reading-order edit distance of
+**0.18610108290582916**, below the issue's 0.25 acceptance ceiling. No OCR
+feature is enabled or required.
+
+Reproduce the scoped artifact with:
+
+```bash
+python3 tools/benchmarks/omnidocbench_native_reading_order.py \
+  /path/to/pinned/OmniDocBench.json \
+  /path/to/official_reading_order_per_page_edit.json \
+  --output native-reading-order.json
+```
+
+The output records the protocol, exact exclusion predicate, official scored
+population, excluded and retained counts, global value, and category values.
 
 ## Native-text results
 
@@ -27,22 +41,22 @@ Lower edit distance is better.
 
 | Category | Pages | Edit distance |
 |---|---:|---:|
-| Global native text | 808 | **0.21389** |
-| English | 275 | 0.07897 |
-| Simplified Chinese | 502 | 0.26020 |
-| English/Chinese mixed | 31 | 0.66092 |
-| Single column | 313 | 0.20288 |
-| Double column | 123 | 0.25292 |
-| One-or-more column | 120 | 0.19934 |
+| Global native text | 780 | **0.18610** |
+| English | 271 | 0.06537 |
+| Simplified Chinese | 480 | 0.22699 |
+| English/Chinese mixed | 29 | 0.63754 |
+| Single column | 302 | 0.17384 |
+| Double column | 113 | 0.18680 |
+| One-or-more column | 119 | 0.19261 |
 | Three column | 45 | 0.13632 |
-| Other layout | 207 | 0.23266 |
+| Other layout | 201 | 0.21141 |
 | Academic literature | 122 | 0.03815 |
-| Books | 83 | 0.08700 |
-| Colorful textbooks | 93 | 0.56693 |
-| Exam papers | 113 | 0.63776 |
-| Magazines | 92 | 0.13655 |
+| Books | 82 | 0.07586 |
+| Colorful textbooks | 81 | 0.50277 |
+| Exam papers | 101 | 0.59472 |
+| Magazines | 91 | 0.12706 |
 | Newspapers | 111 | 0.02294 |
-| PPT-to-PDF | 128 | 0.08633 |
+| PPT-to-PDF | 126 | 0.07447 |
 | Research reports | 66 | 0.15152 |
 
 ## Strategy experiments
@@ -50,12 +64,12 @@ Lower edit distance is better.
 Experiments were evaluated with the same pinned official protocol before being
 rejected:
 
-| Strategy | Text edit | Reading-order edit | Decision |
-|---|---:|---:|---|
-| Published v5.0.0 emission order | 0.51741 | 0.31034 | Native baseline |
-| Layout reconstruction from #564 | 0.38886 | 0.38785 | Reject for ordering |
-| Layout plus automatic line joining | 0.48547 | 0.34643 | Reject globally |
-| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | Reject globally |
+| Strategy | Text edit (all) | Reading edit (all) | Reading edit (native) | Decision |
+|---|---:|---:|---:|---|
+| Published v5.0.0 emission order | 0.51741 | 0.31034 | **0.18610** | Retain |
+| Layout reconstruction from #564 | 0.38886 | 0.38785 | 0.27744 | Reject for ordering |
+| Layout plus automatic line joining | 0.48547 | 0.34643 | 0.22872 | Reject globally |
+| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | 0.22534 | Reject globally |
 
 The alternatives improve selected categories but worsen the official global
 reading-order metric. The current emission-order default is therefore retained;
@@ -68,9 +82,11 @@ positioned `Tj` and `TJ` label/value cells and verifies that values and labels
 are not glued across rows.
 
 - `cargo test -p oxidize-pdf --test issue_495_flat_grid_order_test`: 3 passed
-- Existing corpus baseline: zero parser panics
-- Source changes: none
+- `python3 -m unittest tools/benchmarks/omnidocbench_native_reading_order_test.py`: 7 passed
+- Aggregator failure coverage: unknown and duplicate pages, invalid, non-finite and out-of-range scores, and empty native population
+- Production extraction source changes: none
 
-The original 0.31034 and scoped 0.21389 figures come from the same official
-per-page result artifact. The change is the population required by #565's
-native-text scope, not a replacement metric or evaluator.
+The unfiltered 0.31034 diagnostic and scoped 0.18610 acceptance figure come
+from the same official per-page result artifact. The versioned aggregator and
+its focused tests make the native-text population explicit and reproducible;
+they do not replace or approximate the upstream metric.

--- a/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
+++ b/docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md
@@ -1,0 +1,76 @@
+# Issue #565 — OmniDocBench native-text reading order
+
+Date: 2026-09-02 (UTC)
+
+## Protocol audit
+
+- oxidize-pdf baseline: 5.0.0
+- Dataset revision: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- Upstream evaluator revision: `337cc26965893db3ef53ddc119a6d6bb5bde096f`
+- Evaluator: official `end2end_eval` with `quick_match`
+- OCR: disabled
+
+The reported 0.31034257473747384 baseline averages every page for which the
+official evaluator emits a reading-order result. That population includes 113
+pages without native text, principally scanned notes. Those pages score 1.0
+when OCR is disabled and contribute 0.1227 to the global average, but issue
+#565 explicitly excludes OCR, image-only notes, and fuzzy scans.
+
+Filtering the completed official per-page artifact by the pinned dataset's
+`page_attribute` metadata leaves 808 native-text pages. Their official
+reading-order edit distance is **0.21389295957080867**, below the issue's 0.25
+acceptance ceiling. No OCR feature is enabled or required.
+
+## Native-text results
+
+Lower edit distance is better.
+
+| Category | Pages | Edit distance |
+|---|---:|---:|
+| Global native text | 808 | **0.21389** |
+| English | 275 | 0.07897 |
+| Simplified Chinese | 502 | 0.26020 |
+| English/Chinese mixed | 31 | 0.66092 |
+| Single column | 313 | 0.20288 |
+| Double column | 123 | 0.25292 |
+| One-or-more column | 120 | 0.19934 |
+| Three column | 45 | 0.13632 |
+| Other layout | 207 | 0.23266 |
+| Academic literature | 122 | 0.03815 |
+| Books | 83 | 0.08700 |
+| Colorful textbooks | 93 | 0.56693 |
+| Exam papers | 113 | 0.63776 |
+| Magazines | 92 | 0.13655 |
+| Newspapers | 111 | 0.02294 |
+| PPT-to-PDF | 128 | 0.08633 |
+| Research reports | 66 | 0.15152 |
+
+## Strategy experiments
+
+Experiments were evaluated with the same pinned official protocol before being
+rejected:
+
+| Strategy | Text edit | Reading-order edit | Decision |
+|---|---:|---:|---|
+| Published v5.0.0 emission order | 0.51741 | 0.31034 | Native baseline |
+| Layout reconstruction from #564 | 0.38886 | 0.38785 | Reject for ordering |
+| Layout plus automatic line joining | 0.48547 | 0.34643 | Reject globally |
+| Flat scale-relative XY-Cut | 0.39849 | 0.34357 | Reject globally |
+
+The alternatives improve selected categories but worsen the official global
+reading-order metric. The current emission-order default is therefore retained;
+no benchmark-specific classifier or OCR dependency is introduced.
+
+## Issue #495 and validation
+
+Issue #495 is fixed. `issue_495_flat_grid_order_test` covers independently
+positioned `Tj` and `TJ` label/value cells and verifies that values and labels
+are not glued across rows.
+
+- `cargo test -p oxidize-pdf --test issue_495_flat_grid_order_test`: 3 passed
+- Existing corpus baseline: zero parser panics
+- Source changes: none
+
+The original 0.31034 and scoped 0.21389 figures come from the same official
+per-page result artifact. The change is the population required by #565's
+native-text scope, not a replacement metric or evaluator.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -38,6 +38,12 @@ The official text artifact contains 945 scored text entries; the official
 reading-order artifact contains 921 pages, of which the versioned #565 filter
 classifies 780 as native text.
 
+The clean implementation commit is
+`36a9d11c7da38e3b959171cfad06840cc5ff724e`. Its prediction-tree SHA-256 is
+`6a9240ec5b3a8a800a5f8813942edd2ee51eabed85d33f98e9c3f0d6ce3abedf` and
+the sealed summary SHA-256 is
+`431f967ef1f64ac66cc74ddc62d304164452f10cf29be97eadd080a0081c59a0`.
+
 ## Reproducibility correction
 
 The first rerun incorrectly used the historical comparison runner, which
@@ -48,5 +54,26 @@ back to a combined source PDF (`source.pdf`, page index N-1). Its exporter write
 the extracted text unchanged, preserving the line structure used by the
 official evaluator.
 
-Final clean-commit validation and formal quality review remain pending; no PR
-will be opened before both complete.
+The final gate also verifies materialized Git LFS objects by their committed
+SHA-256 and size when `git-lfs` is unavailable, rejects altered objects, accepts
+the evaluator's prediction-dependent optional text pages only when they belong
+to the pinned dataset, and seals the exact scored-page population in the
+summary.
+
+## Validation and quality review
+
+- Library suite: 6,777 passed, 3 ignored.
+- Focused #564: 4 passed; neighboring #477/#495/#521: 9 passed.
+- T0: 21 passed, 3 maintenance generators ignored; T1: 22 passed.
+- Exporter tests: 2 passed; benchmark gate: 21 passed.
+- Formatting, Clippy, build and `git diff --check`: passed.
+- Kripteia Rust: 94/100 globally; focused #564 tests: 90/100.
+- Kripteia Python: no tests discovered; the 21 `unittest` cases above are the
+  direct test evidence.
+- Kripteia security: no issues in either Rust or Python scope.
+
+The review found and corrected misleading cross-revision extraction metadata,
+missing split-PDF resolution, Git LFS provenance handling and incomplete
+official score-population handling. A proposed `page_no` validation finding was
+disproved against the pinned dataset and was not retained. The repeated final
+review has no remaining findings. No PR was opened during validation.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -104,3 +104,8 @@ bytes were reclaimed. Six project-scoped benchmark paths under `/tmp` were
 inspected (about 1.83 GB total). All were created on 2026-09-03, are newer than
 the five-day cutoff, and include evidence referenced above, so all six were
 preserved. No uncertain cleanup candidates were deleted.
+
+## Delivery
+
+PR #570 was opened against `develop` after the quality review completed with no
+remaining findings: https://github.com/bzsanti/oxidizePdf/pull/570

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -1,0 +1,52 @@
+# Issue #564 — text-quality correction
+
+Date: 2026-09-03 (UTC)
+
+## Outcome
+
+`PlainTextExtractor::preserve_layout()` now uses the complete text engine and
+orders its line groups with the existing scale-relative XY-Cut implementation.
+This retains `/ActualText`, artifact filtering, font metrics and error
+propagation while satisfying both the text-quality gate from #564 and the
+native reading-order gate from #565.
+
+The first correction candidate enabled fragment-level column reconstruction.
+It reached 61.10% text similarity, but was rejected because its native
+reading-order edit distance was 0.27748, above #565's maximum of 0.25.
+
+## Pinned protocol
+
+- Dataset revision: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- Evaluator revision: `337cc26965893db3ef53ddc119a6d6bb5bde096f`
+- Evaluator: official `end2end_eval` / `quick_match`
+- OCR: disabled
+- Predictions written: 981
+- Extraction failures: 1 (`Invalid Filter type`, also present in the baseline)
+
+## Candidate measurements
+
+Lower edit distance and higher similarity are better.
+
+| Metric | v5.0.0 baseline | Candidate | Acceptance |
+|---|---:|---:|---:|
+| Global text edit distance | 0.51741 | **0.39994** | — |
+| Global text similarity | 48.26% | **60.01%** | ≥55% |
+| Global reading-order edit distance | 0.31034 | 0.34447 | diagnostic |
+| Native reading-order edit distance | 0.18610 | **0.22639** | ≤0.25 |
+
+The official text artifact contains 945 scored text entries; the official
+reading-order artifact contains 921 pages, of which the versioned #565 filter
+classifies 780 as native text.
+
+## Reproducibility correction
+
+The first rerun incorrectly used the historical comparison runner, which
+normalizes whitespace before writing Markdown predictions and therefore
+reported only 49.14% similarity. The versioned gate now prefers exact
+page-specific PDFs (`source.pdf_N.pdf`, page index zero) when present and falls
+back to a combined source PDF (`source.pdf`, page index N-1). Its exporter writes
+the extracted text unchanged, preserving the line structure used by the
+official evaluator.
+
+Final clean-commit validation and formal quality review remain pending; no PR
+will be opened before both complete.

--- a/docs/reports/2026-09-03-issue-564-text-quality-correction.md
+++ b/docs/reports/2026-09-03-issue-564-text-quality-correction.md
@@ -77,3 +77,30 @@ missing split-PDF resolution, Git LFS provenance handling and incomplete
 official score-population handling. A proposed `page_no` validation finding was
 disproved against the pinned dataset and was not retained. The repeated final
 review has no remaining findings. No PR was opened during validation.
+
+## Session handoff
+
+The session closed on branch `fix/issue-564-omnidocbench-text-quality` at
+`472f4fbc3b6ad26d3919170d62c9b444cfc7dc0b`, after refreshing
+`origin/develop` to `d1a1ab0e99098e01cc51a04aa5ee315f5772ab4d`. The diff
+against that base contains only the six #564 files listed in this report and
+plan. The quality review is complete; the only unchecked acceptance item is
+opening the PR.
+
+The worktree also contains pre-existing or user-owned changes in `README.md`,
+`docs/reports/2026-09-02-issue-565-omnidocbench-reading-order.md`,
+`oxidize-pdf-core/Cargo.toml`, and eight untracked handoff reports dated
+2026-08-25 through 2026-09-01. They are unrelated to #564 and must not be
+staged with this branch.
+
+To continue, first verify `git diff --check` and
+`git diff --name-status origin/develop...HEAD`; then push only
+`fix/issue-564-omnidocbench-text-quality` and open a PR against `develop`.
+After the PR exists, mark the final checklist item and report its CI status.
+
+For cleanup, `cargo-sweep 0.8.0` was run with both `--dry-run --time 5` and
+`--time 5` against this workspace; both reported nothing eligible, so zero
+bytes were reclaimed. Six project-scoped benchmark paths under `/tmp` were
+inspected (about 1.83 GB total). All were created on 2026-09-03, are newer than
+the five-day cutoff, and include evidence referenced above, so all six were
+preserved. No uncertain cleanup candidates were deleted.

--- a/docs/reports/2026-09-03-issue-568-omnidocbench-gate.md
+++ b/docs/reports/2026-09-03-issue-568-omnidocbench-gate.md
@@ -1,0 +1,102 @@
+# Issue #568 — reproducible OmniDocBench gate
+
+## Contract
+
+The repository owns both sides of the measurement boundary:
+
+- `omnidocbench_export.rs` extracts every dataset page through
+  `PlainTextExtractor::preserve_layout()` with OCR disabled. It writes an empty
+  prediction for a failed page and records that failure instead of silently
+  dropping the page.
+- `omnidocbench_gate.py` resolves source PDFs, records provenance and hashes,
+  validates the official per-page text artifact, reports global and native-text
+  populations separately, and rejects incompatible comparisons.
+
+The gate creates a temporary `git archive` of `--source-root`, adds the same
+versioned exporter to that archive, and compiles it with the archived commit's
+own workspace manifest and lockfile using `--locked --offline`. This measures a
+clean `v5.0.0` worktree and a clean candidate without modifying either checkout
+or introducing a separate path dependency.
+
+## Reproduction identity
+
+- Schema: `oxidize-pdf-omnidocbench-gate/v1`
+- Dataset and evaluator revisions: verified against clean Git checkouts
+- Protocol: official `end2end_eval` / `quick_match` / `text`
+- OCR: disabled; it is neither configured nor linked by the exporter
+- Native population: `native-text-v1`, excluding `data_source == note` and any
+  page whose `special_issue` contains `fuzzy_scan`
+- Extraction configuration: serialized by the Rust exporter from the effective
+  `PlainTextConfig::preserve_layout()` values
+- Build identity: archived `Cargo.lock` hash plus `rustc -Vv` and `cargo -V`
+
+The official text population is derived from the evaluator's versioned text
+categories (`text_block`, `title`, `code_txt`, and `reference`). With the pinned
+dataset this identifies 921 text-scorable pages and 60 pages containing only
+non-text/ignored categories.
+
+## Commands
+
+From this repository, generate predictions and their provenance manifest in one
+command. `PDF_ROOT` may contain nested directories, but source PDF basenames
+must be unique. The dataset image name and `page_no` resolve the source name and
+zero-based page index (for example `paper.pdf_7.jpg` becomes page 6 of
+`paper.pdf`).
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py export \
+  --source-root /path/to/clean/oxidize-pdf-checkout \
+  --dataset-root /data/omnidocbench \
+  --evaluator-root /path/to/clean/evaluator-checkout \
+  --dataset /data/omnidocbench/OmniDocBench.json \
+  --pdf-root /data/source-pdfs \
+  --predictions /artifacts/predictions \
+  --manifest /artifacts/run-manifest.json \
+  --dataset-revision f5f559bddf50e36f7f9899d842d0006f13ce8afc \
+  --evaluator-revision 337cc26965893db3ef53ddc119a6d6bb5bde096f
+```
+
+The command refuses a dirty source checkout by default. `--allow-dirty` is for
+experiments only and records a dirty-state hash; such a run is not labelled as
+the clean Git commit.
+
+Run the pinned upstream evaluator over the generated Markdown directory. Then
+validate its `*_quick_match_text_block_per_page_edit.json` artifact:
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py summarize \
+  --dataset /data/omnidocbench/OmniDocBench.json \
+  --scores /artifacts/model_quick_match_text_block_per_page_edit.json \
+  --predictions /artifacts/predictions \
+  --evaluator-root /path/to/clean/evaluator-checkout \
+  --manifest /artifacts/run-manifest.json \
+  --output /artifacts/summary.json
+```
+
+The summary recomputes the prediction-tree hash and re-verifies the evaluator
+revision. Compare clean, untampered baseline and candidate summaries only when
+their machine-readable identities and population counts agree:
+
+```bash
+python3 tools/benchmarks/omnidocbench_gate.py compare \
+  --baseline /artifacts/v5.0.0-summary.json \
+  --candidate /artifacts/candidate-summary.json \
+  --output /artifacts/comparison.json
+```
+
+## Reproduced final #564 result
+
+Feeding the pinned official per-page artifact for `d5e2d0b` through the gate
+produces:
+
+| Population | Pages | Edit distance | Similarity |
+|---|---:|---:|---:|
+| Official global text | 921 | 0.5085693812417305 | 49.1430618758% |
+| Native text v1 | 780 | 0.41990107039261854 | 58.0098929607% |
+
+This reproduces the final commit rather than the earlier 61.11% experimental
+artifact. The 60 non-scorable dataset pages are reported separately; all 981
+pages must still have prediction files.
+
+The implementation checklist and remaining external full-run validation are in
+`docs/plans/2026-09-03-issue-568-omnidocbench-gate-tdd.md`.

--- a/oxidize-pdf-core/examples/omnidocbench_export.rs
+++ b/oxidize-pdf-core/examples/omnidocbench_export.rs
@@ -1,0 +1,211 @@
+//! Deterministic native-text prediction exporter for OmniDocBench.
+
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::plaintext::{PlainTextConfig, PlainTextExtractor};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct Job {
+    prediction_name: String,
+    pdf_path: PathBuf,
+    page_index: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct Counts {
+    attempted: usize,
+    written: usize,
+    failed: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct Failure {
+    prediction_name: String,
+    error: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ExtractionConfig {
+    api: &'static str,
+    preserve_layout: bool,
+    line_break_mode: &'static str,
+    space_threshold: f64,
+    tj_space_threshold: f64,
+    newline_threshold: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    counts: Counts,
+    failures: Vec<Failure>,
+    extraction_config: ExtractionConfig,
+}
+
+fn prediction_path(output: &Path, name: &str) -> Result<PathBuf, String> {
+    let path = Path::new(name);
+    if path.components().count() != 1
+        || path.extension().and_then(|part| part.to_str()) != Some("md")
+    {
+        return Err(format!("invalid prediction filename: {name}"));
+    }
+    Ok(output.join(path))
+}
+
+fn extraction_config() -> ExtractionConfig {
+    let config = PlainTextConfig::preserve_layout();
+    ExtractionConfig {
+        api: "PlainTextExtractor::preserve_layout",
+        preserve_layout: config.preserve_layout,
+        line_break_mode: "PreserveAll",
+        space_threshold: config.space_threshold,
+        tj_space_threshold: config.tj_space_threshold,
+        newline_threshold: config.newline_threshold,
+    }
+}
+
+fn temporary_output_path(output: &Path) -> Result<PathBuf, String> {
+    let name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("invalid prediction directory: {}", output.display()))?;
+    Ok(output.with_file_name(format!(".{name}.tmp-{}", std::process::id())))
+}
+
+fn write_predictions(jobs: &[Job], staging: &Path) -> Result<Vec<Failure>, String> {
+    let mut jobs_by_pdf: BTreeMap<&Path, Vec<&Job>> = BTreeMap::new();
+    for job in jobs {
+        jobs_by_pdf.entry(&job.pdf_path).or_default().push(job);
+    }
+    let mut failures = Vec::new();
+    for (pdf_path, pdf_jobs) in jobs_by_pdf {
+        let document = PdfReader::open(pdf_path)
+            .map(PdfDocument::new)
+            .map_err(|error| error.to_string());
+        let page_count = document
+            .as_ref()
+            .map_err(Clone::clone)
+            .and_then(|document| document.page_count().map_err(|error| error.to_string()));
+        let mut extractor = PlainTextExtractor::with_config(PlainTextConfig::preserve_layout());
+        for job in pdf_jobs {
+            let destination = prediction_path(staging, &job.prediction_name)?;
+            let extracted = match (&document, &page_count) {
+                (Ok(document), Ok(count)) if job.page_index < *count => extractor
+                    .extract(document, job.page_index)
+                    .map(|result| result.text)
+                    .map_err(|error| error.to_string()),
+                (Ok(_), Ok(count)) => Err(format!(
+                    "page index {} outside document with {} pages",
+                    job.page_index, count
+                )),
+                (Err(error), _) | (_, Err(error)) => Err(error.clone()),
+            };
+            match extracted {
+                Ok(text) => {
+                    fs::write(destination, text.as_bytes()).map_err(|error| error.to_string())?
+                }
+                Err(error) => {
+                    fs::write(destination, []).map_err(|write_error| write_error.to_string())?;
+                    failures.push(Failure {
+                        prediction_name: job.prediction_name.clone(),
+                        error,
+                    });
+                }
+            }
+        }
+    }
+    Ok(failures)
+}
+
+fn run(jobs_path: &Path, output: &Path, report_path: &Path) -> Result<(), String> {
+    let jobs: Vec<Job> = serde_json::from_slice(
+        &fs::read(jobs_path).map_err(|error| format!("read jobs: {error}"))?,
+    )
+    .map_err(|error| format!("parse jobs: {error}"))?;
+    if jobs.is_empty() {
+        return Err("job population is empty".to_string());
+    }
+    if output.exists() {
+        return Err(format!(
+            "prediction directory already exists: {}",
+            output.display()
+        ));
+    }
+    let staging = temporary_output_path(output)?;
+    if staging.exists() {
+        return Err(format!(
+            "staging directory already exists: {}",
+            staging.display()
+        ));
+    }
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    fs::create_dir(&staging).map_err(|error| error.to_string())?;
+    let mut failures = match write_predictions(&jobs, &staging) {
+        Ok(failures) => failures,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(error);
+        }
+    };
+    failures.sort_by(|left, right| left.prediction_name.cmp(&right.prediction_name));
+    let report = Report {
+        counts: Counts {
+            attempted: jobs.len(),
+            written: jobs.len(),
+            failed: failures.len(),
+        },
+        failures,
+        extraction_config: extraction_config(),
+    };
+    let mut rendered = serde_json::to_vec_pretty(&report).map_err(|error| error.to_string())?;
+    rendered.push(b'\n');
+    fs::write(report_path, rendered).map_err(|error| error.to_string())?;
+    fs::rename(staging, output).map_err(|error| error.to_string())
+}
+
+fn main() {
+    let args: Vec<_> = env::args_os().collect();
+    if args.len() != 4 {
+        eprintln!("usage: omnidocbench_export <jobs.json> <predictions-dir> <report.json>");
+        std::process::exit(2);
+    }
+    if let Err(error) = run(
+        Path::new(&args[1]),
+        Path::new(&args[2]),
+        Path::new(&args[3]),
+    ) {
+        eprintln!("error: {error}");
+        std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prediction_names_are_flat_markdown_files() {
+        let output = Path::new("predictions");
+        assert_eq!(
+            prediction_path(output, "source.pdf_7.md").unwrap(),
+            output.join("source.pdf_7.md")
+        );
+        assert!(prediction_path(output, "../escape.md").is_err());
+        assert!(prediction_path(output, "page.txt").is_err());
+    }
+
+    #[test]
+    fn effective_configuration_is_reportable() {
+        let config = extraction_config();
+        assert!(config.preserve_layout);
+        assert_eq!(config.line_break_mode, "PreserveAll");
+        assert_eq!(config.space_threshold, 0.3);
+        assert_eq!(config.tj_space_threshold, 0.2);
+        assert_eq!(config.newline_threshold, 10.0);
+    }
+}

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -235,25 +235,18 @@ impl PlainTextExtractor {
                 tj_space_threshold: self.config.tj_space_threshold,
                 newline_threshold: self.config.newline_threshold,
                 sort_by_position: true,
-                detect_columns: true,
+                detect_columns: false,
                 merge_hyphenated: matches!(
                     self.config.line_break_mode,
                     LineBreakMode::Auto | LineBreakMode::Normalize
                 ),
                 ..Default::default()
             };
-            if let Ok(extracted) =
-                TextExtractor::with_options(options).extract_from_page(document, page_index)
-            {
-                return Ok(PlainTextResult::new(
-                    self.apply_line_break_mode(&extracted.text),
-                ));
-            }
-
-            // Keep the tolerant lightweight parser as a compatibility
-            // fallback. Some recoverable PDFs contain malformed filters that
-            // the full extractor rejects even though their direct page text
-            // stream remains readable.
+            let extracted =
+                TextExtractor::with_options(options).extract_from_page(document, page_index)?;
+            return Ok(PlainTextResult::new(
+                self.apply_line_break_mode(&extracted.text),
+            ));
         }
 
         // Get the page

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -12,6 +12,7 @@ use crate::parser::ParseResult;
 use crate::text::encoding::TextEncoding;
 use crate::text::extraction_cmap::{CMapTextExtractor, FontInfo};
 use crate::text::graphics_state_stack::GraphicsStateStack;
+use crate::text::{ExtractionOptions, TextExtractor};
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
@@ -86,16 +87,15 @@ impl Default for TextState {
 ///
 /// # Architecture
 ///
-/// This extractor uses the same content stream parser as `TextExtractor`,
-/// but discards position metadata to provide a simpler output format. It
-/// tracks minimal position data (x, y coordinates) to determine spacing
-/// and line breaks, then returns clean text strings.
+/// The default mode tracks only the position data needed to determine spacing
+/// and line breaks. Layout-preserving mode delegates reconstruction to
+/// `TextExtractor`, then returns its text without exposing fragment metadata.
 ///
 /// # Performance Characteristics
 ///
-/// - **Memory**: O(1) position tracking vs O(n) fragments
-/// - **CPU**: No fragment sorting, no width calculations
-/// - **Performance**: Comparable to `TextExtractor` (same parser)
+/// - **Default mode**: O(1) position tracking, without fragment sorting
+/// - **Layout-preserving mode**: O(n) fragments and geometric sorting
+/// - **Performance**: Default mode avoids the layout engine's extra work
 ///
 /// # Thread Safety
 ///
@@ -223,6 +223,39 @@ impl PlainTextExtractor {
         document: &PdfDocument<R>,
         page_index: u32,
     ) -> ParseResult<PlainTextResult> {
+        // Layout-aware plain text needs the same font metrics, graphics-state
+        // handling, marked-content filtering and geometric reconstruction as
+        // the position-bearing extractor. Keeping a second partial
+        // implementation here made `preserve_layout()` less accurate than the
+        // lower-level API it is intended to simplify.
+        if self.config.preserve_layout {
+            let options = ExtractionOptions {
+                preserve_layout: true,
+                space_threshold: self.config.space_threshold,
+                tj_space_threshold: self.config.tj_space_threshold,
+                newline_threshold: self.config.newline_threshold,
+                sort_by_position: true,
+                detect_columns: true,
+                merge_hyphenated: matches!(
+                    self.config.line_break_mode,
+                    LineBreakMode::Auto | LineBreakMode::Normalize
+                ),
+                ..Default::default()
+            };
+            if let Ok(extracted) =
+                TextExtractor::with_options(options).extract_from_page(document, page_index)
+            {
+                return Ok(PlainTextResult::new(
+                    self.apply_line_break_mode(&extracted.text),
+                ));
+            }
+
+            // Keep the tolerant lightweight parser as a compatibility
+            // fallback. Some recoverable PDFs contain malformed filters that
+            // the full extractor rejects even though their direct page text
+            // stream remains readable.
+        }
+
         // Get the page
         let page = document.get_page(page_index)?;
 

--- a/oxidize-pdf-core/src/text/plaintext/extractor.rs
+++ b/oxidize-pdf-core/src/text/plaintext/extractor.rs
@@ -224,13 +224,16 @@ impl PlainTextExtractor {
         page_index: u32,
     ) -> ParseResult<PlainTextResult> {
         // Layout-aware plain text needs the same font metrics, graphics-state
-        // handling, marked-content filtering and geometric reconstruction as
-        // the position-bearing extractor. Keeping a second partial
-        // implementation here made `preserve_layout()` less accurate than the
-        // lower-level API it is intended to simplify.
+        // handling and marked-content filtering as the position-bearing
+        // extractor. Rebuild the full engine's flat text with its scale-relative
+        // XY-cut orderer: fragment-level column reconstruction recovers slightly
+        // more benchmark text, but regresses the native reading-order gate.
         if self.config.preserve_layout {
             let options = ExtractionOptions {
-                preserve_layout: true,
+                // The public facade still preserves line structure. This flag
+                // selects the full engine's flat reconstruction so XY-cut can
+                // order complete line groups without exposing fragments.
+                preserve_layout: false,
                 space_threshold: self.config.space_threshold,
                 tj_space_threshold: self.config.tj_space_threshold,
                 newline_threshold: self.config.newline_threshold,
@@ -242,8 +245,9 @@ impl PlainTextExtractor {
                 ),
                 ..Default::default()
             };
-            let extracted =
-                TextExtractor::with_options(options).extract_from_page(document, page_index)?;
+            let extracted = TextExtractor::with_options(options)
+                .with_reading_order(true)
+                .extract_from_page(document, page_index)?;
             return Ok(PlainTextResult::new(
                 self.apply_line_break_mode(&extracted.text),
             ));

--- a/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
+++ b/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
@@ -27,18 +27,7 @@ fn layout_plaintext_filters_artifacts_and_honors_actualtext() {
           0 -20 Td\n/Span << /ActualText (office) >> BDC\n(ofce) Tj\nEMC\nET\n",
     );
 
-    assert!(
-        text.contains("office"),
-        "ActualText substitution was lost: {text:?}"
-    );
-    assert!(
-        !text.contains("ofce"),
-        "visual glyphs leaked beside ActualText: {text:?}"
-    );
-    assert!(
-        !text.contains("page furniture"),
-        "Artifact text leaked: {text:?}"
-    );
+    assert_eq!(text.trim_end(), "office");
 }
 
 #[test]
@@ -48,8 +37,20 @@ fn layout_plaintext_uses_standard14_metrics_for_positioned_runs() {
           (iiiiiiiiiiiiiiii) Tj\n(X) Tj\nET\n",
     );
 
-    assert!(
-        text.contains("iiiiiiiiiiiiiiiiX"),
-        "contiguous AFM runs split: {text:?}"
+    assert_eq!(text.trim_end(), "iiiiiiiiiiiiiiiiX");
+}
+
+#[test]
+fn layout_plaintext_propagates_extraction_errors() {
+    let reader = PdfReader::new(Cursor::new(build_pdf_with_content_stream(b"")))
+        .expect("synthetic PDF should parse");
+    let document = PdfDocument::new(reader);
+    let error = PlainTextExtractor::with_config(PlainTextConfig::preserve_layout())
+        .extract(&document, 1)
+        .expect_err("an out-of-range page must not silently fall back");
+
+    assert_eq!(
+        error.to_string(),
+        "Syntax error at position 0: Page index 1 out of range (document has 1 pages)"
     );
 }

--- a/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
+++ b/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
@@ -1,0 +1,55 @@
+//! Regression coverage for issue #564: layout-aware plain-text extraction
+//! must use the complete text engine rather than the legacy minimal parser.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::synthetic_pdf::build_pdf_with_content_stream;
+use oxidize_pdf::parser::{PdfDocument, PdfReader};
+use oxidize_pdf::text::{PlainTextConfig, PlainTextExtractor};
+use std::io::Cursor;
+
+fn extract(content: &[u8]) -> String {
+    let reader = PdfReader::new(Cursor::new(build_pdf_with_content_stream(content)))
+        .expect("synthetic PDF should parse");
+    let document = PdfDocument::new(reader);
+    PlainTextExtractor::with_config(PlainTextConfig::preserve_layout())
+        .extract(&document, 0)
+        .expect("plain text should extract")
+        .text
+}
+
+#[test]
+fn layout_plaintext_filters_artifacts_and_honors_actualtext() {
+    let text = extract(
+        b"BT\n/F1 12 Tf\n1 0 0 1 100 700 Tm\n\
+          /Artifact BMC\n(page furniture) Tj\nEMC\n\
+          0 -20 Td\n/Span << /ActualText (office) >> BDC\n(ofce) Tj\nEMC\nET\n",
+    );
+
+    assert!(
+        text.contains("office"),
+        "ActualText substitution was lost: {text:?}"
+    );
+    assert!(
+        !text.contains("ofce"),
+        "visual glyphs leaked beside ActualText: {text:?}"
+    );
+    assert!(
+        !text.contains("page furniture"),
+        "Artifact text leaked: {text:?}"
+    );
+}
+
+#[test]
+fn layout_plaintext_uses_standard14_metrics_for_positioned_runs() {
+    let text = extract(
+        b"BT\n/F1 12 Tf\n1 0 0 1 100 700 Tm\n\
+          (iiiiiiiiiiiiiiii) Tj\n(X) Tj\nET\n",
+    );
+
+    assert!(
+        text.contains("iiiiiiiiiiiiiiiiX"),
+        "contiguous AFM runs split: {text:?}"
+    );
+}

--- a/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
+++ b/oxidize-pdf-core/tests/issue_564_plaintext_quality_test.rs
@@ -54,3 +54,21 @@ fn layout_plaintext_propagates_extraction_errors() {
         "Syntax error at position 0: Page index 1 out of range (document has 1 pages)"
     );
 }
+
+#[test]
+fn layout_plaintext_reads_interleaved_columns_left_then_right() {
+    let text = extract(
+        b"BT\n/F1 10 Tf\n\
+          1 0 0 1 330 700 Tm\n(right one) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 700 Tm\n(left one) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 330 680 Tm\n(right two) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 680 Tm\n(left two) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 330 660 Tm\n(right three) Tj\nET\n\
+          BT\n/F1 10 Tf\n1 0 0 1 40 660 Tm\n(left three) Tj\nET\n",
+    );
+
+    assert_eq!(
+        text.trim_end(),
+        "left one\nleft two\nleft three\nright one\nright two\nright three"
+    );
+}

--- a/tools/benchmarks/omnidocbench_gate.py
+++ b/tools/benchmarks/omnidocbench_gate.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Reproducible prediction and score gate for OmniDocBench native PDF text."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "oxidize-pdf-omnidocbench-gate/v1"
+POPULATION_VERSION = "native-text-v1"
+PROTOCOL = "OmniDocBench/end2end_eval/quick_match/text"
+EXCLUDED_DATA_SOURCES = frozenset({"note"})
+EXCLUDED_SPECIAL_ISSUES = frozenset({"fuzzy_scan"})
+OFFICIAL_TEXT_CATEGORIES = frozenset(
+    {"text_block", "title", "code_txt", "code_txt_caption", "reference"}
+)
+IDENTITY_FIELDS = (
+    "schema_version",
+    "dataset_revision",
+    "evaluator_revision",
+    "protocol",
+    "ocr_enabled",
+    "population_version",
+    "extraction_config",
+    "exporter_sha256",
+    "source_lock_sha256",
+    "rustc_version",
+    "cargo_version",
+)
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_object)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"invalid JSON in {path}: {error}") from error
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tree_hash(directory: Path, suffix: str = ".md") -> str:
+    entries = []
+    for path in sorted(directory.rglob(f"*{suffix}"), key=lambda item: item.relative_to(directory).as_posix()):
+        entries.append({"path": path.relative_to(directory).as_posix(), "sha256": file_hash(path)})
+    return canonical_hash(entries)
+
+
+def git_output(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, stdout=subprocess.PIPE, text=True
+    ).stdout.rstrip("\n")
+
+
+def git_provenance(allow_dirty: bool, source_root: Path | None = None) -> dict[str, Any]:
+    prefix = ("-C", str(source_root.resolve())) if source_root else ()
+    sha = git_output(*prefix, "rev-parse", "HEAD")
+    status = git_output(*prefix, "status", "--porcelain=v1", "--untracked-files=all")
+    if status and not allow_dirty:
+        raise ValueError("dirty worktree cannot be labelled as a clean commit; pass --allow-dirty")
+    result: dict[str, Any] = {"git_sha": sha, "worktree_clean": not bool(status)}
+    if status:
+        diff = git_output(*prefix, "diff", "--binary", "HEAD")
+        untracked = git_output(*prefix, "ls-files", "--others", "--exclude-standard", "-z")
+        dirty = hashlib.sha256()
+        dirty.update(status.encode())
+        dirty.update(b"\0")
+        dirty.update(diff.encode())
+        dirty.update(b"\0")
+        dirty.update(untracked.encode())
+        for name in sorted(filter(None, untracked.split("\0"))):
+            path = (source_root / name) if source_root else Path(name)
+            if path.is_file():
+                dirty.update(name.encode())
+                dirty.update(bytes.fromhex(file_hash(path)))
+        result["dirty_state_sha256"] = dirty.hexdigest()
+    return result
+
+
+def verified_revision(root: Path, expected: str, label: str) -> dict[str, Any]:
+    provenance = git_provenance(False, root)
+    if provenance["git_sha"] != expected:
+        raise ValueError(
+            f"{label} revision mismatch: expected {expected}, found {provenance['git_sha']}"
+        )
+    return provenance
+
+
+def command_version(*command: str) -> str:
+    return subprocess.run(
+        list(command), check=True, stdout=subprocess.PIPE, text=True
+    ).stdout.strip()
+
+
+def identity_fixture(**overrides: Any) -> dict[str, Any]:
+    identity = {
+        "schema_version": SCHEMA_VERSION,
+        "dataset_revision": "dataset",
+        "evaluator_revision": "evaluator",
+        "protocol": PROTOCOL,
+        "ocr_enabled": False,
+        "population_version": POPULATION_VERSION,
+        "extraction_config": {
+            "api": "PlainTextExtractor::preserve_layout",
+            "preserve_layout": True,
+            "line_break_mode": "PreserveAll",
+            "space_threshold": 0.3,
+            "tj_space_threshold": 0.2,
+            "newline_threshold": 10.0,
+        },
+        "exporter_sha256": "exporter",
+        "source_lock_sha256": "lock",
+        "rustc_version": "rustc",
+        "cargo_version": "cargo",
+    }
+    identity.update(overrides)
+    return identity
+
+
+def _dataset_metadata(dataset: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    if not isinstance(dataset, list):
+        raise ValueError("dataset JSON must be an array")
+    metadata: dict[str, dict[str, Any]] = {}
+    for entry in dataset:
+        if not isinstance(entry, dict):
+            raise ValueError("each dataset page must be an object")
+        try:
+            info = entry["page_info"]
+            name = Path(info["image_path"]).name
+            attributes = info["page_attribute"]
+        except (KeyError, TypeError) as error:
+            raise ValueError(f"malformed dataset page: {error}") from error
+        if name in metadata:
+            raise ValueError(f"duplicate dataset page: {name}")
+        if not isinstance(attributes, dict):
+            raise ValueError(f"page attributes must be an object: {name}")
+        special = attributes.get("special_issue", [])
+        if not isinstance(special, list) or not all(isinstance(item, str) for item in special):
+            raise ValueError(f"special_issue must be an array of strings: {name}")
+        layout = entry.get("layout_dets", [])
+        if not isinstance(layout, list) or not all(isinstance(item, dict) for item in layout):
+            raise ValueError(f"layout_dets must be an array of objects: {name}")
+        scorable = any(
+            item.get("category_type") in OFFICIAL_TEXT_CATEGORIES
+            and str(item.get("text", "")).strip()
+            and not item.get("ignore", False)
+            for item in layout
+        )
+        metadata[name] = {"attributes": attributes, "text_scorable": scorable}
+    if not metadata:
+        raise ValueError("dataset population is empty")
+    return metadata
+
+
+def summarize_scores(
+    dataset: list[dict[str, Any]], scores: dict[str, Any], failed_pages: int = 0
+) -> dict[str, Any]:
+    if not isinstance(scores, dict):
+        raise ValueError("scores JSON must be an object")
+    metadata = _dataset_metadata(dataset)
+    expected = {name for name, item in metadata.items() if item["text_scorable"]}
+    unknown = sorted(set(scores) - expected)
+    missing = sorted(expected - set(scores))
+    if unknown:
+        raise ValueError(f"scores reference {len(unknown)} unknown pages; first: {unknown[0]}")
+    if missing:
+        raise ValueError(f"missing scores for {len(missing)} pages; first: {missing[0]}")
+
+    native: list[float] = []
+    global_values: list[float] = []
+    for name in sorted(expected):
+        score = scores[name]
+        if (
+            not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not math.isfinite(score)
+            or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError(f"invalid score for {name}: {score!r}")
+        value = float(score)
+        global_values.append(value)
+        attrs = metadata[name]["attributes"]
+        special = set(attrs.get("special_issue", []))
+        if attrs.get("data_source") not in EXCLUDED_DATA_SOURCES and not special.intersection(EXCLUDED_SPECIAL_ISSUES):
+            native.append(value)
+    if not native:
+        raise ValueError("native-text population is empty")
+
+    global_edit = math.fsum(global_values) / len(global_values)
+    native_edit = math.fsum(native) / len(native)
+    return {
+        "population": {
+            "version": POPULATION_VERSION,
+            "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
+            "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+        },
+        "counts": {
+            "dataset": len(metadata),
+            "official_text_scorable": len(expected),
+            "official_text_unscored": len(metadata) - len(expected),
+            "scored": len(scores),
+            "included_native": len(native),
+            "excluded_native": len(global_values) - len(native),
+            "missing": 0,
+            "duplicate": 0,
+            "failed": failed_pages,
+        },
+        "metrics": {
+            "official_global_text_edit_distance": global_edit,
+            "official_global_text_similarity": 1.0 - global_edit,
+            "native_text_edit_distance": native_edit,
+            "native_text_similarity": 1.0 - native_edit,
+        },
+    }
+
+
+def compare_summaries(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    for label, summary in (("baseline", baseline), ("candidate", candidate)):
+        recorded_hash = summary.get("summary_sha256")
+        unhashed = {key: value for key, value in summary.items() if key != "summary_sha256"}
+        if recorded_hash != canonical_hash(unhashed):
+            raise ValueError(f"{label} summary hash is invalid")
+        if summary.get("provenance", {}).get("worktree_clean") is not True:
+            raise ValueError(f"{label} summary is not from a clean worktree")
+        artifacts = summary.get("artifacts", {})
+        if not all(artifacts.get(name) for name in ("dataset_sha256", "scores_sha256", "predictions_sha256")):
+            raise ValueError(f"{label} artifact identity is incomplete")
+    left = baseline.get("identity", {})
+    right = candidate.get("identity", {})
+    mismatches = [field for field in IDENTITY_FIELDS if left.get(field) != right.get(field)]
+    if mismatches:
+        raise ValueError(f"incompatible benchmark identity: {', '.join(mismatches)}")
+    population_counts = ("dataset", "official_text_scorable", "included_native", "excluded_native")
+    count_mismatches = [
+        name
+        for name in population_counts
+        if baseline.get("counts", {}).get(name) != candidate.get("counts", {}).get(name)
+    ]
+    if count_mismatches:
+        raise ValueError(f"incompatible benchmark population counts: {', '.join(count_mismatches)}")
+    before = baseline["metrics"]
+    after = candidate["metrics"]
+    return {
+        "identity_sha256": canonical_hash(left),
+        "official_global_text_similarity_delta": after["official_global_text_similarity"] - before["official_global_text_similarity"],
+        "native_text_similarity_delta": after["native_text_similarity"] - before["native_text_similarity"],
+    }
+
+
+def source_pdf_identity(entry: dict[str, Any]) -> tuple[str, int]:
+    info = entry["page_info"]
+    image_name = Path(info["image_path"]).name
+    page_no = info["page_no"]
+    if not isinstance(page_no, int) or isinstance(page_no, bool) or page_no < 1:
+        raise ValueError(f"invalid page_no for {image_name}: {page_no!r}")
+    stem = Path(image_name).stem
+    suffix = f"_{page_no}"
+    if not stem.endswith(suffix):
+        raise ValueError(f"image name does not end in _<page_no>: {image_name}")
+    source = stem[: -len(suffix)]
+    if not source.lower().endswith(".pdf"):
+        source += ".pdf"
+    return source, page_no - 1
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_json(value))
+
+
+def _pdf_index(root: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() != ".pdf":
+            continue
+        key = path.name.casefold()
+        if key in result:
+            raise ValueError(f"duplicate source PDF basename: {path.name}")
+        result[key] = path.resolve()
+    return result
+
+
+def export_predictions(args: argparse.Namespace) -> None:
+    dataset = load_json(args.dataset)
+    _dataset_metadata(dataset)
+    dataset_root = args.dataset_root.resolve()
+    evaluator_root = args.evaluator_root.resolve()
+    try:
+        args.dataset.resolve().relative_to(dataset_root)
+    except ValueError as error:
+        raise ValueError("--dataset must be inside --dataset-root") from error
+    dataset_provenance = verified_revision(
+        dataset_root, args.dataset_revision, "dataset"
+    )
+    evaluator_provenance = verified_revision(
+        evaluator_root, args.evaluator_revision, "evaluator"
+    )
+    pdfs = _pdf_index(args.pdf_root)
+    jobs = []
+    for entry in sorted(dataset, key=lambda item: Path(item["page_info"]["image_path"]).name):
+        source_name, page_index = source_pdf_identity(entry)
+        source = pdfs.get(source_name.casefold())
+        if source is None:
+            raise ValueError(f"missing source PDF: {source_name}")
+        image_name = Path(entry["page_info"]["image_path"]).name
+        jobs.append({"prediction_name": str(Path(image_name).with_suffix(".md")), "pdf_path": str(source), "page_index": page_index})
+
+    source_root = args.source_root.resolve()
+    provenance = git_provenance(args.allow_dirty, source_root)
+    provenance["dataset_repository"] = dataset_provenance
+    provenance["evaluator_repository"] = evaluator_provenance
+    exporter = Path(__file__).resolve().parents[2] / "oxidize-pdf-core/examples/omnidocbench_export.rs"
+    source_lock = source_root / "Cargo.lock"
+    if not source_lock.is_file():
+        raise ValueError(f"source checkout has no Cargo.lock: {source_root}")
+    with tempfile.TemporaryDirectory(prefix="oxidize-omnidocbench-") as directory:
+        harness = Path(directory)
+        archived_source = harness / "source"
+        jobs_path = harness / "jobs.json"
+        report_path = harness / "export-report.json"
+        core_path = archived_source / "oxidize-pdf-core"
+        if not (source_root / "oxidize-pdf-core/Cargo.toml").is_file():
+            raise ValueError(f"source checkout has no oxidize-pdf-core crate: {source_root}")
+        archive_path = harness / "source.tar"
+        subprocess.run(
+            ["git", "-C", str(source_root), "archive", "--format=tar", f"--output={archive_path}", "HEAD"],
+            check=True,
+        )
+        archived_source.mkdir()
+        with tarfile.open(archive_path) as archive:
+            archive.extractall(archived_source, filter="data")
+        examples = core_path / "examples"
+        examples.mkdir(exist_ok=True)
+        (examples / "omnidocbench_export.rs").write_bytes(exporter.read_bytes())
+        _write_json(jobs_path, jobs)
+        command_env = os.environ.copy()
+        command_env.setdefault(
+            "CARGO_TARGET_DIR",
+            str(Path(__file__).resolve().parents[2] / "target/omnidocbench-gate"),
+        )
+        subprocess.run(
+            ["cargo", "run", "--locked", "--offline", "--quiet", "--release", "--manifest-path", str(archived_source / "Cargo.toml"), "-p", "oxidize-pdf", "--example", "omnidocbench_export", "--", str(jobs_path), str(args.predictions), str(report_path)],
+            check=True,
+            env=command_env,
+        )
+        report = load_json(report_path)
+        archived_lock_sha256 = file_hash(archived_source / "Cargo.lock")
+    identity = identity_fixture(
+        dataset_revision=args.dataset_revision,
+        evaluator_revision=args.evaluator_revision,
+        extraction_config=report["extraction_config"],
+        exporter_sha256=file_hash(exporter),
+        source_lock_sha256=archived_lock_sha256,
+        rustc_version=command_version("rustc", "-Vv"),
+        cargo_version=command_version("cargo", "-V"),
+    )
+    manifest = {
+        "identity": identity,
+        "provenance": provenance,
+        "dataset_sha256": file_hash(args.dataset),
+        "predictions_sha256": tree_hash(args.predictions),
+        "counts": report["counts"],
+        "failures": report["failures"],
+    }
+    _write_json(args.manifest, manifest)
+
+
+def summarize_command(args: argparse.Namespace) -> None:
+    dataset = load_json(args.dataset)
+    scores = load_json(args.scores)
+    manifest = load_json(args.manifest)
+    dataset_sha256 = file_hash(args.dataset)
+    if manifest.get("dataset_sha256") != dataset_sha256:
+        raise ValueError("manifest dataset hash does not match --dataset")
+    dataset_pages = len(_dataset_metadata(dataset))
+    export_counts = manifest.get("counts", {})
+    if export_counts.get("attempted") != dataset_pages or export_counts.get("written") != dataset_pages:
+        raise ValueError("incomplete prediction manifest")
+    if export_counts.get("failed") != len(manifest.get("failures", [])):
+        raise ValueError("prediction failure count does not match failure records")
+    identity = manifest.get("identity", {})
+    missing_identity = [field for field in IDENTITY_FIELDS if field not in identity]
+    if missing_identity:
+        raise ValueError(f"manifest identity is incomplete: {', '.join(missing_identity)}")
+    if identity["ocr_enabled"] is not False or identity["protocol"] != PROTOCOL:
+        raise ValueError("manifest does not describe the supported OCR-free protocol")
+    verified_revision(args.evaluator_root, identity["evaluator_revision"], "evaluator")
+    predictions_sha256 = tree_hash(args.predictions)
+    if manifest.get("predictions_sha256") != predictions_sha256:
+        raise ValueError("prediction tree hash does not match manifest")
+    prediction_count = sum(1 for path in args.predictions.rglob("*.md") if path.is_file())
+    if prediction_count != dataset_pages:
+        raise ValueError("prediction directory is incomplete")
+    result = summarize_scores(dataset, scores, manifest["counts"]["failed"])
+    result["identity"] = manifest["identity"]
+    result["provenance"] = manifest["provenance"]
+    result["artifacts"] = {
+        "dataset_sha256": dataset_sha256,
+        "scores_sha256": canonical_hash(scores),
+        "predictions_sha256": predictions_sha256,
+    }
+    result["summary_sha256"] = canonical_hash(result)
+    _write_json(args.output, result)
+
+
+def compare_command(args: argparse.Namespace) -> None:
+    result = compare_summaries(load_json(args.baseline), load_json(args.candidate))
+    _write_json(args.output, result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    export = commands.add_parser("export", help="generate deterministic Markdown predictions")
+    export.add_argument("--dataset", type=Path, required=True)
+    export.add_argument("--dataset-root", type=Path, required=True, help="clean Git checkout containing the dataset")
+    export.add_argument("--evaluator-root", type=Path, required=True, help="clean pinned evaluator Git checkout")
+    export.add_argument("--pdf-root", type=Path, required=True)
+    export.add_argument("--source-root", type=Path, default=Path.cwd(), help="clean oxidize-pdf checkout to evaluate")
+    export.add_argument("--predictions", type=Path, required=True)
+    export.add_argument("--manifest", type=Path, required=True)
+    export.add_argument("--dataset-revision", required=True)
+    export.add_argument("--evaluator-revision", required=True)
+    export.add_argument("--allow-dirty", action="store_true")
+    export.set_defaults(handler=export_predictions)
+    summary = commands.add_parser("summarize", help="validate official per-page text scores")
+    summary.add_argument("--dataset", type=Path, required=True)
+    summary.add_argument("--scores", type=Path, required=True)
+    summary.add_argument("--predictions", type=Path, required=True)
+    summary.add_argument("--evaluator-root", type=Path, required=True)
+    summary.add_argument("--manifest", type=Path, required=True)
+    summary.add_argument("--output", type=Path, required=True)
+    summary.set_defaults(handler=summarize_command)
+    compare = commands.add_parser("compare", help="compare compatible summaries")
+    compare.add_argument("--baseline", type=Path, required=True)
+    compare.add_argument("--candidate", type=Path, required=True)
+    compare.add_argument("--output", type=Path, required=True)
+    compare.set_defaults(handler=compare_command)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    try:
+        args.handler(args)
+    except (ValueError, KeyError, OSError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmarks/omnidocbench_gate.py
+++ b/tools/benchmarks/omnidocbench_gate.py
@@ -84,13 +84,48 @@ def git_output(*args: str) -> str:
     ).stdout.rstrip("\n")
 
 
+def _matches_lfs_pointer(root: Path, relative: str) -> bool:
+    path = root / relative
+    if not path.is_file():
+        return False
+    pointer = subprocess.run(
+        ["git", "-C", str(root), "show", f"HEAD:{relative}"],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    lines = pointer.decode("ascii", errors="replace").splitlines()
+    if len(lines) != 3 or lines[0] != "version https://git-lfs.github.com/spec/v1":
+        return False
+    if not lines[1].startswith("oid sha256:") or not lines[2].startswith("size "):
+        return False
+    expected_hash = lines[1].removeprefix("oid sha256:")
+    try:
+        expected_size = int(lines[2].removeprefix("size "))
+    except ValueError:
+        return False
+    return path.stat().st_size == expected_size and file_hash(path) == expected_hash
+
+
 def git_provenance(allow_dirty: bool, source_root: Path | None = None) -> dict[str, Any]:
     prefix = ("-C", str(source_root.resolve())) if source_root else ()
+    root = source_root.resolve() if source_root else Path.cwd()
     sha = git_output(*prefix, "rev-parse", "HEAD")
-    status = git_output(*prefix, "status", "--porcelain=v1", "--untracked-files=all")
+    raw_status = git_output(
+        *prefix, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    )
+    entries = [entry for entry in raw_status.split("\0") if entry]
+    materialized_lfs = [
+        entry[3:]
+        for entry in entries
+        if entry.startswith(" M ") and _matches_lfs_pointer(root, entry[3:])
+    ]
+    remaining = [entry for entry in entries if entry[3:] not in materialized_lfs]
+    status = "\0".join(remaining)
     if status and not allow_dirty:
         raise ValueError("dirty worktree cannot be labelled as a clean commit; pass --allow-dirty")
     result: dict[str, Any] = {"git_sha": sha, "worktree_clean": not bool(status)}
+    if materialized_lfs:
+        result["verified_materialized_lfs_files"] = len(materialized_lfs)
     if status:
         diff = git_output(*prefix, "diff", "--binary", "HEAD")
         untracked = git_output(*prefix, "ls-files", "--others", "--exclude-standard", "-z")
@@ -191,7 +226,7 @@ def summarize_scores(
         raise ValueError("scores JSON must be an object")
     metadata = _dataset_metadata(dataset)
     expected = {name for name, item in metadata.items() if item["text_scorable"]}
-    unknown = sorted(set(scores) - expected)
+    unknown = sorted(set(scores) - set(metadata))
     missing = sorted(expected - set(scores))
     if unknown:
         raise ValueError(f"scores reference {len(unknown)} unknown pages; first: {unknown[0]}")
@@ -200,7 +235,7 @@ def summarize_scores(
 
     native: list[float] = []
     global_values: list[float] = []
-    for name in sorted(expected):
+    for name in sorted(scores):
         score = scores[name]
         if (
             not isinstance(score, (int, float))
@@ -225,6 +260,7 @@ def summarize_scores(
             "version": POPULATION_VERSION,
             "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
             "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+            "scored_pages_sha256": canonical_hash(sorted(scores)),
         },
         "counts": {
             "dataset": len(metadata),
@@ -270,6 +306,10 @@ def compare_summaries(baseline: dict[str, Any], candidate: dict[str, Any]) -> di
     ]
     if count_mismatches:
         raise ValueError(f"incompatible benchmark population counts: {', '.join(count_mismatches)}")
+    left_pages = baseline.get("population", {}).get("scored_pages_sha256")
+    right_pages = candidate.get("population", {}).get("scored_pages_sha256")
+    if not left_pages or left_pages != right_pages:
+        raise ValueError("incompatible scored-page population")
     before = baseline["metrics"]
     after = candidate["metrics"]
     return {
@@ -293,6 +333,23 @@ def source_pdf_identity(entry: dict[str, Any]) -> tuple[str, int]:
     if not source.lower().endswith(".pdf"):
         source += ".pdf"
     return source, page_no - 1
+
+
+def resolve_source_pdf(
+    entry: dict[str, Any], pdfs: dict[str, Path]
+) -> tuple[Path, int]:
+    image_name = Path(entry["page_info"]["image_path"]).name
+    split_name = f"{Path(image_name).stem}.pdf"
+    split_pdf = pdfs.get(split_name.casefold())
+    if split_pdf is not None:
+        return split_pdf, 0
+    source_name, page_index = source_pdf_identity(entry)
+    source = pdfs.get(source_name.casefold())
+    if source is None:
+        raise ValueError(
+            f"missing source PDF: tried {split_name} and {source_name}"
+        )
+    return source, page_index
 
 
 def _write_json(path: Path, value: Any) -> None:
@@ -330,10 +387,7 @@ def export_predictions(args: argparse.Namespace) -> None:
     pdfs = _pdf_index(args.pdf_root)
     jobs = []
     for entry in sorted(dataset, key=lambda item: Path(item["page_info"]["image_path"]).name):
-        source_name, page_index = source_pdf_identity(entry)
-        source = pdfs.get(source_name.casefold())
-        if source is None:
-            raise ValueError(f"missing source PDF: {source_name}")
+        source, page_index = resolve_source_pdf(entry, pdfs)
         image_name = Path(entry["page_info"]["image_path"]).name
         jobs.append({"prediction_name": str(Path(image_name).with_suffix(".md")), "pdf_path": str(source), "page_index": page_index})
 

--- a/tools/benchmarks/omnidocbench_gate_test.py
+++ b/tools/benchmarks/omnidocbench_gate_test.py
@@ -1,4 +1,5 @@
 import importlib.util
+import hashlib
 import json
 import argparse
 import shutil
@@ -35,6 +36,7 @@ def page(name, source="book", special=None, page_no=1):
 def sealed_summary(identity=None, dataset_count=1, similarity=0.5):
     value = {
         "identity": identity or GATE.identity_fixture(),
+        "population": {"scored_pages_sha256": "pages"},
         "provenance": {"worktree_clean": True},
         "artifacts": {
             "dataset_sha256": "dataset",
@@ -92,6 +94,13 @@ class JsonAndPopulationTests(unittest.TestCase):
         entry["layout_dets"] = [{"category_type": "code_txt_caption", "text": "caption"}]
         result = GATE.summarize_scores([entry], {"caption.jpg": 0.25})
         self.assertEqual(result["counts"]["official_text_scorable"], 1)
+
+    def test_accepts_evaluator_score_for_known_page_furniture_only_page(self):
+        entry = page("header.jpg")
+        entry["layout_dets"] = [{"category_type": "header", "text": "running title"}]
+        result = GATE.summarize_scores([entry], {"header.jpg": 0.25})
+        self.assertEqual(result["counts"]["official_text_scorable"], 0)
+        self.assertEqual(result["counts"]["scored"], 1)
 
     def test_reports_distinct_global_and_native_populations(self):
         dataset = [
@@ -154,10 +163,46 @@ class IdentityAndHashTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "dirty worktree"):
                 GATE.verified_revision(root, revision, "fixture")
 
+    def test_verified_revision_accepts_only_matching_materialized_lfs_objects(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+            content = b"materialized lfs payload"
+            pointer = (
+                "version https://git-lfs.github.com/spec/v1\n"
+                f"oid sha256:{hashlib.sha256(content).hexdigest()}\n"
+                f"size {len(content)}\n"
+            )
+            (root / "asset.bin").write_text(pointer, encoding="ascii")
+            subprocess.run(["git", "-C", str(root), "add", "asset.bin"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"], check=True)
+            revision = GATE.git_output("-C", str(root), "rev-parse", "HEAD")
+
+            (root / "asset.bin").write_bytes(content)
+            provenance = GATE.verified_revision(root, revision, "fixture")
+            self.assertTrue(provenance["worktree_clean"])
+            self.assertEqual(provenance["verified_materialized_lfs_files"], 1)
+
+            (root / "asset.bin").write_bytes(content + b"tampered")
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.verified_revision(root, revision, "fixture")
+
     def test_population_count_mismatch_is_not_comparable(self):
         baseline = sealed_summary(dataset_count=2)
         candidate = sealed_summary(dataset_count=3)
         with self.assertRaisesRegex(ValueError, "population counts"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_scored_page_population_mismatch_is_not_comparable(self):
+        baseline = sealed_summary()
+        candidate = sealed_summary()
+        candidate["population"]["scored_pages_sha256"] = "different-pages"
+        candidate["summary_sha256"] = GATE.canonical_hash(
+            {key: value for key, value in candidate.items() if key != "summary_sha256"}
+        )
+        with self.assertRaisesRegex(ValueError, "scored-page population"):
             GATE.compare_summaries(baseline, candidate)
 
     def test_compare_rejects_tampered_or_dirty_summaries(self):
@@ -176,6 +221,17 @@ class IdentityAndHashTests(unittest.TestCase):
 
 
 class PdfResolutionTests(unittest.TestCase):
+    def test_prefers_page_specific_pdf_when_dataset_stores_split_pages(self):
+        entry = page("source.pdf_7.jpg", page_no=7)
+        split_pdf = Path("/dataset/ori_pdfs/source.pdf_7.pdf")
+        combined_pdf = Path("/dataset/ori_pdfs/source.pdf")
+        pdfs = {
+            split_pdf.name.casefold(): split_pdf,
+            combined_pdf.name.casefold(): combined_pdf,
+        }
+
+        self.assertEqual(GATE.resolve_source_pdf(entry, pdfs), (split_pdf, 0))
+
     def test_resolves_pdf_suffix_and_one_based_page(self):
         self.assertEqual(
             GATE.source_pdf_identity(page("source.pdf_7.jpg", page_no=7)),

--- a/tools/benchmarks/omnidocbench_gate_test.py
+++ b/tools/benchmarks/omnidocbench_gate_test.py
@@ -1,0 +1,255 @@
+import importlib.util
+import json
+import argparse
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("omnidocbench_gate.py")
+SPEC = importlib.util.spec_from_file_location("omnidocbench_gate", MODULE_PATH)
+assert SPEC and SPEC.loader
+GATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GATE)
+
+
+def page(name, source="book", special=None, page_no=1):
+    return {
+        "layout_dets": [{"category_type": "text_block", "text": "text"}],
+        "page_info": {
+            "image_path": f"images/{name}",
+            "page_no": page_no,
+            "page_attribute": {
+                "data_source": source,
+                "special_issue": special or ["None"],
+                "layout": "single_column",
+                "language": "english",
+            },
+        }
+    }
+
+
+def sealed_summary(identity=None, dataset_count=1, similarity=0.5):
+    value = {
+        "identity": identity or GATE.identity_fixture(),
+        "provenance": {"worktree_clean": True},
+        "artifacts": {
+            "dataset_sha256": "dataset",
+            "scores_sha256": "scores",
+            "predictions_sha256": "predictions",
+        },
+        "counts": {
+            "dataset": dataset_count,
+            "official_text_scorable": dataset_count,
+            "included_native": dataset_count,
+            "excluded_native": 0,
+        },
+        "metrics": {
+            "official_global_text_similarity": similarity,
+            "native_text_similarity": similarity,
+        },
+    }
+    value["summary_sha256"] = GATE.canonical_hash(value)
+    return value
+
+
+class JsonAndPopulationTests(unittest.TestCase):
+    def test_rejects_duplicate_json_keys(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scores.json"
+            path.write_text('{"a.jpg": 0.1, "a.jpg": 0.2}', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate JSON key"):
+                GATE.load_json(path)
+
+    def test_rejects_missing_unknown_and_duplicate_dataset_pages(self):
+        with self.assertRaisesRegex(ValueError, "missing scores"):
+            GATE.summarize_scores([page("a.jpg"), page("b.jpg")], {"a.jpg": 0.1})
+        with self.assertRaisesRegex(ValueError, "unknown pages"):
+            GATE.summarize_scores([page("a.jpg")], {"a.jpg": 0.1, "x.jpg": 0.2})
+        with self.assertRaisesRegex(ValueError, "duplicate dataset page"):
+            GATE.summarize_scores([page("a.jpg"), page("a.jpg")], {"a.jpg": 0.1})
+
+    def test_rejects_invalid_scores(self):
+        for value in (float("nan"), float("inf"), -0.1, 1.1, True, "0.1"):
+            with self.subTest(value=value), self.assertRaisesRegex(ValueError, "invalid score"):
+                GATE.summarize_scores([page("a.jpg")], {"a.jpg": value})
+
+    def test_rejects_malformed_dataset_and_score_shapes(self):
+        with self.assertRaisesRegex(ValueError, "dataset JSON must be an array"):
+            GATE.summarize_scores({}, {})
+        with self.assertRaisesRegex(ValueError, "scores JSON must be an object"):
+            GATE.summarize_scores([page("a.jpg")], [])
+        malformed = page("a.jpg")
+        malformed["page_info"]["page_attribute"]["special_issue"] = "fuzzy_scan"
+        with self.assertRaisesRegex(ValueError, "array of strings"):
+            GATE.summarize_scores([malformed], {"a.jpg": 0.1})
+
+    def test_code_text_caption_is_officially_scorable(self):
+        entry = page("caption.jpg")
+        entry["layout_dets"] = [{"category_type": "code_txt_caption", "text": "caption"}]
+        result = GATE.summarize_scores([entry], {"caption.jpg": 0.25})
+        self.assertEqual(result["counts"]["official_text_scorable"], 1)
+
+    def test_reports_distinct_global_and_native_populations(self):
+        dataset = [
+            page("native.jpg"),
+            page("note.jpg", source="note"),
+            page("fuzzy.jpg", special=["fuzzy_scan"]),
+        ]
+        result = GATE.summarize_scores(
+            dataset, {"native.jpg": 0.2, "note.jpg": 1.0, "fuzzy.jpg": 0.8}, failed_pages=1
+        )
+        self.assertEqual(result["counts"], {
+            "dataset": 3, "official_text_scorable": 3,
+            "official_text_unscored": 0, "scored": 3, "included_native": 1,
+            "excluded_native": 2, "missing": 0, "duplicate": 0, "failed": 1,
+        })
+        self.assertAlmostEqual(result["metrics"]["official_global_text_similarity"], 1 - 2 / 3)
+        self.assertAlmostEqual(result["metrics"]["native_text_similarity"], 0.8)
+
+
+class IdentityAndHashTests(unittest.TestCase):
+    def test_canonical_hash_ignores_mapping_order(self):
+        self.assertEqual(GATE.canonical_hash({"b": 2, "a": 1}), GATE.canonical_hash({"a": 1, "b": 2}))
+
+    def test_compare_rejects_incompatible_identity(self):
+        baseline = sealed_summary(GATE.identity_fixture(dataset_revision="old"))
+        candidate = sealed_summary(GATE.identity_fixture(dataset_revision="new"))
+        with self.assertRaisesRegex(ValueError, "incompatible.*dataset_revision"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_summary_hash_is_repeatable(self):
+        dataset = [page("b.jpg"), page("a.jpg")]
+        first = GATE.summarize_scores(dataset, {"a.jpg": 0.1, "b.jpg": 0.2})
+        second = GATE.summarize_scores(list(reversed(dataset)), {"b.jpg": 0.2, "a.jpg": 0.1})
+        self.assertEqual(GATE.canonical_hash(first), GATE.canonical_hash(second))
+
+    def test_dirty_checkout_requires_explicit_provenance(self):
+        with mock.patch.object(GATE, "git_output", side_effect=["abc123", " M file"]):
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.git_provenance(False)
+
+    def test_dirty_provenance_has_diff_hash(self):
+        with mock.patch.object(GATE, "git_output", side_effect=["abc123", " M file", "diff", "file\0"]):
+            result = GATE.git_provenance(True)
+        self.assertEqual(result["git_sha"], "abc123")
+        self.assertFalse(result["worktree_clean"])
+        self.assertRegex(result["dirty_state_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_verified_revision_uses_real_temporary_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+            subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+            (root / "tracked").write_text("content", encoding="utf-8")
+            subprocess.run(["git", "-C", str(root), "add", "tracked"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"], check=True)
+            revision = GATE.git_output("-C", str(root), "rev-parse", "HEAD")
+            self.assertEqual(GATE.verified_revision(root, revision, "fixture")["git_sha"], revision)
+            (root / "tracked").write_text("changed", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "dirty worktree"):
+                GATE.verified_revision(root, revision, "fixture")
+
+    def test_population_count_mismatch_is_not_comparable(self):
+        baseline = sealed_summary(dataset_count=2)
+        candidate = sealed_summary(dataset_count=3)
+        with self.assertRaisesRegex(ValueError, "population counts"):
+            GATE.compare_summaries(baseline, candidate)
+
+    def test_compare_rejects_tampered_or_dirty_summaries(self):
+        baseline = sealed_summary()
+        candidate = sealed_summary(similarity=0.6)
+        candidate["metrics"]["native_text_similarity"] = 0.9
+        with self.assertRaisesRegex(ValueError, "summary hash"):
+            GATE.compare_summaries(baseline, candidate)
+        candidate = sealed_summary(similarity=0.6)
+        candidate["provenance"]["worktree_clean"] = False
+        candidate["summary_sha256"] = GATE.canonical_hash(
+            {key: value for key, value in candidate.items() if key != "summary_sha256"}
+        )
+        with self.assertRaisesRegex(ValueError, "clean worktree"):
+            GATE.compare_summaries(baseline, candidate)
+
+
+class PdfResolutionTests(unittest.TestCase):
+    def test_resolves_pdf_suffix_and_one_based_page(self):
+        self.assertEqual(
+            GATE.source_pdf_identity(page("source.pdf_7.jpg", page_no=7)),
+            ("source.pdf", 6),
+        )
+
+    def test_resolves_source_without_pdf_in_image_stem(self):
+        self.assertEqual(
+            GATE.source_pdf_identity(page("slides_455.jpg", page_no=455)),
+            ("slides.pdf", 454),
+        )
+
+    def test_exporter_writes_prediction_and_manifest(self):
+        repository = MODULE_PATH.parents[2]
+        fixture = repository / "oxidize-pdf-core/tests/fixtures/issue_498_actual_text_diagnostic.pdf"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pdf_root = root / "pdfs"
+            pdf_root.mkdir()
+            shutil.copy2(fixture, pdf_root / "source.pdf")
+            dataset = root / "dataset.json"
+            dataset.write_text(json.dumps([page("source.pdf_1.jpg")]), encoding="utf-8")
+            predictions = root / "predictions"
+            manifest = root / "manifest.json"
+            args = argparse.Namespace(
+                dataset=dataset,
+                dataset_root=root,
+                evaluator_root=repository,
+                pdf_root=pdf_root,
+                source_root=repository,
+                predictions=predictions,
+                manifest=manifest,
+                dataset_revision="dataset-rev",
+                evaluator_revision="evaluator-rev",
+                allow_dirty=True,
+            )
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), mock.patch.object(
+                GATE, "git_provenance", return_value={"git_sha": "candidate", "worktree_clean": True}
+            ):
+                GATE.export_predictions(args)
+            recorded = GATE.load_json(manifest)
+            self.assertTrue((predictions / "source.pdf_1.md").is_file())
+            self.assertEqual(recorded["counts"], {"attempted": 1, "failed": 0, "written": 1})
+            self.assertEqual(recorded["predictions_sha256"], GATE.tree_hash(predictions))
+
+            scores = root / "scores.json"
+            scores.write_text('{"source.pdf_1.jpg":0.25}', encoding="utf-8")
+            summary = root / "summary.json"
+            summary_args = argparse.Namespace(
+                dataset=dataset,
+                scores=scores,
+                predictions=predictions,
+                evaluator_root=repository,
+                manifest=manifest,
+                output=summary,
+            )
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}):
+                GATE.summarize_command(summary_args)
+            self.assertEqual(GATE.load_json(summary)["metrics"]["official_global_text_similarity"], 0.75)
+            (predictions / "source.pdf_1.md").write_text("tampered", encoding="utf-8")
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), self.assertRaisesRegex(ValueError, "prediction tree hash"):
+                GATE.summarize_command(summary_args)
+
+            second_predictions = root / "predictions-second"
+            second_manifest = root / "manifest-second.json"
+            args.predictions = second_predictions
+            args.manifest = second_manifest
+            with mock.patch.object(GATE, "verified_revision", return_value={"git_sha": "verified", "worktree_clean": True}), mock.patch.object(
+                GATE, "git_provenance", return_value={"git_sha": "candidate", "worktree_clean": True}
+            ):
+                GATE.export_predictions(args)
+            repeated = GATE.load_json(second_manifest)
+            self.assertEqual(recorded["predictions_sha256"], repeated["predictions_sha256"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/benchmarks/omnidocbench_native_reading_order.py
+++ b/tools/benchmarks/omnidocbench_native_reading_order.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Aggregate official OmniDocBench reading-order scores for native-text pages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+EXCLUDED_DATA_SOURCES = frozenset({"note"})
+EXCLUDED_SPECIAL_ISSUES = frozenset({"fuzzy_scan"})
+DIMENSIONS = ("data_source", "layout", "language")
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def aggregate_native_scores(
+    dataset: list[dict[str, Any]], scores: dict[str, float]
+) -> dict[str, Any]:
+    """Return native-only averages from an official per-page score artifact."""
+    metadata = {}
+    for page in dataset:
+        name = Path(page["page_info"]["image_path"]).name
+        if name in metadata:
+            raise ValueError(f"duplicate dataset page basename: {name}")
+        metadata[name] = page["page_info"]["page_attribute"]
+    missing = sorted(set(scores) - set(metadata))
+    if missing:
+        raise ValueError(f"scores reference {len(missing)} unknown pages; first: {missing[0]}")
+
+    selected: list[tuple[str, float, dict[str, Any]]] = []
+    excluded = 0
+    for name, score in scores.items():
+        if (
+            not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not math.isfinite(score)
+            or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError(f"invalid edit-distance score for {name}: {score!r}")
+        attributes = metadata[name]
+        special_issues = set(attributes.get("special_issue", []))
+        if (
+            attributes.get("data_source") in EXCLUDED_DATA_SOURCES
+            or special_issues & EXCLUDED_SPECIAL_ISSUES
+        ):
+            excluded += 1
+            continue
+        selected.append((name, float(score), attributes))
+
+    if not selected:
+        raise ValueError("no native-text pages remain after filtering")
+
+    categories: dict[str, dict[str, dict[str, float | int]]] = {}
+    for dimension in DIMENSIONS:
+        groups: dict[str, list[float]] = defaultdict(list)
+        for _, score, attributes in selected:
+            groups[str(attributes.get(dimension, "unknown"))].append(score)
+        categories[dimension] = {
+            label: {"pages": len(values), "edit_distance": sum(values) / len(values)}
+            for label, values in sorted(groups.items())
+        }
+
+    values = [score for _, score, _ in selected]
+    return {
+        "protocol": "OmniDocBench end2end_eval/quick_match per-page reading-order Edit_dist",
+        "filter": {
+            "excluded_data_sources": sorted(EXCLUDED_DATA_SOURCES),
+            "excluded_special_issues": sorted(EXCLUDED_SPECIAL_ISSUES),
+        },
+        "official_scored_pages": len(scores),
+        "excluded_pages": excluded,
+        "native_pages": len(values),
+        "native_edit_distance": sum(values) / len(values),
+        "categories": categories,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset", type=Path, help="Pinned OmniDocBench.json")
+    parser.add_argument("scores", type=Path, help="Official reading_order_per_page_edit.json")
+    parser.add_argument("--output", type=Path, help="Write JSON here instead of stdout")
+    args = parser.parse_args()
+
+    result = aggregate_native_scores(_load_json(args.dataset), _load_json(args.scores))
+    rendered = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmarks/omnidocbench_native_reading_order_test.py
+++ b/tools/benchmarks/omnidocbench_native_reading_order_test.py
@@ -1,0 +1,94 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("omnidocbench_native_reading_order.py")
+SPEC = importlib.util.spec_from_file_location("native_reading_order", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def page(
+    name: str,
+    source: str,
+    layout: str = "single_column",
+    language: str = "english",
+    special_issue=None,
+):
+    return {
+        "page_info": {
+            "image_path": f"images/{name}",
+            "page_attribute": {
+                "data_source": source,
+                "layout": layout,
+                "language": language,
+                "special_issue": special_issue or ["None"],
+            },
+        }
+    }
+
+
+class NativeReadingOrderAggregationTests(unittest.TestCase):
+    def test_excludes_notes_and_fuzzy_scans_and_aggregates_categories(self):
+        dataset = [
+            page("book.jpg", "book", "double_column"),
+            page("paper.jpg", "academic_literature"),
+            page("scan.jpg", "note"),
+            page("fuzzy.jpg", "book", special_issue=["fuzzy_scan"]),
+        ]
+        result = MODULE.aggregate_native_scores(
+            dataset,
+            {"book.jpg": 0.4, "paper.jpg": 0.2, "scan.jpg": 1.0, "fuzzy.jpg": 0.8},
+        )
+
+        self.assertEqual(result["official_scored_pages"], 4)
+        self.assertEqual(result["excluded_pages"], 2)
+        self.assertEqual(result["native_pages"], 2)
+        self.assertAlmostEqual(result["native_edit_distance"], 0.3)
+        self.assertEqual(
+            result["categories"]["layout"]["double_column"],
+            {"pages": 1, "edit_distance": 0.4},
+        )
+
+    def test_rejects_unknown_score_pages(self):
+        with self.assertRaisesRegex(ValueError, "unknown pages"):
+            MODULE.aggregate_native_scores(
+                [page("known.jpg", "book")], {"missing.jpg": 0.1}
+            )
+
+    def test_rejects_non_numeric_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": "0.1"}
+            )
+
+    def test_rejects_non_finite_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": float("nan")}
+            )
+
+    def test_rejects_out_of_range_scores(self):
+        with self.assertRaisesRegex(ValueError, "invalid edit-distance score"):
+            MODULE.aggregate_native_scores(
+                [page("page.jpg", "book")], {"page.jpg": 1.01}
+            )
+
+    def test_rejects_duplicate_dataset_basenames(self):
+        with self.assertRaisesRegex(ValueError, "duplicate dataset page basename"):
+            MODULE.aggregate_native_scores(
+                [page("same.jpg", "book"), page("same.jpg", "academic_literature")],
+                {"same.jpg": 0.1},
+            )
+
+    def test_rejects_an_empty_native_population(self):
+        with self.assertRaisesRegex(ValueError, "no native-text pages"):
+            MODULE.aggregate_native_scores(
+                [page("scan.jpg", "note")], {"scan.jpg": 1.0}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Release v5.0.1

Patch release restoring layout-aware plaintext extraction quality after v5.0.0.

### Included
- #564 / #570: global OmniDocBench text similarity improves from 48.26% to 60.01% (target >=55%)
- #565: reproducible native reading-order acceptance protocol
- #568: pinned and sealed OmniDocBench quality gate

### Release preparation
- workspace and lockfile version set to 5.0.1
- README dependency example updated
- CHANGELOG entry dated 2026-09-04
- no public API break and no ISO compliance change

### Local validation
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- cargo package -p oxidize-pdf --allow-dirty (977 files, 18.7 MiB / 5.1 MiB compressed)
- packaged manifest contains no path dependencies

The tag will only be created from the merged main commit after CI is fully green.